### PR TITLE
Update variable expansion

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -852,18 +852,31 @@ and ultimately removed.</para>
   </varlistentry>
   <varlistentry>
   <term>--debug=time</term>
-<listitem>
+  <listitem>
 <para>Prints various time profiling information:</para>
-<itemizedlist>
-<listitem>The time spent executing each individual build command</listitem>
-<listitem>The total build time (time SCons ran from beginning to end)</listitem>
-<listitem>The total time spent reading and executing SConscript files</listitem>
-<listitem>The total time spent SCons itself spend running
-(that is, not counting reading and executing SConscript files)</listitem>
-<listitem>The total time spent executing all build commands</listitem>
-<listitem>The elapsed wall-clock time spent executing those build commands</listitem>
-<listitem>The time spent processing each file passed to the <emphasis>SConscript()</emphasis> function</listitem>
-</itemizedlist>
+  <itemizedlist>
+    <listitem>
+<para>The time spent executing each individual build command</para>
+    </listitem>
+    <listitem>
+<para>The total build time (time SCons ran from beginning to end)</para>
+    </listitem>
+    <listitem>
+<para>The total time spent reading and executing SConscript files</para>
+    </listitem>
+    <listitem>
+<para>The total time spent SCons itself spend running
+(that is, not counting reading and executing SConscript files)</para>
+    </listitem>
+    <listitem>
+<para>The total time spent executing all build commands</para></listitem>
+<listitem>
+<para>The elapsed wall-clock time spent executing those build commands</para>
+    </listitem>
+    <listitem>
+<para>The time spent processing each file passed to the <emphasis>SConscript()</emphasis> function</para>
+    </listitem>
+  </itemizedlist>
 <para>
 (When
 <command>scons</command>

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,9 @@
 
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
+  From Mats Wichmann:
+    - Updated manpage scons.xml to fix a nested list problem
+
   From Daniel Moody:
     - Updated Jar builder to handle nodes and directories better
     - Updated Jar builder to flatten source list which could contain embedded lists


### PR DESCRIPTION
This issue was originally created at: 2001-09-12 22:00:00.
This issue was reported by: `stevenknight`.
stevenknight said at 2001-09-12 22:00:00
>Change to '$' as the interpolation character, and modification flags that look like Python methods, per the mailing list discussion.

issues@scons said at 2001-09-12 22:00:00
>Converted from SourceForge task item 37993

stevenknight said at 2006-05-20 20:51:40
>No white space in keyword.

