### PR TITLE
Quiet UtilTest ResourceWarning

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -103,6 +103,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - update wiki links to new github location
     - update bug links to new github location
     - convert TestCmd.read to use with statement on open (quiets 17 py3 warnings)
+    - quiet warning in UtilTests.py
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/UtilTests.py
+++ b/src/engine/SCons/UtilTests.py
@@ -488,8 +488,10 @@ class UtilTestCase(unittest.TestCase):
         filename = tempfile.mktemp()
         str = '1234567890 ' + filename
         try:
-            open(filename, 'w').write(str)
-            assert open(get_native_path(filename)).read() == str
+            with open(filename, 'w') as f:
+                f.write(str)
+            with open(get_native_path(filename)) as f:
+                assert f.read() == str
         finally:
             try:
                 os.unlink(filename)


### PR DESCRIPTION
Minor: Use context manager around file opens to quiet a Python 3 resource leak warning.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation

Notes: no scons change; cleans warning in test only.  No documentation impact.