### PR TITLE
Reduce travis texlive install footprint

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,7 +8,7 @@ sudo apt-get -y install gdc
 # dependencies for docbook tests
 sudo apt-get -y install docbook-xml xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf
 # dependencies for latex tests
-sudo apt-get -y install texlive texlive-bibtex-extra texlive-latex3 biber texmaker 
+sudo apt-get -y install texlive texlive-latex3 biber texmaker 
 # need some things for building dependencies for other tests
 sudo apt-get -y install python-pip python-dev build-essential libpcre3-dev autoconf automake libtool bison subversion git
 # dependencies for docbook tests continued

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,7 +8,7 @@ sudo apt-get -y install gdc
 # dependencies for docbook tests
 sudo apt-get -y install docbook-xml xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf
 # dependencies for latex tests
-sudo apt-get -y install texlive-full biber texmaker 
+sudo apt-get -y install texlive texlive-bibtex-extra texlive-latex3 biber texmaker 
 # need some things for building dependencies for other tests
 sudo apt-get -y install python-pip python-dev build-essential libpcre3-dev autoconf automake libtool bison subversion git
 # dependencies for docbook tests continued


### PR DESCRIPTION
The travis install script install all the langs and docs for latex tools. not installing this saves hundreds of MB of download and installing, and is not used any tests anyways.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation