### PR TITLE
Initialize options with an SCONSFLAGS environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-
+language: python
 install:
   - sudo apt-get -y install clang gdc docbook-xml xsltproc libxml2-dev libxslt-dev python-pip python-dev fop docbook-xsl-doc-pdf texlive-full biber texmaker build-essential libpcre3-dev autoconf automake libtool bison subversion git
   - sudo pip install lxml


### PR DESCRIPTION
This issue was originally created at: 2001-09-12 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-09-12 22:00:00
>Read options from $SCONSFLAGS in the external environment, and then let the command-line flags override them as appropriate.  This must be documented at the same time the code goes in.

issues@scons said at 2001-09-12 22:00:00
>Converted from SourceForge task item 37995

stevenknight said at 2006-05-20 20:51:15
>No white space in keyword.

