### PR TITLE
fix #3106  MSVC handling MSVC_BATCH with targetdir which requires escaping

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -25,6 +25,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
   From William Deegan:
     - Remove long deprecated SCons.Options code and tests.  This removes BoolOption,EnumOption,
       ListOption,PackageOption, and PathOption which have been replaced by *Variable() many years ago.
+    - Fix issue # 3106 MSVC if using MSVC_BATCH and target dir had a space would fail due to quirk in
+      MSVC's handling of escaped targetdirs when batch compiling.
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Tool/msvc.py
+++ b/src/engine/SCons/Tool/msvc.py
@@ -195,7 +195,10 @@ def msvc_output_flag(target, source, env, for_signature):
         # that the test(s) for this can be run on non-Windows systems
         # without having a hard-coded backslash mess up command-line
         # argument parsing.
-        return '/Fo${TARGET.dir}' + os.sep
+        # Adding double os.sep's as if the TARGET.dir has a space or otherwise
+        # needs to be quoted they are needed per MSVC's odd behavior
+        # See: https://github.com/SCons/scons/issues/3106
+        return '/Fo${TARGET.dir}' + os.sep*2
 
 CAction = SCons.Action.Action("$CCCOM", "$CCCOMSTR",
                               batch_key=msvc_batch_key,

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir.py
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir.py
@@ -1,0 +1,11 @@
+import TestSCons
+
+
+
+test = TestSCons.TestSCons()
+
+test.skip_if_not_msvc()
+
+
+test.dir_fixture('MSVC_BATCH-spaces-targetdir')
+test.run()

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/SConstruct
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/SConstruct
@@ -1,0 +1,8 @@
+import os.path
+
+env=Environment(MSVC_BATCH=True)
+
+td='tar ge tdir'
+VariantDir(td,'src')
+env.Program(os.path.join(td,'test_program'),
+            [os.path.join(td,a) for a in ['a.c','b.c','c.c']])

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/src/a.c
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/src/a.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+extern void myfuncb();
+extern void myfuncc();
+
+
+void myfunca() {
+    printf("myfunca\n");
+}
+
+int main(int argc, char *argv[]) {
+    myfunca();
+    myfuncb();
+    myfuncc();
+}

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/src/b.c
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/src/b.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void myfuncb() {
+    printf("myfuncb\n");
+}

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/src/c.c
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/src/c.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void myfuncc() {
+    printf("myfuncc\n");
+}

--- a/test/MSVC/batch.py
+++ b/test/MSVC/batch.py
@@ -32,6 +32,7 @@ explicit suffix settings so that the test should work when run on any
 platform.
 """
 
+import os
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -97,8 +98,8 @@ test.run(arguments = 'MSVC_BATCH=1 .')
 
 test.must_match('prog.exe', "prog.c\nf1.c\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
-/Fo.\\ prog.c f1.c f2.c
-""", mode='r')
+/Fo.%s prog.c f1.c f2.c
+"""%os.sep, mode='r')
 
 test.up_to_date(options = 'MSVC_BATCH=1', arguments = '.')
 
@@ -110,9 +111,9 @@ test.run(arguments = 'MSVC_BATCH=1 .')
 
 test.must_match('prog.exe', "prog.c\nf1.c 2\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
-/Fo.\\ prog.c f1.c f2.c
-/Fo.\\ f1.c
-""", mode='r')
+/Fo.%s prog.c f1.c f2.c
+/Fo.%s f1.c
+"""%(os.sep, os.sep), mode='r')
 
 test.up_to_date(options = 'MSVC_BATCH=1', arguments = '.')
 

--- a/test/MSVC/batch.py
+++ b/test/MSVC/batch.py
@@ -72,6 +72,7 @@ for infile in sys.argv[2:]:
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 cccom = r'%(_python_)s fake_cl.py $_MSVC_OUTPUT_FLAG $CHANGED_SOURCES'
 linkcom = r'%(_python_)s fake_link.py ${TARGET.windows} $SOURCES'
 env = Environment(tools=['msvc', 'mslink'],
@@ -96,7 +97,7 @@ test.run(arguments = 'MSVC_BATCH=1 .')
 
 test.must_match('prog.exe', "prog.c\nf1.c\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
-/Fo. prog.c f1.c f2.c
+/Fo.\\ prog.c f1.c f2.c
 """, mode='r')
 
 test.up_to_date(options = 'MSVC_BATCH=1', arguments = '.')
@@ -109,8 +110,8 @@ test.run(arguments = 'MSVC_BATCH=1 .')
 
 test.must_match('prog.exe', "prog.c\nf1.c 2\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
-/Fo. prog.c f1.c f2.c
-/Fo. f1.c
+/Fo.\\ prog.c f1.c f2.c
+/Fo.\\ f1.c
 """, mode='r')
 
 test.up_to_date(options = 'MSVC_BATCH=1', arguments = '.')


### PR DESCRIPTION
MSVC handling MSVC_BATCH with targetdir which requires escaping.
If the target dir has a space in it and using batch compiles then the 
```
/Fo argument must end with two dirseps
/Fo".]target dir\\"
```
Fixes Issue #3106 

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation