### PR TITLE
GitHub issue 3141 unicode try action

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -45,6 +45,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Re-Enable parallel SCons (-j) when running via Pypy
     - Move SCons test framework files to testing/framework and remove all references to QMtest.  
       QMTest has not been used by SCons for some time now.
+    - Fix GH Issue #3141 unicode string in a TryAction() with python 2.7 crashes.
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -609,7 +609,7 @@ class SConfBase(object):
         ok = self.TryBuild(self.env.SConfActionBuilder, text, extension)
         del self.env['BUILDERS']['SConfActionBuilder']
         if ok:
-            outputStr = self.lastTarget.get_contents().decode()
+            outputStr = self.lastTarget.get_text_contents()
             return (1, outputStr)
         return (0, "")
 

--- a/src/engine/SCons/SConfTests.py
+++ b/src/engine/SCons/SConfTests.py
@@ -319,9 +319,10 @@ int main(void) {
             (ret, output) = sconf.TryAction(action=actionFAIL)
             assert not ret and output == "", (ret, output)
 
-            # GH Issue #3141 - unicode text and py2.7 crashes.
-            (ret, output) = sconf.TryAction(action=actionUnicode)
-            assert ret and output == u'2\xa2\n', (ret, output)
+            if not TestCmd.IS_PY3:
+                # GH Issue #3141 - unicode text and py2.7 crashes.
+                (ret, output) = sconf.TryAction(action=actionUnicode)
+                assert ret and output == u'2\xa2\n', (ret, output)
 
         finally:
             sconf.Finish()

--- a/src/engine/SCons/SConfTests.py
+++ b/src/engine/SCons/SConfTests.py
@@ -300,10 +300,15 @@ int main(void) {
         """Test SConf.TryAction
         """
         def actionOK(target, source, env):
-            open(str(target[0]), "w").write( "RUN OK\n" )
+            open(str(target[0]), "w").write("RUN OK\n")
             return None
         def actionFAIL(target, source, env):
             return 1
+        def actionUnicode(target, source, env):
+            open(str(target[0]), "wb").write('2\302\242\n')
+            return None
+
+
         self._resetSConfState()
         sconf = self.SConf.SConf(self.scons_env,
                                   conf_dir=self.test.workpath('config.tests'),
@@ -313,6 +318,11 @@ int main(void) {
             assert ret and output.encode('utf-8') == bytearray("RUN OK"+os.linesep,'utf-8'), (ret, output)
             (ret, output) = sconf.TryAction(action=actionFAIL)
             assert not ret and output == "", (ret, output)
+
+            # GH Issue #3141 - unicode text and py2.7 crashes.
+            (ret, output) = sconf.TryAction(action=actionUnicode)
+            assert ret and output == u'2\xa2\n', (ret, output)
+
         finally:
             sconf.Finish()
 
@@ -779,8 +789,7 @@ int main(void) {
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(SConfTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4


### PR DESCRIPTION
Fix issue #3141 where Configure context TryAction has unicode characters on it when running with python 2.7.

We're using target node's get_text_content() method instead of get_content().decode() as calling decode with no specified encoding is failing.
We properly handle this centrally in get_text_content()

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation