### PR TITLE
Add FLAGS keyword to override environments

### DIFF
--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -56,6 +56,10 @@ def CacheRetrieveFunc(target, source, env):
             fs.symlink(fs.readlink(cachefile), t.get_internal_path())
         else:
             env.copy_from_cache(cachefile, t.get_internal_path())
+            try:
+                os.utime(cachefile, None)
+            except OSError:
+                pass
         st = fs.stat(cachefile)
         fs.chmod(t.get_internal_path(), stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
     return 0

--- a/test/CacheDir/readonly-cache.py
+++ b/test/CacheDir/readonly-cache.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify that using the cache works even if it's read-only
+"""
+
+import os
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write(['SConstruct'], """\
+CacheDir('cache')
+Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
+""")
+
+test.write('file.in', "file.in\n")
+
+test.run(arguments = '--debug=explain --cache-debug=- .')
+
+test.unlink('file.out')
+
+test.run(arguments = '--debug=explain --cache-debug=- .')
+
+test.unlink('file.out')
+
+for root, dirs, files in os.walk("cache",topdown=False):
+	for file in files:
+		os.chmod(os.path.join(root,file),0o444)
+	for dir in dirs:
+		os.chmod(os.path.join(root,dir),0o555)
+
+test.run(arguments = '--debug=explain --cache-debug=- .')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
This issue was originally created at: 2005-07-15 04:46:12.
This issue was reported by: `gregnoel`.
gregnoel said at 2005-07-15 04:46:12
>This patch adds a FLAGS keyword to override environments (only).  A complete
>patch would also add a FLAGS keyword to standard environments, but that turned
>out to be much more complex and I don't have time to do it before I leave on
>holiday.  I'm submitting this patch as a placeholder and a promise: if I make it
>back (travel is getting more dangerous these days) I'll update this patch to
>include standard environments.  Worst case, someone else can do it.  (Or someone
>can work on it while I'm gone; fixing standard environments looks very messy, so
>any help would be appreciated.)
> 
>What this patch allows is something like this:
>     env.Program('foo', 'bar.cpp', FLAGS = '-O2 -Dfoo -lfoobar')
>and the flags will be automatically merged into the appropriate environment
>variables.  It invokes MergeFlags under the covers, so this will also work:
>     dict = env.ParseFlags('-O2 -Dfoo -lfoobar')
>     dict['SWIGFLAGS'] = '-c++ -python'
>     env.Object('bar.i', FLAGS = dict)
>The flags can also be a list, with the expected semantics:
>     env.Program('foo', 'bar.cpp', FLAGS = ['-O2', '!pkg-config ...'])
>Unfortunately, mixing dicts and strings isn't supported (maybe that will be a
>future enhancement).
> 
>As a workaround for standard environments, this works:
>     env = Environment().MergeFlags(['-O2', '!pkg-config ...'])

stevenknight said at 2006-01-05 18:16:06
>Changing version to "unspecified" to conform to new scheme.

kmaples said at 2006-05-20 17:03:29
>making the default milestone consistent across the project

kmaples said at 2006-05-20 17:14:13
>making the version consistent across the project

stevenknight said at 2006-05-26 03:46:34
>Created an attachment (id=5)
>diff for Environment.py

stevenknight said at 2006-05-26 03:47:47
>Added file attachment as part of final severing of SourceForge ties.

gregnoel said at 2007-05-17 17:53:54
>This should be assigned to me.  I've already got some additional work beyond the
>current patch and it's something I'd like to do.

gregnoel said at 2007-05-17 17:55:53
>Humpf.  I thought accepting an issue automatically assigned it to me.

gregnoel said at 2007-05-17 17:57:35
>Okay, already; I guess I have to assign it to myself, then accept it.

gregnoel said at 2008-03-16 00:40:52
>Created an attachment (id=331)
>Final patch; applied 14-Mar-2008

gregnoel said at 2008-03-16 00:43:08
>Patch applied; includes code, tests, docs, release description


More information about this issue is at http://simtech.sf.net/flags.txt.

gregnoel attached [flags-diff](https://github.com/bdbaddog/scons/tigris-issue-attachments/blob/master/331/flags-diff) at 2008-03-16 00:40:51.
>Final patch; applied 14-Mar-2008

stevenknight attached [flags.txt](https://github.com/bdbaddog/scons/tigris-issue-attachments/blob/master/5/flags.txt) at 2008-03-25 11:08:15.
>diff for Environment.py
