### PR TITLE
Subclass Builder for StringType and FunctionType

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -22,6 +22,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed Variables.GenerateHelpText() to now use the sort parameter. Due to incorrect 2to3 fixer changes 
       8 years ago it was being used as a boolean parameter.  Now you can specify sort to be a callable, or boolean
       value. (True = normal sort). Manpage also updated.
+    - Fixed Tool loading logic from exploding sys.path with many site_scons/site_tools prepended on py3.
 
   From Thomas Berg:
     - Fixed a regression in scons-3.0.0 where "from __future__ import print_function" was imposed

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -222,8 +222,10 @@ class Tool(object):
 
             # Don't reload a tool we already loaded.
             sys_modules_value = sys.modules.get(found_name,False)
+
+            found_module = None
             if sys_modules_value and sys_modules_value.__file__ == spec.origin:
-                return sys.modules[found_name]
+                found_module = sys.modules[found_name]
             else:
                 # Not sure what to do in the case that there already
                 # exists sys.modules[self.name] but the source file is
@@ -235,7 +237,11 @@ class Tool(object):
                     # If we found it in SCons.Tool, then add it to the module
                     setattr(SCons.Tool, self.name, module)
 
-                return module
+                found_module = module
+            
+            if found_module is not None:
+                sys.path = oldpythonpath
+                return found_module
 
 
         sys.path = oldpythonpath


### PR DESCRIPTION
This issue was originally created at: 2001-07-19 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-07-19 22:00:00
>The Builder class has explicit checks for the type of object used to build the target.  It would be better OO design to do these as subclasses.

issues@scons said at 2001-07-19 22:00:00
>Converted from SourceForge task item 34797

stevenknight said at 2006-05-20 20:48:48
>No white space in keyword.

