### PR TITLE
PATH does not include /sw/bin on OS X

### DIFF
--- a/test/Deprecated/Options/chdir.py
+++ b/test/Deprecated/Options/chdir.py
@@ -46,7 +46,7 @@ SConscript_contents = """\
 Import("opts")
 env = Environment()
 opts.Update(env)
-print("VARIABLE =", repr(env['VARIABLE']))
+print("VARIABLE = %s"%repr(env['VARIABLE']))
 """
 
 test.write(['bin', 'opts.cfg'], """\

--- a/test/Deprecated/Options/import.py
+++ b/test/Deprecated/Options/import.py
@@ -48,7 +48,7 @@ SConscript_contents = """\
 Import("opts")
 env = Environment()
 opts.Update(env)
-print("VARIABLE =", env.get('VARIABLE'))
+print("VARIABLE = %s"%env.get('VARIABLE'))
 """
 
 test.write(['bin', 'opts.cfg'], """\

--- a/test/ExecuteInvalidateCache.py
+++ b/test/ExecuteInvalidateCache.py
@@ -40,9 +40,9 @@ subfn = os.path.join('sub', 'foo')
 test.write('SConstruct', """\
 def exists(node):
     if node.exists():
-        print(str(node), "exists")
+        print(str(node)+" exists")
     else:
-        print(str(node), "does not exist")
+        print(str(node)+" does not exist")
 
 Execute(Delete('abc'))
 n1 = File('abc')

--- a/test/SConscript/Return.py
+++ b/test/SConscript/Return.py
@@ -39,13 +39,8 @@ x = SConscript('SConscript2')
 y, z = SConscript('SConscript3')
 a4, b4 = SConscript('SConscript4')
 foo, bar = SConscript('SConscript5')
-print("x =", x)
-print("y =", y)
-print("z =", z)
-print("a4 =", a4)
-print("b4 =", b4)
-print("foo =", foo)
-print("bar =", bar)
+for var in ['x','y','z','a4','b4','foo','bar']:
+    print("%s = %s"%(var,globals()[var]))
 """)
 
 test.write('SConscript1', """\

--- a/test/SConscript/SConscript.py
+++ b/test/SConscript/SConscript.py
@@ -37,7 +37,7 @@ import foo
 
 assert foo.foo == 4
 
-print("SConstruct", os.getcwd())
+print("SConstruct "+ os.getcwd())
 SConscript('SConscript')
 
 x1 = "SConstruct x1"

--- a/test/SConscript/env.py
+++ b/test/SConscript/env.py
@@ -50,14 +50,14 @@ test.write(['sub1', 'SConscript'], """\
 env = Environment()
 env.Import("x")
 print("sub1/SConscript")
-print("x =", x)
+print("x = %s"%x)
 """)
 
 test.write(['sub2', 'SConscript'], """\
 env = Environment()
 env.Import("y")
 print("sub2/SConscript")
-print("y =", y)
+print("y = %s"%y)
 """)
 
 test.write('s1', "\n")

--- a/test/SConstruct.py
+++ b/test/SConstruct.py
@@ -41,7 +41,7 @@ wpath = test.workpath()
 
 test.write('sconstruct', """
 import os
-print("sconstruct", os.getcwd())
+print("sconstruct "+os.getcwd())
 """)
 
 test.run(arguments = ".",
@@ -51,7 +51,7 @@ test.run(arguments = ".",
 
 test.write('Sconstruct', """
 import os
-print("Sconstruct", os.getcwd())
+print("Sconstruct "+os.getcwd())
 """)
 
 test.run(arguments = ".",
@@ -60,7 +60,7 @@ test.run(arguments = ".",
 
 test.write('SConstruct', """
 import os
-print("SConstruct", os.getcwd())
+print("SConstruct "+os.getcwd())
 """)
 
 test.run(arguments = ".",

--- a/test/Scanner/empty-implicit.py
+++ b/test/Scanner/empty-implicit.py
@@ -37,7 +37,7 @@ test.write('SConstruct', r"""
 import os.path
 
 def scan(node, env, envkey, arg):
-    print('XScanner: node =', os.path.split(str(node))[1])
+    print('XScanner: node = '+os.path.split(str(node))[1])
     return []
 
 def exists_check(node, env):

--- a/test/Scanner/scan-once.py
+++ b/test/Scanner/scan-once.py
@@ -36,7 +36,7 @@ test.write('SConstruct', r"""
 import os.path
 
 def scan(node, env, envkey, arg):
-    print('XScanner: node =', os.path.split(str(node))[1])
+    print('XScanner: node = '+ os.path.split(str(node))[1])
     return []
 
 def exists_check(node, env):

--- a/test/Variables/chdir.py
+++ b/test/Variables/chdir.py
@@ -46,7 +46,7 @@ SConscript_contents = """\
 Import("opts")
 env = Environment()
 opts.Update(env)
-print("VARIABLE =", repr(env['VARIABLE']))
+print("VARIABLE = "+repr(env['VARIABLE']))
 """
 
 test.write(['bin', 'opts.cfg'], """\

--- a/test/option--C.py
+++ b/test/option--C.py
@@ -51,7 +51,7 @@ test.subdir('sub', ['sub', 'dir'])
 
 test.write('SConstruct', """
 import os
-print("SConstruct", os.getcwd())
+print("SConstruct "+os.getcwd())
 """)
 
 test.write(['sub', 'SConstruct'], """

--- a/test/option-f.py
+++ b/test/option-f.py
@@ -41,12 +41,12 @@ print("SConscript " + os.getcwd())
 
 test.write(subdir_BuildThis, """
 import os
-print("subdir/BuildThis", os.getcwd())
+print("subdir/BuildThis "+ os.getcwd())
 """)
 
 test.write('Build2', """
 import os
-print("Build2", os.getcwd())
+print("Build2 "+ os.getcwd())
 """)
 
 wpath = test.workpath()

--- a/test/overrides.py
+++ b/test/overrides.py
@@ -35,9 +35,9 @@ _python_ = TestSCons._python_
 test.write('SConstruct', """
 env = Environment(CCFLAGS='-DFOO', LIBS=['a'])
 def build(target, source, env):
-    print("env['CC'] =", env['CC'])
-    print("env['CCFLAGS'] =", env['CCFLAGS'])
-    print("env['LIBS'] =", env['LIBS'])
+    print("env['CC'] = "+env['CC'])
+    print("env['CCFLAGS'] = "+env['CCFLAGS'])
+    print("env['LIBS'] = "+str(env['LIBS']))
 builder = Builder(action=build, CC='buildcc', LIBS='buildlibs')
 env['BUILDERS']['Build'] = builder
 

--- a/test/tool_args.py
+++ b/test/tool_args.py
@@ -38,13 +38,13 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 # Test passing kw args to Tool constructor
 env1 = Environment(tools=[Tool('FooTool', toolpath=['.'], kw1='kw1val')])
-print("env1['TOOL_FOO'] =", env1.get('TOOL_FOO'))
-print("env1['kw1'] =", env1.get('kw1'))
+print("env1['TOOL_FOO'] = "+str(env1.get('TOOL_FOO')))
+print("env1['kw1'] = "+env1.get('kw1'))
 
 # Test apply_tools taking a list of (name, kwargs_dict)
 env2 = Environment(tools=[('FooTool', {'kw2':'kw2val'})], toolpath=['.'])
-print("env2['TOOL_FOO'] =", env2.get('TOOL_FOO'))
-print("env2['kw2'] =", env2.get('kw2'))
+print("env2['TOOL_FOO'] = "+str(env2.get('TOOL_FOO')))
+print("env2['kw2'] = "+env2.get('kw2'))
 
 """)
 

--- a/test/toolpath/basic.py
+++ b/test/toolpath/basic.py
@@ -35,65 +35,65 @@ def foo(env):
     env['TOOL_FOO'] = 1
 
 env1 = Environment(tools=[foo, 'bar'], toolpath=['tools'])
-print("env1['TOOL_FOO'] =", env1.get('TOOL_FOO'))
-print("env1['TOOL_BAR'] =", env1.get('TOOL_BAR'))
+print("env1['TOOL_FOO'] = %s"%env1.get('TOOL_FOO'))
+print("env1['TOOL_BAR'] = %s"%env1.get('TOOL_BAR'))
 
 # pick a built-in tool with pretty simple behavior
 env2 = Environment(tools=['zip'])
-print("env2['ZIP'] =", env2.get('ZIP'))
-print("env2['TOOL_zip1'] =", env2.get('TOOL_zip1'))
-print("env2['TOOLDIR_zip'] =", env2.get('TOOLDIR_zip'))
+print("env2['ZIP'] = %s"%env2.get('ZIP'))
+print("env2['TOOL_zip1'] = %s"%env2.get('TOOL_zip1'))
+print("env2['TOOLDIR_zip'] = %s"%env2.get('TOOLDIR_zip'))
 
 # Only find tools in current dir, or Scons.Tool.TOOLNAME
 env3 = Environment(tools=['zip'], toolpath=['.'])
-print("env3['ZIP'] =", env3.get('ZIP'))
-print("env3['TOOL_zip1'] =", env3.get('TOOL_zip1'))
-print("env3['TOOLDIR_zip'] =", env3.get('TOOLDIR_zip'))
+print("env3['ZIP'] = %s"%env3.get('ZIP'))
+print("env3['TOOL_zip1'] = %s"%env3.get('TOOL_zip1'))
+print("env3['TOOLDIR_zip'] = %s"%env3.get('TOOLDIR_zip'))
 
 env4 = Environment(tools=['zip'], toolpath=['tools'])
-print("env4['ZIP'] =", env4.get('ZIP'))
-print("env4['TOOL_zip1'] =", env4.get('TOOL_zip1'))
-print("env4['TOOLDIR_zip'] =", env4.get('TOOLDIR_zip'))
+print("env4['ZIP'] = %s"%env4.get('ZIP'))
+print("env4['TOOL_zip1'] = %s"%env4.get('TOOL_zip1'))
+print("env4['TOOLDIR_zip'] = %s"%env4.get('TOOLDIR_zip'))
 
 # Should pick up from tools dir, and then current dir
 env5 = Environment(tools=['zip'], toolpath=['tools', '.'])
-print("env5['ZIP'] =", env5.get('ZIP'))
-print("env5['TOOL_zip1'] =", env5.get('TOOL_zip1'))
-print("env5['TOOLDIR_zip'] =", env5.get('TOOLDIR_zip'))
+print("env5['ZIP'] = %s"%env5.get('ZIP'))
+print("env5['TOOL_zip1'] = %s"%env5.get('TOOL_zip1'))
+print("env5['TOOLDIR_zip'] = %s"%env5.get('TOOLDIR_zip'))
 
 
 # Should pick up from current dir, and then tools dir
 env6 = Environment(tools=['zip'], toolpath=['.', 'tools'])
-print("env6['ZIP'] =", env6.get('ZIP'))
-print("env6['TOOL_zip1'] =", env6.get('TOOL_zip1'))
-print("env6['TOOLDIR_zip'] =", env6.get('TOOLDIR_zip'))
+print("env6['ZIP'] = %s"%env6.get('ZIP'))
+print("env6['TOOL_zip1'] = %s"%env6.get('TOOL_zip1'))
+print("env6['TOOLDIR_zip'] = %s"%env6.get('TOOLDIR_zip'))
 
 env7 = Environment(TOOLPATH="tools", tools=['zip'], toolpath=['$TOOLPATH'])
-print("env7['ZIP'] =", env7.get('ZIP'))
-print("env7['TOOL_zip1'] =", env7.get('TOOL_zip1'))
-print("env7['TOOLDIR_zip'] =", env7.get('TOOLDIR_zip'))
+print("env7['ZIP'] = %s"%env7.get('ZIP'))
+print("env7['TOOL_zip1'] = %s"%env7.get('TOOL_zip1'))
+print("env7['TOOLDIR_zip'] = %s"%env7.get('TOOLDIR_zip'))
 
 env8 = Environment(tools=[])
 env8.Tool('zip', toolpath=['tools'])
-print("env8['ZIP'] =", env8.get('ZIP'))
-print("env8['TOOL_zip1'] =", env8.get('TOOL_zip1'))
-print("env8['TOOLDIR_zip'] =", env8.get('TOOLDIR_zip'))
+print("env8['ZIP'] = %s"%env8.get('ZIP'))
+print("env8['TOOL_zip1'] = %s"%env8.get('TOOL_zip1'))
+print("env8['TOOLDIR_zip'] = %s"%env8.get('TOOLDIR_zip'))
 
 env9 = Environment(tools=[])
 Tool('zip', toolpath=['tools'])(env9)
-print("env9['ZIP'] =", env9.get('ZIP'))
-print("env9['TOOL_zip1'] =", env9.get('TOOL_zip1'))
-print("env9['TOOLDIR_zip'] =", env9.get('TOOLDIR_zip'))
+print("env9['ZIP'] = %s"%env9.get('ZIP'))
+print("env9['TOOL_zip1'] = %s"%env9.get('TOOL_zip1'))
+print("env9['TOOLDIR_zip'] = %s"%env9.get('TOOLDIR_zip'))
 
 env0 = Environment(TOOLPATH='tools', tools=[])
 env0.Tool('zip', toolpath=['$TOOLPATH'])
-print("env0['ZIP'] =", env0.get('ZIP'))
-print("env0['TOOL_zip1'] =", env0.get('TOOL_zip1'))
-print("env0['TOOLDIR_zip'] =", env0.get('TOOLDIR_zip'))
+print("env0['ZIP'] = %s"%env0.get('ZIP'))
+print("env0['TOOL_zip1'] = %s"%env0.get('TOOL_zip1'))
+print("env0['TOOLDIR_zip'] = %s"%env0.get('TOOLDIR_zip'))
 
 base = Environment(tools=[], toolpath=['tools'])
 derived = base.Clone(tools=['bar'])
-print("derived['TOOL_BAR'] =", derived.get('TOOL_BAR'))
+print("derived['TOOL_BAR'] = %s"%derived.get('TOOL_BAR'))
 """)
 
 test.write('zip.py', r"""

--- a/test/toolpath/nested/image/SConstruct
+++ b/test/toolpath/nested/image/SConstruct
@@ -10,26 +10,26 @@ toollist = ['Toolpath_TestTool1',
 
 print('Test where tools are located under site_scons/site_tools')
 env1 = Environment(tools=toollist)
-print("env1['Toolpath_TestTool1'] =", env1.get('Toolpath_TestTool1'))
-print("env1['Toolpath_TestTool2'] =", env1.get('Toolpath_TestTool2'))
-print("env1['Toolpath_TestTool1_1'] =", env1.get('Toolpath_TestTool1_1'))
-print("env1['Toolpath_TestTool1_2'] =", env1.get('Toolpath_TestTool1_2'))
-print("env1['Toolpath_TestTool2_1'] =", env1.get('Toolpath_TestTool2_1'))
-print("env1['Toolpath_TestTool2_2'] =", env1.get('Toolpath_TestTool2_2'))
+print("env1['Toolpath_TestTool1'] = %s"%env1.get('Toolpath_TestTool1'))
+print("env1['Toolpath_TestTool2'] = %s"%env1.get('Toolpath_TestTool2'))
+print("env1['Toolpath_TestTool1_1'] = %s"%env1.get('Toolpath_TestTool1_1'))
+print("env1['Toolpath_TestTool1_2'] = %s"%env1.get('Toolpath_TestTool1_2'))
+print("env1['Toolpath_TestTool2_1'] = %s"%env1.get('Toolpath_TestTool2_1'))
+print("env1['Toolpath_TestTool2_2'] = %s"%env1.get('Toolpath_TestTool2_2'))
 
 print('Test where toolpath is set in the env constructor')
 env2 = Environment(tools=toollist, toolpath=['Libs/tools_example'])
-print("env2['Toolpath_TestTool1'] =", env2.get('Toolpath_TestTool1'))
-print("env2['Toolpath_TestTool2'] =", env2.get('Toolpath_TestTool2'))
-print("env2['Toolpath_TestTool1_1'] =", env2.get('Toolpath_TestTool1_1'))
-print("env2['Toolpath_TestTool1_2'] =", env2.get('Toolpath_TestTool1_2'))
-print("env2['Toolpath_TestTool2_1'] =", env2.get('Toolpath_TestTool2_1'))
-print("env2['Toolpath_TestTool2_2'] =", env2.get('Toolpath_TestTool2_2'))
+print("env2['Toolpath_TestTool1'] = %s"%env2.get('Toolpath_TestTool1'))
+print("env2['Toolpath_TestTool2'] = %s"%env2.get('Toolpath_TestTool2'))
+print("env2['Toolpath_TestTool1_1'] = %s"%env2.get('Toolpath_TestTool1_1'))
+print("env2['Toolpath_TestTool1_2'] = %s"%env2.get('Toolpath_TestTool1_2'))
+print("env2['Toolpath_TestTool2_1'] = %s"%env2.get('Toolpath_TestTool2_1'))
+print("env2['Toolpath_TestTool2_2'] = %s"%env2.get('Toolpath_TestTool2_2'))
 
 print('Test a Clone')
 base = Environment(tools=[], toolpath=['Libs/tools_example'])
 derived = base.Clone(tools=['subdir1.Toolpath_TestTool1_1'])
-print("derived['Toolpath_TestTool1_1'] =", derived.get('Toolpath_TestTool1_1'))
+print("derived['Toolpath_TestTool1_1'] = %s"%derived.get('Toolpath_TestTool1_1'))
 
 
 print('Test using syspath as the toolpath')
@@ -52,18 +52,18 @@ toollist = ['tools_example.Toolpath_TestTool1',
 	    ]
 
 env3 = Environment(tools=toollist, toolpath=searchpaths)
-print("env3['Toolpath_TestTool1'] =", env3.get('Toolpath_TestTool1'))
-print("env3['Toolpath_TestTool2'] =", env3.get('Toolpath_TestTool2'))
-print("env3['Toolpath_TestTool1_1'] =", env3.get('Toolpath_TestTool1_1'))
-print("env3['Toolpath_TestTool1_2'] =", env3.get('Toolpath_TestTool1_2'))
-print("env3['Toolpath_TestTool2_1'] =", env3.get('Toolpath_TestTool2_1'))
-print("env3['Toolpath_TestTool2_2'] =", env3.get('Toolpath_TestTool2_2'))
+print("env3['Toolpath_TestTool1'] = %s"%env3.get('Toolpath_TestTool1'))
+print("env3['Toolpath_TestTool2'] = %s"%env3.get('Toolpath_TestTool2'))
+print("env3['Toolpath_TestTool1_1'] = %s"%env3.get('Toolpath_TestTool1_1'))
+print("env3['Toolpath_TestTool1_2'] = %s"%env3.get('Toolpath_TestTool1_2'))
+print("env3['Toolpath_TestTool2_1'] = %s"%env3.get('Toolpath_TestTool2_1'))
+print("env3['Toolpath_TestTool2_2'] = %s"%env3.get('Toolpath_TestTool2_2'))
 
 
 print('Test using PyPackageDir')
 toollist = ['Toolpath_TestTool2_1', 'Toolpath_TestTool2_2']
 env4 = Environment(tools = toollist, toolpath = [PyPackageDir('tools_example.subdir1.subdir2')])
-print("env4['Toolpath_TestTool2_1'] =", env4.get('Toolpath_TestTool2_1'))
-print("env4['Toolpath_TestTool2_2'] =", env4.get('Toolpath_TestTool2_2'))
+print("env4['Toolpath_TestTool2_1'] = %s"%env4.get('Toolpath_TestTool2_1'))
+print("env4['Toolpath_TestTool2_2'] = %s"%env4.get('Toolpath_TestTool2_2'))
 
 sys.path = oldsyspath

--- a/test/toolpath/relative_import/image/SConstruct
+++ b/test/toolpath/relative_import/image/SConstruct
@@ -1,10 +1,10 @@
 env = Environment(tools=['TestTool1', 'TestTool1.TestTool1_2'], toolpath=['tools'])
 
 # Test a relative import within the root of the tools directory
-print("env['TestTool1'] =", env.get('TestTool1'))
-print("env['TestTool1_1'] =", env.get('TestTool1_1'))
+print("env['TestTool1'] = %s"%env.get('TestTool1'))
+print("env['TestTool1_1'] = %s"%env.get('TestTool1_1'))
 
 # Test a relative import within a sub dir
-print("env['TestTool1_2'] =", env.get('TestTool1_2'))
-print("env['TestTool1_2_1'] =", env.get('TestTool1_2_1'))
-print("env['TestTool1_2_2'] =", env.get('TestTool1_2_2'))
+print("env['TestTool1_2'] = %s"%env.get('TestTool1_2'))
+print("env['TestTool1_2_1'] = %s"%env.get('TestTool1_2_1'))
+print("env['TestTool1_2_2'] = %s"%env.get('TestTool1_2_2'))


### PR DESCRIPTION
This issue was originally created at: 2005-05-07 12:52:36.
This issue was reported by: `gregnoel`.
gregnoel said at 2005-05-07 12:52:36
>On OS X, many packages are not provided by Apple, but can be acquired from the
>Fink project, which places all of its binaries in /sw/bin.  I would imagine that
>most Mac developers use fink, so that directory should be added to the PATH when
>running on OS X.
> 
>This one-line patch does that:
> 
>--- Platform/darwin.old Fri May  6 19:50:29 2005
>+++ Platform/darwin.py  Fri May  6 19:37:52 2005
>@@ -38,3 +38,4 @@
> def generate(env):
>     posix.generate(env)
>     env['SHLIBSUFFIX'] = '.dylib'
>+    env['ENV']['PATH'] = env['ENV']['PATH'] + ':/sw/bin'
> 
>It's probably not the ideal solution, but it works for me.

stevenknight said at 2005-10-07 19:49:06
>Patch has been accepted and integrated for next release.  Thanks!

stevenknight said at 2006-01-05 18:14:55
>Changing version to "unspecified" to conform to new scheme.

kmaples said at 2006-05-20 17:03:30
>making the default milestone consistent across the project

kmaples said at 2006-05-20 17:14:13
>making the version consistent across the project

