### PR TITLE
Testing: python 3 fix for must_contain

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -103,8 +103,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - update wiki links to new github location
     - update bug links to new github location
     - convert TestCmd.read to use with statement on open (quiets 17 py3 warnings)
-    - quiet warning in UtilTests.py
-    - fix tests specifying octal constants for Py3
+    - quiet py3 warning in UtilTests.py
+    - fix tests specifying octal constants for py3
+    - fix must_contain tests for py3
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/test/Docbook/basic/xinclude/xinclude.py
+++ b/test/Docbook/basic/xinclude/xinclude.py
@@ -44,7 +44,7 @@ test.dir_fixture('image')
 # Normal invocation
 test.run()
 test.must_exist(test.workpath('manual_xi.xml'))
-test.must_contain(test.workpath('manual_xi.xml'),'<para>This is an included text.')
+test.must_contain(test.workpath('manual_xi.xml'),'<para>This is an included text.', mode='r')
 
 
 # Cleanup

--- a/test/Docbook/dependencies/xinclude/xinclude.py
+++ b/test/Docbook/dependencies/xinclude/xinclude.py
@@ -44,7 +44,7 @@ test.dir_fixture('image')
 # Normal invocation
 test.run()
 test.must_exist(test.workpath('manual_xi.xml'))
-test.must_contain(test.workpath('manual_xi.xml'),'<para>This is an included text.')
+test.must_contain(test.workpath('manual_xi.xml'),'<para>This is an included text.', mode='r')
 
 # Change included file
 test.write('include.txt', 'This is another text.')

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -265,18 +265,26 @@ class TestCommon(TestCmd):
             print("Unwritable files: `%s'" % "', `".join(unwritable))
         self.fail_test(missing + unwritable)
 
-    def must_contain(self, file, required, mode = 'rb', find = None):
-        """Ensures that the specified file contains the required text.
+    def must_contain(self, file, required, mode='rb', find=None):
+        """Ensures specified file contains the required text.
+
+        Args:
+            file (string): name of file to search in.
+            required (string): text to search for. For the default
+              find function, type must match the return type from
+              reading the file; current implementation will convert.
+            mode (string): file open mode.
+            find (func): optional custom search routine. Must take the
+              form "find(output, line)" returning non-zero on success
+              and None on failure.
+
+        Calling test exits FAILED if search result is false
         """
         if 'b' in mode:
             # Python 3: reading a file in binary mode returns a 
             # bytes object. We cannot find the index of a different
-            # (str) type in that, so encode "required". For Py2
-            # it is all just strings, so it still works.
-            try:
-                required = required.encode()
-            except AttributeError:
-                pass    # in case it's encoded already
+            # (str) type in that, so convert.
+            required = to_bytes(required)
         file_contents = self.read(file, mode)
         if find is None:
             def find(o, l):

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -268,6 +268,15 @@ class TestCommon(TestCmd):
     def must_contain(self, file, required, mode = 'rb', find = None):
         """Ensures that the specified file contains the required text.
         """
+        if 'b' in mode:
+            # Python 3: reading a file in binary mode returns a 
+            # bytes object. We cannot find the index of a different
+            # (str) type in that, so encode "required". For Py2
+            # it is all just strings, so it still works.
+            try:
+                required = required.encode()
+            except AttributeError:
+                pass    # in case it's encoded already
         file_contents = self.read(file, mode)
         if find is None:
             def find(o, l):


### PR DESCRIPTION
TestCommon defines a method must_contain which checks for a file including
a given string. With Python 3, the test runs into some typing problems.
This could be fixed either by changing all the tests which call the
routine either omitting the mode argument (which then defaults to 'rb'),
or specifying a mode which includes 'b'; or by modifying must_contain to
align the types of the file data and the data to check for. This patch
uses the latter approach.

This is a test-only change, no run-time scons code is modified.

Signed-off-by: Mats Wichmann <mats@linux.com>

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation (no doc impacts)