### PR TITLE
Allow Command to take more builder options

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -5,6 +5,9 @@
                             Change Log
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
+  From Jason Kenny
+    - Update Command() function to accept target_scanner, source_factory, and target_factory arguments.
+      This make Command act more like a one-off builder.
 
   From Philipp Maierhöfer:
     - Avoid crash with UnicodeDecodeError on Python 3 when a Latex log file in

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -1984,9 +1984,22 @@ class Base(SubstitutionEnvironment):
             'target_factory' : self.fs.Entry,
             'source_factory' : self.fs.Entry,
         }
+        # source scanner
         try: bkw['source_scanner'] = kw['source_scanner']
         except KeyError: pass
         else: del kw['source_scanner']
+        #target scanner
+        try: bkw['target_scanner'] = kw['target_scanner']
+        except KeyError: pass
+        else: del kw['target_scanner']
+        #source factory
+        try: bkw['source_factory'] = kw['source_factory']
+        except KeyError: pass
+        else: del kw['source_factory']
+        #target factory
+        try: bkw['target_factory'] = kw['target_factory']
+        except KeyError: pass
+        else: del kw['target_factory']
         bld = SCons.Builder.Builder(**bkw)
         return bld(self, target, source, **kw)
 

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -937,19 +937,29 @@ for a single special-case build.
 </para>
 
 <para>
-As a special case, the
-<varname>source_scanner</varname>
-keyword argument can
+&b-Command; builder accepts
+<varname>source_scanner</varname>,
+<varname>target_scanner</varname>,
+<varname>source_factory</varname>, and
+<varname>target_factory</varname>
+keyword arguments. The *_scanner args can
 be used to specify
 a Scanner object
-that will be used to scan the sources.
-(The global
+that will be used to apply a custom
+scanner for a source or target.
+For example, the global
 <literal>DirScanner</literal>
 object can be used
 if any of the sources will be directories
 that must be scanned on-disk for
 changes to files that aren't
-already specified in other Builder of function calls.)
+already specified in other Builder of function calls.
+The *_factory args take a factory function that the
+Command will use to turn any sources or targets
+specified as strings into SCons Nodes.
+See the sections "Builder Objects"
+below, for more information about how these
+args work in a Builder.
 </para>
 
 <para>

--- a/test/Command.py
+++ b/test/Command.py
@@ -21,7 +21,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
@@ -43,6 +42,7 @@ test.write('build.py', build_py)
 test.write(['expand_chdir_sub', 'subbuild.py'], build_py)
 
 test.write('SConstruct', """
+from __future__ import print_function
 import os
 import sys
 


### PR DESCRIPTION
This adds the ability for Command to act more like a one-off builder. This is useful for cases in which other build systems, and allowing Scons to scanners to correctly understand the output for better implicit depends on handling

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation