### PR TITLE
Hashable literal

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,10 @@
 
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
+  From Philipp Maierhöfer
+    - Added a __hash__ method to the class Scons.Subst.Literal. Required when substituting Literal
+      objects when SCons runs with Python 3.
+
   From Richard West:
     - Add SConstruct.py, Sconstruct.py, sconstruct.py to the search path for the root SConstruct file.
       Allows easier debugging within Visual Studio

--- a/src/engine/SCons/Subst.py
+++ b/src/engine/SCons/Subst.py
@@ -86,6 +86,9 @@ class Literal(object):
     def __neq__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash(self.lstr)
+
 class SpecialAttrWrapper(object):
     """This is a wrapper for what we call a 'Node special attribute.'
     This is any of the attributes of a Node that we can reference from

--- a/test/Subst/Literal.py
+++ b/test/Subst/Literal.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify that Literal objects expand correctly in ${_concat()}.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write('SConstruct', """\
+env = Environment(PRE='pre=', MID=Literal('\$$ORIGIN'), SUF='')
+print(env.subst('${_concat(PRE, MID, SUF, __env__)}'))
+""")
+
+test.run()
+
+expect = """\
+pre=\$ORIGIN
+"""
+
+test.run(arguments='-Q -q', stdout=expect)
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Subst/Literal.py
+++ b/test/Subst/Literal.py
@@ -45,6 +45,8 @@ pre=\$ORIGIN
 
 test.run(arguments='-Q -q', stdout=expect)
 
+test.pass_test()
+
 # Local Variables:
 # tab-width:4
 # indent-tabs-mode:nil


### PR DESCRIPTION
Make class SCons.Subst.Literal hashable.

When using Python 3, substitution of Literal objects requires the objects to be hashable, otherwise an error will be thrown. The returned hash value is that of the lstr member.

This is not a feature update so I didn't write a test case and there is no need for updated documentation/readme imo.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation