### PR TITLE
Fix py3 ResourceWarning in TestCmd

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -102,6 +102,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - xml validity fixes from SConstruct.py change
     - update wiki links to new github location
     - update bug links to new github location
+    - convert TestCmd.read to use with statement on open (quiets 17 py3 warnings)
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1247,9 +1247,11 @@ class TestCmd(object):
         if mode[0] != 'r':
             raise ValueError("mode must begin with 'r'")
         if IS_PY3 and 'b' not in mode:
-            return open(file, mode, newline=newline).read()
+            with open(file, mode, newline=newline) as f:
+                return f.read()
         else:
-            return open(file, mode).read()
+            with open(file, mode) as f:
+                return f.read()
 
     def rmdir(self, dir):
         """Removes the specified dir name.


### PR DESCRIPTION
class TestCmd method read() uses a shortcut to return data from
a file, "return open(...).read()".  Python 3 warns this is a
resource leak because the file has no chance to be closed with
the open being in the return statement.  Split into two lines
and use a context manager (with statement).

Checklist notes: no new functionality; this is a change to get tests not to spit warnings (17 warnings when running tests under python3 are eliminated). No documentation impact. 

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation

