### PR TITLE
Add a Node.PY subsystem.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,6 +8,7 @@
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Daniel Moody:
+    - Updated Jar builder to flatten source list which could contain embedded lists
     - Jar can take multiple targets, and will make a duplicate jar from the sources for each target
     - Added some warnings in case the Jar builder makes an implicit target
     - Added Jar method and changed jar build to be more specific. Jar method will take in

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,6 +8,7 @@
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Daniel Moody:
+    - Updated Jar builder to handle nodes and directories better
     - Updated Jar builder to flatten source list which could contain embedded lists
     - Jar can take multiple targets, and will make a duplicate jar from the sources for each target
     - Added some warnings in case the Jar builder makes an implicit target

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -145,6 +145,13 @@ def Jar(env, target = None, source = [], *args, **kw):
         else:
             return [env.fs.File(s)]
 
+    def dir_to_class(s):
+        dir_targets = env.JavaClassDir(source = s, *args, **kw)
+        if(dir_targets == []):
+            return [env.fs.Dir(s)]
+        else:
+            return dir_targets
+
     # In the case that we are passed just string to a node which is directory
     # but does not exist, we need to check all the current targets to see if
     # that directory is going to exist so we can add it as a source to Jar builder
@@ -169,14 +176,13 @@ def Jar(env, target = None, source = [], *args, **kw):
                 target_classes.extend(file_to_class(s))
             else:
                 # found a dir so make sure its a dir of class files
-                target_classes.extend(env.JavaClassDir(source = env.fs.Dir(s), *args, **kw))
+                target_classes.extend(dir_to_class(s))
         else:
             if os.path.isfile(s):
                 # found a file that exists on the FS, make sure its a class file
                 target_classes.extend(file_to_class(s))
             elif os.path.isdir(s):
-                # found a dir on the FS, add it as a dir of class files
-                target_classes.append(env.fs.Dir(s))
+                target_classes.extend(dir_to_class(s))
             elif s[-len(java_suffix):] == java_suffix or s[-len(java_class_suffix):] == java_class_suffix:
                 # found a file that may not exists and is only a string
                 # so add it after converting it to a class file

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -161,7 +161,7 @@ def Jar(env, target = None, source = [], *args, **kw):
     # loop through the sources and handle each accordingly
     # the goal here is to get all the source files into a class
     # file or a directory that contains class files
-    for s in source:
+    for s in SCons.Util.flatten(source):
         s = env.subst(s)
         if isinstance(s, SCons.Node.FS.Base):
             if isinstance(s, SCons.Node.FS.File):

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -133,7 +133,7 @@ def Jar(env, target = None, source = [], *args, **kw):
     # setup for checking through all the sources and handle accordingly
     java_class_suffix = env.subst('$JAVACLASSSUFFIX')
     java_suffix = env.subst('$JAVASUFFIX')
-    target_classes = []
+    target_nodes = []
 
     # function for determining what to do with a file and not a directory
     # if its already a class file then it can be used as a
@@ -145,9 +145,20 @@ def Jar(env, target = None, source = [], *args, **kw):
         else:
             return [env.fs.File(s)]
 
+    # function for calling the JavaClassDir builder if a directory is
+    # passed as a source to Jar builder. The JavaClassDir builder will
+    # return an empty list if there were not target classes built from
+    # the directory, in this case assume the user wanted the directory
+    # copied into the jar as is (it contains other files such as
+    # resources or class files compiled from proir commands)
+    # TODO: investigate the expexcted behavior for directories that
+    #       have mixed content, such as Java files along side other files
+    #       files.
     def dir_to_class(s):
         dir_targets = env.JavaClassDir(source = s, *args, **kw)
         if(dir_targets == []):
+            # no classes files could be built from the source dir
+            # so pass the dir as is.
             return [env.fs.Dir(s)]
         else:
             return dir_targets
@@ -173,34 +184,35 @@ def Jar(env, target = None, source = [], *args, **kw):
         if isinstance(s, SCons.Node.FS.Base):
             if isinstance(s, SCons.Node.FS.File):
                 # found a file so make sure its a class file
