### PR TITLE
Add SConstruct.py to the search list

### DIFF
--- a/doc/design/native.xml
+++ b/doc/design/native.xml
@@ -64,8 +64,9 @@
  <para>
 
   By default, the &SCons; utility searches for a file named
-  &SConstruct;, &Sconstruct;, &sconstruct;, &SConstruct.py or &sconstruct.py; (in that order) in the
-  current directory, and reads its configuration from the first file
+  &SConstruct;, &Sconstruct;, &sconstruct;, &SConstruct.py, &Sconstruct.py
+  or &sconstruct.py; (in that order) in the current directory,
+  and reads its configuration from the first file
   found.  A <option>-f</option> command-line option exists to read a
   different file name.
 

--- a/doc/design/native.xml
+++ b/doc/design/native.xml
@@ -64,7 +64,7 @@
  <para>
 
   By default, the &SCons; utility searches for a file named
-  &SConstruct;, &Sconstruct;, &sconstruct; or &SConstruct.py; (in that order) in the
+  &SConstruct;, &Sconstruct;, &sconstruct;, &SConstruct.py or &sconstruct.py; (in that order) in the
   current directory, and reads its configuration from the first file
   found.  A <option>-f</option> command-line option exists to read a
   different file name.

--- a/doc/design/native.xml
+++ b/doc/design/native.xml
@@ -64,7 +64,7 @@
  <para>
 
   By default, the &SCons; utility searches for a file named
-  &SConstruct;, &Sconstruct; or &sconstruct; (in that order) in the
+  &SConstruct;, &Sconstruct;, &sconstruct; or &SConstruct.py; (in that order) in the
   current directory, and reads its configuration from the first file
   found.  A <option>-f</option> command-line option exists to read a
   different file name.

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -107,6 +107,7 @@ searches for a file named
 <emphasis>Sconstruct</emphasis>,
 <emphasis>sconstruct</emphasis>,
 <emphasis>SConstruct.py</emphasis>
+<emphasis>Sconstruct.py</emphasis>
 or
 <emphasis>sconstruct.py</emphasis>
 (in that order) in the current directory and reads its
@@ -639,6 +640,7 @@ before searching for the
 <emphasis>Sconstruct</emphasis>,
 <emphasis>sconstruct</emphasis>,
 <emphasis>SConstruct.py</emphasis>
+<emphasis>Sconstruct.py</emphasis>
 or
 <emphasis>sconstruct.py</emphasis>
 file, or doing anything
@@ -655,6 +657,7 @@ except that it will search for
 <emphasis>Sconstruct</emphasis>,
 <emphasis>sconstruct</emphasis>,
 <emphasis>SConstruct.py</emphasis>
+<emphasis>Sconstruct.py</emphasis>
 or
 <emphasis>sconstruct.py</emphasis>
 in the specified directory.)</para>
@@ -1667,6 +1670,7 @@ scons --tree=all,prune,status target
 <emphasis>Sconstruct ,</emphasis>
 <emphasis>sconstruct ,</emphasis>
 <emphasis>SConstruct.py</emphasis>
+<emphasis>Sconstruct.py</emphasis>
 or
 <emphasis>sconstruct.py</emphasis>
 file is found, and uses that

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -105,9 +105,10 @@ rebuild them.</para>
 searches for a file named
 <emphasis>SConstruct</emphasis>,
 <emphasis>Sconstruct</emphasis>,
-<emphasis>sconstruct</emphasis>
-or
+<emphasis>sconstruct</emphasis>,
 <emphasis>SConstruct.py</emphasis>
+or
+<emphasis>sconstruct.py</emphasis>
 (in that order) in the current directory and reads its
 configuration from the first file found.
 An alternate file name may be
@@ -636,9 +637,10 @@ yet have any results in the cache.</para>
 before searching for the
 <emphasis>SConstruct</emphasis>,
 <emphasis>Sconstruct</emphasis>,
-<emphasis>sconstruct</emphasis>
-or
+<emphasis>sconstruct</emphasis>,
 <emphasis>SConstruct.py</emphasis>
+or
+<emphasis>sconstruct.py</emphasis>
 file, or doing anything
 else.  Multiple
 <option>-C</option>
@@ -651,9 +653,10 @@ equivalent to
 except that it will search for
 <emphasis>SConstruct</emphasis>,
 <emphasis>Sconstruct</emphasis>,
-<emphasis>sconstruct</emphasis>
-or
+<emphasis>sconstruct</emphasis>,
 <emphasis>SConstruct.py</emphasis>
+or
+<emphasis>sconstruct.py</emphasis>
 in the specified directory.)</para>
 
 <!--  .TP -->
@@ -1662,9 +1665,10 @@ scons --tree=all,prune,status target
 <para>Walks up the directory structure until an
 <emphasis>SConstruct ,</emphasis>
 <emphasis>Sconstruct ,</emphasis>
-<emphasis>sconstruct</emphasis>
-or
+<emphasis>sconstruct ,</emphasis>
 <emphasis>SConstruct.py</emphasis>
+or
+<emphasis>sconstruct.py</emphasis>
 file is found, and uses that
 as the top of the directory tree.
 If no targets are specified on the command line,

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -105,8 +105,9 @@ rebuild them.</para>
 searches for a file named
 <emphasis>SConstruct</emphasis>,
 <emphasis>Sconstruct</emphasis>,
-or
 <emphasis>sconstruct</emphasis>
+or
+<emphasis>SConstruct.py</emphasis>
 (in that order) in the current directory and reads its
 configuration from the first file found.
 An alternate file name may be
@@ -635,8 +636,9 @@ yet have any results in the cache.</para>
 before searching for the
 <emphasis>SConstruct</emphasis>,
 <emphasis>Sconstruct</emphasis>,
-or
 <emphasis>sconstruct</emphasis>
+or
+<emphasis>SConstruct.py</emphasis>
 file, or doing anything
 else.  Multiple
 <option>-C</option>
@@ -649,8 +651,9 @@ equivalent to
 except that it will search for
 <emphasis>SConstruct</emphasis>,
 <emphasis>Sconstruct</emphasis>,
-or
 <emphasis>sconstruct</emphasis>
+or
+<emphasis>SConstruct.py</emphasis>
 in the specified directory.)</para>
 
 <!--  .TP -->
@@ -1658,9 +1661,10 @@ scons --tree=all,prune,status target
   <listitem>
 <para>Walks up the directory structure until an
 <emphasis>SConstruct ,</emphasis>
-<emphasis>Sconstruct</emphasis>
-or
+<emphasis>Sconstruct ,</emphasis>
 <emphasis>sconstruct</emphasis>
+or
+<emphasis>SConstruct.py</emphasis>
 file is found, and uses that
 as the top of the directory tree.
 If no targets are specified on the command line,

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -137,6 +137,7 @@
 <!ENTITY SConstruct "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>SConstruct</filename>">
 <!ENTITY Sconstruct "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>Sconstruct</filename>">
 <!ENTITY sconstruct "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>sconstruct</filename>">
+<!ENTITY SConstruct.py "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>SConstruct.py</filename>">
 <!ENTITY sconsign "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>.sconsign</filename>">
 <!ENTITY src "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>src</filename>">
 

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -138,6 +138,7 @@
 <!ENTITY Sconstruct "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>Sconstruct</filename>">
 <!ENTITY sconstruct "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>sconstruct</filename>">
 <!ENTITY SConstruct.py "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>SConstruct.py</filename>">
+<!ENTITY Sconstruct.py "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>Sconstruct.py</filename>">
 <!ENTITY sconstruct.py "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>sconstruct.py</filename>">
 <!ENTITY sconsign "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>.sconsign</filename>">
 <!ENTITY src "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>src</filename>">

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -138,6 +138,7 @@
 <!ENTITY Sconstruct "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>Sconstruct</filename>">
 <!ENTITY sconstruct "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>sconstruct</filename>">
 <!ENTITY SConstruct.py "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>SConstruct.py</filename>">
+<!ENTITY sconstruct.py "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>sconstruct.py</filename>">
 <!ENTITY sconsign "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>.sconsign</filename>">
 <!ENTITY src "<filename xmlns='http://www.scons.org/dbxsd/v1.0'>src</filename>">
 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,7 +8,7 @@
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Richard West:
-    - Add SConstruct.py and sconstruct.py to the search path for the root SConstruct file.
+    - Add SConstruct.py, Sconstruct.py, sconstruct.py to the search path for the root SConstruct file.
       Allows easier debugging within Visual Studio
 
   From Bernard Blackham:

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,10 @@
 
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
+  From Richard West:
+    - Add SConstruct.py to the search path for the root SConstruct file.
+      Allows easier debugging within Visual Studio
+
   From Daniel Moody:
     - Set the pickling protocal back to highest which was causing issues 
       with variant dir tests. This will cause issues if reading sconsigns

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,7 +8,7 @@
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Richard West:
-    - Add SConstruct.py to the search path for the root SConstruct file.
+    - Add SConstruct.py and sconstruct.py to the search path for the root SConstruct file.
       Allows easier debugging within Visual Studio
 
   From Daniel Moody:

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -623,7 +623,7 @@ def _SConstruct_exists(dirname='', repositories=[], filelist=None):
     current directory.
     """
     if not filelist:
-        filelist = ['SConstruct', 'Sconstruct', 'sconstruct', 'SConstruct.py', 'sconstruct.py']
+        filelist = ['SConstruct', 'Sconstruct', 'sconstruct', 'SConstruct.py', 'Sconstruct.py', 'sconstruct.py']
     for file in filelist:
         sfile = os.path.join(dirname, file)
         if os.path.isfile(sfile):

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -623,7 +623,7 @@ def _SConstruct_exists(dirname='', repositories=[], filelist=None):
     current directory.
     """
     if not filelist:
-        filelist = ['SConstruct', 'Sconstruct', 'sconstruct', 'SConstruct.py']
+        filelist = ['SConstruct', 'Sconstruct', 'sconstruct', 'SConstruct.py', 'sconstruct.py']
     for file in filelist:
         sfile = os.path.join(dirname, file)
         if os.path.isfile(sfile):

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -623,7 +623,7 @@ def _SConstruct_exists(dirname='', repositories=[], filelist=None):
     current directory.
     """
     if not filelist:
-        filelist = ['SConstruct', 'Sconstruct', 'sconstruct']
+        filelist = ['SConstruct', 'Sconstruct', 'sconstruct', 'SConstruct.py']
     for file in filelist:
         sfile = os.path.join(dirname, file)
         if os.path.isfile(sfile):

--- a/test/SConstruct.py
+++ b/test/SConstruct.py
@@ -39,6 +39,15 @@ scons: \*\*\* No SConstruct file found.
 
 wpath = test.workpath()
 
+test.write('SConstruct.py', """
+import os
+print("SConstruct.py "+os.getcwd())
+""")
+
+test.run(arguments = ".",
+         stdout = test.wrap_stdout(read_str = 'SConstruct.py %s\n' % wpath,
+                                   build_str = "scons: `.' is up to date.\n"))
+
 test.write('sconstruct', """
 import os
 print("sconstruct "+os.getcwd())

--- a/test/SConstruct.py
+++ b/test/SConstruct.py
@@ -39,6 +39,15 @@ scons: \*\*\* No SConstruct file found.
 
 wpath = test.workpath()
 
+test.write('sconstruct.py', """
+import os
+print("sconstruct.py "+os.getcwd())
+""")
+
+test.run(arguments = ".",
+         stdout = test.wrap_stdout(read_str = 'sconstruct.py %s\n' % wpath,
+                                   build_str = "scons: `.' is up to date.\n"))
+
 test.write('SConstruct.py', """
 import os
 print("SConstruct.py "+os.getcwd())

--- a/test/SConstruct.py
+++ b/test/SConstruct.py
@@ -48,6 +48,15 @@ test.run(arguments = ".",
          stdout = test.wrap_stdout(read_str = 'sconstruct.py %s\n' % wpath,
                                    build_str = "scons: `.' is up to date.\n"))
 
+test.write('Sconstruct.py', """
+import os
+print("sconstruct.py "+os.getcwd())
+""")
+
+test.run(arguments = ".",
+         stdout = test.wrap_stdout(read_str = 'sconstruct.py %s\n' % wpath,
+                                   build_str = "scons: `.' is up to date.\n"))
+
 test.write('SConstruct.py', """
 import os
 print("SConstruct.py "+os.getcwd())


### PR DESCRIPTION
This is a small change to allow scons to pick up on SConstruct.py if SConstruct isn't found
in relation to https://github.com/SCons/scons/issues/3039

At the moment to get debugging to work within Visual Studio I have to create a dummy SConstruct file within the following in
```
exec(compile(open('SConstruct.py').read(), 'SConstruct.py', 'exec'))
```
Then have the real code located within SConstruct.py
This is because Visual Studio doesn't recognize the code within the file as python due to the lack of a file extension. This just makes life a little bit easier.
SConscript files within sub-directories are fine since you need to specify those with a file path within the script sitting above anyway.