### PR TITLE
Fix Jar to use SCons to check for files instead of python

### DIFF
--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -163,19 +163,6 @@ def Jar(env, target = None, source = [], *args, **kw):
         else:
             return dir_targets
 
-    # In the case that we are passed just string to a node which is directory
-    # but does not exist, we need to check all the current targets to see if
-    # that directory is going to exist so we can add it as a source to Jar builder
-    def get_all_targets(env, node='.'):
-        def get_all_targets_iter(env, node):
-            if node.has_builder():
-                yield node
-            for kid in node.all_children():
-                for kid in get_all_targets(env, kid):
-                    yield kid
-        node = env.arg2nodes(node, env.fs.Entry)[0]
-        return list(get_all_targets_iter(env, node))
-
     # loop through the sources and handle each accordingly
     # the goal here is to get all the source files into a class
     # file or a directory that contains class files
@@ -203,21 +190,8 @@ def Jar(env, target = None, source = [], *args, **kw):
             except:
                 pass
 
-            if s[-len(java_suffix):] == java_suffix or s[-len(java_class_suffix):] == java_class_suffix:
-                # found a file that may not exists and is only a string
-                # so add it after converting it to a class file
-                target_nodes.extend(file_to_class(s))
-            else:
-                # found a swig file so add it after converting it to class files
-                if(os.path.splitext(str(s))[1] == ".i"):
-                    target_nodes.extend(env.JavaClassFile(source = s, *args, **kw))
-                else:
-                    # The final else case handles anything not caught above and makes
-                    # sure other nodes that are sources for this jar get add as
-                    # a source to the JarFile builder
-                    for node in get_all_targets(env):
-                        if(s == str(node)):
-                            target_nodes.append(node)
+            SCons.Warnings.Warning("File: " + str(s) + " could not be identified as File or Directory, skipping.")
+            
     # at this point all our sources have been converted to classes or directories of class
     # so pass it to the Jar builder
     return env.JarFile(target = target, source = target_nodes, *args, **kw)

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -189,13 +189,21 @@ def Jar(env, target = None, source = [], *args, **kw):
                 # found a dir so get the class files out of it
                 target_nodes.extend(dir_to_class(s))
         else:
-            if os.path.isfile(s):
-                # found a file that exists on the FS, make sure its a class file
-                target_nodes.extend(file_to_class(s))
-            elif os.path.isdir(s):
-                # found a dir so get the class files out of it
-                target_nodes.extend(dir_to_class(s))
-            elif s[-len(java_suffix):] == java_suffix or s[-len(java_class_suffix):] == java_class_suffix:
+            try:
+                # source is string try to convert it to file
+                target_nodes.extend(file_to_class(env.fs.File(s)))
+                continue
+            except:
+                pass
+            
+            try:
+                # source is string try to covnert it to dir
+                target_nodes.extend(dir_to_class(env.fs.Dir(s)))
+                continue
+            except:
+                pass
+
+            if s[-len(java_suffix):] == java_suffix or s[-len(java_class_suffix):] == java_class_suffix:
                 # found a file that may not exists and is only a string
                 # so add it after converting it to a class file
                 target_nodes.extend(file_to_class(s))

--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -337,6 +337,7 @@ test.must_exist(['testdir2', 'barTest', 'com', 'javasource', 'JavaFile3.class'])
 
 # make some directories to test in
 test.subdir('listOfLists',
+            ['manifest_dir'],
             ['listOfLists', 'src'],
             ['listOfLists', 'src', 'com'],
             ['listOfLists', 'src', 'com', 'javasource'],
@@ -346,14 +347,14 @@ test.subdir('listOfLists',
 test.write(['listOfLists', 'SConstruct'], """
 foo = Environment()
 foo.VariantDir('build', 'src', duplicate=0)
+foo.VariantDir('test', '../manifest_dir', duplicate=0)
 sourceFiles = ["src/com/javasource/JavaFile1.java", "src/com/javasource/JavaFile2.java", "src/com/javasource/JavaFile3.java",]
 list_of_class_files = foo.Java('build', source=sourceFiles)
 resources = ['build/com/resource/resource1.txt', 'build/com/resource/resource2.txt']
 for resource in resources:
     foo.Command(resource, list_of_class_files, Copy(resource, resource.replace('build','src')))
-foo.Command('build/MANIFEST.mf', list_of_class_files, Copy('build/MANIFEST.mf', 'MANIFEST.mf'))
 contents = [list_of_class_files, resources]
-foo.Jar(target = 'lists', source = contents + ['build/MANIFEST.mf'], JARCHDIR='build')
+foo.Jar(target = 'lists', source = contents + ['test/MANIFEST.mf'], JARCHDIR='build')
 foo.Command("listsTest", [], Mkdir("listsTest") )
 foo.Command('listsTest/src/com/javasource/JavaFile3.java', 'lists.jar', foo['JAR'] + ' xvf ../lists.jar', chdir='listsTest')
 """)
@@ -394,7 +395,7 @@ public class JavaFile3
 }
 """)
 
-test.write(['listOfLists', 'MANIFEST.mf'],
+test.write(['manifest_dir','MANIFEST.mf'],
 """Manifest-Version: 1.0
 MyManifestTest: Test
 """)


### PR DESCRIPTION
This fixes the issue https://github.com/SCons/scons/issues/3042, and adds a test for the case of variant dirs which reflect what is reported in the issue.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation