### PR TITLE
fix for variant dir tests from Interactive tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ install:
 # so allow failure so the coverage stage can be reached with python 2
 matrix:
   allow_failures:
-    - python: 3.5
-    - python: 3.6
     - python: pypy
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ language: python
 install:
     - ./.travis/install.sh
 
-# python 3 is not fulling passing at this time
-# so allow failure so the coverage stage can be reached with python 2
+# pypy is not passing, but allow failures for coverage stage to be reached
 matrix:
   allow_failures:
     - python: pypy

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,10 @@
 
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
+  From Daniel Moody:
+    - Made a small change to scons main __init__.py to set the pickling protocal 
+      to choose the latest which fixed 2 failing test varient dir test from Interactive
+
   From Ray Donnelly:
     - Fix the PATH created by scons.bat (and other .bat files) to provide a normalized
       PATH.  Some pythons in the 3.6 series are no longer able to handle paths which

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,9 +8,10 @@
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Daniel Moody:
-    - Made a small change to scons main __init__.py to set the pickling protocal 
-      to choose the latest which fixed 2 failing test varient dir test from Interactive
-
+    - Set the pickling protocal back to highest which was causing issues 
+      with variant dir tests. This will cause issues if reading sconsigns
+      pickled with the previous lower protocal.
+      
   From Ray Donnelly:
     - Fix the PATH created by scons.bat (and other .bat files) to provide a normalized
       PATH.  Some pythons in the 3.6 series are no longer able to handle paths which

--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -98,7 +98,7 @@ import pickle
 
 # Was pickle.HIGHEST_PROTOCOL
 # Changed to 2 so py3.5+'s pickle will be compatible with py2.7.
-PICKLE_PROTOCOL = -2
+PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
 
 # TODO: FIXME
 # In 3.x, 'profile' automatically loads the fast version if available.

--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -98,7 +98,7 @@ import pickle
 
 # Was pickle.HIGHEST_PROTOCOL
 # Changed to 2 so py3.5+'s pickle will be compatible with py2.7.
-PICKLE_PROTOCOL = 2
+PICKLE_PROTOCOL = -2
 
 # TODO: FIXME
 # In 3.x, 'profile' automatically loads the fast version if available.


### PR DESCRIPTION
2 of the test from the Interactive tests were failing with exit status -11 when the finish command was called.

Although I am not sure exactly why this fixes it (someone please explain if you know), I debugged the segfault (exit code -11) from the failing tests and got this stack trace:

```
scons>>> exit

Program received signal SIGSEGV, Segmentation fault.
PyModule_GetState (m=0x0) at ../Objects/moduleobject.c:538
538	../Objects/moduleobject.c: No such file or directory.
(gdb) bt
#0  PyModule_GetState (m=0x0) at ../Objects/moduleobject.c:538
#1  0x000000000053fe8a in _Pickle_GetState (module=<optimized out>) at ../Modules/_pickle.c:165
#2  _Pickle_GetGlobalState.53466 () at ../Modules/_pickle.c:173
#3  0x000000000042fb48 in save_bytes (obj=b'.', self=0x7ffff4e27930) at ../Modules/_pickle.c:2025
#4  save.53676 (self=self@entry=0x7ffff4e27930, obj=b'.', pers_save=pers_save@entry=0) at ../Modules/_pickle.c:3772
#5  0x00000000004302bf in batch_dict_exact (
    obj={b'.': b'\x80\x02}q\x01U\nSConstructq\x02cSCons.SConsign\nSConsignEntry\nq\x03)\x81q\x04}q\x05(U\x0b_version_idq\x06K\x02U\x05ninfoq\x07cSCons.Node.FS\nFileNodeInfo\nq\x08)\x81q\t}q\n(U\ttimestampq\x0bJ\xa9b\x7fZh\x06K\x02U\x04sizeq\x0cM\xbe\x01ubU\x05binfoq\rcSCons.Node.FS\nFileBuildInfo\nq\x0e)\x81q\x0f}q\x10(U\x08bsourcesq\x11]q\x12U\tbimplicitq\x13]q\x14U\x08bdependsq\x15]q\x16h\x06K\x02U\x0bbdependsigsq\x17]q\x18U\x07bactsigq\x19NU\rbimplicitsigsq\x1a]q\x1bU\x0bbsourcesigsq\x1c]q\x1dububs.', '.': b'\x80\x02}q\x00X\n\x00\x00\x00SConstructq\x01cSCons.SConsign\nSConsignEntry\nq\x02)\x81q\x03}q\x04(X\x05\x00\x00\x00ninfoq\x05cSCons.Node.FS\nFileNodeInfo\nq\x06)\x81q\x07}q\x08(X\x04\x00\x00\x00sizeq\tM\xbe\x01X\t\x00\x00\x00timestampq\nJ\xa9b\x7fZX\x0b\x00\x00\x00_version_idq\x0bK\x02ubh\x0bK\x02X\x05\x00\x00\x00binfoq\x0ccSCons.Node.FS\nFileBuildInfo\nq\r)\x81q\x0e}q\x0f(X\x07\x00\x00\x00bactsigq\x10NX\x08\x00\x00\x00bdependsq\x11]q\x12X\x0b\x00\x00\x00bdependsigsq\x13]q\x14X\r\x00\x00\x00bimplicitsigsq\x15]...(truncated), self=0x7ffff4e27930) at ../Modules/_pickle.c:2797
#6  save_dict (
    obj={b'.': b'\x80\x02}q\x01U\nSConstructq\x02cSCons.SConsign\nSConsignEntry\nq\x03)\x81q\x04}q\x05(U\x0b_version_idq\x06K\x02U\x05ninfoq\x07cSCons.Node.FS\nFileNodeInfo\nq\x08)\x81q\t}q\n(U\ttimestampq\x0bJ\xa9b\x7fZh\x06K\x02U\x04sizeq\x0cM\xbe\x01ubU\x05binfoq\rcSCons.Node.FS\nFileBuildInfo\nq\x0e)\x81q\x0f}q\x10(U\x08bsourcesq\x11]q\x12U\tbimplicitq\x13]q\x14U\x08bdependsq\x15]q\x16h\x06K\x02U\x0bbdependsigsq\x17]q\x18U\x07bactsigq\x19NU\rbimplicitsigsq\x1a]q\x1bU\x0bbsourcesigsq\x1c]q\x1dububs.', '.': b'\x80\x02}q\x00X\n\x00\x00\x00SConstructq\x01cSCons.SConsign\nSConsignEntry\nq\x02)\x81q\x03}q\x04(X\x05\x00\x00\x00ninfoq\x05cSCons.Node.FS\nFileNodeInfo\nq\x06)\x81q\x07}q\x08(X\x04\x00\x00\x00sizeq\tM\xbe\x01X\t\x00\x00\x00timestampq\nJ\xa9b\x7fZX\x0b\x00\x00\x00_version_idq\x0bK\x02ubh\x0bK\x02X\x05\x00\x00\x00binfoq\x0ccSCons.Node.FS\nFileBuildInfo\nq\r)\x81q\x0e}q\x0f(X\x07\x00\x00\x00bactsigq\x10NX\x08\x00\x00\x00bdependsq\x11]q\x12X\x0b\x00\x00\x00bdependsigsq\x13]q\x14X\r\x00\x00\x00bimplicitsigsq\x15]...(truncated), self=0x7ffff4e27930) at ../Modules/_pickle.c:2856
#7  save.53676 (self=self@entry=0x7ffff4e27930, 
    obj=obj@entry={b'.': b'\x80\x02}q\x01U\nSConstructq\x02cSCons.SConsign\nSConsignEntry\nq\x03)\x81q\x04}q\x05(U\x0b_version_idq\x06K\x02U\x05ninfoq\x07cSCons.Node.FS\nFileNodeInfo\nq\x08)\x81q\t}q\n(U\ttimestampq\x0bJ\xa9b\x7fZh\x06K\x02U\x04sizeq\x0cM\xbe\x01ubU\x05binfoq\rcSCons.Node.FS\nFileBuildInfo\nq\x0e)\x81q\x0f}q\x10(U\x08bsourcesq\x11]q\x12U\tbimplicitq\x13]q\x14U\x08bdependsq\x15]q\x16h\x06K\x02U\x0bbdependsigsq\x17]q\x18U\x07bactsigq\x19NU\rbimplicitsigsq\x1a]q\x1bU\x0bbsourcesigsq\x1c]q\x1dububs.', '.': b'\x80\x02}q\x00X\n\x00\x00\x00SConstructq\x01cSCons.SConsign\nSConsignEntry\nq\x02)\x81q\x03}q\x04(X\x05\x00\x00\x00ninfoq\x05cSCons.Node.FS\nFileNodeInfo\nq\x06)\x81q\x07}q\x08(X\x04\x00\x00\x00sizeq\tM\xbe\x01X\t\x00\x00\x00timestampq\nJ\xa9b\x7fZX\x0b\x00\x00\x00_version_idq\x0bK\x02ubh\x0bK\x02X\x05\x00\x00\x00binfoq\x0ccSCons.Node.FS\nFileBuildInfo\nq\r)\x81q\x0e}q\x0f(X\x07\x00\x00\x00bactsigq\x10NX\x08\x00\x00\x00bdependsq\x11]q\x12X\x0b\x00\x00\x00bdependsigsq\x13]q\x14X\r\x00\x00\x00bimplicitsigsq\x15]...(truncated), pers_save=pers_save@entry=0) at ../Modules/_pickle.c:3780
#8  0x00000000004308c9 in dump (self=self@entry=0x7ffff4e27930, 
    obj=obj@entry={b'.': b'\x80\x02}q\x01U\nSConstructq\x02cSCons.SConsign\nSConsignEntry\nq\x03)\x81q\x04}q\x05(U\x0b_version_idq\x06K\x02U\x05ninfoq\x07cSCons.Node.FS\nFileNodeInfo\nq\x08)\x81q\t}q\n(U\ttimestampq\x0bJ\xa9b\x7fZh\x06K\x02U\x04sizeq\x0cM\xbe\x01ubU\x05binfoq\rcSCons.Node.FS\nFileBuildInfo\nq\x0e)\x81q\x0f}q\x10(U\x08bsourcesq\x11]q\x12U\tbimplicitq\x13]q\x14U\x08bdependsq\x15]q\x16h\x06K\x02U\x0bbdependsigsq\x17]q\x18U\x07bactsigq\x19NU\rbimplicitsigsq\x1a]q\x1bU\x0bbsourcesigsq\x1c]q\x1dububs.', '.': b'\x80\x02}q\x00X\n\x00\x00\x00SConstructq\x01cSCons.SConsign\nSConsignEntry\nq\x02)\x81q\x03}q\x04(X\x05\x00\x00\x00ninfoq\x05cSCons.Node.FS\nFileNodeInfo\nq\x06)\x81q\x07}q\x08(X\x04\x00\x00\x00sizeq\tM\xbe\x01X\t\x00\x00\x00timestampq\nJ\xa9b\x7fZX\x0b\x00\x00\x00_version_idq\x0bK\x02ubh\x0bK\x02X\x05\x00\x00\x00binfoq\x0ccSCons.Node.FS\nFileBuildInfo\nq\r)\x81q\x0e}q\x0f(X\x07\x00\x00\x00bactsigq\x10NX\x08\x00\x00\x00bdependsq\x11]q\x12X\x0b\x00\x00\x00bdependsigsq\x13]q\x14X\r\x00\x00\x00bimplicitsigsq\x15]...(truncated)) at ../Modules/_pickle.c:3941
#9  0x0000000000431429 in _pickle_dump_impl.isra.39 (fix_imports=1, protocol=2, file=<_io.BufferedWriter at remote 0x7ffff6998518>, 
    obj={b'.': b'\x80\x02}q\x01U\nSConstructq\x02cSCons.SConsign\nSConsignEntry\nq\x03)\x81q\x04}q\x05(U\x0b_version_idq\x06K\x02U\x05ninfoq\x07cSCons.Node.FS\nFileNodeInfo\nq\x08)\x81q\t}q\n(U\ttimestampq\x0bJ\xa9b\x7fZh\x06K\x02U\x04sizeq\x0cM\xbe\x01ubU\x05binfoq\rcSCons.Node.FS\nFileBuildInfo\nq\x0e)\x81q\x0f}q\x10(U\x08bsourcesq\x11]q\x12U\tbimplicitq\x13]q\x14U\x08bdependsq\x15]q\x16h\x06K\x02U\x0bbdependsigsq\x17]q\x18U\x07bactsigq\x19NU\rbimplicitsigsq\x1a]q\x1bU\x0bbsourcesigsq\x1c]q\x1dububs.', '.': b'\x80\x02}q\x00X\n\x00\x00\x00SConstructq\x01cSCons.SConsign\nSConsignEntry\nq\x02)\x81q\x03}q\x04(X\x05\x00\x00\x00ninfoq\x05cSCons.Node.FS\nFileNodeInfo\nq\x06)\x81q\x07}q\x08(X\x04\x00\x00\x00sizeq\tM\xbe\x01X\t\x00\x00\x00timestampq\nJ\xa9b\x7fZX\x0b\x00\x00\x00_version_idq\x0bK\x02ubh\x0bK\x02X\x05\x00\x00\x00binfoq\x0ccSCons.Node.FS\nFileBuildInfo\nq\r)\x81q\x0e}q\x0f(X\x07\x00\x00\x00bactsigq\x10NX\x08\x00\x00\x00bdependsq\x11]q\x12X\x0b\x00\x00\x00bdependsigsq\x13]q\x14X\r\x00\x00\x00bimplicitsigsq\x15]...(truncated)) at ../Modules/_pickle.c:6989
#10 _pickle_dump.53884 (module=<optimized out>, args=<optimized out>, kwargs=<optimized out>) at ../Modules/clinic/_pickle.c.h:399
```
The stack trace suggested an issue with pickling so I just played with the pickle protocol setting in the init.py for scons. The result was all tests passing.
 
## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation