### PR TITLE
Python 3.7 removed splitunc function

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,7 +7,10 @@
 
 RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
-  From Matthew Marinets
+  From Daniel Moody:
+    - Updated FS.py to handle removal of splitunc function from python 3.7
+
+  From Matthew Marinets:
     - Fixed an issue that caused the Java emitter to incorrectly parse arguments to constructors that 
       implemented a class.
 

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -132,7 +132,10 @@ def initialize_do_splitdrive():
     global do_splitdrive
     global has_unc
     drive, path = os.path.splitdrive('X:/foo')
-    has_unc = hasattr(os.path, 'splitunc')
+    # splitunc is removed from python 3.7 and newer  
+    # so we can also just test if splitdrive works with UNC
+    has_unc = (hasattr(os.path, 'splitunc') 
+        or os.path.splitdrive(r'\\split\drive\test')[0] == r'\\split\drive')
 
     do_splitdrive = not not drive or has_unc
 

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -605,7 +605,7 @@ class VariantDirTestCase(unittest.TestCase):
                 print("File `%s' alter_targets() `%s' != expected `%s'" % (f, tp, expect))
                 errors = errors + 1
 
-        self.failIf(errors)
+        self.assertFalse(errors)
 
 class BaseTestCase(_tempdirTestCase):
     def test_stat(self):

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -1657,7 +1657,12 @@ class FSTestCase(_tempdirTestCase):
             import ntpath
             x = test.workpath(*dirs)
             drive, path = ntpath.splitdrive(x)
-            unc, path = ntpath.splitunc(path)
+            try:
+                unc, path = ntpath.splitunc(path)
+            except AttributeError:
+                # could be python 3.7 or newer, make sure splitdrive can do UNC
+                assert ntpath.splitdrive(r'\\split\drive\test')[0] == r'\\split\drive'
+                pass
             path = strip_slash(path)
             return '//' + path[1:]
 


### PR DESCRIPTION
Python 3.7 has removed splitunc function: https://docs.python.org/3/whatsnew/3.7.html#api-and-feature-removals

This PR is to handle that and maintain backwards compatibility with other python versions

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation