### PR TITLE
Module used an undefined class name

### DIFF
--- a/src/engine/SCons/Tool/MSCommon/arch.py
+++ b/src/engine/SCons/Tool/MSCommon/arch.py
@@ -37,22 +37,22 @@ class ArchDefinition(object):
         self.synonyms = synonyms
 
 SupportedArchitectureList = [
-    ArchitectureDefinition(
+    ArchDefinition(
         'x86',
         ['i386', 'i486', 'i586', 'i686'],
     ),
 
-    ArchitectureDefinition(
+    ArchDefinition(
         'x86_64',
         ['AMD64', 'amd64', 'em64t', 'EM64T', 'x86_64'],
     ),
 
-    ArchitectureDefinition(
+    ArchDefinition(
         'ia64',
         ['IA64'],
     ),
     
-    ArchitectureDefinition(
+    ArchDefinition(
         'arm',
         ['ARM'],
     ),


### PR DESCRIPTION
ArchDefinition is defined, then ArchitectureDefinition is used.
It is not clear this is actually used (the problem was flagged
by Sphinx, which was walking through every file), but let's not
leave it broken.

Signed-off-by: Mats Wichmann <mats@linux.com>
