### PR TITLE
 update mtime on cache retrieval

### DIFF
--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -56,6 +56,10 @@ def CacheRetrieveFunc(target, source, env):
             fs.symlink(fs.readlink(cachefile), t.get_internal_path())
         else:
             env.copy_from_cache(cachefile, t.get_internal_path())
+            try:
+                os.utime(cachefile, None)
+            except OSError:
+                pass
         st = fs.stat(cachefile)
         fs.chmod(t.get_internal_path(), stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
     return 0

--- a/test/CacheDir/readonly-cache.py
+++ b/test/CacheDir/readonly-cache.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify accessing cache works even if it's read-only.
+"""
+
+import os
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write(['SConstruct'], """\
+CacheDir('cache')
+Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
+""")
+
+test.write('file.in', "file.in\n")
+
+test.run(arguments = '--debug=explain --cache-debug=- .')
+
+test.unlink('file.out')
+
+test.run(arguments = '--debug=explain --cache-debug=- .')
+
+test.unlink('file.out')
+
+for root, dirs, files in os.walk("cache",topdown=False):
+	for file in files:
+		os.chmod(os.path.join(root,file),0o444)
+	for dir in dirs:
+		os.chmod(os.path.join(root,dir),0o555)
+
+test.run(arguments = '--debug=explain --cache-debug=- .')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/CacheDir/readonly-cache.py
+++ b/test/CacheDir/readonly-cache.py
@@ -28,8 +28,11 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify accessing cache works even if it's read-only.
 """
 
+import glob
 import os
 import TestSCons
+import time
+from stat import *
 
 test = TestSCons.TestSCons()
 
@@ -42,9 +45,21 @@ test.write('file.in', "file.in\n")
 
 test.run(arguments = '--debug=explain --cache-debug=- .')
 
+cachefile = glob.glob("cache/??/*")[0]
+
+time0 = os.stat(cachefile).st_mtime
+
+time.sleep(.1)
+
 test.unlink('file.out')
 
 test.run(arguments = '--debug=explain --cache-debug=- .')
+
+time1  = os.stat(cachefile).st_mtime
+
+# make sure that mtime has been updated on cache use
+if time1 <= time0:
+    test.fail_test()
 
 test.unlink('file.out')
 


### PR DESCRIPTION
With this patch when regular files are retrieved from the cache, the cached files mtime is updated. This is to allow one keep a cache on a disk that's mounted noatime, and then to still be able to prune old files.

If it's not possible to update the mtime on the cached file, because the filesystem is read-only, for example, then it simply does nothing.

One caveat is that the mtime is not updated for symlinks. This shouldn't be much of a problem being that symlinks don't consume much disk space and additionally should be easy to recreate.