### PR TITLE
Reenable parallel builds with Pypy

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -25,6 +25,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
   From William Deegan:
     - Remove long deprecated SCons.Options code and tests.  This removes BoolOption,EnumOption,
       ListOption,PackageOption, and PathOption which have been replaced by *Variable() many years ago.
+    - Re-Enable parallel SCons (-j) when running via Pypy
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -48,6 +48,7 @@ import sys
 import time
 import traceback
 import sysconfig
+import platform
 
 import SCons.CacheDir
 import SCons.Debug
@@ -1253,7 +1254,8 @@ def _build_targets(fs, options, targets, target_top):
     BuildTask.options = options
 
 
-    python_has_threads = sysconfig.get_config_var('WITH_THREAD')
+    is_pypy = platform.python_implementation() == 'PyPy'
+    python_has_threads = sysconfig.get_config_var('WITH_THREAD') or is_pypy
     # to check if python configured with threads.
     global num_jobs
     num_jobs = options.num_jobs


### PR DESCRIPTION
Reenable parallel builds with Pypy
The check to see if threading was enabled with the running version of python mistakenly disabled parallel builds when running Pypy


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation