### PR TITLE
typo in customized decider example in user guide.

### DIFF
--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -518,7 +518,7 @@ cc -o hello hello.o
         <file name="SConstruct" printme="1">
 Program('hello.c')
 def decide_if_changed(dependency, target, prev_ni):
-    if self.get_timestamp() != prev_ni.timestamp:
+    if dependency.get_timestamp() != prev_ni.timestamp:
         dep = str(dependency)
         tgt = str(target)
         if specific_part_of_file_has_changed(dep, tgt):

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -97,6 +97,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - xml validity fixes from SConstruct.py change
     - update wiki links to new github location
     - update bug links to new github location
+    
+  From Hao Wu
+    - typo in customized decider example in user guide 
 
 
 


### PR DESCRIPTION
credit: https://stackoverflow.com/questions/39856184/does-scons-customized-decider-function-require-to-be-class-member

