### PR TITLE
Replace usage of unittest.TestSuite with unittest.main()

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -98,6 +98,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - update wiki links to new github location
     - update bug links to new github location
 
+  From Hao Wu
+    - Replace usage of unittest.TestSuite with unittest.main() (fix #3113)
+
 
 
 

--- a/src/engine/SCons/ActionTests.py
+++ b/src/engine/SCons/ActionTests.py
@@ -50,7 +50,6 @@ import SCons.Environment
 import SCons.Errors
 
 import TestCmd
-import TestUnit
 
 # Initial setup of the common environment for all tests,
 # a temporary working directory containing a

--- a/src/engine/SCons/CacheDirTests.py
+++ b/src/engine/SCons/CacheDirTests.py
@@ -29,7 +29,6 @@ import sys
 import unittest
 
 from TestCmd import TestCmd
-import TestUnit
 
 import SCons.CacheDir
 
@@ -287,16 +286,7 @@ class FileTestCase(BaseTestCase):
             SCons.CacheDir.CacheRetrieveSilent = save_CacheRetrieveSilent
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        CacheDirTestCase,
-        FileTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
-
+    unittest.main()
 # Local Variables:
 # tab-width:4
 # indent-tabs-mode:nil

--- a/src/engine/SCons/DefaultsTests.py
+++ b/src/engine/SCons/DefaultsTests.py
@@ -32,7 +32,6 @@ import unittest
 from collections import UserDict
 
 import TestCmd
-import TestUnit
 
 import SCons.Errors
 
@@ -77,13 +76,7 @@ class DefaultsTestCase(unittest.TestCase):
         
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [ DefaultsTestCase,
-               ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/ErrorsTests.py
+++ b/src/engine/SCons/ErrorsTests.py
@@ -28,8 +28,6 @@ import os
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 
 
@@ -126,8 +124,7 @@ class ErrorsTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(ErrorsTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/ExecutorTests.py
+++ b/src/engine/SCons/ExecutorTests.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Executor
 
 
@@ -483,12 +481,7 @@ class ExecutorTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [ ExecutorTestCase ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/MemoizeTests.py
+++ b/src/engine/SCons/MemoizeTests.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Memoize
 
 # Enable memoization counting
@@ -165,15 +163,7 @@ class CountValueTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        CountDictTestCase,
-        CountValueTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Node/AliasTests.py
+++ b/src/engine/SCons/Node/AliasTests.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Node.Alias
 
@@ -113,16 +111,7 @@ class AliasBuildInfoTestCase(unittest.TestCase):
         bi = SCons.Node.Alias.AliasBuildInfo()
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        AliasTestCase,
-        AliasBuildInfoTestCase,
-        AliasNodeInfoTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Node/NodeTests.py
+++ b/src/engine/SCons/Node/NodeTests.py
@@ -30,8 +30,6 @@ import re
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Node
 import SCons.Util
@@ -1349,15 +1347,7 @@ class NodeListTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [ BuildInfoBaseTestCase,
-                 NodeInfoBaseTestCase,
-                 NodeTestCase,
-                 NodeListTestCase ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Node/PythonTests.py
+++ b/src/engine/SCons/Node/PythonTests.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Node.Python
 
@@ -113,16 +111,7 @@ class ValueBuildInfoTestCase(unittest.TestCase):
         bi = SCons.Node.Python.ValueBuildInfo()
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        ValueTestCase,
-        ValueBuildInfoTestCase,
-        ValueNodeInfoTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Platform/PlatformTests.py
+++ b/src/engine/SCons/Platform/PlatformTests.py
@@ -28,8 +28,6 @@ import SCons.compat
 import collections
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Platform
 import SCons.Environment
@@ -204,17 +202,8 @@ class PlatformEscapeTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
+    unittest.main()
     
-    tclasses = [ PlatformTestCase,
-                 TempFileMungeTestCase,
-                 PlatformEscapeTestCase,
-                ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    
-    TestUnit.run(suite)
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/SConfTests.py
+++ b/src/engine/SCons/SConfTests.py
@@ -33,8 +33,6 @@ from types import *
 import unittest
 
 import TestCmd
-import TestUnit
-
 
 sys.stdout = io.StringIO()
 

--- a/src/engine/SCons/Scanner/DTests.py
+++ b/src/engine/SCons/Scanner/DTests.py
@@ -26,7 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import unittest
 
 import TestCmd
-import TestUnit
 
 import SCons.Scanner.D
 
@@ -266,14 +265,7 @@ class DScannerTestCase(unittest.TestCase):
         self.helper('multiline.d', ['A.d'])
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        DScannerTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Scanner/DirTests.py
+++ b/src/engine/SCons/Scanner/DirTests.py
@@ -28,7 +28,6 @@ import sys
 import unittest
 
 import TestCmd
-import TestUnit
 
 import SCons.Node.FS
 import SCons.Scanner.Dir
@@ -121,14 +120,8 @@ class DirEntryScannerTestCase(DirScannerTestBase):
         sss = list(map(str, deps))
         assert sss == [], sss
 
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(DirScannerTestCase())
-    suite.addTest(DirEntryScannerTestCase())
-    return suite
-
 if __name__ == "__main__":
-    TestUnit.run(suite())
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Scanner/LaTeXTests.py
+++ b/src/engine/SCons/Scanner/LaTeXTests.py
@@ -31,7 +31,6 @@ import sys
 import unittest
 
 import TestCmd
-import TestUnit
 
 import SCons.Node.FS
 import SCons.Scanner.LaTeX
@@ -156,16 +155,8 @@ class LaTeXScannerTestCase3(unittest.TestCase):
          files = ['inc5.xyz', 'subdir/inc4.eps']
          deps_match(self, deps, files)
 
-
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(LaTeXScannerTestCase1())
-    suite.addTest(LaTeXScannerTestCase2())
-    suite.addTest(LaTeXScannerTestCase3())
-    return suite
-
 if __name__ == "__main__":
-    TestUnit.run(suite())
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Scanner/ProgTests.py
+++ b/src/engine/SCons/Scanner/ProgTests.py
@@ -28,7 +28,6 @@ import sys
 import unittest
 
 import TestCmd
-import TestUnit
 
 import SCons.Node.FS
 import SCons.Scanner.Prog
@@ -274,7 +273,7 @@ def suite():
     return suite
 
 if __name__ == "__main__":
-    TestUnit.run(suite())
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Scanner/RCTests.py
+++ b/src/engine/SCons/Scanner/RCTests.py
@@ -29,7 +29,6 @@ import collections
 import os
 
 import TestCmd
-import TestUnit
 
 import SCons.Scanner.RC
 import SCons.Node.FS
@@ -167,7 +166,7 @@ def suite():
     return suite
 
 if __name__ == "__main__":
-    TestUnit.run(suite())
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Script/MainTests.py
+++ b/src/engine/SCons/Script/MainTests.py
@@ -25,8 +25,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Script.Main
 
@@ -41,12 +39,7 @@ import SCons.Script.Main
 # of private functionality.
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = []
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/SubstTests.py
+++ b/src/engine/SCons/SubstTests.py
@@ -32,8 +32,6 @@ import unittest
 
 from collections import UserDict
 
-import TestUnit
-
 import SCons.Errors
 
 from SCons.Subst import *
@@ -1243,21 +1241,7 @@ class subst_dict_TestCase(unittest.TestCase):
         assert SOURCES == ['s3', 'v-rstr-s4', 'v-s5'], SOURCES
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        CLVar_TestCase,
-        LiteralTestCase,
-        SpecialAttrWrapperTestCase,
-        quote_spaces_TestCase,
-        scons_subst_TestCase,
-        scons_subst_list_TestCase,
-        scons_subst_once_TestCase,
-        subst_dict_TestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/TaskmasterTests.py
+++ b/src/engine/SCons/TaskmasterTests.py
@@ -30,7 +30,6 @@ import copy
 import sys
 import unittest
 
-import TestUnit
 
 import SCons.Taskmaster
 import SCons.Errors
@@ -1239,8 +1238,7 @@ Taskmaster: No candidate anymore.
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(TaskmasterTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Tool/JavaCommonTests.py
+++ b/src/engine/SCons/Tool/JavaCommonTests.py
@@ -27,8 +27,6 @@ import os.path
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Scanner.IDL
 import SCons.Tool.JavaCommon
 
@@ -568,12 +566,7 @@ public class Foo
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [ parse_javaTestCase ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Tool/javacTests.py
+++ b/src/engine/SCons/Tool/javacTests.py
@@ -24,8 +24,6 @@
 import os
 import unittest
 
-import TestUnit
-
 import SCons.Tool.javac
 
 class DummyNode(object):
@@ -40,14 +38,14 @@ class pathoptTestCase(unittest.TestCase):
         popt = SCons.Tool.javac.pathopt('-foopath', 'FOOPATH')
         env = {'FOOPATH': path}
         actual = popt(None, None, env, None)
-        self.assertEquals(expect, actual)
+        self.assertEqual(expect, actual)
 
     def assert_pathopt_default(self, expect, path, default):
         popt = SCons.Tool.javac.pathopt('-foopath', 'FOOPATH', default='DPATH')
         env = {'FOOPATH': path,
                'DPATH': default}
         actual = popt(None, None, env, None)
-        self.assertEquals(expect, actual)
+        self.assertEqual(expect, actual)
 
     def test_unset(self):
         self.assert_pathopt([], None)
@@ -101,5 +99,4 @@ class pathoptTestCase(unittest.TestCase):
             '')
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(pathoptTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()

--- a/src/engine/SCons/Tool/wixTests.py
+++ b/src/engine/SCons/Tool/wixTests.py
@@ -33,7 +33,6 @@ from SCons.Tool.wix import *
 from SCons.Environment import Environment
 
 import TestCmd
-import TestUnit
 
 
 # create fake candle and light, so the tool's exists() method will succeed
@@ -53,8 +52,7 @@ class WixTestCase(unittest.TestCase):
         assert env.subst('$WIXSRCSUF') == '.wxs'
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(WixTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/UtilTests.py
+++ b/src/engine/SCons/UtilTests.py
@@ -32,7 +32,6 @@ import unittest
 from collections import UserDict, UserList, UserString
 
 import TestCmd
-import TestUnit
 
 import SCons.Errors
 

--- a/src/engine/SCons/Variables/BoolVariableTests.py
+++ b/src/engine/SCons/Variables/BoolVariableTests.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Variables
 
@@ -118,8 +116,7 @@ class BoolVariableTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(BoolVariableTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Variables/EnumVariableTests.py
+++ b/src/engine/SCons/Variables/EnumVariableTests.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Variables
 
@@ -195,8 +193,7 @@ class EnumVariableTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(EnumVariableTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Variables/ListVariableTests.py
+++ b/src/engine/SCons/Variables/ListVariableTests.py
@@ -27,8 +27,6 @@ import copy
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Errors
 import SCons.Variables
 
@@ -125,8 +123,7 @@ class ListVariableTestCase(unittest.TestCase):
         n = l.__class__(copy.copy(l))
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(ListVariableTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Variables/PackageVariableTests.py
+++ b/src/engine/SCons/Variables/PackageVariableTests.py
@@ -30,8 +30,6 @@ import SCons.Errors
 import SCons.Variables
 
 import TestCmd
-import TestUnit
-
 
 class PackageVariableTestCase(unittest.TestCase):
     def test_PackageVariable(self):
@@ -115,8 +113,7 @@ class PackageVariableTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(PackageVariableTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Variables/PathVariableTests.py
+++ b/src/engine/SCons/Variables/PathVariableTests.py
@@ -31,8 +31,6 @@ import SCons.Errors
 import SCons.Variables
 
 import TestCmd
-import TestUnit
-
 
 class PathVariableTestCase(unittest.TestCase):
     def test_PathVariable(self):
@@ -228,8 +226,7 @@ class PathVariableTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(PathVariableTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Variables/VariablesTests.py
+++ b/src/engine/SCons/Variables/VariablesTests.py
@@ -27,7 +27,6 @@ import sys
 import unittest
 
 import TestSCons
-import TestUnit
 
 import SCons.Variables
 import SCons.Subst
@@ -60,7 +59,9 @@ def check(key, value, env):
 def checkSave(file, expected):
     gdict = {}
     ldict = {}
-    exec(open(file, 'r').read(), gdict, ldict)
+    with open(file, 'r') as f:
+        exec(f.read(), gdict, ldict)
+
     assert expected == ldict, "%s\n...not equal to...\n%s" % (expected, ldict)
 
 class VariablesTestCase(unittest.TestCase):
@@ -690,13 +691,7 @@ class UnknownVariablesTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [ VariablesTestCase,
-                 UnknownVariablesTestCase ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/WarningsTests.py
+++ b/src/engine/SCons/WarningsTests.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import sys
 import unittest
 
-import TestUnit
-
 import SCons.Warnings
 
 class TestOutput(object):
@@ -127,8 +125,7 @@ class WarningsTestCase(unittest.TestCase):
         assert to.out == "Foo", to.out
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(WarningsTestCase, 'test_')
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4


### PR DESCRIPTION
fix the easy ones follow the instruction in #3113.

the tests below have warning like
```
./home/hwu/dev/scons/src/engine/SCons/dblite.py:117: ResourceWarning: unclosed file <_io.BufferedWriter name='.sconsign.dblite'>
  self._open(self._file_name, "wb", self._mode)
/home/hwu/dev/scons/src/engine/SCons/dblite.py:206: ResourceWarning: unclosed file <_io.BufferedReader name='.sconsign.dblite'>
  return dblite(file, flag, mode)


ERROR: test_basic (__main__.cppAllTestCase)
Test basic #include scanning
----------------------------------------------------------------------
Traceback (most recent call last):
  File "src/engine/SCons/cppTests.py", line 431, in setUp
    self.cpp = self.cpp_class(current = ".",
AttributeError: 'cppAllTestCase' object has no attribute 'cpp_class'

======================================================================
ERROR: test_expression (__main__.cppAllTestCase)
Test #if with arithmetic expressions
----------------------------------------------------------------------
Traceback (most recent call last):
  File "src/engine/SCons/cppTests.py", line 431, in setUp
    self.cpp = self.cpp_class(current = ".",
AttributeError: 'cppAllTestCase' object has no attribute 'cpp_class'
```

```
Scanner/CTests.py
463:    TestUnit.run(suite())

Scanner/ScannerTests.py
628:    TestUnit.run(suite())

Scanner/FortranTests.py
536:    TestUnit.run(suite())

Scanner/IDLTests.py
448:    TestUnit.run(suite())

Tool/ToolTests.py
83:    TestUnit.run(suite)

EnvironmentTests.py
3982:    TestUnit.run(suite)

Node/FSTests.py
3781:    TestUnit.run(suite)

PathListTests.py
201:    TestUnit.run(suite)

BuilderTests.py
1645:    TestUnit.run(suite)

cppTests.py
741:    TestUnit.run(suite)

SConsignTests.py
396:    TestUnit.run(suite)
```

I'd like to get the easy ones fixed in batch and deal with the remaining one by one.