### PR TITLE
Refactor ParseConfig() into useful pieces

### DIFF
--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -132,10 +132,10 @@ foo = Environment(tools = ['javac', 'jar'],
                   JAR = r'%(where_jar)s')
 jar = foo.Dictionary('JAR')
 bar = foo.Clone(JAR = r'%(_python_)s wrapper_with_args.py ' + jar)
-foo.Java(target = 'classes', source = 'com/sub/foo')
-bar.Java(target = 'classes', source = 'com/sub/bar')
-foo.Jar(target = 'foo', source = 'classes/com/sub/foo')
-bar.Jar(target = 'bar', source = 'classes/com/sub/bar')
+foo_classes = foo.Java(target = 'classes', source = 'com/sub/foo')
+bar_classes = bar.Java(target = 'classes', source = 'com/sub/bar')
+foo.Jar(target = 'foo', source = foo_classes)
+bar.Jar(target = 'bar', source = bar_classes)
 """ % locals())
 
 test.subdir('com',
@@ -229,7 +229,7 @@ public class Example6
 
 test.run(arguments = '.')
 
-expected_wrapper_out = "wrapper_with_args.py %(where_jar)s cf bar.jar classes/com/sub/bar\n"
+expected_wrapper_out = "wrapper_with_args.py %(where_jar)s cf bar.jar -C classes com/sub/bar/Example4.class -C classes com/sub/bar/Example5.class -C classes com/sub/bar/Example6.class\n"
 expected_wrapper_out = expected_wrapper_out.replace('/', os.sep)
 test.must_match('wrapper.out',
                 expected_wrapper_out % locals(), mode='r')


### PR DESCRIPTION
This issue was originally created at: 2005-07-15 03:51:14.
This issue was reported by: `gregnoel`.
gregnoel said at 2005-07-15 03:51:14
>This patch (in the referenced URL, since I seem to have problems uploading
>files) takes the internal functions used by ParseConfig() to parse the flags
>into individual environment variables and exposes them for public use.  Using
>these functions, a user can simply provide all the flags in one place and they
>will be automatically placed into the appropriate environment variables.  This
>patch is against 0.96.90, not CVS HEAD, so there may be some minor variances.
> 
>The documentation changes are given below.  I'm sorry I don't have the source so
>that I can prepare a suitable diff.
> 
>For ParseConfig(), its signature is unchanged and the only changes to the
>wording are to mention that it uses MergeFlags(), to remove the mention of
>ASFLAGS (which isn't passed to compile steps, so these flags end up being
>dropped), and to update what's done with some other flags.
> 
>First paragraph, second sentence: "The default {\ul function} is MergeFlags,
>which expects ..."  At the end, add this sentence: "See {\bd ParseFlags} for a
>description of how the flags are handled."
> 
>The second paragraph will be moved to the ParseFlags entry, but this is how it
>should be edited: First sentence: remove "-Wa," and "ASFLAGS,".  Second
>sentence: "A {\bd -pthread} or {\bd -mno-cygwin} option gets added ..."  Third
>sentence: "A {\bd -framework} option gets added to the FRAMEWORKS variable and a
>{\bd -frameworkdir=} or {\bd -F} option gets added to the FRAMEWORKPATH variable."
> 
>MergeFlags signature: env.MergeFlags(arg, [unique])
> 
>Description: If the argument is not a dictionary, it is converted to one by
>calling {\bd ParseFlags} on the argument.  Otherwise, the items in the
>dictionary are merged with the corresponding environment variables.  By default,
>duplicate values are eliminated; however, you can specify {\bd unique=0} to
>allow duplicate values to be added.
> 
>Examples:
>     env.MergeFlags('-O3') will add an optimization flag to CCFLAGS.
>     env.MergeFlags(['!pkg-config gtk+-2.0 --cflags', '-O3']) will combine the
>flags returned from running {\ul pkg-config} with an optimization flag and merge
>them into the environment variables.
>     env.MergeFlags(['-O3',
>          '!pkg-config gtk+-2.0 --cflags --libs',
>          '!pkg-config libpng12 --cflags --libs'])
> 
>ParseFlags signature: env.ParseFlags(flags, ...)
> 
>Description: This function returns a dictionary containing the command-line
>flags broken out into the appropriate environment variables.  It is intended as
>a companion function to {\bd MergeFlags}; having the functions separate allows
>the flags in the dictionary to be modified before merging them into the
>environment variables.  Note that {\bd MergeFlags} will call this function if
>its argument is not a dictionary, so the normal usage is just to call {\bd
>MergeFlags} with a list of strings.
> 
>{\bd ParseFlags} iterates recursively over its arguments and the options in each
>string are added to the dictionary.  If the first character in the string is an
>exclamation mark ("!" or bang), the remainder of the string is executed as a
>command and the output of the command treated as options to be added.
> 
>(((The second paragraph from the ParseConfig description is moved here.)))
> 
>Examples (all produce the same result):
>     dict = env.ParseFlags('-O2 -Dfoo -Dbar=1')
>     dict = env.ParseFlags('-O2', '-Dfoo', '-Dbar=1')
>     dict = env.ParseFlags(['-O2', '-Dfoo -Dbar=1'])
>     dict = env.ParseFlags('-O2', '!echo -Dfoo -Dbar=1')

gregnoel said at 2005-07-15 04:48:14
>This patch needs framework support and provides the underlying machinery for the
>FLAGS keyword.

gregnoel said at 2005-08-11 14:25:40
>The patch has been modified to deal with the '-include foo' command line option.
> The option is place in CCFLAGS.

stevenknight said at 2006-01-05 18:15:38
>Changing version to "unspecified" to conform to new scheme.

stevenknight said at 2006-05-04 06:01:18
>Patch integrated for next release.

kmaples said at 2006-05-20 17:03:29
>making the default milestone consistent across the project

kmaples said at 2006-05-20 17:14:12
>making the version consistent across the project


More information about this issue is at http://simtech.sf.net/parse_config.txt.
