### PR TITLE
Replace all instances of `int main()` with `int main(void)`

### DIFF
--- a/bin/SConsExamples.py
+++ b/bin/SConsExamples.py
@@ -39,7 +39,7 @@
 #           env.Program('foo')
 #         </file>
 #         <file name="foo.c">
-#           int main() { printf("foo.c\n"); }
+#           int main(void) { printf("foo.c\n"); }
 #         </file>
 #       </scons_example>
 #

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -37,6 +37,12 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Updated manpage scons.xml to fix a nested list problem
     - Updated doc terminionly: use prepend instead of append as appropriate
 
+  From Jonathon Reinhart:
+    - Replace all instances of `int main()` in C code with `int main(void)`.
+      Specifically, this fixes the test cases use by Configure.CheckCC() which
+      would fail when using -Wstrict-prototypes.
+
+
 RELEASE 3.0.1 - Mon, 12 Nov 2017 15:31:33 -0700
 
   From Daniel Moody:

--- a/src/engine/SCons/Conftest.py
+++ b/src/engine/SCons/Conftest.py
@@ -136,7 +136,7 @@ def CheckBuilder(context, text = None, language = None):
 
     if not text:
         text = """
-int main() {
+int main(void) {
     return 0;
 }
 """
@@ -157,7 +157,7 @@ def CheckCC(context):
     """
     context.Display("Checking whether the C compiler works... ")
     text = """
-int main()
+int main(void)
 {
     return 0;
 }
@@ -177,7 +177,7 @@ def CheckSHCC(context):
     """
     context.Display("Checking whether the (shared) C compiler works... ")
     text = """
-int foo()
+int foo(void)
 {
     return 0;
 }
@@ -197,7 +197,7 @@ def CheckCXX(context):
     """
     context.Display("Checking whether the C++ compiler works... ")
     text = """
-int main()
+int main(void)
 {
     return 0;
 }
@@ -217,7 +217,7 @@ def CheckSHCXX(context):
     """
     context.Display("Checking whether the (shared) C++ compiler works... ")
     text = """
-int main()
+int main(void)
 {
     return 0;
 }
@@ -290,7 +290,7 @@ char %s();""" % function_name
 #include <assert.h>
 %(hdr)s
 
-int main() {
+int main(void) {
 #if defined (__stub_%(name)s) || defined (__stub___%(name)s)
   fail fail fail
 #else
@@ -400,7 +400,7 @@ def CheckType(context, type_name, fallback = None,
 %(include)s
 %(header)s
 
-int main() {
+int main(void) {
   if ((%(name)s *) 0)
     return 0;
   if (sizeof (%(name)s))
@@ -465,7 +465,7 @@ def CheckTypeSize(context, type_name, header = None, language = None, expect = N
         src = src + r"""
 typedef %s scons_check_type;
 
