### PR TITLE
Fix for issue #3013 (and duplicate 3018). Side effects cause internal error with variant_dir

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,9 @@
 
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
+  From Bernard Blackham:
+   - Fixed handling of side-effects in task master (fixes #3013).
+
   From Daniel Moody:
     - Set the pickling protocal back to highest which was causing issues 
       with variant dir tests. This will cause issues if reading sconsigns

--- a/src/engine/SCons/Taskmaster.py
+++ b/src/engine/SCons/Taskmaster.py
@@ -470,14 +470,23 @@ class Task(object):
                 pending_children.discard(t)
             for p in t.waiting_parents:
                 parents[p] = parents.get(p, 0) + 1
+            t.waiting_parents = set()
 
         for t in targets:
             if t.side_effects is not None:
                 for s in t.side_effects:
                     if s.get_state() == NODE_EXECUTING:
                         s.set_state(NODE_NO_STATE)
+                        
+                    # The side-effects may have been transferred to
+                    # NODE_NO_STATE by executed_with{,out}_callbacks, but was
+                    # not taken out of the waiting parents/pending children
+                    # data structures. Check for that now.
+                    if s.get_state() == NODE_NO_STATE and s.waiting_parents:
+                        pending_children.discard(s)
                         for p in s.waiting_parents:
                             parents[p] = parents.get(p, 0) + 1
+                        s.waiting_parents = set()
                     for p in s.waiting_s_e:
                         if p.ref_count == 0:
                             self.tm.candidates.append(p)

--- a/test/SideEffect/Issues/3013/files/SConscript
+++ b/test/SideEffect/Issues/3013/files/SConscript
@@ -1,0 +1,5 @@
+Import('env')
+
+primary = env.make_file('output', 'test.cpp')
+this_causes_problems = env.SideEffect('output_side_effect', 'output')
+

--- a/test/SideEffect/Issues/3013/files/SConstruct
+++ b/test/SideEffect/Issues/3013/files/SConstruct
@@ -1,0 +1,21 @@
+env = Environment()
+
+def make_file(target, source, env):
+    with open(str(target[0]), 'w') as f:
+        f.write('gobldygook')
+    with open(str(target[0]) + '_side_effect', 'w') as side_effect:
+        side_effect.write('anything')
+
+env.Append(
+    BUILDERS={'make_file': Builder(action=Action(make_file))}
+)
+
+env.objdir = 'build'
+
+SConscript(
+    'SConscript',
+    variant_dir=env.objdir,
+    exports={'env':env},
+    duplicate=0
+)
+

--- a/test/SideEffect/Issues/3013/files/test.cpp
+++ b/test/SideEffect/Issues/3013/files/test.cpp
@@ -1,0 +1,2 @@
+void some_function() {}
+

--- a/test/SideEffect/Issues/3013/sideffect_with_variantdir.py
+++ b/test/SideEffect/Issues/3013/sideffect_with_variantdir.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Test materials for Github Issue 3013 submitted by Stefan Ross:
+https://github.com/SCons/scons/issues/3013
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.dir_fixture('files')
+
+test.run(
+    arguments = '-j2'
+)
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:
+


### PR DESCRIPTION
From bitbucket PR: https://bitbucket.org/scons/scons/pull-requests/303

Fixes #3013 
Fixes #3018 

Mixing SideEffects, VariantDir and parallel build could lead to stack trace due to uncleared waiting parents on sideeffect nodes.

Original patch by @bblackham

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation - None