### PR TITLE
default shared object suffix on UNIX system should be .so (not .os!)

### DIFF
--- a/src/engine/SCons/Tool/cc.py
+++ b/src/engine/SCons/Tool/cc.py
@@ -90,7 +90,7 @@ def generate(env):
     env['CPPDEFSUFFIX']  = ''
     env['INCPREFIX']  = '-I'
     env['INCSUFFIX']  = ''
-    env['SHOBJSUFFIX'] = '.os'
+    env['SHOBJSUFFIX'] = '.so'
     env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 0
 
     env['CFILESUFFIX'] = '.c'

--- a/src/engine/SCons/Tool/cxx.py
+++ b/src/engine/SCons/Tool/cxx.py
@@ -84,7 +84,7 @@ def generate(env):
     env['CPPDEFSUFFIX']  = ''
     env['INCPREFIX']  = '-I'
     env['INCSUFFIX']  = ''
-    env['SHOBJSUFFIX'] = '.os'
+    env['SHOBJSUFFIX'] = '.so'
     env['OBJSUFFIX'] = '.o'
     env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 0
 


### PR DESCRIPTION
Looks like GCC implementation fixed this but when using cython/pyext which uses default createCFileBuilders this is not getting fixed alone the path.

This causes when using cython/pyext Tools file to create object file ending with ".os" instead of ".so".

Or if I ".os" has ever being a valid shared object output suffix which I am completely not aware of ...