-int main()
+int main(void)
 {
     static int test_array[1 - 2 * !(((long int) (sizeof(scons_check_type))) == %d)];
     test_array[0] = 0;
@@ -498,7 +498,7 @@ int main()
         src = src + """
 #include <stdlib.h>
 #include <stdio.h>
-int main() {
+int main(void) {
     printf("%d", (int)sizeof(""" + type_name + """));
     return 0;
 }
@@ -560,7 +560,7 @@ def CheckDeclaration(context, symbol, includes = None, language = None):
     context.Display('Checking whether %s is declared... ' % symbol)
 
     src = src + r"""
-int main()
+int main(void)
 {
 #ifndef %s
     (void) %s;

--- a/src/engine/SCons/SConfTests.py
+++ b/src/engine/SCons/SConfTests.py
@@ -115,9 +115,9 @@ class SConfTestCase(unittest.TestCase):
 
         def checks(self, sconf, TryFuncString):
             TryFunc = self.SConf.SConfBase.__dict__[TryFuncString]
-            res1 = TryFunc( sconf, "int main() { return 0; }\n", ".c" )
+            res1 = TryFunc( sconf, "int main(void) { return 0; }\n", ".c" )
             res2 = TryFunc( sconf,
-                            '#include "no_std_header.h"\nint main() {return 0; }\n',
+                            '#include "no_std_header.h"\nint main(void) {return 0; }\n',
                             '.c' )
             return (res1,res2)
 
@@ -254,7 +254,7 @@ class SConfTestCase(unittest.TestCase):
         def checks(sconf):
             prog = """
 #include <stdio.h>
-int main() {
+int main(void) {
   printf( "Hello" );
   return 0;
 }
@@ -755,7 +755,7 @@ int main() {
             prog = """
 #include <stdio.h>
 
-int main() {
+int main(void) {
   printf( "Hello" );
   return 0;
 }

--- a/src/engine/SCons/Scanner/CTests.py
+++ b/src/engine/SCons/Scanner/CTests.py
@@ -48,7 +48,7 @@ test.write('f1.cpp',"""
 #include \"f1.h\"
 #include <f2.h>
 
-int main()
+int main(void)
 {
    return 0;
 }
@@ -60,7 +60,7 @@ test.write('f2.cpp',"""
 #include \"f1.h\"
 #import <f4.h>
 
-int main()
+int main(void)
 {
    return 0;
 }
@@ -79,7 +79,7 @@ test.write('f3.cpp',"""
 
 const char* x = "#include <never.h>"
 
-int main()
+int main(void)
 {
    return 0;
 }
@@ -113,7 +113,7 @@ test.write('fa.cpp',"""
 #include \"fa.h\"
 #include <fb.h>
 
-int main()
+int main(void)
 {
    return 0;
 }
@@ -135,7 +135,7 @@ test.write(['work', 'src', 'fff.c'], """
 #include <iii.h>
 #include <jjj.h>
 
-int main()
+int main(void)
 {
     return 0;
 }
@@ -144,7 +144,7 @@ int main()
 test.write([ 'work', 'src', 'aaa.c'], """
 #include "bbb.h"
 
-int main()
+int main(void)
 {
    return 0;
 }
@@ -155,7 +155,7 @@ test.write([ 'work', 'src', 'bbb.h'], "\n")
 test.write([ 'repository', 'src', 'ccc.c'], """
 #include "ddd.h"
 
-int main()
+int main(void)
 {
    return 0;
 }

--- a/src/engine/SCons/Scanner/IDLTests.py
+++ b/src/engine/SCons/Scanner/IDLTests.py
@@ -159,7 +159,7 @@ test.write(['work', 'src', 'fff.c'], """
 #include <iii.idl>
 #include <jjj.idl>
 
-int main()
+int main(void)
 {
     return 0;
 }
@@ -168,7 +168,7 @@ int main()
 test.write([ 'work', 'src', 'aaa.c'], """
 #include "bbb.idl"
 
-int main()
+int main(void)
 {
    return 0;
 }
@@ -179,7 +179,7 @@ test.write([ 'work', 'src', 'bbb.idl'], "\n")
 test.write([ 'repository', 'src', 'ccc.c'], """
 #include "ddd.idl"
 
-int main()
+int main(void)
 {
    return 0;
 }

--- a/test/CacheDir/up-to-date-q.py
+++ b/test/CacheDir/up-to-date-q.py
@@ -55,7 +55,7 @@ test = TestSCons.TestSCons()
 test.subdir('cache', 'alpha', 'beta')
 
 foo_c = """
-int main(){ return 0; }
+int main(void){ return 0; }
 """
 
 sconstruct = """

--- a/test/Case.py
+++ b/test/Case.py
@@ -43,7 +43,7 @@ test.write('main.c', """\
 
 void foo();
 void bar();
-int main() {
+int main(void) {
     foo();
     bar();
     exit (0);

--- a/test/Configure/VariantDir-SConscript.py
+++ b/test/Configure/VariantDir-SConscript.py
@@ -96,7 +96,7 @@ test.write(['sub', 'TestProgram.c'], """\
 #include "TestProgram.h"
 #include <stdio.h>
 
-int main() {
+int main(void) {
   printf( "Hello\\n" );
 }
 """)

--- a/test/Configure/VariantDir.py
+++ b/test/Configure/VariantDir.py
@@ -63,7 +63,7 @@ env.Program( 'TestProgram', 'TestProgram.c' )
 test.write('TestProgram.c', """\
 #include <stdio.h>
 
-int main() {
+int main(void) {
   printf( "Hello\\n" );
 }
 """)

--- a/test/Configure/VariantDir2.py
+++ b/test/Configure/VariantDir2.py
@@ -41,7 +41,7 @@ SConscript('SConscript', variant_dir='build', src='.')
 test.write('SConscript', """\
 env = Environment()
 config = env.Configure(conf_dir='sconf', log_file='config.log')
-config.TryRun("int main() {}", ".c")
+config.TryRun("int main(void) {}", ".c")
 config.Finish()
 """)
 

--- a/test/Configure/basic.py
+++ b/test/Configure/basic.py
@@ -61,7 +61,7 @@ env.Program( 'TestProgram', 'TestProgram.c' )
 test.write('TestProgram.c', """\
 #include <stdio.h>
 
-int main() {
+int main(void) {
   printf( "Hello\\n" );
 }
 """)

--- a/test/Configure/build-fail.py
+++ b/test/Configure/build-fail.py
@@ -58,7 +58,7 @@ def _check(context):
         result = context.TryRun('''
         #include "%s"
 
-        int main() { return 0; }
+        int main(void) { return 0; }
         ''' % inc, '.cpp')[0]
         if result:
             import sys

--- a/test/Configure/clean.py
+++ b/test/Configure/clean.py
@@ -53,7 +53,7 @@ env.Program( 'TestProgram', 'TestProgram.c' )
 test.write('TestProgram.c', """\
 #include <stdio.h>
 
-int main() {
+int main(void) {
   printf( "Hello\\n" );
 }
 """)

--- a/test/Configure/custom-tests.py
+++ b/test/Configure/custom-tests.py
@@ -41,12 +41,12 @@ CR  = test.CR   # cached rebuild (up to date)
 NCF = test.NCF  # non-cached build failure
 CF  = test.CF   # cached build failure
 
-compileOK = '#include <stdio.h>\\nint main() {printf("Hello");return 0;}'
+compileOK = '#include <stdio.h>\\nint main(void) {printf("Hello");return 0;}'
 compileFAIL = "syntax error"
 linkOK = compileOK
-linkFAIL = "void myFunc(); int main() { myFunc(); }"
+linkFAIL = "void myFunc(); int main(void) { myFunc(); }"
 runOK = compileOK
-runFAIL = "int main() { return 1; }"
+runFAIL = "int main(void) { return 1; }"
 
 test.write('pyAct.py', """\
 from __future__ import print_function

--- a/test/Configure/help.py
+++ b/test/Configure/help.py
@@ -53,7 +53,7 @@ env.Program( 'TestProgram', 'TestProgram.c' )
 test.write('TestProgram.c', """\
 #include <stdio.h>
 
-int main() {
+int main(void) {
   printf( "Hello\\n" );
 }
 """)

--- a/test/FindSourceFiles.py
+++ b/test/FindSourceFiles.py
@@ -63,7 +63,7 @@ foo_c = env.Substfile('foo.c.in', SUBST_DICT = {'__A__' : '0' })
 foo = env.Program(foo_c)
 """)
 
-test.write('src/foo.c.in', """ int main() { return __A__;}
+test.write('src/foo.c.in', """ int main(void) { return __A__;}
 """)
 
 test.run(arguments = 'package')

--- a/test/Interactive/added-include.py
+++ b/test/Interactive/added-include.py
@@ -41,7 +41,7 @@ test.write('foo.h.in', """
 test.write('foo.c', """
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     printf("foo.c\\n");
     return 0;
@@ -81,7 +81,7 @@ test.write('foo.c', """
 
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     printf("%s\\n", FOO_STRING);
     return 0;

--- a/test/Interactive/implicit-VariantDir.py
+++ b/test/Interactive/implicit-VariantDir.py
@@ -74,7 +74,7 @@ test.write(['src', 'foo.c'], """
 
 #define FOO_PRINT_STRING "Hello from foo.c"
 
-int main()
+int main(void)
 {
     printf(FOO_PRINT_STRING "\\n");
     return 0;
@@ -115,7 +115,7 @@ test.write(['src', 'foo.c'], """
 #include "foo.h"
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     printf(FOO_PRINT_STRING "\\n");
     return 0;

--- a/test/LINK/VersionedLib-VariantDir.py
+++ b/test/LINK/VersionedLib-VariantDir.py
@@ -65,7 +65,7 @@ test.write(['src','bin','main.c'], """
 __declspec(dllimport)
 #endif
 int foo();
-int main()
+int main(void)
 {
   return foo();
 }

--- a/test/LINK/VersionedLib-j2.py
+++ b/test/LINK/VersionedLib-j2.py
@@ -57,7 +57,7 @@ test.write('main.c', """
 __declspec(dllimport)
 #endif
 int foo();
-int main() { return foo(); }
+int main(void) { return foo(); }
 """)
 
 test.write('SConstruct', """

--- a/test/LINK/VersionedLib-subdir.py
+++ b/test/LINK/VersionedLib-subdir.py
@@ -58,7 +58,7 @@ test.write('main.c', """
 __declspec(dllimport)
 #endif
 int foo();
-int main()
+int main(void)
 {
   return foo();
 }

--- a/test/Libs/Library.py
+++ b/test/Libs/Library.py
@@ -152,7 +152,7 @@ void nrd() {
 
 test.write('uses-nrd.c', r"""
 void nrd();
-int main() {
+int main(void) {
     nrd();
     return 0;
 }

--- a/test/MSVC/pch-basics.py
+++ b/test/MSVC/pch-basics.py
@@ -39,7 +39,7 @@ test.skip_if_not_msvc()
 test.write('Main.cpp', """\
 #include "Precompiled.h"
  
-int main()
+int main(void)
 {
     return testf();
 }

--- a/test/MSVC/pch-spaces-subdir.py
+++ b/test/MSVC/pch-spaces-subdir.py
@@ -39,7 +39,7 @@ test.skip_if_not_msvc()
 test.write('Main.cpp', """\
 #include "Precompiled.h"
 
-int main()
+int main(void)
 {
     return testf();
 }

--- a/test/MSVS/CPPPATH-Dirs.py
+++ b/test/MSVS/CPPPATH-Dirs.py
@@ -68,7 +68,7 @@ test.write('SConstruct', SConscript_contents)
 
 test.write('main.cpp', """\
 #include <stdio.h>
-int main() {
+int main(void) {
   printf("hello, world!\\n");
 }
 """)

--- a/test/QT/CPPPATH-appended.py
+++ b/test/QT/CPPPATH-appended.py
@@ -57,7 +57,7 @@ env.Program(target = 'aaa', source = 'aaa.cpp')
 
 test.write(['sub', 'aaa.cpp'], r"""
 #include "aaa.h"
-int main() { aaa(); return 0; }
+int main(void) { aaa(); return 0; }
 """)
 
 test.write(['sub', 'aaa.h'], r"""

--- a/test/QT/CPPPATH.py
+++ b/test/QT/CPPPATH.py
@@ -47,7 +47,7 @@ env.Program(target = 'aaa', source = 'aaa.cpp', CPPPATH=['$CPPPATH', './local_in
 
 test.write('aaa.cpp', r"""
 #include "aaa.h"
-int main() { aaa(); return 0; }
+int main(void) { aaa(); return 0; }
 """)
 
 test.write('aaa.h', r"""

--- a/test/QT/QTFLAGS.py
+++ b/test/QT/QTFLAGS.py
@@ -127,7 +127,7 @@ test.write(['work1', 'main.cpp'], """
 #include "uic-another_ui_file.hpp"
 void mocFromCpp();
 
-int main() {
+int main(void) {
   mocFromH();
   mocFromCpp();
   an_ui_file();
@@ -189,7 +189,7 @@ env2.Program('main.cpp')
 """ % {'QTDIR':QT})
 
 test.write(['work2', 'main.cpp'], """
-int main() { return 0; }
+int main(void) { return 0; }
 """)
 
 # Ignore stderr, because if Qt is not installed,

--- a/test/QT/empty-env.py
+++ b/test/QT/empty-env.py
@@ -46,7 +46,7 @@ env.Program('main', 'main.cpp', CPPDEFINES=['FOO'], LIBS=[])
 
 test.write('main.cpp', r"""
 #include "foo6.h"
-int main() { foo6(); return 0; }
+int main(void) { foo6(); return 0; }
 """)
 
 test.write(['qt', 'include', 'foo6.h'], """\

--- a/test/QT/manual.py
+++ b/test/QT/manual.py
@@ -119,7 +119,7 @@ test.write('main.cpp', r"""
 #include "eee.h"
 #include "uic_fff.hpp"
 
-int main() {
+int main(void) {
   aaa(); bbb(); ccc(); ddd(); eee(); fff(); return 0;
 }
 """)

--- a/test/QT/moc-from-header.py
+++ b/test/QT/moc-from-header.py
@@ -61,7 +61,7 @@ if env['PLATFORM'] == 'darwin':
 
 test.write('aaa.cpp', r"""
 #include "aaa.h"
-int main() { aaa(); return 0; }
+int main(void) { aaa(); return 0; }
 """)
 
 test.write('aaa.h', r"""

--- a/test/QT/reentrant.py
+++ b/test/QT/reentrant.py
@@ -56,7 +56,7 @@ env.Program('main', 'main.cpp', CPPDEFINES=['FOO'], LIBS=[])
 
 test.write('main.cpp', r"""
 #include "foo5.h"
-int main() { foo5(); return 0; }
+int main(void) { foo5(); return 0; }
 """)
 
 test.run()

--- a/test/RPATH.py
+++ b/test/RPATH.py
@@ -46,7 +46,7 @@ Program('foo', 'foo.c', LIBS='bar', LIBPATH='bar', RPATH='bar')
 
 test.write('foo.c', """\
 #include <stdlib.h>
-int main() {
+int main(void) {
     void bar();
     bar();
     exit (0);

--- a/test/YACC/live.py
+++ b/test/YACC/live.py
@@ -60,7 +60,7 @@ extern int yyparse();
 int yyerror(char *s);
 int yylex();
 
-int main()
+int main(void)
 {
     return yyparse();
 }
@@ -108,7 +108,7 @@ file_hpp = 'file.hpp'
 test.write("hello.cpp", """\
 #include "%(file_hpp)s"
 
-int main()
+int main(void)
 {
 }
 """ % locals())


### PR DESCRIPTION
This PR replaces all instances of `int main()` in `.py` files with `int main(void)`.

The consensus here is that `int main(void)` is also valid in C++: https://stackoverflow.com/q/44859450/119527

Fixes #3095.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation