### PR TITLE
Expand framework support

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -15,6 +15,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed a regression in scons-3.0.0 where "from __future__ import print_function" was imposed
       on the scope where SConstruct is executed, breaking existing builds using PY 2.7.
 
+  From William Deegan:
+    - Fix broken subst logic where a string with "$$(abc)" was being treated as "$(abc) and the
+      logic for removing the signature escapes was then failing because there was no closing "$)".
+      This was introduced by a pull request to allow recursive variable evaluations to yield a string
+      such as "$( $( some stuff $) $)".
+
 RELEASE 3.0.0 - Mon, 18 Sep 2017 08:32:04 -0700
 
 NOTE: This is a major release.  You should expect that some targets may rebuild when upgrading.

--- a/src/engine/SCons/SubstTests.py
+++ b/src/engine/SCons/SubstTests.py
@@ -336,6 +336,10 @@ class scons_subst_TestCase(SubstTestCase):
         # Test double-dollar-sign behavior.
         "$$FFF$HHH",            "$FFFIII",
 
+        # Test double-dollar-sign before open paren. It's not meant
+        # to be signature escaping
+        'echo $$(pwd) > XYZ',   'echo $(pwd) > XYZ',
+
         # Test that a Literal will stop dollar-sign substitution.
         "$XXX $LITERAL $FFF",   "GGG $XXX GGG",
 


### PR DESCRIPTION
This issue was originally created at: 2005-06-16 13:49:58.
This issue was reported by: `gregnoel`.
gregnoel said at 2005-06-16 13:49:58
>Expand framework support to compile and link steps (currently, frameworks are
>just supported for bundles).  Splits FRAMEWORKSFLAGS into two separate pieces:
>FRAMEWORKPATH and FRAMEWORKS; both are a list of names.  Created a construction
>variable _CCCOMCOM to hold the C Compiler COMmon COMmand flags; _FRAMEWORKPATH
>is appended to this for OS X.  Psuedo-variables _FRAMEWORKPATH and _FRAMEWORKS
>created to place the correct expansion of frameworks in the right places.  Some
>logic cleaned up: redundant code removed from gnulink.py and a typo fixed (the
>rpath option has only one hyphen, not two).
> 
>I seem to have little success when trying to attach files, so the patch is in
>the URL.

gregnoel said at 2005-06-16 13:52:21
>Oops, sorry, this was supposed to be a patch, not a defect.

stevenknight said at 2006-01-05 18:15:24
>Changing version to "unspecified" to conform to new scheme.

stevenknight said at 2006-05-03 18:45:42
>Patch was integrated for release 0.96.91.  Thank you!

kmaples said at 2006-05-20 17:03:29
>making the default milestone consistent across the project

kmaples said at 2006-05-20 17:14:12
>making the version consistent across the project


More information about this issue is at http://simtech.sf.net/diffs.txt.
