### PR TITLE
Make test FORTRANMODDIR.py work with non-empty FORTRANMODDIRPREFIX.

### DIFF
--- a/test/Fortran/FORTRANMODDIR.py
+++ b/test/Fortran/FORTRANMODDIR.py
@@ -31,7 +31,7 @@ Verify the following things:
 * The dependency scanner does not expect a module file to be created
   from a "module procedure" statement.
 * The dependency scanner expects the module files to be created in the correct
-  module directory (is is verified by the test.up_to_date()).
+  module directory (this is verified by the test.up_to_date()).
 """
 
 import TestSCons
@@ -58,17 +58,17 @@ for t in sys.argv[3:] + modules:
 """)
 
 test.write('SConstruct', """
-env = Environment(FORTRANCOM = r'%(_python_)s myfortran.py $_FORTRANMODFLAG $SOURCE $TARGET',
+env = Environment(F90COM = r'%(_python_)s myfortran.py $_FORTRANMODFLAG $SOURCE $TARGET',
                   FORTRANMODDIRPREFIX='moduledir=', FORTRANMODDIR='modules')
-env.Object(target = 'test1.obj', source = 'test1.f')
-env.Object(target = 'sub2/test2.obj', source = 'test1.f',
+env.Object(target = 'test1.obj', source = 'test1.f90')
+env.Object(target = 'sub2/test2.obj', source = 'test1.f90',
            FORTRANMODDIR='${TARGET.dir}')
-env.Object(target = 'sub3/test3.obj', source = 'test1.f',
-           FORTRANCOM = r'%(_python_)s myfortran.py moduledir=$FORTRANMODDIR $SOURCE $TARGET',
+env.Object(target = 'sub3/test3.obj', source = 'test1.f90',
+           F90COM = r'%(_python_)s myfortran.py moduledir=$FORTRANMODDIR $SOURCE $TARGET',
            FORTRANMODDIR='${TARGET.dir}')
 """ % locals())
 
-test.write('test1.f', """\
+test.write('test1.f90', """\
 module mod_foo
   implicit none
   interface q
@@ -83,7 +83,7 @@ end module mod_foo
 program test
   use mod_foo
   implicit none
-  print *, 'test.f'
+  print *, 'test1.f90'
   call p
   call q
 end


### PR DESCRIPTION
Fixed the test FORTRANMODDIR.py which failes since FORTRANMODDIRPREFIX has been set in the gfortran tool.

Diagnosis: SCons is working correctly here, but the test expects wrong results.

I fixed it in such a way that it comes as closely as possible to what I think was the intention of the original author. It verifies the following:
* _FORTRANMODFLAG is correctly constructed from FORTRANMODDIRPREFIX and FORTRANMODDIR.
* The dependency scanner does not expect a module file to be created from a "module procedure" statement.
* The dependency scanner expects the module files to be created in the correct module directory as set with FORTRANMODDIR (this is verified by the test.up_to_date()).

Note that the original Fortran source file contained invalid code. Doesn't really matter here, because the test is synthetic (not calling a compiler, but a Python script instead). Anyway, IMO the test should act on valid code, so I fixed it.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation