### PR TITLE
First attempt to fix fortran issue with submodules.

### DIFF
--- a/src/engine/SCons/Scanner/Fortran.py
+++ b/src/engine/SCons/Scanner/Fortran.py
@@ -292,14 +292,15 @@ def FortranScan(path_variable="FORTRANPATH"):
 #   ^\s*               : any amount of white space
 #   MODULE             : match the string MODULE, case insensitive
 #   \s+                : match one or more white space characters
-#   (?!PROCEDURE)      : but *don't* match if the next word matches
-#                        PROCEDURE (negative lookahead assertion),
-#                        case insensitive
+#   (?!PROCEDURE|SUBROUTINE|FUNCTION)
+#                      : but *don't* match if the next word matches
+#                        PROCEDURE, SUBROUTINE or FUNCTION (negative
+#                        lookahead assertion), case insensitive
 #   (\w+)              : match one or more alphanumeric characters
 #                        that make up the defined module name and
 #                        save it in a group
 
-    def_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE)(\w+)"""
+    def_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
 
     scanner = F90Scanner("FortranScan",
                          "$FORTRANSUFFIXES",


### PR DESCRIPTION
I noticed that the scanner was already set up to ignore module followed
by the keyword procedure (case insensitive). Here, I then modify the
regex used for that to also ignore module followed by the keywords
subroutine or function. However, this does not fix the original problem
and I was able to confirm that SCons fails before the scanner is called
as printing out the value of the variable defmodules (not included in
the commit) is not printed. By changing the test files to something that
does not fail, I was able to confirm that the printout does happen in
that case and that module followed by subroutine and function are
correctly ignored.

See email thread at:
https://pairlist4.pair.net/pipermail/scons-users/2018-April/006893.html



## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation