### PR TITLE
Fix EnvironmentError printing bug

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -48,6 +48,11 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       Specifically, this fixes the test cases use by Configure.CheckCC() which
       would fail when using -Wstrict-prototypes.
 
+  From Fredrik Medley:
+    - Fix exception when printing of EnviromentError messages.
+      Specifically, this fixes error reporting of the race condition when
+      initializing the cache which error previously was hidden.
+
 
 RELEASE 3.0.1 - Mon, 12 Nov 2017 15:31:33 -0700
 

--- a/src/engine/SCons/Errors.py
+++ b/src/engine/SCons/Errors.py
@@ -190,14 +190,13 @@ def convert_to_BuildError(status, exc_info=None):
         # error, which might be different from the target being built
         # (for example, failure to create the directory in which the
         # target file will appear).
-        try:
-            filename = status.filename
-        except AttributeError:
-            filename = None
+        filename = getattr(status, 'filename', None)
+        strerror = getattr(status, 'strerror', str(status))
+        errno = getattr(status, 'errno', 2)
 
         buildError = BuildError(
-            errstr=status.strerror,
-            status=status.errno,
+            errstr=strerror,
+            status=errno,
             exitstatus=2,
             filename=filename,
             exc_info=exc_info)

--- a/src/engine/SCons/ErrorsTests.py
+++ b/src/engine/SCons/ErrorsTests.py
@@ -23,6 +23,8 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
+import errno
+import os
 import sys
 import unittest
 
@@ -99,6 +101,29 @@ class ErrorsTestCase(unittest.TestCase):
             raise SCons.Errors.ExplicitExit("node")
         except SCons.Errors.ExplicitExit as e:
             assert e.node == "node"
+
+    def test_convert_EnvironmentError_to_BuildError(self):
+        """Test the convert_to_BuildError function on EnvironmentError
+        exceptions.
+        """
+        ee = SCons.Errors.EnvironmentError("test env error")
+        be = SCons.Errors.convert_to_BuildError(ee)
+        assert be.errstr == "test env error"
+        assert be.status == 2
+        assert be.exitstatus == 2
+        assert be.filename is None
+
+    def test_convert_OSError_to_BuildError(self):
+        """Test the convert_to_BuildError function on OSError
+        exceptions.
+        """
+        ose = OSError(7, 'test oserror')
+        be = SCons.Errors.convert_to_BuildError(ose)
+        assert be.errstr == 'test oserror'
+        assert be.status == 7
+        assert be.exitstatus == 2
+        assert be.filename is None
+
 
 if __name__ == "__main__":
     suite = unittest.makeSuite(ErrorsTestCase, 'test_')


### PR DESCRIPTION
EnvironmentErrors does not need to have the attributes strerror or
errno. This commit makes the code robust for such situation.

One example of such EnvironmentError is CacheDir.py:
raise SCons.Errors.EnvironmentError(msg)

Signed-off-by: Fredrik Medley <fredrik.medley@autoliv.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation