### PR TITLE
Remove forced u" on string value that causes

### DIFF
--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -678,7 +678,7 @@ class _ActionAction(ActionBase):
                 source = executor.get_all_sources()
             t = ' and '.join(map(str, target))
             l = '\n  '.join(self.presub_lines(env))
-            out = u"Building %s with action:\n  %s\n" % (t, l)
+            out = "Building %s with action:\n  %s\n" % (t, l)
             sys.stdout.write(out)
         cmd = None
         if show and self.strfunction:


### PR DESCRIPTION
TypeError: can only join an iterable of bytes (item 3 has type 'unicode'):
...
  File "/home/jkenny/env/lib/python2.7/site-packages/scons-3.0.1/SCons/Action.py", line 185:
    return _function_contents(obj.__call__.__func__)
  File "/home/jkenny/env/lib/python2.7/site-packages/scons-3.0.1/SCons/Action.py", line 301:
    contents = [_code_contents(func.__code__, func.__doc__)]
  File "/home/jkenny/env/lib/python2.7/site-packages/scons-3.0.1/SCons/Action.py", line 264:
    contents.extend(bytearray(',', 'utf-8').join(z))

This is breaking Parts. Not sure why this is not seen in SCons testing as the code that is broken is 
SCons.Action._object_contents(...)

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation