### PR TITLE
Fix typos from issue 3194

### DIFF
--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -571,7 +571,7 @@ int main() { printf("Hello, world!\n"); }
         The <emphasis>content signature</emphasis>,
         or MD5 checksum, of the contents of the
         <varname>dependency</varname>
-        file the list time the &target; was built.
+        file the last time the &target; was built.
         </para>
         </listitem>
 
@@ -583,7 +583,7 @@ int main() { printf("Hello, world!\n"); }
         <listitem>
         <para>
         The size in bytes of the <varname>dependency</varname>
-        file the list time the target was built.
+        file the last time the target was built.
         </para>
         </listitem>
 
@@ -595,7 +595,7 @@ int main() { printf("Hello, world!\n"); }
         <listitem>
         <para>
         The modification time of the <varname>dependency</varname>
-        file the list time the &target; was built.
+        file the last time the &target; was built.
         </para>
         </listitem>
 


### PR DESCRIPTION
Trivial typo fix for https://github.com/SCons/scons/issues/3149

I see two instances use \&target\;, one uses plain target... does that need attention?  Which is the correct way? (seems unnecessary to have an entity for the word target, but not my call).

Signed-off-by: Mats Wichmann <mats@linux.com>
