### PR TITLE
updated test to reflect the removal of find function from mingw tool

### DIFF
--- a/test/MinGW/MinGWSharedLibrary.py
+++ b/test/MinGW/MinGWSharedLibrary.py
@@ -32,8 +32,11 @@ when using MinGW.
 import sys
 import TestSCons
 
+import SCons.Tool
 import SCons.Tool.mingw
 import SCons.Defaults
+from SCons.Platform.mingw import MINGW_DEFAULT_PATHS
+from SCons.Platform.cygwin import CYGWIN_DEFAULT_PATHS
 
 _python_ = TestSCons._python_
 
@@ -42,9 +45,9 @@ test = TestSCons.TestSCons()
 if sys.platform not in ('cygwin','win32',):
     test.skip_test("Skipping mingw test on non-Windows %s platform."%sys.platform)
 
-if not SCons.Tool.mingw.find(SCons.Defaults.DefaultEnvironment()):
+gcc = SCons.Tool.find_program_path(test.Environment(), 'gcc', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
+if not gcc:
     test.skip_test("Skipping mingw test, no MinGW found.\n")
-
 
 test.write('foobar.cc', """
 int abc(int a) {

--- a/test/MinGW/WINDOWS_INSERT_DEF.py
+++ b/test/MinGW/WINDOWS_INSERT_DEF.py
@@ -31,8 +31,11 @@ Make sure that WINDOWS_INSERT_DEF isn't ignored when using MinGW.
 import sys
 import TestSCons
 
+import SCons.Tool
 import SCons.Tool.mingw
 import SCons.Defaults
+from SCons.Platform.mingw import MINGW_DEFAULT_PATHS
+from SCons.Platform.cygwin import CYGWIN_DEFAULT_PATHS
 
 test = TestSCons.TestSCons()
 
@@ -40,7 +43,8 @@ if sys.platform not in ('cygwin', 'win32'):
     test.skip_test(
         "Skipping mingw test on non-Windows platform: %s" % sys.platform)
 
-if not SCons.Tool.mingw.find(SCons.Defaults.DefaultEnvironment()):
+gcc = SCons.Tool.find_program_path(test.Environment(), 'gcc', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
+if not gcc:
     test.skip_test("Skipping mingw test, no MinGW found.\n")
 
 test.write('hello.c', r"""


### PR DESCRIPTION
In PR https://github.com/SCons/scons/pull/3052 the find function was removed from the mingw tool, but a few tests still used it to detect the tool. This PR uses the new generic find function to see if 'gcc' binary is on the windows installation in the default mingw paths.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation