### PR TITLE
AppendUnique appends duplicated values

### DIFF
--- a/test/Variables/import.py
+++ b/test/Variables/import.py
@@ -48,7 +48,7 @@ SConscript_contents = """\
 Import("opts")
 env = Environment()
 opts.Update(env)
-print("VARIABLE =", env.get('VARIABLE'))
+print("VARIABLE = %s"%env.get('VARIABLE'))
 """
 
 test.write(['bin', 'opts.cfg'], """\


### PR DESCRIPTION
This issue was originally created at: 2005-06-05 08:02:45.
This issue was reported by: `gregnoel`.
gregnoel said at 2005-06-05 08:02:45
>On May 10, 2005, at 13:01 US/Pacific, Steven Knight wrote, "... the current
>behavior of AppendUnique() is sub-optimal and should be changed."  In another
>message, Gary Oberbrunner concured.  The behavior in question is that
>AppendUnique does not remove multiple occurences of the same value in the list
>that is being appended.  That is, if the new list is
>        ['foo', 'bar', 'foobar', 'foo', 'bar']
>all five elements are added, even though 'foo' and 'bar' are duplicated.

stevenknight said at 2006-01-05 18:15:11
>Changing version to "unspecified" to conform to new scheme.

kmaples said at 2006-05-20 17:03:31
>making the default milestone consistent across the project

kmaples said at 2006-05-20 17:14:14
>making the version consistent across the project

bdbaddog said at 2008-03-15 22:40:58
>Does the following, demonstrate the bug?
>----------------------------------------------
>env=Environment(tool=[])
>env['TEST3']=['a']
>env.AppendUnique(TEST3=['a','a','b','b','a','c','c'])
>print 'TEST3 is now:%s'%env['TEST3']
>-------------------------------------
> 
>Which outputs (in latest svn):
>TEST3 is now:['a', 'b', 'b', 'c', 'c']

gregnoel said at 2008-11-30 12:24:54
>Bug party triage.  May already be fixed.  Gary to research.

garyo said at 2008-12-04 17:40:24
>Still broken in current trunk.  Will fix.

garyo said at 2008-12-04 19:23:07
>Fixed in r3804.

evgen said at 2016-08-30 17:50:48
>Not resolved, according to this discussion: 
>http://four.pairlist.net/pipermail/scons-users/2013-September/001736.html
>- at least, when nodes are involved

