### PR TITLE
Handle Win32 / Windows NT installation.

### DIFF
--- a/QMTest/TestSCons.py
+++ b/QMTest/TestSCons.py
@@ -792,6 +792,15 @@ class TestSCons(TestCommon):
             where_jar = self.where_is('jar', ENV['PATH'])
         if not where_jar:
             self.skip_test("Could not find Java jar, skipping test(s).\n")
+        elif sys.platform == "darwin":
+            # on Mac there is a place holder java installed to start the java install process
+            # so we need to check the output in this case, more info here:
+            # http://anas.pk/2015/09/02/solution-no-java-runtime-present-mac-yosemite/
+            sp = subprocess.Popen([where_jar, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = sp.communicate()
+            sp.wait()
+            if("No Java runtime" in str(stderr)):
+                self.skip_test("Could not find Java jar, skipping test(s).\n")
         return where_jar
 
     def java_where_java(self, version=None):
@@ -800,8 +809,18 @@ class TestSCons(TestCommon):
         """
         ENV = self.java_ENV(version)
         where_java = self.where_is('java', ENV['PATH'])
+
         if not where_java:
             self.skip_test("Could not find Java java, skipping test(s).\n")
+        elif sys.platform == "darwin":
+            # on Mac there is a place holder java installed to start the java install process
+            # so we need to check the output in this case, more info here:
+            # http://anas.pk/2015/09/02/solution-no-java-runtime-present-mac-yosemite/
+            sp = subprocess.Popen([where_java, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = sp.communicate()
+            sp.wait()
+            if("No Java runtime" in str(stderr)):
+                self.skip_test("Could not find Java java, skipping test(s).\n")
         return where_java
 
     def java_where_javac(self, version=None):
@@ -815,6 +834,15 @@ class TestSCons(TestCommon):
             where_javac = self.where_is('javac', ENV['PATH'])
         if not where_javac:
             self.skip_test("Could not find Java javac, skipping test(s).\n")
+        elif sys.platform == "darwin":
+            # on Mac there is a place holder java installed to start the java install process
+            # so we need to check the output in this case, more info here:
+            # http://anas.pk/2015/09/02/solution-no-java-runtime-present-mac-yosemite/
+            sp = subprocess.Popen([where_javac, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = sp.communicate()
+            sp.wait()
+            if("No Java runtime" in str(stderr)):
+                self.skip_test("Could not find Java javac, skipping test(s).\n")
         self.run(program = where_javac,
                  arguments = '-version',
                  stderr=None,

--- a/QMTest/TestSCons.py
+++ b/QMTest/TestSCons.py
@@ -784,6 +784,16 @@ class TestSCons(TestCommon):
         print("Could not determine JAVA_HOME: %s is not a directory" % home)
         self.fail_test()
 
+    def java_mac_check(self, where_java_bin, java_bin_name):
+        # on Mac there is a place holder java installed to start the java install process
+        # so we need to check the output in this case, more info here:
+        # http://anas.pk/2015/09/02/solution-no-java-runtime-present-mac-yosemite/
+        sp = subprocess.Popen([where_java_bin, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = sp.communicate()
+        sp.wait()
+        if("No Java runtime" in str(stderr)):
+            self.skip_test("Could not find Java " + java_bin_name + ", skipping test(s).\n")
+
     def java_where_jar(self, version=None):
         ENV = self.java_ENV(version)
         if self.detect_tool('jar', ENV=ENV):
@@ -792,15 +802,9 @@ class TestSCons(TestCommon):
             where_jar = self.where_is('jar', ENV['PATH'])
         if not where_jar:
             self.skip_test("Could not find Java jar, skipping test(s).\n")
-        elif sys.platform == "darwin":
-            # on Mac there is a place holder java installed to start the java install process
-            # so we need to check the output in this case, more info here:
-            # http://anas.pk/2015/09/02/solution-no-java-runtime-present-mac-yosemite/
-            sp = subprocess.Popen([where_jar, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = sp.communicate()
-            sp.wait()
-            if("No Java runtime" in str(stderr)):
-                self.skip_test("Could not find Java jar, skipping test(s).\n")
+        elif sys.platform == "darwin": 
+            self.java_mac_check(where_jar, 'jar')
+
         return where_jar
 
     def java_where_java(self, version=None):
@@ -813,14 +817,8 @@ class TestSCons(TestCommon):
         if not where_java:
             self.skip_test("Could not find Java java, skipping test(s).\n")
         elif sys.platform == "darwin":
-            # on Mac there is a place holder java installed to start the java install process
-            # so we need to check the output in this case, more info here:
-            # http://anas.pk/2015/09/02/solution-no-java-runtime-present-mac-yosemite/
-            sp = subprocess.Popen([where_java, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = sp.communicate()
-            sp.wait()
-            if("No Java runtime" in str(stderr)):
-                self.skip_test("Could not find Java java, skipping test(s).\n")
+            self.java_mac_check(where_java, 'java')
+
         return where_java
 
     def java_where_javac(self, version=None):
@@ -835,14 +833,8 @@ class TestSCons(TestCommon):
         if not where_javac:
             self.skip_test("Could not find Java javac, skipping test(s).\n")
         elif sys.platform == "darwin":
-            # on Mac there is a place holder java installed to start the java install process
-            # so we need to check the output in this case, more info here:
-            # http://anas.pk/2015/09/02/solution-no-java-runtime-present-mac-yosemite/
-            sp = subprocess.Popen([where_javac, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = sp.communicate()
-            sp.wait()
-            if("No Java runtime" in str(stderr)):
-                self.skip_test("Could not find Java javac, skipping test(s).\n")
+            self.java_mac_check(where_javac, 'javac')
+
         self.run(program = where_javac,
                  arguments = '-version',
                  stderr=None,


### PR DESCRIPTION
This issue was originally created at: 2001-08-28 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-08-28 22:00:00
>Through distutils, of course, although it will require some tweaking to start creating our own world, not just put things under the default C:\Python20 directory.

issues@scons said at 2001-08-28 22:00:00
>Converted from SourceForge task item 37154

stevenknight said at 2006-05-20 20:50:49
>No white space in keyword.

