### PR TITLE
udpated travis file to update apt-get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: trusty
 language: python
 
+addons:
+    apt:
+      update: true
+
 install:
     - ./.travis/install.sh
 


### PR DESCRIPTION
Fix for https://github.com/SCons/scons/issues/3130.

Should fix clang not getting installed in travis.