### PR TITLE
Coveralls badge not pointing to master branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,10 @@ SCons - a software construction tool
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/SCons/scons?svg=true&branch=master
    :target: https://ci.appveyor.com/project/SCons/scons
-   :alt: AppVeyor CI Status
+   :alt: AppVeyor CI build Status
    
-.. image:: https://coveralls.io/repos/github/SCons/scons/badge.svg
-   :target: https://coveralls.io/github/SCons/scons
+.. image:: https://coveralls.io/repos/github/SCons/scons/badge.svg?branch=master
+   :target: https://coveralls.io/github/SCons/scons?branch=master
    :alt: Coveralls.io Coverage Status
 
 


### PR DESCRIPTION
Updated the README so the Coveralls badge is pointing to the master branch, otherwise it points to the most recent build.

also made a small change to the alt text so it will say build like the travis alt text.