-                target_classes.extend(file_to_class(s))
+                target_nodes.extend(file_to_class(s))
             else:
-                # found a dir so make sure its a dir of class files
-                target_classes.extend(dir_to_class(s))
+                # found a dir so get the class files out of it
+                target_nodes.extend(dir_to_class(s))
         else:
             if os.path.isfile(s):
                 # found a file that exists on the FS, make sure its a class file
-                target_classes.extend(file_to_class(s))
+                target_nodes.extend(file_to_class(s))
             elif os.path.isdir(s):
-                target_classes.extend(dir_to_class(s))
+                # found a dir so get the class files out of it
+                target_nodes.extend(dir_to_class(s))
             elif s[-len(java_suffix):] == java_suffix or s[-len(java_class_suffix):] == java_class_suffix:
                 # found a file that may not exists and is only a string
                 # so add it after converting it to a class file
-                target_classes.extend(file_to_class(s))
+                target_nodes.extend(file_to_class(s))
             else:
                 # found a swig file so add it after converting it to class files
                 if(os.path.splitext(str(s))[1] == ".i"):
-                    target_classes.extend(env.JavaClassFile(source = s, *args, **kw))
+                    target_nodes.extend(env.JavaClassFile(source = s, *args, **kw))
                 else:
-                    # found a directory that does not yet exist, but can exist as a node
-                    # check the target nodes to make sure it will be built, then add
-                    # it as a source
+                    # The final else case handles anything not caught above and makes
+                    # sure other nodes that are sources for this jar get add as
+                    # a source to the JarFile builder
                     for node in get_all_targets(env):
                         if(s == str(node)):
-                            target_classes.append(node)
+                            target_nodes.append(node)
     # at this point all our sources have been converted to classes or directories of class
     # so pass it to the Jar builder
-    return env.JarFile(target = target, source = target_classes, *args, **kw)
+    return env.JarFile(target = target, source = target_nodes, *args, **kw)
 
 def generate(env):
     """Add Builders and construction variables for jar to an Environment."""

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -190,7 +190,7 @@ def Jar(env, target = None, source = [], *args, **kw):
                     # check the target nodes to make sure it will be built, then add
                     # it as a source
                     for node in get_all_targets(env):
-                        if(s in str(node) and os.path.splitext(str(node))[1] == ""):
+                        if(s == str(node)):
                             target_classes.append(node)
     # at this point all our sources have been converted to classes or directories of class
     # so pass it to the Jar builder

--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -330,6 +330,93 @@ test.must_exist(['testdir2','bar.jar'])
 test.must_exist(['testdir2', 'barTest', 'com', 'javasource', 'JavaFile1.class'])
 test.must_exist(['testdir2', 'barTest', 'com', 'javasource', 'JavaFile2.class'])
 test.must_exist(['testdir2', 'barTest', 'com', 'javasource', 'JavaFile3.class'])
+
+
+#######
+# test list of lists
+
+# make some directories to test in
+test.subdir('listOfLists',
+            ['listOfLists', 'src'],
+            ['listOfLists', 'src', 'com'],
+            ['listOfLists', 'src', 'com', 'javasource'],
+            ['listOfLists', 'src', 'com', 'resource'])
+
+# simple SConstruct which passes the 3 .java as source
+# and extracts the jars back to classes
+test.write(['listOfLists', 'SConstruct'], """
+foo = Environment()
+list_of_class_files = foo.Java('src', source=['src'])
+resources = ['src/com/resource/resource1.txt', 'src/com/resource/resource2.txt']
+contents = [list_of_class_files, resources]
+foo.Jar(target = 'lists', source = contents + ['MANIFEST.mf'], JARCHDIR='src')
+foo.Command("listsTest", [], Mkdir("listsTest") )
+foo.Command('listsTest/src/com/javasource/JavaFile3.java', 'lists.jar', foo['JAR'] + ' xvf ../lists.jar', chdir='listsTest')
+""")
+
+test.write(['listOfLists', 'src', 'com', 'javasource', 'JavaFile1.java'], """\
+package com.javasource;
+
+public class JavaFile1
+{
+     public static void main(String[] args)
+     {
+
+     }
+}
+""")
+
+test.write(['listOfLists', 'src', 'com', 'javasource', 'JavaFile2.java'], """\
+package com.javasource;
+
+public class JavaFile2
+{
+     public static void main(String[] args)
+     {
+
+     }
+}
+""")
+
+test.write(['listOfLists', 'src', 'com', 'javasource', 'JavaFile3.java'], """\
+package com.javasource;
+
+public class JavaFile3
+{
+     public static void main(String[] args)
+     {
+
+     }
+}
+""")
+
+test.write(['listOfLists', 'MANIFEST.mf'],
+"""Manifest-Version: 1.0
+MyManifestTest: Test
+""")
+
+test.write(['listOfLists', 'src', 'com', 'resource', 'resource1.txt'], """\
+this is a resource file
+""")
+
+test.write(['listOfLists', 'src', 'com', 'resource', 'resource2.txt'], """\
+this is another resource file
+""")
+
+
+test.run(chdir='listOfLists')
+
+#test single target jar
+test.must_exist(['listOfLists','lists.jar'])
+
+# make sure there are class in the jar
+test.must_exist(['listOfLists', 'listsTest', 'com', 'javasource', 'JavaFile1.class'])
+test.must_exist(['listOfLists', 'listsTest', 'com', 'javasource', 'JavaFile2.class'])
+test.must_exist(['listOfLists', 'listsTest', 'com', 'javasource', 'JavaFile3.class'])
+test.must_exist(['listOfLists', 'listsTest', 'com', 'resource', 'resource1.txt'])
+test.must_exist(['listOfLists', 'listsTest', 'com', 'resource', 'resource2.txt'])
+test.must_exist(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'])
+test.must_contain(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'], b"MyManifestTest: Test" )
 test.pass_test()
 
 

--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -342,14 +342,18 @@ test.subdir('listOfLists',
             ['listOfLists', 'src', 'com', 'javasource'],
             ['listOfLists', 'src', 'com', 'resource'])
 
-# simple SConstruct which passes the 3 .java as source
-# and extracts the jars back to classes
+# test varient dir and lists of lists
 test.write(['listOfLists', 'SConstruct'], """
 foo = Environment()
-list_of_class_files = foo.Java('src', source=['src'])
-resources = ['src/com/resource/resource1.txt', 'src/com/resource/resource2.txt']
+foo.VariantDir('build', 'src', duplicate=0)
+sourceFiles = ["src/com/javasource/JavaFile1.java", "src/com/javasource/JavaFile2.java", "src/com/javasource/JavaFile3.java",]
+list_of_class_files = foo.Java('build', source=sourceFiles)
+resources = ['build/com/resource/resource1.txt', 'build/com/resource/resource2.txt']
+for resource in resources:
+    foo.Command(resource, list_of_class_files, Copy(resource, resource.replace('build','src')))
+foo.Command('build/MANIFEST.mf', list_of_class_files, Copy('build/MANIFEST.mf', 'MANIFEST.mf'))
 contents = [list_of_class_files, resources]
-foo.Jar(target = 'lists', source = contents + ['MANIFEST.mf'], JARCHDIR='src')
+foo.Jar(target = 'lists', source = contents + ['build/MANIFEST.mf'], JARCHDIR='build')
 foo.Command("listsTest", [], Mkdir("listsTest") )
 foo.Command('listsTest/src/com/javasource/JavaFile3.java', 'lists.jar', foo['JAR'] + ' xvf ../lists.jar', chdir='listsTest')
 """)


### PR DESCRIPTION
This issue was originally created at: 2001-07-19 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-07-19 22:00:00
>Tracks dependencies on in-core Python values.  Dictionaries should be equivalent to directories, strings should be "files."  This will allow us to write build-engine dependency tests more efficiently, without having to set up real files.

issues@scons said at 2001-07-19 22:00:00
>Converted from SourceForge task item 34793

