### PR TITLE
Asynchronus update of source file confuses build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ venv.bak/
 
 # SCons files
 .sconsign.*
+
+# Tool output
+.coverage
+htmlcov
+

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -11,6 +11,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Whatever John Doe did.
 
+  From William Deegan:
+    - Fix issue where code in utility routine to_String_for_subst() had code whose result was never
+      properly returned.  
+      (Found by: James Rinkevich https://pairlist4.pair.net/pipermail/scons-users/2017-October/006358.html )
+
   From Thomas Berg:
     - Fixed a regression in scons-3.0.0 where "from __future__ import print_function" was imposed
       on the scope where SConstruct is executed, breaking existing builds using PY 2.7.

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -481,10 +481,7 @@ def to_String_for_subst(s,
     if isinstance(s, BaseStringTypes):
         return s
     elif isinstance(s, SequenceTypes):
-        l = []
-        for e in s:
-            l.append(to_String_for_subst(e))
-        return ' '.join( s )
+        return ' '.join([to_String_for_subst(e) for e in s])
     elif isinstance(s, UserString):
         # s.data can only be either a unicode or a regular
         # string. Please see the UserString initializer.


### PR DESCRIPTION
This issue was originally created at: 2005-07-15 03:59:28.
This issue was reported by: `gregnoel`.
gregnoel said at 2005-07-15 03:59:28
>If a source file (such as a header) is modified in mid-build, the signature of
>the modified file is retained in the dependencies for targets already built
>using the unmodified file.  A subsequent run of SCons should rebuild those
>components that used the unmodified file, but does not.
> 
>This was acknowledged as a bug by Steven Knight when it was reported on the
>mailing list and is recorded here so that the issue does not get lost.

stevenknight said at 2006-01-05 18:15:54
>Changing version to "unspecified" to conform to new scheme.

kmaples said at 2006-05-20 17:03:28
>making the default milestone consistent across the project

kmaples said at 2006-05-20 17:14:12
>making the version consistent across the project

stevenknight said at 2007-05-22 08:39:58
>This needs a specific test case (or more than one) to isolate the specific
>problem(s) being described.
> 
>If the header file is a generated file, then anything that uses that header file
>better have a dependency on it, or else the DAG is incomplete.  If the DAG is
>complete, then the header file would be updated before anything that uses it.
> 
>If the problem here is that something unknown to SCons can modify a header file
>mid-build and mess up the signatures, the eventual solution there is some sort
>of "validation" mode that would check every time a file is referenced to make
>sure (e.g.) its timestamp is still the same as the original reference.
> 
>Please update (and/or open new issues) to clarify.

issues@scons said at 2007-05-22 14:25:38
>Created an attachment (id=190)
>Zip file to demonstrate bug

gregnoel said at 2007-05-22 14:47:14
>The bug that I was originally reporting seems to be fixed (the saved signature
>reflects the contents of the file when it is first encountered instead of when
>it is last encountered), but it does leave the strangeness identified in the
>zipfile immediately prior to this note.  You have to decide if it's a feature or
>a bug.
> 
>Unzip the file into a scratch directory.  You should get a SConstruct, a shell
>script, a header file, and two C files.
> 
>Run 'scons' the first time.  All three build steps should be executed.  What has
>happened is that the middle build step has changed the header file, so the first
>build is now out-of-date.  (The third is OK since the header was changed before
>it ran.)
> 
>Run 'scons' again.  The middle build step is up-to-date, so it is not run, but
>both of the other two steps are run.  This is correct for one.c, since hdr.h has
>changed since it was last run, but redundant for two.c, since hdr.h has _not_
>changed since it was last run.
> 
>(In previous releases, _none_ of the build steps would be run, since the sig for
>hdr.h was saved for the run of two.c and used for one.c.  Now it seems to save
>the sig at the first reference and use it for both.)
> 
>Run 'scons' a third time.  This time everything is up-to-date and it correctly
>does nothing.
> 
>Failing to rebuild one.c is clearly a bug and seems to have gone away.  An extra
>rebuild of two.c is a waste of cycles, but otherwise harmless.  It's your choice
>as to whether this situation is still a bug.  If you think it's OK, go ahead and
>close this issue.

gregnoel said at 2007-05-27 11:12:57
>*** Issue 6 has been confirmed by votes. ***

stevenknight said at 2007-08-29 17:48:45
>I'm not going to fix this--at least now--but I've captured the test case in a
>script so that it can be modified if we ever change this behavior--or used as
>the basis for a companion script if we add some configurable mode or the like:
> 
>http://scons.tigris.org/servlets/ReadMsg?list=dev&msgNo=4210
>http://scons.tigris.org/servlets/ReadMsg?list=commits&msgNo=965
> 
>If someone else wants to take a crack at it, feel free to open this back up.  It
>will involve examining every file for every built node to make sure it hasn't
>changed (an N^2 issue when lots of .h files are involved), and copying the
>NodeInfo objects that store each file's metadata (content, signature,
>timestamp), instead of just holding a list of pointers to each Node's own
>NodeInfo object.


An anonymous user attached [bug6.zip](https://github.com/bdbaddog/scons/tigris-issue-attachments/blob/master/190/bug6.zip) at 2007-05-22 14:25:37.
>Zip file to demonstrate bug
