### PR TITLE
Change octal constants in QT tests

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -104,6 +104,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - update bug links to new github location
     - convert TestCmd.read to use with statement on open (quiets 17 py3 warnings)
     - quiet warning in UtilTests.py
+    - fix tests specifying octal constants for Py3
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/test/QT/generated-ui.py
+++ b/test/QT/generated-ui.py
@@ -61,7 +61,7 @@ import SCons.Defaults
 def ExpHeaderScanner(node, env, path):
    return []
 def generate(env):
-   HeaderAction=SCons.Action.Action([SCons.Defaults.Copy('$TARGET','$SOURCE'),SCons.Defaults.Chmod('$TARGET',0755)])
+   HeaderAction=SCons.Action.Action([SCons.Defaults.Copy('$TARGET','$SOURCE'),SCons.Defaults.Chmod('$TARGET',0o755)])
    HeaderBuilder= SCons.Builder.Builder(action=HeaderAction)
    env['BUILDERS']['ExportHeaders'] = HeaderBuilder
 def exists(env):

--- a/test/QT/up-to-date.py
+++ b/test/QT/up-to-date.py
@@ -66,7 +66,7 @@ import SCons.Defaults
 def ExpHeaderScanner(node, env, path):
    return []
 def generate(env):
-   HeaderAction=SCons.Action.Action([SCons.Defaults.Copy('$TARGET','$SOURCE'),SCons.Defaults.Chmod('$TARGET',0755)])
+   HeaderAction=SCons.Action.Action([SCons.Defaults.Copy('$TARGET','$SOURCE'),SCons.Defaults.Chmod('$TARGET',0o755)])
    HeaderBuilder= SCons.Builder.Builder(action=HeaderAction)
    env['BUILDERS']['ExportHeaders'] = HeaderBuilder
 def exists(env):


### PR DESCRIPTION
Resolving two test failures in Python 3 caused by:
http://www.python.org/dev/peps/pep-3127/:

    octal literals must now be specified with a leading "0o" or "0O" instead of "0";
the syntax works for all python versions.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation