### PR TITLE
Add -j support

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -4056,7 +4056,9 @@ and return
 -1, 0 or 1
 (like the standard Python
 <emphasis>cmp</emphasis>
-function).</para>
+function).
+
+Optionally a Boolean value of True for <emphasis>sort</emphasis> will cause a standard alphabetical sort to be performed</para>
 
 <literallayout class="monospaced">
 Help(vars.GenerateHelpText(env))

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -15,6 +15,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix issue where code in utility routine to_String_for_subst() had code whose result was never
       properly returned.  
       (Found by: James Rinkevich https://pairlist4.pair.net/pipermail/scons-users/2017-October/006358.html )
+    - Fixed Variables.GenerateHelpText() to now use the sort parameter. Due to incorrect 2to3 fixer changes 
+      8 years ago it was being used as a boolean parameter.  Now you can specify sort to be a callable, or boolean
+      value. (True = normal sort). Manpage also updated.
 
   From Thomas Berg:
     - Fixed a regression in scons-3.0.0 where "from __future__ import print_function" was imposed

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -1619,6 +1619,17 @@ def to_str (s):
         return s
     return str (s, 'utf-8')
 
+
+
+# No cmp in py3, so we'll define it.
+def cmp(a, b):
+    """
+    Define cmp because it's no longer available in python3
+    Works under python 2 as well
+    """
+    return (a > b) - (a < b)
+
+
 # Local Variables:
 # tab-width:4
 # indent-tabs-mode:nil

--- a/src/engine/SCons/Variables/VariablesTests.py
+++ b/src/engine/SCons/Variables/VariablesTests.py
@@ -487,8 +487,28 @@ B: b - alpha test
     default: 42
     actual: 54
 """
+
+        expectBackwards = """
+B: b - alpha test
+    default: 42
+    actual: 54
+
+ANSWER: THE answer to THE question
+    default: 42
+    actual: 54
+
+A: a - alpha test
+    default: 42
+    actual: 54
+"""
         text = opts.GenerateHelpText(env, sort=cmp)
         assert text == expectAlpha, text
+
+        textBool = opts.GenerateHelpText(env, sort=True)
+        assert text == expectAlpha, text
+
+        textBackwards = opts.GenerateHelpText(env, sort=lambda x, y: cmp(y, x))
+        assert textBackwards == expectBackwards, "Expected:\n%s\nGot:\n%s\n"%(textBackwards, expectBackwards) 
 
     def test_FormatVariableHelpText(self):
         """Test generating custom format help text"""

--- a/src/engine/SCons/Variables/VariablesTests.py
+++ b/src/engine/SCons/Variables/VariablesTests.py
@@ -32,6 +32,7 @@ import TestUnit
 import SCons.Variables
 import SCons.Subst
 import SCons.Warnings
+from SCons.Util import cmp
 
 
 class Environment(object):
@@ -49,12 +50,6 @@ class Environment(object):
         return key in self.dict
 
 
-def cmp(a, b):
-    """
-    Define cmp because it's no longer available in python3
-    Works under python 2 as well
-    """
-    return (a > b) - (a < b)
 
 
 def check(key, value, env):

--- a/src/engine/SCons/Variables/__init__.py
+++ b/src/engine/SCons/Variables/__init__.py
@@ -30,6 +30,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import sys
+from functools import cmp_to_key
 
 import SCons.Environment
 import SCons.Errors
@@ -287,9 +288,13 @@ class Variables(object):
 
         env - an environment that is used to get the current values
               of the options.
+        cmp - Either a function as follows: The specific sort function should take two arguments and return -1, 0 or 1 
+              or a boolean to indicate if it should be sorted.
         """
 
-        if sort:
+        if callable(sort):
+            options = sorted(self.options, key=cmp_to_key(lambda x,y: sort(x.key,y.key)))
+        elif sort is True:
             options = sorted(self.options, key=lambda x: x.key)
         else:
             options = self.options


### PR DESCRIPTION
This issue was originally created at: 2001-07-19 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-07-19 22:00:00
>Use the new Job class to support a simple end-to-end -j test.

issues@scons said at 2001-07-25 22:00:00
>Converted from SourceForge task item 34796

stevenknight said at 2006-05-20 20:48:13
>No white space in keyword.

