### PR TITLE
Fix py3 swig tests

### DIFF
--- a/test/SWIG/live.py
+++ b/test/SWIG/live.py
@@ -46,6 +46,7 @@ swig = test.where_is('swig')
 if not swig:
     test.skip_test('Can not find installed "swig", skipping test.\n')
 
+
 python, python_include, python_libpath, python_lib = \
              test.get_platform_python_info()
 Python_h = python_include + '/Python.h'

--- a/test/SWIG/recursive-includes-cpp.py
+++ b/test/SWIG/recursive-includes-cpp.py
@@ -78,7 +78,7 @@ if TestCmd.IS_WINDOWS:
 else:
     TARGET_ARCH = ""
 test.write('SConstruct', """\
-import distutils.sysconfig
+import sysconfig
 import sys
 import os
 
@@ -88,7 +88,7 @@ env = Environment(
         '-python'
     ],
     CPPPATH = [ 
-        distutils.sysconfig.get_python_inc()
+        sysconfig.get_config_var("INCLUDEPY")
     ],
     SHLIBPREFIX = "",
     tools = [ 'default', 'swig' ]
@@ -96,6 +96,7 @@ env = Environment(
 
 if sys.platform == 'darwin':
     env['LIBS']=['python%d.%d'%(sys.version_info[0],sys.version_info[1])]
+    env.Append(LIBPATH=[sysconfig.get_config_var("LIBDIR")])
 elif sys.platform == 'win32':
     env.Append(LIBS=['python%d%d'%(sys.version_info[0],sys.version_info[1])])
     env.Append(LIBPATH=[os.path.dirname(sys.executable) + "/libs"])

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1264,12 +1264,12 @@ SConscript( sconscript )
         Returns:
             (path to python, include path, library path, library name)
         """
-        python = os.environ.get('python_executable',self.where_is('python'))
+        python = os.environ.get('python_executable', self.where_is('python'))
         if not python:
             self.skip_test('Can not find installed "python", skipping test.\n')
 
         if sys.platform == 'win32':
-            self.run(program = python, stdin = """\
+            self.run(program=python, stdin="""\
 import sysconfig
 try:
     if sys.platform == 'win32':
@@ -1293,11 +1293,14 @@ except:
 print(py_ver)
                 """)
         else:
-            self.run(program = python, stdin = """\
-import sysconfig
+            self.run(program=python, stdin="""\
+import sys, sysconfig
 print(sysconfig.get_config_var("INCLUDEPY"))
 print(sysconfig.get_config_var("LIBDIR"))
-print("python"+sysconfig.get_config_var("LDVERSION"))
+py_library_ver = sysconfig.get_config_var("LDVERSION")
+if not py_library_ver:
+    py_library_ver = '%d.%d' % sys.version_info[:2]
+print("python"+py_library_ver)
 """)
 
         return [python] + self.stdout().strip().split('\n')

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1261,13 +1261,16 @@ SConscript( sconscript )
         Returns a path to a Python executable suitable for testing on
         this platform and its associated include path, library path,
         and library name.
+        Returns:
+            (path to python, include path, library path, library name)
         """
         python = os.environ.get('python_executable',self.where_is('python'))
         if not python:
             self.skip_test('Can not find installed "python", skipping test.\n')
 
-        self.run(program = python, stdin = """\
-import os, sys
+        if sys.platform == 'win32':
+            self.run(program = python, stdin = """\
+import sysconfig
 try:
     if sys.platform == 'win32':
         py_ver = 'python%d%d' % sys.version_info[:2]
@@ -1288,6 +1291,13 @@ except:
     print(os.path.join(sys.prefix, 'include', py_ver))
     print(os.path.join(sys.prefix, 'lib', py_ver, 'config'))
 print(py_ver)
+                """)
+        else:
+            self.run(program = python, stdin = """\
+import sysconfig
+print(sysconfig.get_config_var("INCLUDEPY"))
+print(sysconfig.get_config_var("LIBDIR"))
+print("python"+sysconfig.get_config_var("LDVERSION"))
 """)
 
         return [python] + self.stdout().strip().split('\n')


### PR DESCRIPTION
The logic in TestSCons.get_platform_python_info() was using distutils.sysconfig which doesn't work with python3. I've updated to use sysconfig (at least for non-windows).
The changes should work on all supported versions of python on non-windows.


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation