### PR TITLE
Use prepend for inserts

### DIFF
--- a/QMTest/TestCommon.py
+++ b/QMTest/TestCommon.py
@@ -680,7 +680,7 @@ class TestCommon(TestCmd):
         The parameters are the same as the base TestCmd.run() method,
         with the addition of:
 
-                options Extra options that get appended to the beginning
+                options Extra options that get prepended to the beginning
                         of the arguments.
 
                 stdout  The expected standard output from

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -13,6 +13,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Mats Wichmann:
     - Updated manpage scons.xml to fix a nested list problem
+    - Updated doc terminionly: use prepend instead of append as appropriate
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Defaults.xml
+++ b/src/engine/SCons/Defaults.xml
@@ -76,7 +76,8 @@ An automatically-generated construction variable
 containing the C preprocessor command-line options
 to define values.
 The value of &cv-_CPPDEFFLAGS; is created
-by appending &cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
+by respectively prepending and appending
+&cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
 to the beginning and end
 of each definition in &cv-CPPDEFINES;.
 </para>
@@ -99,7 +100,8 @@ If &cv-CPPDEFINES; is a string,
 the values of the
 &cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
 construction variables
-will be added to the beginning and end.
+will be respectively prepended and appended to the beginning and end
+of each definition in &cv-CPPDEFINES;.
 </para>
 
 <example_commands>
@@ -113,7 +115,7 @@ If &cv-CPPDEFINES; is a list,
 the values of the
 &cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
 construction variables
-will be appended to the beginning and end
+will be respectively prepended and appended to the beginning and end
 of each element in the list.
 If any element is a list or tuple,
 then the first item is the name being
@@ -131,7 +133,7 @@ If &cv-CPPDEFINES; is a dictionary,
 the values of the
 &cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
 construction variables
-will be appended to the beginning and end
+will be respectively prepended and appended to the beginning and end
 of each item from the dictionary.
 The key of each dictionary item
 is a name being defined
@@ -159,7 +161,7 @@ env = Environment(CPPDEFINES={'B':2, 'A':None})
 <para>
 The prefix used to specify preprocessor definitions
 on the C compiler command line.
-This will be appended to the beginning of each definition
+This will be prepended to the beginning of each definition
 in the &cv-CPPDEFINES; construction variable
 when the &cv-_CPPDEFFLAGS; variable is automatically generated.
 </para>
@@ -185,7 +187,7 @@ An automatically-generated construction variable
 containing the C preprocessor command-line options
 for specifying directories to be searched for include files.
 The value of &cv-_CPPINCFLAGS; is created
-by appending &cv-INCPREFIX; and &cv-INCSUFFIX;
+by respectively prepending and appending &cv-INCPREFIX; and &cv-INCSUFFIX;
 to the beginning and end
 of each directory in &cv-CPPPATH;.
 </para>
@@ -227,7 +229,7 @@ through the automatically-generated
 &cv-_CPPINCFLAGS;
 construction variable,
 which is constructed by
-appending the values of the
+respectively prepending and appending the value of the
 &cv-INCPREFIX; and &cv-INCSUFFIX;
 construction variables
 to the beginning and end
@@ -304,7 +306,7 @@ The default list is:
 <para>
 The prefix used to specify an include directory on the C compiler command
 line.
-This will be appended to the beginning of each directory
+This will be prepended to the beginning of each directory
 in the &cv-CPPPATH; and &cv-FORTRANPATH; construction variables
 when the &cv-_CPPINCFLAGS; and &cv-_FORTRANINCFLAGS;
 variables are automatically generated.
@@ -388,7 +390,7 @@ An automatically-generated construction variable
 containing the linker command-line options
 for specifying directories to be searched for library.
 The value of &cv-_LIBDIRFLAGS; is created
-by appending &cv-LIBDIRPREFIX; and &cv-LIBDIRSUFFIX;
+by respectively prepending and appending &cv-LIBDIRPREFIX; and &cv-LIBDIRSUFFIX;
 to the beginning and end
 of each directory in &cv-LIBPATH;.
 </para>
@@ -399,7 +401,7 @@ of each directory in &cv-LIBPATH;.
 <summary>
 <para>
 The prefix used to specify a library directory on the linker command line.
-This will be appended to the beginning of each directory
+This will be prepended to the beginning of each directory
 in the &cv-LIBPATH; construction variable
 when the &cv-_LIBDIRFLAGS; variable is automatically generated.
 </para>
@@ -424,7 +426,7 @@ An automatically-generated construction variable
 containing the linker command-line options
 for specifying libraries to be linked with the resulting target.
 The value of &cv-_LIBFLAGS; is created
-by appending &cv-LIBLINKPREFIX; and &cv-LIBLINKSUFFIX;
+by respectively prepending and appending &cv-LIBLINKPREFIX; and &cv-LIBLINKSUFFIX;
 to the beginning and end
 of each filename in &cv-LIBS;.
 </para>
@@ -435,7 +437,7 @@ of each filename in &cv-LIBS;.
 <summary>
 <para>
 The prefix used to specify a library to link on the linker command line.
-This will be appended to the beginning of each library
+This will be prepended to the beginning of each library
 in the &cv-LIBS; construction variable
 when the &cv-_LIBFLAGS; variable is automatically generated.
 </para>
@@ -489,7 +491,7 @@ through the automatically-generated
 &cv-_LIBDIRFLAGS;
 construction variable,
 which is constructed by
-appending the values of the
+respectively prepending and appending the values of the
 &cv-LIBDIRPREFIX; and &cv-LIBDIRSUFFIX;
 construction variables
 to the beginning and end
@@ -520,7 +522,7 @@ through the automatically-generated
 &cv-_LIBFLAGS;
 construction variable,
 which is constructed by
-appending the values of the
+respectively prepending and appending the values of the
 &cv-LIBLINKPREFIX; and &cv-LIBLINKSUFFIX;
 construction variables
 to the beginning and end

--- a/src/engine/SCons/Platform/posix.xml
+++ b/src/engine/SCons/Platform/posix.xml
@@ -46,7 +46,7 @@ An automatically-generated construction variable
 containing the rpath flags to be used when linking
 a program with shared libraries.
 The value of &cv-_RPATH; is created
-by appending &cv-RPATHPREFIX; and &cv-RPATHSUFFIX;
+by respectively prepending &cv-RPATHPREFIX; and appending &cv-RPATHSUFFIX;
 to the beginning and end
 of each directory in &cv-RPATH;.
 </para>
@@ -58,7 +58,7 @@ of each directory in &cv-RPATH;.
 <para>
 The prefix used to specify a directory to be searched for
 shared libraries when running programs.
-This will be appended to the beginning of each directory
+This will be prepended to the beginning of each directory
 in the &cv-RPATH; construction variable
 when the &cv-_RPATH; variable is automatically generated.
 </para>

--- a/src/engine/SCons/Tool/fortran.xml
+++ b/src/engine/SCons/Tool/fortran.xml
@@ -251,7 +251,7 @@ through the automatically-generated
 &cv-link-_FORTRANINCFLAGS;
 construction variable,
 which is constructed by
-respectiviely prepending and appending the values of the
+respectively prepending and appending the values of the
 &cv-link-INCPREFIX; and &cv-link-INCSUFFIX;
 construction variables
 to the beginning and end

--- a/src/engine/SCons/Tool/fortran.xml
+++ b/src/engine/SCons/Tool/fortran.xml
@@ -125,7 +125,8 @@ containing the Fortran compiler command-line options
 for specifying directories to be searched for include
 files and module files.
 The value of &cv-link-_FORTRANINCFLAGS; is created
-by prepending/appending &cv-link-INCPREFIX; and &cv-link-INCSUFFIX;
+by respectively prepending and appending
+&cv-link-INCPREFIX; and &cv-link-INCSUFFIX;
 to the beginning and end
 of each directory in &cv-link-FORTRANPATH;.
 </para>
@@ -148,7 +149,7 @@ for module files, as well.
 <para>
 The prefix used to specify a module directory on the Fortran compiler command
 line.
-This will be appended to the beginning of the directory
+This will be prepended to the beginning of the directory
 in the &cv-link-FORTRANMODDIR; construction variables
 when the &cv-link-_FORTRANMODFLAG; variables is automatically generated.
 </para>
@@ -160,7 +161,7 @@ when the &cv-link-_FORTRANMODFLAG; variables is automatically generated.
 <para>
 The suffix used to specify a module directory on the Fortran compiler command
 line.
-This will be appended to the beginning of the directory
+This will be appended to the end of the directory
 in the &cv-link-FORTRANMODDIR; construction variables
 when the &cv-link-_FORTRANMODFLAG; variables is automatically generated.
 </para>
@@ -176,8 +177,8 @@ for specifying the directory location where the Fortran
 compiler should place any module files that happen to get
 generated during compilation.
 The value of &cv-link-_FORTRANMODFLAG; is created
-by prepending/appending &cv-link-FORTRANMODDIRPREFIX; and
-&cv-link-FORTRANMODDIRSUFFIX;
+by respectively prepending and appending
+&cv-link-FORTRANMODDIRPREFIX; and &cv-link-FORTRANMODDIRSUFFIX;
 to the beginning and end of the directory in &cv-link-FORTRANMODDIR;.
 </para>
 </summary>
@@ -250,7 +251,7 @@ through the automatically-generated
 &cv-link-_FORTRANINCFLAGS;
 construction variable,
 which is constructed by
-appending the values of the
+respectiviely prepending and appending the values of the
 &cv-link-INCPREFIX; and &cv-link-INCSUFFIX;
 construction variables
 to the beginning and end

--- a/src/engine/SCons/Tool/msvc.xml
+++ b/src/engine/SCons/Tool/msvc.xml
@@ -305,7 +305,8 @@ containing the command-line options
 for specifying directories to be searched
 by the resource compiler.
 The value of &cv-RCINCFLAGS; is created
-by appending &cv-RCINCPREFIX; and &cv-RCINCSUFFIX;
+by respectively prepending and appending
+&cv-RCINCPREFIX; and &cv-RCINCSUFFIX;
 to the beginning and end
 of each directory in &cv-CPPPATH;.
 </para>
@@ -317,7 +318,7 @@ of each directory in &cv-CPPPATH;.
 <para>
 The prefix (flag) used to specify an include directory
 on the resource compiler command line.
-This will be appended to the beginning of each directory
+This will be prepended to the beginning of each directory
 in the &cv-CPPPATH; construction variable
 when the &cv-RCINCFLAGS; variable is expanded.
 </para>

--- a/src/engine/SCons/Tool/swig.xml
+++ b/src/engine/SCons/Tool/swig.xml
@@ -153,7 +153,8 @@ An automatically-generated construction variable
 containing the SWIG command-line options
 for specifying directories to be searched for included files.
 The value of &cv-_SWIGINCFLAGS; is created
-by appending &cv-SWIGINCPREFIX; and &cv-SWIGINCSUFFIX;
+by respectively prepending and appending
+&cv-SWIGINCPREFIX; and &cv-SWIGINCSUFFIX;
 to the beginning and end
 of each directory in &cv-SWIGPATH;.
 </para>
@@ -164,7 +165,7 @@ of each directory in &cv-SWIGPATH;.
 <summary>
 <para>
 The prefix used to specify an include directory on the SWIG command line.
-This will be appended to the beginning of each directory
+This will be prepended to the beginning of each directory
 in the &cv-SWIGPATH; construction variable
 when the &cv-_SWIGINCFLAGS; variable is automatically generated.
 </para>
@@ -238,7 +239,7 @@ through the automatically-generated
 &cv-_SWIGINCFLAGS;
 construction variable,
 which is constructed by
-appending the values of the
+respectively prepending and appending the values of the
 &cv-SWIGINCPREFIX; and &cv-SWIGINCSUFFIX;
 construction variables
 to the beginning and end


### PR DESCRIPTION
Scratching an itch: a number of places "append to the beginning", a better word to use here is "prepend".  This is a documentation change only, no executable statements are affected.