### PR TITLE
Clean up and name tests

### DIFF
--- a/test/Deprecated/Options/Options.py
+++ b/test/Deprecated/Options/Options.py
@@ -334,8 +334,8 @@ opts.Add('UNSPECIFIED',
 
 env = Environment(options=opts)
 
-def compare(a,b):
-    return a < b
+def compare(a, b):
+    return (a > b) - (a < b)
 
 Help('Variables settable in custom.py or on the command line:\\n' + opts.GenerateHelpText(env,sort=compare))
 

--- a/test/Variables/Variables.py
+++ b/test/Variables/Variables.py
@@ -320,8 +320,8 @@ opts.Add('UNSPECIFIED',
 
 env = Environment(variables=opts)
 
-def compare(a,b):
-    return a < b
+def compare(a, b):
+    return (a > b) - (a < b)
 
 Help('Variables settable in custom.py or on the command line:\\n' + opts.GenerateHelpText(env,sort=compare))
 


### PR DESCRIPTION
This issue was originally created at: 2001-07-19 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-07-19 22:00:00
>The purely Aegis "t0001.{py,t}" test names aren't very inviting.  Give them real names (we're not going to care about order).  Break up t0001.t while we're at it.

issues@scons said at 2001-07-19 22:00:00
>Converted from SourceForge task item 34798

stevenknight said at 2006-05-20 20:48:30
>No white space in keyword.

