### PR TITLE
ParseConfig doesn't understand -Wl flags.

### DIFF
--- a/test/Deprecated/Options/chdir.py
+++ b/test/Deprecated/Options/chdir.py
@@ -43,6 +43,7 @@ SConscript('subdir/SConscript')
 """)
 
 SConscript_contents = """\
+from __future__ import print_function
 Import("opts")
 env = Environment()
 opts.Update(env)

--- a/test/Deprecated/Options/import.py
+++ b/test/Deprecated/Options/import.py
@@ -45,6 +45,7 @@ SConscript('subdir/SConscript')
 """)
 
 SConscript_contents = """\
+from __future__ import print_function
 Import("opts")
 env = Environment()
 opts.Update(env)

--- a/test/ExecuteInvalidateCache.py
+++ b/test/ExecuteInvalidateCache.py
@@ -38,6 +38,8 @@ test = TestSCons.TestSCons()
 subfn = os.path.join('sub', 'foo')
 
 test.write('SConstruct', """\
+from __future__ import print_function
+
 def exists(node):
     if node.exists():
         print(str(node), "exists")

--- a/test/SConscript/Return.py
+++ b/test/SConscript/Return.py
@@ -34,6 +34,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+from __future__ import print_function
+
 SConscript('SConscript1')
 x = SConscript('SConscript2')
 y, z = SConscript('SConscript3')

--- a/test/SConscript/SConscript.py
+++ b/test/SConscript/SConscript.py
@@ -32,6 +32,7 @@ test.write('foo.py', "foo = 4\n")
 
 
 test.write('SConstruct', """\
+from __future__ import print_function
 import os
 import foo
 

--- a/test/SConscript/env.py
+++ b/test/SConscript/env.py
@@ -47,6 +47,7 @@ env.SConscript(['s3', 's4'])
 """)
 
 test.write(['sub1', 'SConscript'], """\
+from __future__ import print_function
 env = Environment()
 env.Import("x")
 print("sub1/SConscript")
@@ -54,6 +55,7 @@ print("x =", x)
 """)
 
 test.write(['sub2', 'SConscript'], """\
+from __future__ import print_function
 env = Environment()
 env.Import("y")
 print("sub2/SConscript")

--- a/test/SConstruct.py
+++ b/test/SConstruct.py
@@ -40,6 +40,7 @@ scons: \*\*\* No SConstruct file found.
 wpath = test.workpath()
 
 test.write('sconstruct', """
+from __future__ import print_function
 import os
 print("sconstruct", os.getcwd())
 """)
@@ -50,6 +51,7 @@ test.run(arguments = ".",
 
 
 test.write('Sconstruct', """
+from __future__ import print_function
 import os
 print("Sconstruct", os.getcwd())
 """)
@@ -59,6 +61,7 @@ test.run(arguments = ".",
                                    build_str = "scons: `.' is up to date.\n"))
 
 test.write('SConstruct', """
+from __future__ import print_function
 import os
 print("SConstruct", os.getcwd())
 """)

--- a/test/Scanner/empty-implicit.py
+++ b/test/Scanner/empty-implicit.py
@@ -34,6 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', r"""
+from __future__ import print_function
 import os.path
 
 def scan(node, env, envkey, arg):

--- a/test/Scanner/scan-once.py
+++ b/test/Scanner/scan-once.py
@@ -33,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', r"""
+from __future__ import print_function
 import os.path
 
 def scan(node, env, envkey, arg):

--- a/test/Variables/chdir.py
+++ b/test/Variables/chdir.py
@@ -43,6 +43,7 @@ SConscript('subdir/SConscript')
 """)
 
 SConscript_contents = """\
+from __future__ import print_function
 Import("opts")
 env = Environment()
 opts.Update(env)

--- a/test/Variables/import.py
+++ b/test/Variables/import.py
@@ -45,6 +45,7 @@ SConscript('subdir/SConscript')
 """)
 
 SConscript_contents = """\
+from __future__ import print_function
 Import("opts")
 env = Environment()
 opts.Update(env)

--- a/test/option--C.py
+++ b/test/option--C.py
@@ -50,6 +50,7 @@ wpath_sub_foo_bar = test.workpath('sub', 'foo', 'bar')
 test.subdir('sub', ['sub', 'dir'])
 
 test.write('SConstruct', """
+from __future__ import print_function
 import os
 print("SConstruct", os.getcwd())
 """)

--- a/test/option-f.py
+++ b/test/option-f.py
@@ -35,16 +35,19 @@ test.subdir('subdir')
 subdir_BuildThis = os.path.join('subdir', 'Buildthis')
 
 test.write('SConscript', """
+from __future__ import print_function
 import os
 print("SConscript " + os.getcwd())
 """)
 
 test.write(subdir_BuildThis, """
+from __future__ import print_function
 import os
 print("subdir/BuildThis", os.getcwd())
 """)
 
 test.write('Build2', """
+from __future__ import print_function
 import os
 print("Build2", os.getcwd())
 """)

--- a/test/overrides.py
+++ b/test/overrides.py
@@ -33,6 +33,7 @@ test = TestSCons.TestSCons()
 _python_ = TestSCons._python_
 
 test.write('SConstruct', """
+from __future__ import print_function
 env = Environment(CCFLAGS='-DFOO', LIBS=['a'])
 def build(target, source, env):
     print("env['CC'] =", env['CC'])

--- a/test/tool_args.py
+++ b/test/tool_args.py
@@ -37,6 +37,7 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 # Test passing kw args to Tool constructor
+from __future__ import print_function
 env1 = Environment(tools=[Tool('FooTool', toolpath=['.'], kw1='kw1val')])
 print("env1['TOOL_FOO'] =", env1.get('TOOL_FOO'))
 print("env1['kw1'] =", env1.get('kw1'))

--- a/test/toolpath/basic.py
+++ b/test/toolpath/basic.py
@@ -31,6 +31,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+from __future__ import print_function
 def foo(env):
     env['TOOL_FOO'] = 1
 

--- a/test/toolpath/nested/image/SConstruct
+++ b/test/toolpath/nested/image/SConstruct
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, os
 
 toollist = ['Toolpath_TestTool1',

--- a/test/toolpath/relative_import/image/SConstruct
+++ b/test/toolpath/relative_import/image/SConstruct
@@ -1,3 +1,4 @@
+from __future__ import print_function
 env = Environment(tools=['TestTool1', 'TestTool1.TestTool1_2'], toolpath=['tools'])
 
 # Test a relative import within the root of the tools directory


### PR DESCRIPTION
This issue was originally created at: 2004-05-03 01:46:30.
This issue was reported by: `noselasd`.
noselasd said at 2004-05-03 01:46:30
>This has annoyed me abit. ParseConfig(..) is nice to parse output of
>xxx-config programs and pkg-config. However ParseConfig doesn't understand
>the -Wl flag. Which means 'pass flag to linker'. It ends up in the CPPDEFINES
>as far as I can see.
>Thus on a machine here, every pkg-config --libs will have among others
>'-Wl,-R/usr/pkg/lib' . And as ParseConfig places that in the CPPDEFINES, it
>should go to LINKFLAGS I guess. I get a warning on compiling every .c file that
>linking isn't done, and linking might fail since it actually doesn't get all
>link flags.
>I guess this goes for other -Wl flags as well, afaik ther's -Wsomething to pass 
>flags to the assembler and preprocessor as well.

stevenknight said at 2004-05-03 07:01:11
>Fix has been checked in for next release.  Thanks!

stevenknight said at 2006-01-05 18:14:20
>Changing version to "unspecified" to conform to new scheme.

kmaples said at 2006-05-20 17:03:30
>making the default milestone consistent across the project

kmaples said at 2006-05-20 17:14:13
>making the version consistent across the project

