### PR TITLE
Set the pip installation directory to be non version specific by default

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -15,6 +15,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
   From Richard West:
     - Add SConstruct.py, Sconstruct.py, sconstruct.py to the search path for the root SConstruct file.
       Allows easier debugging within Visual Studio
+    - Set the default pip installation directory to be non version specific
+      to aid with development of external tools (such as using pytest)
 
   From Bernard Blackham:
    - Fixed handling of side-effects in task master (fixes #3013).

--- a/src/setup.py
+++ b/src/setup.py
@@ -247,10 +247,12 @@ class install_lib(_install_lib):
             if Options.standalone_lib:
                 # ...but they asked for a standalone directory.
                 self.install_dir = os.path.join(prefix, "scons")
-            elif Options.version_lib or not Options.standard_lib:
+            elif Options.version_lib:
                 # ...they asked for a version-specific directory,
-                # or they get it by default.
                 self.install_dir = os.path.join(prefix, "scons-%s" % Version)
+            elif not Options.standard_lib:
+                # default.
+                self.install_dir = os.path.join(prefix, "scons")
 
         msg = "Installed SCons library modules into %s" % self.install_dir
         Installed.append(msg)


### PR DESCRIPTION
Hi,
I've recently changed setup.py so that by default pip install installs to a non version specific directory
such as
`pythondir\Lib\site-packages\scons`
instead of the original
`pythondir\Lib\site-packages\scons-versionnumber`

This makes life a bit easier when writing external tools, where your using pytest and need to know where the installed scons directory is