### PR TITLE
Replace use of imp library with importlib.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -215,8 +215,10 @@ RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700
 
-  From William Deegan:
+  From Matěj Cepl
+    - replace use of imp library for Python >= 3.5 with importlib; no change in functionality
 
+  From William Deegan:
     - Fix Issue #3283 - Handle using --config=force in combination with Decider('MD5-timestamp').
       3.0.2 in fix for issue #2980 added that deciders can throw DeciderNeedsNode exception.
       The Configure logic directly calls the decider when using --config=force but wasn't handling

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -47,14 +47,15 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 
-import importlib
 import os
+import importlib
 import sys
 import tempfile
 
 import SCons.Errors
 import SCons.Subst
 import SCons.Tool
+import SCons.Util
 
 
 def platform_default():
@@ -110,7 +111,7 @@ def platform_module(name = platform_default()):
                     mod = importer.load_module(full_name)
                 except ImportError:
                     raise SCons.Errors.UserError("No platform named '%s'" % name)
-            setattr(SCons.Platform, name, mod)
+                setattr(SCons.Platform, name, mod)
     return sys.modules[full_name]
 
 

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -111,7 +111,7 @@ def platform_module(name = platform_default()):
                     mod = importer.load_module(full_name)
                 except ImportError:
                     raise SCons.Errors.UserError("No platform named '%s'" % name)
-                setattr(SCons.Platform, name, mod)
+            setattr(SCons.Platform, name, mod)
     return sys.modules[full_name]
 
 

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -753,7 +753,7 @@ def _load_site_scons_dir(topdir, site_dir_name=None):
                         exec(compile(fp.read(), fp.name, 'exec'), site_m)
                     except KeyboardInterrupt:
                         raise
-                    except Exception as e:
+                    except Exception:
                         fmt = '*** Error loading site_init file %s:\n'
                         sys.stderr.write(fmt % repr(site_init_file))
                         raise
@@ -763,7 +763,7 @@ def _load_site_scons_dir(topdir, site_dir_name=None):
                                 m.__dict__[k] = site_m[k]
                 except KeyboardInterrupt:
                     raise
-                except ImportError as e:
+                except ImportError:
                     fmt = '*** cannot import site init file %s:\n'
                     sys.stderr.write(fmt % repr(site_init_file))
                     raise

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -38,9 +38,7 @@ tool definition.
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import re
 import os
-import shutil
 
 import SCons.Builder
 import SCons.Errors
@@ -57,6 +55,7 @@ try:
 except ImportError:
     # Python 2.7
     from collections import Callable
+import SCons.Util
 
 DefaultToolpath = []
 
@@ -142,7 +141,7 @@ class Tool(object):
         sys.path = self.toolpath + sys.path
         # sys.stderr.write("Tool:%s\nPATH:%s\n"%(self.name,sys.path))
 
-        if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] in (0, 1, 2, 3, 4)):
+        if SCons.Util.PY2 or SCons.Util.PY34:
             # Py 2 code
             try:
                 try:

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -31,7 +31,7 @@ import SCons.Defaults
 import SCons.Environment
 from SCons.Variables import *
 from SCons.Errors import *
-from SCons.Util import is_List, is_String, make_path_relative, PY2, PY34
+from SCons.Util import is_List, is_String, make_path_relative
 from SCons.Warnings import warn, Warning
 
 import os

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -31,7 +31,7 @@ import SCons.Defaults
 import SCons.Environment
 from SCons.Variables import *
 from SCons.Errors import *
-from SCons.Util import is_List, make_path_relative
+from SCons.Util import is_List, is_String, make_path_relative, PY2, PY34
 from SCons.Warnings import warn, Warning
 
 import os
@@ -68,7 +68,7 @@ def Tag(env, target, source, *more_tags, **kw_tags):
     for x in more_tags:
         kw_tags[x] = ''
 
-    if not SCons.Util.is_List(target):
+    if not is_List(target):
         target=[target]
     else:
         # hmm, sometimes the target list, is a list of a list
@@ -263,12 +263,12 @@ def putintopackageroot(target, source, env, pkgroot, honor_install_location=1):
     All attributes of the source file will be copied to the new file.
     """
     # make sure the packageroot is a Dir object.
-    if SCons.Util.is_String(pkgroot):  pkgroot=env.Dir(pkgroot)
-    if not SCons.Util.is_List(source): source=[source]
+    if is_String(pkgroot):  pkgroot=env.Dir(pkgroot)
+    if not is_List(source): source=[source]
 
     new_source = []
     for file in source:
-        if SCons.Util.is_String(file): file = env.File(file)
+        if is_String(file): file = env.File(file)
 
         if file.is_under(pkgroot):
             new_source.append(file)

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -38,6 +38,8 @@ import hashlib
 PY3 = sys.version_info[0] == 3
 PYPY = hasattr(sys, 'pypy_translation_info')
 
+PY2 = sys.version_info[0] == 2
+PY34 = sys.version_info[0] == 3 and sys.version_info[1] <= 4
 
 try:
     from collections import UserDict, UserList, UserString

--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -66,6 +66,15 @@ import importlib
 PYPY = hasattr(sys, 'pypy_translation_info')
 
 
+def import_as(module, name):
+    """
+    Imports the specified module (from our local directory) as the
+    specified name, returning the loaded module object.
+    """
+    sys.modules[name] = importlib.import_module(module)
+    return sys.modules[name]
+
+
 def rename_module(new, old):
     """
     Attempt to import the old module and load it under the new name.

--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -51,10 +51,7 @@ obsessive about it.)
 We name the compatibility modules with an initial '_scons_' (for example,
 _scons_subprocess.py is our compatibility module for subprocess) so
 that we can still try to import the real module name and fall back to
-our compatibility module if we get an ImportError.  The import_as()
-function defined below loads the module as the "real" name (without the
-'_scons'), after which all of the "import {module}" statements in the
-rest of our code will find our pre-loaded compatibility module.
+our compatibility module if we get an ImportError.
 """
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
@@ -64,15 +61,6 @@ import sys
 import importlib
 
 PYPY = hasattr(sys, 'pypy_translation_info')
-
-
-def import_as(module, name):
-    """
-    Imports the specified module (from our local directory) as the
-    specified name, returning the loaded module object.
-    """
-    sys.modules[name] = importlib.import_module(module)
-    return sys.modules[name]
 
 
 def rename_module(new, old):


### PR DESCRIPTION
imp library has been deprecated since 3.4 and in 3.7 it finally breaks builds.

Preserving compatibility with python >= 2.7.

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
No functionality has been changed or added.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation