### PR TITLE
Prevent TypeError with None in error message

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -9,6 +9,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Gary Oberbrunner:
     - Fix bug when Installing multiple subdirs outside the source tree
+    - fix to_str to handle None without raising exception
 
   From Mats Wichmann:
     - Updated manpage scons.xml to fix a nested list problem

--- a/src/engine/SCons/Errors.py
+++ b/src/engine/SCons/Errors.py
@@ -95,7 +95,7 @@ class BuildError(Exception):
 
         # py3: errstr should be string and not bytes.
 
-        self.errstr = SCons.Util.to_str(errstr)
+        self.errstr = SCons.Util.to_String(errstr)
         self.status = status
         self.exitstatus = exitstatus
         self.filename = filename
@@ -176,8 +176,8 @@ def convert_to_BuildError(status, exc_info=None):
             filename = status.filename
         except AttributeError:
             filename = None
-        
-        buildError = BuildError( 
+
+        buildError = BuildError(
             errstr=status.args[0],
             status=status.errno,
             exitstatus=2,
@@ -195,7 +195,7 @@ def convert_to_BuildError(status, exc_info=None):
         except AttributeError:
             filename = None
 
-        buildError = BuildError( 
+        buildError = BuildError(
             errstr=status.strerror,
             status=status.errno,
             exitstatus=2,
@@ -217,7 +217,7 @@ def convert_to_BuildError(status, exc_info=None):
             errstr="Error %s" % status,
             status=status,
             exitstatus=2)
-    
+
     #import sys
     #sys.stderr.write("convert_to_BuildError: status %s => (errstr %s, status %s)\n"%(status,buildError.errstr, buildError.status))
     return buildError

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -1617,7 +1617,6 @@ def to_bytes (s):
 def to_str (s):
     if s is None:
         return 'None'
-    print("to_str %s", repr(s))
     if bytes is str or is_String(s):
         return s
     return str (s, 'utf-8')

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -1608,11 +1608,16 @@ class NullSeq(Null):
 del __revision__
 
 def to_bytes (s):
+    if s is None:
+        return b'None'
     if isinstance (s, (bytes, bytearray)) or bytes is str:
         return s
     return bytes (s, 'utf-8')
 
 def to_str (s):
+    if s is None:
+        return 'None'
+    print("to_str %s", repr(s))
     if bytes is str or is_String(s):
         return s
     return str (s, 'utf-8')

--- a/src/engine/SCons/UtilTests.py
+++ b/src/engine/SCons/UtilTests.py
@@ -312,6 +312,10 @@ class UtilTestCase(unittest.TestCase):
         assert to_String(1) == "1", to_String(1)
         assert to_String([ 1, 2, 3]) == str([1, 2, 3]), to_String([1,2,3])
         assert to_String("foo") == "foo", to_String("foo")
+        assert to_String(None) == 'None'
+        # test low level string converters too
+        assert to_str(None) == 'None'
+        assert to_bytes(None) == b'None'
 
         s1=UserString('blah')
         assert to_String(s1) == s1, s1


### PR DESCRIPTION
I ran into a problem where SCons was generating an error that
contained a None (don't ask me how), and this got passed through
to_str() which caused a TypeError because None isn't a bytes-like
object.

I fixed it two ways: enable to_str and to_bytes to handle None without
complaint, and change Errors.py to use to_String() instead of to_str(),
since it seems more robust.
