### PR TITLE
Added missing FORTRANMODDIRPREFIX to the gfortran tool.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -10,6 +10,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
   From Philipp Maierhöfer
     - Added a __hash__ method to the class Scons.Subst.Literal. Required when substituting Literal
       objects when SCons runs with Python 3.
+    - Added missing FORTRANMODDIRPREFIX to the gfortran tool.
 
   From Richard West:
     - Add SConstruct.py, Sconstruct.py, sconstruct.py to the search path for the root SConstruct file.

--- a/test/Fortran/gfortran.py
+++ b/test/Fortran/gfortran.py
@@ -26,7 +26,8 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the gfortran tool compiles a .f90 file to an executable,
-placing module files in the directory specified by FORTRANMODDIR.
+one time with and one time without placing module files in a subdirectory
+specified by FORTRANMODDIR.
 """
 
 import TestSCons
@@ -41,7 +42,7 @@ if not gfortran:
     test.skip_test("Could not find gfortran tool, skipping test.\n")
 
 test.write('SConstruct', """
-env = Environment(tools=['gfortran','link'], F90PATH='modules', FORTRANMODDIR='modules')
+env = Environment(tools=['gfortran','link'])
 env.Program('test1', 'test1.f90')
 """)
 
@@ -64,7 +65,36 @@ end program main
 test.run(arguments = '.')
 
 test.must_exist('test1' + _exe)
-test.must_exist(['modules', 'test1mod.mod'])
+test.must_exist('test1mod.mod')
+
+test.up_to_date(arguments = '.')
+
+
+test.write('SConstruct', """
+env = Environment(tools=['gfortran','link'], F90PATH='modules', FORTRANMODDIR='modules')
+env.Program('test2', 'test2.f90')
+""")
+
+test.write('test2.f90', """\
+module test2mod
+  implicit none
+  contains
+  subroutine hello
+    implicit none
+    print *, "hello"
+  end subroutine hello
+end module test2mod
+program main
+  use test2mod
+  implicit none
+  call hello()
+end program main
+""")
+
+test.run(arguments = '.')
+
+test.must_exist('test2' + _exe)
+test.must_exist(['modules', 'test2mod.mod'])
 
 test.up_to_date(arguments = '.')
 


### PR DESCRIPTION
Added the missing FORTRANMODDIRPREFIX=-J to the gfortran tool. Without this, FORTRANMODDIR cannot be used.

Also added a test which compiles a .f90 source file to an executable with gfortran and checks that module files are place in FORTRANMODDIR correctly, the executable is created and the build is recognised as up-to-date (i.e. the dependency scanner finds the module file in the module directory).

Documentation update is not required, because this restores the documented behaviour.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation