### PR TITLE
Support LINKFLAGS

### DIFF
--- a/src/engine/SCons/Builder.py
+++ b/src/engine/SCons/Builder.py
@@ -742,6 +742,8 @@ class BuilderBase(object):
 
         result = []
         for s in SCons.Util.flatten(source):
+            if s is None:
+                continue
             if SCons.Util.is_String(s):
                 match_suffix = match_src_suffix(env.subst(s))
                 if not match_suffix and not '.' in s:


### PR DESCRIPTION
This issue was originally created at: 2001-07-30 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-07-30 22:00:00
>Be able to link in specified libraries using an LDFLAGS construction variable.

issues@scons said at 2001-07-30 22:00:00
>Converted from SourceForge task item 35381

stevenknight said at 2006-05-20 20:50:37
>No white space in keyword.

