### PR TITLE
Rebuild in response to changed .c file

### DIFF
--- a/QMTest/TestSConsMSVS.py
+++ b/QMTest/TestSConsMSVS.py
@@ -1039,8 +1039,8 @@ class TestSConsMSVS(TestSCons):
             input = """\
 import SCons
 import SCons.Tool.MSCommon
-print("self.scons_version =", repr(SCons.__%s__))
-print("self._msvs_versions =", str(SCons.Tool.MSCommon.query_versions()))
+print("self.scons_version =%%s"%%repr(SCons.__%s__))
+print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
 """ % 'version'
         
             self.run(arguments = '-n -q -Q -f -', stdin = input)


### PR DESCRIPTION
This issue was originally created at: 2001-07-19 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-07-19 22:00:00
>This is where we add storing signature values from invocation to invocation in a .consign or .sconsign file.

issues@scons said at 2001-07-19 22:00:00
>Converted from SourceForge task item 34799

stevenknight said at 2006-05-20 20:49:02
>No white space in keyword.

