### PR TITLE
Resolve issue where sconsigns were getting corrupted when using Timestamp-MD5 decider fixes #2980

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/**
-bootstrap/**
+/build/**
+/bootstrap/**
 .idea/
 src/build/**
 
@@ -27,8 +27,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-
-
 
 # mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ htmlcov
 *.bkp
 *.bak
 *~
+!/test/Decider/switch-rebuild.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ os:
   - linux
   - osx
 
+sudo: required
+
+
 install:
     - ./.travis/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ addons:
     apt:
       update: true
 
+os:
+  - linux
+  - osx
+
 install:
     - ./.travis/install.sh
 
@@ -15,7 +19,7 @@ install:
 matrix:
   allow_failures:
     - python: pypy
-
+    - os: osx
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ os:
 
 sudo: required
 
+osx_image: xcode9.4
+
 
 install:
     - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,8 @@ addons:
 
 os:
   - linux
-  - osx
 
 sudo: required
-
-osx_image: xcode9.4
-
 
 install:
     - ./.travis/install.sh
@@ -24,7 +20,6 @@ install:
 matrix:
   allow_failures:
     - python: pypy
-    - os: osx
 
 jobs:
   include:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,6 +3,7 @@ set -x
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     echo "OSX"
+    brew install python --framework --universal
 else
     # dependencies for clang tests
     sudo apt-get -y install clang

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,44 +1,49 @@
 #!/usr/bin/env bash
 set -x
 
-# setup clang for clang tests using local clang installation
-
-
-if [ ! -f /usr/local/clang-5.0.0/bin/clang ]; then
-    echo "No Clang 5.0.0 trying 7.0.0"
-    sudo ln -s /usr/local/clang-7.0.0/bin/clang /usr/bin/clang
-    sudo ln -s /usr/local/clang-7.0.0/bin/clang++ /usr/bin/clang++
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    echo "OSX"
 else
-    echo "Clang 5.0.0"
-    sudo ln -s /usr/local/clang-5.0.0/bin/clang /usr/bin/clang
-    sudo ln -s /usr/local/clang-5.0.0/bin/clang++ /usr/bin/clang++
-fi
+    # dependencies for clang tests
+    sudo apt-get -y install clang
 
-# dependencies for gdc tests
-sudo apt-get -y install gdc 
-# dependencies for docbook tests
-sudo apt-get -y install docbook-xml xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf
-# dependencies for latex tests
-sudo apt-get -y install texlive texlive-latex3 biber texmaker ghostscript
-# need some things for building dependencies for other tests
-sudo apt-get -y install python-pip python-dev build-essential libpcre3-dev autoconf automake libtool bison subversion git
-# dependencies for docbook tests continued
-sudo pip install lxml
-# dependencies for D tests
-sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
-wget -qO - https://dlang.org/d-keyring.gpg | sudo apt-key add -
-sudo apt-get update && sudo apt-get -y --allow-unauthenticated install dmd-bin 
-# dependencies for ldc tests
-wget https://github.com/ldc-developers/ldc/releases/download/v1.4.0/ldc2-1.4.0-linux-x86_64.tar.xz
-tar xf ldc2-1.4.0-linux-x86_64.tar.xz
-sudo cp -rf ldc2-1.4.0-linux-x86_64/* /
+    # setup clang for clang tests using local clang installation
+    if [ ! -f /usr/local/clang-5.0.0/bin/clang ]; then
+        echo "No Clang 5.0.0 trying 7.0.0"
+        sudo ln -s /usr/local/clang-7.0.0/bin/clang /usr/bin/clang
+        sudo ln -s /usr/local/clang-7.0.0/bin/clang++ /usr/bin/clang++
+    else
+        echo "Clang 5.0.0"
+        sudo ln -s /usr/local/clang-5.0.0/bin/clang /usr/bin/clang
+        sudo ln -s /usr/local/clang-5.0.0/bin/clang++ /usr/bin/clang++
+    fi
 
-ls -l /usr/lib/*python*{so,a}*
+    # dependencies for gdc tests
+    sudo apt-get -y install gdc
+    # dependencies for docbook tests
+    sudo apt-get -y install docbook-xml xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf
+    # dependencies for latex tests
+    sudo apt-get -y install texlive-full biber texmaker
+    # need some things for building dependencies for other tests
+    sudo apt-get -y install python-pip python-dev build-essential libpcre3-dev autoconf automake libtool bison subversion git
+    # dependencies for docbook tests continued
+    sudo pip install lxml
+    # dependencies for D tests
+    sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
+    wget -qO - https://dlang.org/d-keyring.gpg | sudo apt-key add -
+    sudo apt-get update && sudo apt-get -y --allow-unauthenticated install dmd-bin
+    # dependencies for ldc tests
+    wget https://github.com/ldc-developers/ldc/releases/download/v1.4.0/ldc2-1.4.0-linux-x86_64.tar.xz
+    tar xf ldc2-1.4.0-linux-x86_64.tar.xz
+    sudo cp -rf ldc2-1.4.0-linux-x86_64/* /
 
-# For now skip swig if py27
-if [[ "$PYVER" == 27 ]]; then
-    # dependencies for swig tests
-    wget https://github.com/swig/swig/archive/rel-3.0.12.tar.gz
-    tar xzf rel-3.0.12.tar.gz
-    cd swig-rel-3.0.12 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ..
+    ls -l /usr/lib/*python*{so,a}*
+
+    # For now skip swig if py27
+    if [[ "$PYVER" == 27 ]]; then
+        # dependencies for swig tests
+        wget https://github.com/swig/swig/archive/rel-3.0.12.tar.gz
+        tar xzf rel-3.0.12.tar.gz
+        cd swig-rel-3.0.12 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ..
+    fi
 fi

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -60,6 +60,11 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       William Blevins patch and the current code is that the more complicated creation of file to csig
       map is only done when the count of children for the current node doesn't match the previous count
       which is loaded from the sconsign.
+    - Fix issue #2980 with credit to Piotr Bartosik (and William Blevins).  This is an issue where using
+      TimeStamp-MD5 Decider and CacheDir can yield incorrect md5's being written into the .sconsign.  
+      The difference between Piotr Bartosik's patch and the current code is that the more complicated 
+      creation of file to csig map is only done when the count of children for the current node doesn't 
+      match the previous count which is loaded from the sconsign.
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -24,8 +24,6 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
   From William Deegan:
     - Remove long deprecated SCons.Options code and tests.  This removes BoolOption,EnumOption,
       ListOption,PackageOption, and PathOption which have been replaced by *Variable() many years ago.
-    - Fix issue # 3106 MSVC if using MSVC_BATCH and target dir had a space would fail due to quirk in
-      MSVC's handling of escaped targetdirs when batch compiling.
     - Re-Enable parallel SCons (-j) when running via Pypy
     - Move SCons test framework files to testing/framework and remove all references to QMtest.
       QMTest has not been used by SCons for some time now.
@@ -35,40 +33,28 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       - Default path for clang/clangxx : C:\Program Files\LLVM\bin
       - Default path for mingw         : C:\MinGW\bin and/or  C:\mingw-w64\*\mingw64\bin
       - Key program to locate mingw    : mingw32-make (as the gcc with mingw prefix has no fixed name)
-    - Fix GH Issue #3141 unicode string in a TryAction() with python 2.7 crashes.
     - Fixed issue causing stack trace when python Action function contains a unicode string when being
       run with Python 2.7
     - Add alternate path to QT install for Centos in qt tool: /usr/lib64/qt-3.3/bin
-    - Fix GH Issue #2580 - # in FRAMEWORKPATH doesn't get properly expanded. The # is left in the
-      command line.
-    - Fix GH Issue #3212 - Use of Py3 and CacheDir + Configure's TryCompile (or likely and Python Value Nodes)
-      yielded trying to combine strings and bytes which threw exception.
-    - Updated logic for mingw and clang on win32 to search default tool install paths if not
-      found in normal SCons PATH.  If the user specifies PATH or tool specific paths they
-      will be used and the default paths below will be ignored.
-      - Default path for clang/clangxx : C:\Program Files\LLVM\bin
-      - Default path for mingw         : c:\MinGW\bin
     - Fix Java tools to search reasonable default paths for Win32, Linux, macOS.  Add required paths
       for swig and java native interface to JAVAINCLUDES.  You should add these to your CPPPATH if you need
       to compile with them.  This handles spaces in paths in default Java paths on windows.
     - Added more java paths to match install for Centos 7 of openjdk
     - Fix new logic which populates JAVAINCLUDES to handle the case where javac is not found.
-    - Fix GH Issue #3225 SCons.Util.Flatten() doesn't handle MappingView's produced by dictionary as return
-      values from dict().{items(), keys(), values()}.
-    - Fix issue #2980 with credit to William Blevins.  This is an issue where using TimeStamp-MD5 Decider
-      and CacheDir can yield incorrect md5's being written into the .sconsign.  The difference between
-      William Blevins patch and the current code is that the more complicated creation of file to csig
-      map is only done when the count of children for the current node doesn't match the previous count
-      which is loaded from the sconsign.
+    - Fix GH Issue #2580 - # in FRAMEWORKPATH doesn't get properly expanded. The # is left in the
+      command line.
     - Fix issue #2980 with credit to Piotr Bartosik (and William Blevins).  This is an issue where using
       TimeStamp-MD5 Decider and CacheDir can yield incorrect md5's being written into the .sconsign.  
       The difference between Piotr Bartosik's patch and the current code is that the more complicated 
       creation of file to csig map is only done when the count of children for the current node doesn't 
       match the previous count which is loaded from the sconsign.
-    - Move SCons test framework files to testing/framework and remove all references to QMtest.
-      QMTest has not been used by SCons for some time now.
-    - Fixed issue causing stack trace when python Action function contains a unicode string when being
-      run with Python 2.7
+    - Fix issue # 3106 MSVC if using MSVC_BATCH and target dir had a space would fail due to quirk in
+      MSVC's handling of escaped targetdirs when batch compiling.
+    - Fix GH Issue #3141 unicode string in a TryAction() with python 2.7 crashes.
+    - Fix GH Issue #3212 - Use of Py3 and CacheDir + Configure's TryCompile (or likely and Python Value Nodes)
+      yielded trying to combine strings and bytes which threw exception.
+    - Fix GH Issue #3225 SCons.Util.Flatten() doesn't handle MappingView's produced by dictionary as return
+      values from dict().{items(), keys(), values()}.
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -56,7 +56,10 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fix GH Issue #3225 SCons.Util.Flatten() doesn't handle MappingView's produced by dictionary as return
       values from dict().{items(), keys(), values()}.
     - Fix issue #2980 with credit to William Blevins.  This is an issue where using TimeStamp-MD5 Decider
-      and CacheDir can yield incorrect md5's being written into the .sconsign.
+      and CacheDir can yield incorrect md5's being written into the .sconsign.  The difference between
+      William Blevins patch and the current code is that the more complicated creation of file to csig
+      map is only done when the count of children for the current node doesn't match the previous count
+      which is loaded from the sconsign.
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -65,6 +65,10 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       The difference between Piotr Bartosik's patch and the current code is that the more complicated 
       creation of file to csig map is only done when the count of children for the current node doesn't 
       match the previous count which is loaded from the sconsign.
+    - Move SCons test framework files to testing/framework and remove all references to QMtest.
+      QMTest has not been used by SCons for some time now.
+    - Fixed issue causing stack trace when python Action function contains a unicode string when being
+      run with Python 2.7
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -15,7 +15,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fix the PATH created by scons.bat (and other .bat files) to provide a normalized
       PATH.  Some pythons in the 3.6 series are no longer able to handle paths which
       have ".." in them and end up crashing.  This is done by cd'ing into the directory
-      we want to add to the path and then useing %CD% to give us the normalized directory
+      we want to add to the path and then using %CD% to give us the normalized directory
       See bug filed under Python 3.6: https://bugs.python.org/issue32457.
       Note: On Win32 PATH's which have not been normalized may cause undefined behavior
       by other executables being run by SCons (or any subprocesses of executables being run by SCons).
@@ -55,7 +55,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fix new logic which populates JAVAINCLUDES to handle the case where javac is not found.
     - Fix GH Issue #3225 SCons.Util.Flatten() doesn't handle MappingView's produced by dictionary as return
       values from dict().{items(), keys(), values()}.
-      
+    - Fix issue #2980 with credit to William Blevins.  This is an issue where using TimeStamp-MD5 Decider
+      and CacheDir can yield incorrect md5's being written into the .sconsign.
+
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.
 

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -2485,6 +2485,12 @@ class FileNodeInfo(SCons.Node.NodeInfoBase):
 
 
 class FileBuildInfo(SCons.Node.BuildInfoBase):
+    """
+    This is info loaded from sconsign.
+    We're adding dependency_map to cache file->csig mapping
+    for all dependencies.  Currently this is only used when using
+    MD5-timestamp decider. (It's needed because
+    """
     __slots__ = ('dependency_map')
     current_version_id = 2
 
@@ -3289,6 +3295,8 @@ class File(Base):
             for child, signature in zip(children, signatures):
                 schild = str(child)
                 m[schild] = signature
+
+
 
         # store this info so we can avoid regenerating it.
         binfo.dependency_map = m

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3253,11 +3253,24 @@ class File(Base):
         return self.state != SCons.Node.up_to_date
 
     def changed_timestamp_then_content(self, target, prev_ni):
+        """
+        Used when decider for file is Timestamp-MD5
+
+        NOTE: If the timestamp hasn't change this will skip md5'ing the
+              file and just copy the prev_ni provided.  If the prev_ni
+              is wrong. It will propogate it.
+              See: https://github.com/SCons/scons/issues/2980
+        
+        Args:
+            self - self
+            target -
+            prev_ni - The NodeInfo object loaded from previous builds .sconsign
+
+        Returns: 
+            Boolean - Indicates if node(File) has changed.
+        """
         if not self.changed_timestamp_match(target, prev_ni):
             try:
-                if str(self) == 'beta.h' and prev_ni.csig == '2ff783593a2224d0574181661ab5f1b7':
-                    print("in problem code")
-                print('Setting csig [%s]:%s'%(str(self),prev_ni.csig))
                 self.get_ninfo().csig = prev_ni.csig
             except AttributeError:
                 pass

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3263,8 +3263,8 @@ class File(Base):
               See: https://github.com/SCons/scons/issues/2980
         
         Args:
-            self - self
-            target -
+            self - dependency
+            target - target
             prev_ni - The NodeInfo object loaded from previous builds .sconsign
 
         Returns: 

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3326,9 +3326,12 @@ class File(Base):
         result = self
         if not self.exists():
             norm_name = _my_normcase(self.name)
-            for dir in self.dir.get_all_rdirs():
-                try: node = dir.entries[norm_name]
-                except KeyError: node = dir.file_on_disk(self.name)
+            for repo_dir in self.dir.get_all_rdirs():
+                try:
+                    node = repo_dir.entries[norm_name]
+                except KeyError:
+                    node = repo_dir.file_on_disk(self.name)
+
                 if node and node.exists() and \
                    (isinstance(node, File) or isinstance(node, Entry)
                     or not node.is_derived()):
@@ -3349,6 +3352,28 @@ class File(Base):
                         break
         self._memo['rfile'] = result
         return result
+
+    def find_repo_file(self):
+        """
+        For this node, find if there exists a corresponding file in one or more repositories
+        :return: list of corresponding files in repositories
+        """
+        retvals = []
+
+        norm_name = _my_normcase(self.name)
+        for repo_dir in self.dir.get_all_rdirs():
+            try:
+                node = repo_dir.entries[norm_name]
+            except KeyError:
+                node = repo_dir.file_on_disk(self.name)
+
+            if node and node.exists() and \
+                    (isinstance(node, File) or isinstance(node, Entry) \
+                     or not node.is_derived()):
+                retvals.append(node)
+
+        return retvals
+
 
     def rstr(self):
         return str(self.rfile())

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -2494,9 +2494,17 @@ class FileNodeInfo(SCons.Node.NodeInfoBase):
 class FileBuildInfo(SCons.Node.BuildInfoBase):
     """
     This is info loaded from sconsign.
-    We're adding dependency_map to cache file->csig mapping
-    for all dependencies.  Currently this is only used when using
-    MD5-timestamp decider. (It's needed because
+
+    Attributes unique to FileBuildInfo:
+        dependency_map : Caches file->csig mapping
+                    for all dependencies.  Currently this is only used when using
+                    MD5-timestamp decider.
+                    It's used to ensure that we copy the correct
+                    csig from previous build to be written to .sconsign when current build
+                    is done. Previously the matching of csig to file was strictly by order
+                    they appeared in bdepends, bsources, or bimplicit, and so a change in order
+                    or count of any of these could yield writing wrong csig, and then false positive
+                    rebuilds
     """
     __slots__ = ('dependency_map')
     current_version_id = 2

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -2485,7 +2485,7 @@ class FileNodeInfo(SCons.Node.NodeInfoBase):
 
 
 class FileBuildInfo(SCons.Node.BuildInfoBase):
-    __slots__ = ()
+    __slots__ = ('dependency_map')
     current_version_id = 2
 
     def convert_to_sconsign(self):
@@ -3261,6 +3261,9 @@ class File(Base):
         """
         Build mapping from file -> signature
 
+        This method also updates binfo.dependency_map to avoid rebuilding
+        the map for every dependency of the node we're workingon.
+
         Args:
             self - self
             binfo - buildinfo from node being considered
@@ -3286,6 +3289,9 @@ class File(Base):
             for child, signature in zip(children, signatures):
                 schild = str(child)
                 m[schild] = signature
+
+        # store this info so we can avoid regenerating it.
+        binfo.dependency_map = m
         return m
 
     def _get_previous_signatures(self, dmap):
@@ -3358,8 +3364,13 @@ class File(Base):
 
         # Now get sconsign name -> csig map and then get proper prev_ni if possible
         bi = node.get_stored_info().binfo
-        dmap = self._build_dependency_map(bi)
-        prev_ni = self._get_previous_signatures(dmap)
+        try:
+            dependency_map = bi.dependency_map
+        except AttributeError as e:
+            dependency_map = self._build_dependency_map(bi)
+
+
+        prev_ni = self._get_previous_signatures(dependency_map)
 
         if not self.changed_timestamp_match(target, prev_ni):
             try:

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -285,11 +285,13 @@ def set_duplicate(duplicate):
             Link_Funcs.append(link_dict[func])
 
 def LinkFunc(target, source, env):
-    # Relative paths cause problems with symbolic links, so
-    # we use absolute paths, which may be a problem for people
-    # who want to move their soft-linked src-trees around. Those
-    # people should use the 'hard-copy' mode, softlinks cannot be
-    # used for that; at least I have no idea how ...
+    """
+    Relative paths cause problems with symbolic links, so
+    we use absolute paths, which may be a problem for people
+    who want to move their soft-linked src-trees around. Those
+    people should use the 'hard-copy' mode, softlinks cannot be
+    used for that; at least I have no idea how ...
+    """
     src = source[0].get_abspath()
     dest = target[0].get_abspath()
     dir, file = os.path.split(dest)

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -56,6 +56,7 @@ import SCons.Util
 import SCons.Warnings
 
 from SCons.Debug import Trace
+from . import DeciderNeedsNode
 
 print_duplicate = 0
 
@@ -3255,7 +3256,87 @@ class File(Base):
     def changed_state(self, target, prev_ni):
         return self.state != SCons.Node.up_to_date
 
-    def changed_timestamp_then_content(self, target, prev_ni):
+
+    def _build_dependency_map(self, binfo):
+        """
+        Build mapping from file -> signature
+
+        Args:
+            self - self
+            binfo - buildinfo from node being considered
+
+        Returns:
+            dictionary of file->signature mappings
+        """
+
+        # For an "empty" binfo properties like bsources
+        # do not exist: check this to avoid exception.
+        if (len(binfo.bsourcesigs) + len(binfo.bdependsigs) + \
+                len(binfo.bimplicitsigs)) == 0:
+            return {}
+
+        pairs = [
+            (binfo.bsources, binfo.bsourcesigs),
+            (binfo.bdepends, binfo.bdependsigs),
+            (binfo.bimplicit, binfo.bimplicitsigs)
+           ]
+
+        m = {}
+        for children, signatures in pairs:
+            for child, signature in zip(children, signatures):
+                schild = str(child)
+                m[schild] = signature
+        return m
+
+    def _get_previous_signatures(self, dmap):
+        """
+        Return a list of corresponding csigs from previous
+        build in order of the node/files in children.
+
+        Args:
+            self - self
+            dmap - Dictionary of file -> csig
+            children - List of children
+
+        Returns:
+            List of csigs for provided list of children
+        """
+        prev = []
+
+
+
+        # First try the simple name for node
+        c_str = str(self)
+        if os.altsep:
+            c_str = c_str.replace(os.sep, os.altsep)
+        df = dmap.get(c_str)
+        if not df:
+            print("No Luck1:%s"%c_str)
+            try:
+                # this should yield a path which matches what's in the sconsign
+                c_str = self.get_path()
+                if os.altsep:
+                    c_str = c_str.replace(os.sep, os.altsep)
+
+                df = dmap.get(c_str)
+                if not df:
+                    print("No Luck:%s"%[str(s) for s in self.find_repo_file()])
+                    print("       :%s"%self.rfile())
+
+            except AttributeError as e:
+                import pdb;
+                pdb.set_trace()
+
+
+        if df:
+            return df
+        else:
+            print("CHANGE_DEBUG: file:%s PREV_BUILD_FILES:%s" % (c_str, ",".join(dmap.keys())))
+            pass
+
+        return None
+
+    def changed_timestamp_then_content(self, target, prev_ni, node=None):
         """
         Used when decider for file is Timestamp-MD5
 
@@ -3272,6 +3353,14 @@ class File(Base):
         Returns: 
             Boolean - Indicates if node(File) has changed.
         """
+        if node is None:
+            raise DeciderNeedsNode(self.changed_timestamp_then_content)
+
+        # Now get sconsign name -> csig map and then get proper prev_ni if possible
+        bi = node.get_stored_info().binfo
+        dmap = self._build_dependency_map(bi)
+        prev_ni = self._get_previous_signatures(dmap)
+
         if not self.changed_timestamp_match(target, prev_ni):
             try:
                 # NOTE: We're modifying the current node's csig in a query.
@@ -3315,7 +3404,9 @@ class File(Base):
                         # ...and they'd like a local copy.
                         e = LocalCopy(self, r, None)
                         if isinstance(e, SCons.Errors.BuildError):
-                            raise
+                            # Likely this should be re-raising exception e
+                            # (which would be BuildError)
+                            raise e
                         SCons.Node.store_info_map[self.store_info](self)
                     if T: Trace(' 1\n')
                     return 1

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -43,7 +43,7 @@ import stat
 import sys
 import time
 import codecs
-from itertools import izip, chain
+from itertools import chain
 
 import SCons.Action
 import SCons.Debug
@@ -3301,7 +3301,7 @@ class File(Base):
 
 
         # store this info so we can avoid regenerating it.
-        binfo.dependency_map = { str(child):signature for child, signature in izip(chain(binfo.bsources, binfo.bdepends, binfo.bimplicit),
+        binfo.dependency_map = { str(child):signature for child, signature in zip(chain(binfo.bsources, binfo.bdepends, binfo.bimplicit),
                                      chain(binfo.bsourcesigs, binfo.bdependsigs, binfo.bimplicitsigs))}
 
         return binfo.dependency_map

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -1065,21 +1065,22 @@ _classEntry = Entry
 
 
 class LocalFS(object):
+    """
+    This class implements an abstraction layer for operations involving
+    a local file system.  Essentially, this wraps any function in
+    the os, os.path or shutil modules that we use to actually go do
+    anything with or to the local file system.
 
-    # This class implements an abstraction layer for operations involving
-    # a local file system.  Essentially, this wraps any function in
-    # the os, os.path or shutil modules that we use to actually go do
-    # anything with or to the local file system.
-    #
-    # Note that there's a very good chance we'll refactor this part of
-    # the architecture in some way as we really implement the interface(s)
-    # for remote file system Nodes.  For example, the right architecture
-    # might be to have this be a subclass instead of a base class.
-    # Nevertheless, we're using this as a first step in that direction.
-    #
-    # We're not using chdir() yet because the calling subclass method
-    # needs to use os.chdir() directly to avoid recursion.  Will we
-    # really need this one?
+    Note that there's a very good chance we'll refactor this part of
+    the architecture in some way as we really implement the interface(s)
+    for remote file system Nodes.  For example, the right architecture
+    might be to have this be a subclass instead of a base class.
+    Nevertheless, we're using this as a first step in that direction.
+
+    We're not using chdir() yet because the calling subclass method
+    needs to use os.chdir() directly to avoid recursion.  Will we
+    really need this one?
+    """
     #def chdir(self, path):
     #    return os.chdir(path)
     def chmod(self, path, mode):
@@ -3258,7 +3259,7 @@ class File(Base):
 
         NOTE: If the timestamp hasn't changed this will skip md5'ing the
               file and just copy the prev_ni provided.  If the prev_ni
-              is wrong. It will propogate it.
+              is wrong. It will propagate it.
               See: https://github.com/SCons/scons/issues/2980
         
         Args:
@@ -3271,6 +3272,7 @@ class File(Base):
         """
         if not self.changed_timestamp_match(target, prev_ni):
             try:
+                # NOTE: We're modifying the current node's csig in a query.
                 self.get_ninfo().csig = prev_ni.csig
             except AttributeError:
                 pass
@@ -3284,6 +3286,12 @@ class File(Base):
             return 1
 
     def changed_timestamp_match(self, target, prev_ni):
+        """
+        Return True if the timestamps don't match or if there is no previous timestamp
+        :param target:
+        :param prev_ni: Information about the node from the previous build
+        :return:
+        """
         try:
             return self.get_timestamp() != prev_ni.timestamp
         except AttributeError:

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -690,10 +690,15 @@ class Base(SCons.Node.Node):
 
     @SCons.Memoize.CountMethodCall
     def stat(self):
-        try: return self._memo['stat']
-        except KeyError: pass
-        try: result = self.fs.stat(self.get_abspath())
-        except os.error: result = None
+        try: 
+            return self._memo['stat']
+        except KeyError: 
+            pass
+        try: 
+            result = self.fs.stat(self.get_abspath())
+        except os.error: 
+            result = None
+
         self._memo['stat'] = result
         return result
 
@@ -705,13 +710,17 @@ class Base(SCons.Node.Node):
 
     def getmtime(self):
         st = self.stat()
-        if st: return st[stat.ST_MTIME]
-        else: return None
+        if st: 
+            return st[stat.ST_MTIME]
+        else: 
+            return None
 
     def getsize(self):
         st = self.stat()
-        if st: return st[stat.ST_SIZE]
-        else: return None
+        if st: 
+            return st[stat.ST_SIZE]
+        else: 
+            return None
 
     def isdir(self):
         st = self.stat()
@@ -3246,6 +3255,9 @@ class File(Base):
     def changed_timestamp_then_content(self, target, prev_ni):
         if not self.changed_timestamp_match(target, prev_ni):
             try:
+                if str(self) == 'beta.h' and prev_ni.csig == '2ff783593a2224d0574181661ab5f1b7':
+                    print("in problem code")
+                print('Setting csig [%s]:%s'%(str(self),prev_ni.csig))
                 self.get_ninfo().csig = prev_ni.csig
             except AttributeError:
                 pass

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3256,7 +3256,7 @@ class File(Base):
         """
         Used when decider for file is Timestamp-MD5
 
-        NOTE: If the timestamp hasn't change this will skip md5'ing the
+        NOTE: If the timestamp hasn't changed this will skip md5'ing the
               file and just copy the prev_ni provided.  If the prev_ni
               is wrong. It will propogate it.
               See: https://github.com/SCons/scons/issues/2980

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -2464,7 +2464,7 @@ class FileTestCase(_tempdirTestCase):
     def test_changed(self):
         """ 
         Verify that changes between BuildInfo's list of souces, depends, and implicit 
-        dependencies do not corrupt content signiture values written to .SConsign
+        dependencies do not corrupt content signature values written to .SConsign
         when using CacheDir and Timestamp-MD5 decider.
         This is for issue #2980
         """

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -1134,7 +1134,10 @@ class FSTestCase(_tempdirTestCase):
             e1 = fs.Entry(p)
             e2 = fs.Entry(path)
             assert e1 is e2, (e1, e2)
-            assert str(e1) is str(e2), (str(e1), str(e2))
+            a=str(e1)
+            b=str(e2)
+            assert a == b, ("Strings should match for same file/node\n%s\n%s"%(a,b))
+
 
         # Test for a bug in 0.04 that did not like looking up
         # dirs with a trailing slash on Windows.

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -3752,38 +3752,7 @@ class AbsolutePathTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    suite.addTest(VariantDirTestCase())
-    suite.addTest(find_fileTestCase())
-    suite.addTest(StringDirTestCase())
-    suite.addTest(stored_infoTestCase())
-    suite.addTest(has_src_builderTestCase())
-    suite.addTest(prepareTestCase())
-    suite.addTest(SConstruct_dirTestCase())
-    suite.addTest(clearTestCase())
-    suite.addTest(disambiguateTestCase())
-    suite.addTest(postprocessTestCase())
-    suite.addTest(SpecialAttrTestCase())
-    suite.addTest(SaveStringsTestCase())
-    tclasses = [
-        AbsolutePathTestCase,
-        BaseTestCase,
-        CacheDirTestCase,
-        DirTestCase,
-        DirBuildInfoTestCase,
-        DirNodeInfoTestCase,
-        EntryTestCase,
-        FileTestCase,
-        FileBuildInfoTestCase,
-        FileNodeInfoTestCase,
-        FSTestCase,
-        GlobTestCase,
-        RepositoryTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -41,6 +41,7 @@ import SCons.Errors
 import SCons.Node.FS
 import SCons.Util
 import SCons.Warnings
+import SCons.Environment
 
 built_it = None
 
@@ -2460,6 +2461,142 @@ class FileTestCase(_tempdirTestCase):
         assert not build_f1.exists(), "%s did not realize that %s disappeared" % (build_f1, src_f1)
         assert not os.path.exists(build_f1.get_abspath()), "%s did not get removed after %s was removed" % (build_f1, src_f1)
 
+    def test_changed(self):
+        """ 
+        Verify that changes between BuildInfo's list of souces, depends, and implicit 
+        dependencies do not corrupt content signiture values written to .SConsign
+        when using CacheDir and Timestamp-MD5 decider.
+        This is for issue #2980
+        """
+        # node should have
+        # 1 source (for example main.cpp)
+        # 0 depends
+        # N implicits (for example ['alpha.h', 'beta.h', 'gamma.h', '/usr/bin/g++'])
+
+        class ChangedNode(SCons.Node.FS.File):
+            def __init__(self, name, directory=None, fs=None):
+                SCons.Node.FS.File.__init__(self, name, directory, fs)
+                self.name = name
+                self.Tag('found_includes', [])
+                self.stored_info = None
+                self.build_env = None
+                self.changed_since_last_build = 4
+                self.timestamp = 1
+
+            def get_stored_info(self):
+                return self.stored_info
+
+            def get_build_env(self):
+                return self.build_env
+
+            def get_timestamp(self):
+                """ Fake timestamp so they always match"""
+                return self.timestamp
+
+            def get_contents(self):
+                return self.name
+
+            def get_ninfo(self):
+                """ mocked to ensure csig will equal the filename"""
+                try:
+                    return self.ninfo
+                except AttributeError:
+                    self.ninfo = FakeNodeInfo(self.name, self.timestamp)
+                    return self.ninfo
+
+            def get_csig(self):
+                ninfo = self.get_ninfo()
+                try:
+                    return ninfo.csig
+                except AttributeError:
+                    pass
+
+                return "Should Never Happen"
+
+        class ChangedEnvironment(SCons.Environment.Base):
+
+            def __init__(self):
+                SCons.Environment.Base.__init__(self)
+                self.decide_source = self._changed_timestamp_then_content
+
+        class FakeNodeInfo(object):
+            def __init__(self, csig, timestamp):
+                self.csig = csig
+                self.timestamp = timestamp
+
+
+        #Create nodes
+        fs = SCons.Node.FS.FS()
+        d = self.fs.Dir('.')
+
+        node = ChangedNode('main.o',d,fs)  # main.o
+        s1 = ChangedNode('main.cpp',d,fs) # main.cpp
+        s1.timestamp = 2 # this changed
+        i1 = ChangedNode('alpha.h',d,fs) # alpha.h - The bug is caused because the second build adds this file
+        i1.timestamp = 2 # This is the new file.
+        i2 = ChangedNode('beta.h',d,fs) # beta.h
+        i3 = ChangedNode('gamma.h',d,fs) # gamma.h - In the bug beta.h's csig from binfo overwrites this ones
+        i4 = ChangedNode('/usr/bin/g++',d,fs) # /usr/bin/g++
+
+
+
+        node.add_source([s1])
+        node.add_dependency([])
+        node.implicit = [i1, i2, i3, i4]
+        node.implicit_set = set()
+        # node._add_child(node.implicit, node.implicit_set, [n7, n8, n9])
+        # node._add_child(node.implicit, node.implicit_set, [n10, n11, n12])
+
+        # Mock out node's scan method
+        # node.scan = lambda *args: None
+
+        # Mock out nodes' children() ?
+        # Should return Node's.
+        # All those nodes should have changed_since_last_build set to match Timestamp-MD5's
+        # decider method...
+
+        # Generate sconsign entry needed
+        sconsign_entry = SCons.SConsign.SConsignEntry()
+        sconsign_entry.binfo = node.new_binfo()
+        sconsign_entry.ninfo = node.new_ninfo()
+
+        # mock out loading info from sconsign
+        # This will cause node.get_stored_info() to return our freshly created sconsign_entry
+        node.stored_info = sconsign_entry
+
+        # binfo = information from previous build (from sconsign)
+        # We'll set the following attributes (which are lists): "bsources", "bsourcesigs",
+        # "bdepends","bdependsigs", "bimplicit", "bimplicitsigs"
+        bi = sconsign_entry.binfo
+        bi.bsources = ['main.cpp']
+        bi.bsourcesigs=[FakeNodeInfo('main.cpp',1),]
+
+        bi.bdepends = []
+        bi.bdependsigs = []
+
+        bi.bimplicit = ['beta.h','gamma.h']
+        bi.bimplicitsigs = [FakeNodeInfo('beta.h',1), FakeNodeInfo('gamma.h',1)]
+
+        ni = sconsign_entry.ninfo
+        # We'll set the following attributes (which are lists): sources, depends, implicit lists
+
+        #Set timestamp-md5
+        #Call changed
+        #Check results
+        node.build_env = ChangedEnvironment()
+
+        changed = node.changed()
+
+        # change to true to debug
+        if False:
+            print("Changed:%s"%changed)
+            print("%15s -> csig:%s"%(s1.name, s1.ninfo.csig))
+            print("%15s -> csig:%s"%(i1.name, i1.ninfo.csig))
+            print("%15s -> csig:%s"%(i2.name, i2.ninfo.csig))
+            print("%15s -> csig:%s"%(i3.name, i3.ninfo.csig))
+            print("%15s -> csig:%s"%(i4.name, i4.ninfo.csig))
+
+        self.assertEqual(i2.name,i2.ninfo.csig, "gamma.h's fake csig should equal gamma.h but equals:%s"%i2.ninfo.csig)
 
 
 class GlobTestCase(_tempdirTestCase):

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -2524,7 +2524,6 @@ class FileTestCase(_tempdirTestCase):
                 self.csig = csig
                 self.timestamp = timestamp
 
-
         #Create nodes
         fs = SCons.Node.FS.FS()
         d = self.fs.Dir('.')
@@ -2537,8 +2536,6 @@ class FileTestCase(_tempdirTestCase):
         i2 = ChangedNode('beta.h',d,fs) # beta.h
         i3 = ChangedNode('gamma.h',d,fs) # gamma.h - In the bug beta.h's csig from binfo overwrites this ones
         i4 = ChangedNode('/usr/bin/g++',d,fs) # /usr/bin/g++
-
-
 
         node.add_source([s1])
         node.add_dependency([])

--- a/src/engine/SCons/Node/NodeTests.py
+++ b/src/engine/SCons/Node/NodeTests.py
@@ -1349,6 +1349,7 @@ class NodeListTestCase(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
+
 # Local Variables:
 # tab-width:4
 # indent-tabs-mode:nil

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -45,6 +45,7 @@ from __future__ import print_function
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
+import os
 import collections
 import copy
 from itertools import chain
@@ -381,6 +382,7 @@ class NodeInfoBase(object):
         """
         state = other.__getstate__()
         self.__setstate__(state)
+
     def format(self, field_list=None, names=0):
         if field_list is None:
             try:
@@ -1214,7 +1216,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         return _exists_map[self._func_exists](self)
 
     def rexists(self):
-        """Does this node exist locally or in a repositiory?"""
+        """Does this node exist locally or in a repository?"""
         # There are no repositories by default:
         return _rexists_map[self._func_rexists](self)
 
@@ -1464,6 +1466,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
                     c_str = c_str.replace(os.sep, os.altsep)
                 df = dmap.get(c_str)
                 if not df:
+                    print("No Luck1:%s"%c_str)
                     try:
                         # this should yield a path which matches what's in the sconsign
                         c_str = c.get_path()
@@ -1471,6 +1474,10 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
                             c_str = c_str.replace(os.sep, os.altsep)
 
                         df = dmap.get(c_str)
+                        if not df:
+                            print("No Luck:%s"%[str(s) for s in c.find_repo_file()])
+                            print("       :%s"%c.rfile())
+
                     except AttributeError as e:
                         import pdb;
                         pdb.set_trace()
@@ -1482,9 +1489,13 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             if df:
                 prev.append(df)
                 continue
+            else:
+                print("CHANGE_DEBUG: file:%s PREV_BUILD_FILES:%s" % (c_str, ",".join(dmap.keys())))
 
             prev.append(None)
             continue
+
+            c.find_repo_file()
 
             # TODO: This may not be necessary at all..
             # try:
@@ -1550,9 +1561,12 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         result = False
 
         children = self.children()
-
         bi = node.get_stored_info().binfo
-        # previous_children = bi.bsourcesigs + bi.bdependsigs + bi.bimplicitsigs
+
+        # then_names = bi.bsources + bi.bdepends + bi.bimplicit
+        # print("CHANGED : %s"%[str(s) for s in then_names])
+        # print("CHILDREN: %s"%[str(s) for s in children])
+
         previous_map_by_file_name = self._build_dependency_map(bi)
 
         # Now build new then based on map built above.

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1458,8 +1458,6 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             prev.append(dmap.get(c))
         return prev
 
-
-
     def changed(self, node=None, allowcache=False):
         """
         Returns if the node is up-to-date with respect to the BuildInfo
@@ -1492,7 +1490,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
 
         bi = node.get_stored_info().binfo
         previous_children = bi.bsourcesigs + bi.bdependsigs + bi.bimplicitsigs
-        # TODO: Can we move this into the if diff below?
+
         children = self.children()
 
         diff = len(children) - len(previous_children)
@@ -1515,6 +1513,8 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             
             result = True
 
+        # TODO: There are still possible errors due to timestamp-MD5 + cachedir + changed implicit or regular dependencies (but the same # of such as the previous build).
+
 
         for child, prev_ni in zip(children, previous_children):
             if _decider_map[child.changed_since_last_build](child, self, prev_ni):
@@ -1524,7 +1524,6 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         if self.has_builder():
             contents = self.get_executor().get_contents()
 
-            import SCons.Util
             newsig = SCons.Util.MD5signature(contents)
             if bi.bactsig != newsig:
                 if t: Trace(': bactsig %s != newsig %s' % (bi.bactsig, newsig))

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1491,11 +1491,11 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         result = False
 
         bi = node.get_stored_info().binfo
-        then = bi.bsourcesigs + bi.bdependsigs + bi.bimplicitsigs
+        previous_children = bi.bsourcesigs + bi.bdependsigs + bi.bimplicitsigs
         # TODO: Can we move this into the if diff below?
         children = self.children()
 
-        diff = len(children) - len(then)
+        diff = len(children) - len(previous_children)
         if diff:
             # The old and new dependency lists are different lengths.
             # This always indicates that the Node must be rebuilt.
@@ -1505,16 +1505,18 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             # # entries to equal the new dependency list, for the benefit
             # # of the loop below that updates node information.
             # then.extend([None] * diff)
-            # if t: Trace(': old %s new %s' % (len(then), len(children)))
+            
+            if t: Trace(': old %s new %s' % (len(previous_children), len(children)))
+            
             dmap = self._build_dependency_map(bi)
 
             # Now build new then based on map built above.
-            then = self._get_previous_signatures(dmap, children)
+            previous_children = self._get_previous_signatures(dmap, children)
             
             result = True
 
 
-        for child, prev_ni in zip(children, then):
+        for child, prev_ni in zip(children, previous_children):
             if _decider_map[child.changed_since_last_build](child, self, prev_ni):
                 if t: Trace(': %s changed' % child)
                 result = True

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1491,13 +1491,11 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         result = False
 
         bi = node.get_stored_info().binfo
-        # then = bi.bsourcesigs + bi.bdependsigs + bi.bimplicitsigs
+        then = bi.bsourcesigs + bi.bdependsigs + bi.bimplicitsigs
         # TODO: Can we move this into the if diff below?
-        dmap = self._build_dependency_map(bi)
         children = self.children()
 
-        # diff = len(children) - len(then)
-        diff = len(children) - len(dmap)
+        diff = len(children) - len(then)
         if diff:
             # The old and new dependency lists are different lengths.
             # This always indicates that the Node must be rebuilt.
@@ -1508,11 +1506,13 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             # # of the loop below that updates node information.
             # then.extend([None] * diff)
             # if t: Trace(': old %s new %s' % (len(then), len(children)))
+            dmap = self._build_dependency_map(bi)
 
+            # Now build new then based on map built above.
+            then = self._get_previous_signatures(dmap, children)
+            
             result = True
 
-        # Now build new then based on map built above.
-        then = self._get_previous_signatures(dmap, children)
 
         for child, prev_ni in zip(children, then):
             if _decider_map[child.changed_since_last_build](child, self, prev_ni):

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1485,9 +1485,9 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
                     if t: Trace(': %s changed' % child)
                     result = True
 
-        contents = self.get_executor().get_contents()
         if self.has_builder():
             import SCons.Util
+            contents = self.get_executor().get_contents()
             newsig = SCons.Util.MD5signature(contents)
             if bi.bactsig != newsig:
                 if t: Trace(': bactsig %s != newsig %s' % (bi.bactsig, newsig))

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1169,13 +1169,17 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         binfo.bsources = [s for s in sources if s not in seen and not seen.add(s)]
         binfo.bsourcesigs = [s.get_ninfo() for s in binfo.bsources]
 
-
         binfo.bdepends = [d for d in self.depends if d not in ignore_set]
         binfo.bdependsigs = [d.get_ninfo() for d in self.depends]
 
-        binfo.bimplicit = [i for i in self.implicit or [] if i not in ignore_set]
-        binfo.bimplicitsigs = [i.get_ninfo() for i in binfo.bimplicit]
-
+        # Because self.implicit is initialized to None (and not empty list [])
+        # we have to handle this case
+        if not self.implicit:
+            binfo.bimplicit = []
+            binfo.bimplicitsigs = []
+        else:
+            binfo.bimplicit = [i for i in self.implicit if i not in ignore_set]
+            binfo.bimplicitsigs = [i.get_ninfo() for i in binfo.bimplicit]
 
         return binfo
 

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1636,7 +1636,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         # so we only print them after running them through this lambda
         # to turn them into the right relative Node and then return
         # its string.
-        def stringify( s, E=self.dir.Entry ) :
+        def stringify( s, E=self.dir.Entry):
             if hasattr( s, 'dir' ) :
                 return str(E(s))
             return str(s)

--- a/src/engine/SCons/Tool/docbook/__init__.py
+++ b/src/engine/SCons/Tool/docbook/__init__.py
@@ -166,6 +166,8 @@ xsltproc_com_priority = ['xsltproc', 'saxon', 'saxon-xslt', 'xalan']
 #       see: http://saxon.sourceforge.net/
 xsltproc_com = {'xsltproc' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE',
                 'saxon' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE $DOCBOOK_XSLTPROCPARAMS',
+                # Note if saxon-xslt is version 5.5 the proper arguments are: (swap order of docbook_xsl and source)
+                #  'saxon-xslt' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $SOURCE $DOCBOOK_XSL  $DOCBOOK_XSLTPROCPARAMS',
                 'saxon-xslt' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE $DOCBOOK_XSLTPROCPARAMS',
                 'xalan' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -q -out $TARGET -xsl $DOCBOOK_XSL -in $SOURCE'}
 xmllint_com = {'xmllint' : '$DOCBOOK_XMLLINT $DOCBOOK_XMLLINTFLAGS --xinclude $SOURCE > $TARGET'}

--- a/src/engine/SCons/dblite.py
+++ b/src/engine/SCons/dblite.py
@@ -75,7 +75,8 @@ class dblite(object):
 
     def __init__(self, file_base_name, flag, mode):
         assert flag in (None, "r", "w", "c", "n")
-        if (flag is None): flag = "r"
+        if flag is None:
+            flag = "r"
 
         base, ext = os.path.splitext(file_base_name)
         if ext == dblite_suffix:
@@ -106,13 +107,13 @@ class dblite(object):
             self._chown_to = -1  # don't chown
             self._chgrp_to = -1  # don't chgrp
 
-        if (self._flag == "n"):
+        if self._flag == "n":
             self._open(self._file_name, "wb", self._mode)
         else:
             try:
                 f = self._open(self._file_name, "rb")
             except IOError as e:
-                if (self._flag != "c"):
+                if self._flag != "c":
                     raise e
                 self._open(self._file_name, "wb", self._mode)
             else:
@@ -132,7 +133,7 @@ class dblite(object):
                             corruption_warning(self._file_name)
 
     def close(self):
-        if (self._needs_sync):
+        if self._needs_sync:
             self.sync()
 
     def __del__(self):

--- a/test/Decider/MD5-timestamp-Repository.py
+++ b/test/Decider/MD5-timestamp-Repository.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify behavior of the MD5-timestamp Decider() setting when combined with Repository() usage
+"""
+
+import os
+import stat
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.subdir('Repository', 'work')
+repository = test.workpath('Repository')
+
+
+test.write(['Repository','content1.in'], "content1.in 1\n")
+test.write(['Repository','content2.in'], "content2.in 1\n")
+test.write(['Repository','content3.in'], "content3.in 1\n")
+# test.writable('Repository', 0)
+
+
+test.write(['work','SConstruct'], """\
+Repository(r'%s')
+DefaultEnvironment(tools=[])
+m = Environment(tools=[])
+m.Decider('MD5-timestamp')
+m.Command('content1.out', 'content1.in', Copy('$TARGET', '$SOURCE'))
+m.Command('content2.out', 'content2.in', Copy('$TARGET', '$SOURCE'))
+m.Command('content3.out', 'content3.in', Copy('$TARGET', '$SOURCE'))
+"""%repository)
+
+test.run(chdir='work',arguments='.')
+
+test.up_to_date(chdir='work',arguments='.')
+
+test.sleep()
+
+test.write(['Repository','content1.in'], "content1.in 2\n")
+
+test.touch(['Repository','content2.in'])
+
+time_content = os.stat(os.path.join(repository,'content3.in'))[stat.ST_MTIME]
+test.write(['Repository','content3.in'], "content3.in 2\n")
+test.touch(['Repository','content3.in'], time_content)
+
+# We should only see content1.out rebuilt.  The timestamp of content2.in
+# has changed, but its content hasn't, so the follow-on content check says
+# to not rebuild it.  The content of content3.in has changed, but that's
+# masked by the fact that its timestamp is the same as the last run.
+
+expect = test.wrap_stdout("""\
+Copy("content1.out", "%s")
+"""%os.path.join(repository,'content1.in'))
+
+test.run(chdir='work', arguments='.', stdout=expect)
+
+test.up_to_date(chdir='work', arguments='.')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
This is a fix for the case when using Timestamp-MD5 decider + cachedir where the wrong md5 can be written out to the .sconsign file due to the way build info loaded from previous run's .sconsign contains a different number (generally less)  of sources + dependencies + implicit dependencies.  The previous code was blindly appending Nones into the list which gets propagated.  See issue #2980  for more details.

The function: File().changed_timestamp_then_content() will overwrite the existing node info's csig with the csig read from the .sconsign. 
This is meant to ensure that the md5 is still in the written sconsign when the file is invalidated due to timestamp mismatch.
However this bug and possible some other cases yield the wrong BuildInfo to NodeInfo mapping and can cause the written .sconsign to contain another files csig. Yielding unnecessary rebuilds and negating possible file retrievals from the cachedir.

This bugfix only fixes the case when the count of sources+depends+implicit dependencies  changed between the previous build and the current build.


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation - None