### PR TITLE
Windows clang tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,8 @@ image: Visual Studio 2017
 shallow_clone: true
 
 install:
-  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  #set python version, and cygwin tools for clang tests
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\cygwin64\\bin;C:\\msys64;%PATH%"
   - python --version
   - pip install lxml
   - pip install pypiwin32

--- a/test/Clang/clang_default_environment.py
+++ b/test/Clang/clang_default_environment.py
@@ -34,7 +34,7 @@ if not test.where_is('clang'):
     test.skip_test("Could not find 'clang', skipping test.\n")
 
 if 'win32' == sys.platform:
-    test.skip_test("this test is not setup for clang in default msvs environment, skipping test.\n")
+    test.skip_test("This test is not setup for clang in default msvs environment, skipping test.\n")
 
 ##  This will likely NOT use clang
 

--- a/test/Clang/clang_default_environment.py
+++ b/test/Clang/clang_default_environment.py
@@ -25,12 +25,16 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
+import sys
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang', skipping test.\n")
+
+if 'win32' == sys.platform:
+    test.skip_test("this test is not setup for clang in default msvs environment, skipping test.\n")
 
 ##  This will likely NOT use clang
 

--- a/test/Clang/clang_shared_library.py
+++ b/test/Clang/clang_shared_library.py
@@ -25,7 +25,8 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
-from SCons.Environment import Base
+import sys
+import os
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
@@ -33,23 +34,26 @@ test = TestSCons.TestSCons()
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang', skipping test.\n")
 
-platform = Base()['PLATFORM']
-if platform == 'posix':
+clang_dir = os.path.dirname(test.where_is('clang'))
+
+if 'linux' in sys.platform:
     filename = 'foo.os'
     libraryname = 'libfoo.so'
-elif platform == 'darwin':
+elif sys.platform == 'darwin':
     filename = 'foo.os'
     libraryname = 'libfoo.dylib'
-elif platform == 'win32':
+elif sys.platform == 'win32':
     filename = 'foo.obj'
     libraryname = 'foo.dll'
 else:
+    print("Could not determine platform.")
     test.fail_test()
 
 test.write('SConstruct', """\
 env = Environment(tools=['clang', 'link'])
+env.PrependENVPath('PATH', r'%s')
 env.SharedLibrary('foo', 'foo.c')
-""")
+""" % clang_dir)
 
 test.write('foo.c', """\
 int bar() {

--- a/test/Clang/clang_shared_library.py
+++ b/test/Clang/clang_shared_library.py
@@ -43,7 +43,7 @@ elif sys.platform == 'darwin':
     filename = 'foo.os'
     libraryname = 'libfoo.dylib'
 elif sys.platform == 'win32':
-    filename = 'foo.obj'
+    filename = 'foo.os'
     libraryname = 'foo.dll'
 else:
     print("Could not determine platform.")

--- a/test/Clang/clang_specific_environment.py
+++ b/test/Clang/clang_specific_environment.py
@@ -25,6 +25,7 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
+import os
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
@@ -32,10 +33,13 @@ test = TestSCons.TestSCons()
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang', skipping test.\n")
 
+clang_dir = os.path.dirname(test.where_is('clang'))
+
 test.write('SConstruct', """\
 env = Environment(tools=['clang', 'link'])
+env.PrependENVPath('PATH', r'%s')
 env.Program('foo.c')
-""")
+""" % clang_dir)
 
 test.write('foo.c', """\
 #include <stdio.h>

--- a/test/Clang/clang_static_library.py
+++ b/test/Clang/clang_static_library.py
@@ -30,7 +30,7 @@ import os
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang') and not test.where_is('ar'):
+if not test.where_is('clang') or not test.where_is('ar'):
     test.skip_test("Could not find 'clang' and 'ar', skipping test.\n")
 
 clang_dir = os.path.dirname(test.where_is('clang'))

--- a/test/Clang/clang_static_library.py
+++ b/test/Clang/clang_static_library.py
@@ -41,7 +41,7 @@ env = Environment(tools=['clang', 'ar'])
 env.PrependENVPath('PATH', r'%s')
 env.PrependENVPath('PATH', r'%s')
 env.StaticLibrary('foo', 'foo.c')
-""" % clang_dir, ar_dir)
+""" % (clang_dir, ar_dir))
 
 test.write('foo.c', """\
 int bar() {

--- a/test/Clang/clang_static_library.py
+++ b/test/Clang/clang_static_library.py
@@ -30,16 +30,18 @@ import os
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang'):
-    test.skip_test("Could not find 'clang', skipping test.\n")
+if not test.where_is('clang') and not test.where_is('ar'):
+    test.skip_test("Could not find 'clang' and 'ar', skipping test.\n")
 
 clang_dir = os.path.dirname(test.where_is('clang'))
+ar_dir = os.path.dirname(test.where_is('ar'))
 
 test.write('SConstruct', """\
 env = Environment(tools=['clang', 'ar'])
 env.PrependENVPath('PATH', r'%s')
+env.PrependENVPath('PATH', r'%s')
 env.StaticLibrary('foo', 'foo.c')
-""" % clang_dir)
+""" % clang_dir, ar_dir)
 
 test.write('foo.c', """\
 int bar() {

--- a/test/Clang/clang_static_library.py
+++ b/test/Clang/clang_static_library.py
@@ -25,6 +25,7 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
+import os
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
@@ -32,10 +33,13 @@ test = TestSCons.TestSCons()
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang', skipping test.\n")
 
+clang_dir = os.path.dirname(test.where_is('clang'))
+
 test.write('SConstruct', """\
 env = Environment(tools=['clang', 'ar'])
+env.PrependENVPath('PATH', r'%s')
 env.StaticLibrary('foo', 'foo.c')
-""")
+""" % clang_dir)
 
 test.write('foo.c', """\
 int bar() {

--- a/test/Clang/clangxx_default_environment.py
+++ b/test/Clang/clangxx_default_environment.py
@@ -34,7 +34,7 @@ if not test.where_is('clang++'):
     test.skip_test("Could not find 'clang++', skipping test.\n")
 
 if 'win32' == sys.platform:
-    test.skip_test("this test is not setup for clang++ in default msvs environment, skipping test.\n")
+    test.skip_test("This test is not setup for clang++ in default msvs environment, skipping test.\n")
 
 ## This will likely NOT use clang++.
 

--- a/test/Clang/clangxx_default_environment.py
+++ b/test/Clang/clangxx_default_environment.py
@@ -25,12 +25,16 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
+import sys
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang'):
+if not test.where_is('clang++'):
     test.skip_test("Could not find 'clang++', skipping test.\n")
+
+if 'win32' == sys.platform:
+    test.skip_test("this test is not setup for clang++ in default msvs environment, skipping test.\n")
 
 ## This will likely NOT use clang++.
 

--- a/test/Clang/clangxx_shared_library.py
+++ b/test/Clang/clangxx_shared_library.py
@@ -25,32 +25,36 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
-
-from SCons.Environment import Base
+import sys
+import os
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang'):
+if not test.where_is('clang++'):
     test.skip_test("Could not find 'clang++', skipping test.\n")
 
-platform = Base()['PLATFORM']
-if platform == 'posix':
+clang_dir = os.path.dirname(test.where_is('clang++'))
+
+if 'linux' in sys.platform:
     filename = 'foo.os'
     libraryname = 'libfoo.so'
-elif platform == 'darwin':
+elif sys.platform == 'darwin':
     filename = 'foo.os'
     libraryname = 'libfoo.dylib'
-elif platform == 'win32':
+elif sys.platform == 'win32':
     filename = 'foo.obj'
     libraryname = 'foo.dll'
 else:
+    print("Could not determine platform.")
     test.fail_test()
+
 
 test.write('SConstruct', """\
 env = Environment(tools=['clang++', 'link'])
+env.PrependENVPath('PATH', r'%s')
 env.SharedLibrary('foo', 'foo.cpp')
-""")
+""" % clang_dir)
 
 test.write('foo.cpp', """\
 int bar() {

--- a/test/Clang/clangxx_shared_library.py
+++ b/test/Clang/clangxx_shared_library.py
@@ -43,7 +43,7 @@ elif sys.platform == 'darwin':
     filename = 'foo.os'
     libraryname = 'libfoo.dylib'
 elif sys.platform == 'win32':
-    filename = 'foo.obj'
+    filename = 'foo.os'
     libraryname = 'foo.dll'
 else:
     print("Could not determine platform.")

--- a/test/Clang/clangxx_specific_environment.py
+++ b/test/Clang/clangxx_specific_environment.py
@@ -25,17 +25,21 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
+import os
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang'):
+if not test.where_is('clang++'):
     test.skip_test("Could not find 'clang++', skipping test.\n")
+
+clang_dir = os.path.dirname(test.where_is('clang++'))
 
 test.write('SConstruct', """\
 env = Environment(tools=['clang++', 'link'])
+env.PrependENVPath('PATH', r'%s')
 env.Program('foo.cpp')
-""")
+""" % clang_dir)
 
 test.write('foo.cpp', """\
 #include <iostream>

--- a/test/Clang/clangxx_static_library.py
+++ b/test/Clang/clangxx_static_library.py
@@ -25,17 +25,21 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
+import os
 
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang'):
+if not test.where_is('clang++'):
     test.skip_test("Could not find 'clang++', skipping test.\n")
+
+clang_dir = os.path.dirname(test.where_is('clang++'))
 
 test.write('SConstruct', """\
 env = Environment(tools=['clang++', 'ar'])
+env.PrependENVPath('PATH', r'%s')
 env.StaticLibrary('foo', 'foo.cpp')
-""")
+""" % clang_dir)
 
 test.write('foo.cpp', """\
 int bar() {

--- a/test/Clang/clangxx_static_library.py
+++ b/test/Clang/clangxx_static_library.py
@@ -30,16 +30,18 @@ import os
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang++'):
-    test.skip_test("Could not find 'clang++', skipping test.\n")
+if not test.where_is('clang++') and not test.where_is('ar'):
+    test.skip_test("Could not find 'clang++' and 'ar', skipping test.\n")
 
 clang_dir = os.path.dirname(test.where_is('clang++'))
+ar_dir = os.path.dirname(test.where_is('ar'))
 
 test.write('SConstruct', """\
 env = Environment(tools=['clang++', 'ar'])
 env.PrependENVPath('PATH', r'%s')
+env.PrependENVPath('PATH', r'%s')
 env.StaticLibrary('foo', 'foo.cpp')
-""" % clang_dir)
+""" % clang_dir, ar_dir)
 
 test.write('foo.cpp', """\
 int bar() {

--- a/test/Clang/clangxx_static_library.py
+++ b/test/Clang/clangxx_static_library.py
@@ -41,7 +41,7 @@ env = Environment(tools=['clang++', 'ar'])
 env.PrependENVPath('PATH', r'%s')
 env.PrependENVPath('PATH', r'%s')
 env.StaticLibrary('foo', 'foo.cpp')
-""" % clang_dir, ar_dir)
+""" % (clang_dir, ar_dir))
 
 test.write('foo.cpp', """\
 int bar() {

--- a/test/Clang/clangxx_static_library.py
+++ b/test/Clang/clangxx_static_library.py
@@ -30,7 +30,7 @@ import os
 _exe = TestSCons._exe
 test = TestSCons.TestSCons()
 
-if not test.where_is('clang++') and not test.where_is('ar'):
+if not test.where_is('clang++') or not test.where_is('ar'):
     test.skip_test("Could not find 'clang++' and 'ar', skipping test.\n")
 
 clang_dir = os.path.dirname(test.where_is('clang++'))


### PR DESCRIPTION
On windows, a SCons environment will only include the system32 path, unless default windows environment is used in which case the path is setup from the vcvars batch script.

The clang test do not use the msvs environment and therefore do not have the clang or other necessary cygwin binaries in the path when scons goes to build.

This pull request updates the test to add the correct binaries to the path, and skips tests that are meant to use the default environment.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation