### PR TITLE
SCons should ignore MSVS versions that don't have a compiler installed

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -9,6 +9,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Daniel Moody:
     - Updated FS.py to handle removal of splitunc function from python 3.7
+    - Updated the vc.py to ignore MSVS versions where not compiler could be found
 
   From Matthew Marinets:
     - Fixed an issue that caused the Java emitter to incorrectly parse arguments to constructors that 

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -361,7 +361,9 @@ def get_installed_vcs():
             VC_DIR = find_vc_pdir(ver)
             if VC_DIR:
                 debug('found VC %s' % ver)
-                if os.path.exists(os.path.join(VC_DIR, r'bin\cl.exe')):
+                # check to see if the x86 or 64 bit compiler is in the bin dir
+                if (os.path.exists(os.path.join(VC_DIR, r'bin\cl.exe'))
+                    or os.path.exists(os.path.join(VC_DIR, r'bin\amd64\cl.exe'))):
                     installed_versions.append(ver)
                 else:
                     debug('find_vc_pdir no cl.exe found %s' % ver)
@@ -571,6 +573,7 @@ def msvc_setup_env(env):
         debug('vc.py:msvc_setup_env() env:%s -> %s'%(k,v))
         env.PrependENVPath(k, v, delete_existing=True)
     
+    # final check to issue a warning if the compiler is not present
     msvc_cl = find_program_path(env, 'cl')
     if not msvc_cl:
         SCons.Warnings.warn(SCons.Warnings.VisualCMissingWarning, 

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -43,6 +43,7 @@ import platform
 from string import digits as string_digits
 
 import SCons.Warnings
+from SCons.Tool import find_program_path
 
 from . import common
 
@@ -357,9 +358,13 @@ def get_installed_vcs():
     for ver in _VCVER:
         debug('trying to find VC %s' % ver)
         try:
-            if find_vc_pdir(ver):
+            VC_DIR = find_vc_pdir(ver)
+            if VC_DIR:
                 debug('found VC %s' % ver)
-                installed_versions.append(ver)
+                if os.path.exists(os.path.join(VC_DIR, r'bin\cl.exe')):
+                    installed_versions.append(ver)
+                else:
+                    debug('find_vc_pdir no cl.exe found %s' % ver)
             else:
                 debug('find_vc_pdir return None for ver %s' % ver)
         except VisualCException as e:
@@ -565,6 +570,11 @@ def msvc_setup_env(env):
     for k, v in d.items():
         debug('vc.py:msvc_setup_env() env:%s -> %s'%(k,v))
         env.PrependENVPath(k, v, delete_existing=True)
+    
+    msvc_cl = find_program_path(env, 'cl')
+    if not msvc_cl:
+        SCons.Warnings.warn(SCons.Warnings.VisualCMissingWarning, 
+            "Could not find MSVC compiler 'cl.exe', it may need to be installed separately with Visual Studio")
 
 def msvc_exists(version=None):
     vcs = cached_get_installed_vcs()

--- a/test/MSVS/vs-10.0Exp-exec.py
+++ b/test/MSVS/vs-10.0Exp-exec.py
@@ -55,9 +55,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-11.0-exec.py
+++ b/test/MSVS/vs-11.0-exec.py
@@ -55,9 +55,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-11.0Exp-exec.py
+++ b/test/MSVS/vs-11.0Exp-exec.py
@@ -55,10 +55,14 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
+    
 exec(test.stdout())
 
 

--- a/test/MSVS/vs-14.0-exec.py
+++ b/test/MSVS/vs-14.0-exec.py
@@ -55,9 +55,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-6.0-clean.py
+++ b/test/MSVS/vs-6.0-clean.py
@@ -72,7 +72,7 @@ env.MSVSSolution(target = 'Test.dsw',
                  variant = 'Release')
 """%{'HOST_ARCH':host_arch})
 
-test.run(arguments=".")
+test.run()
 
 test.must_exist(test.workpath('Test.dsp'))
 dsp = test.read('Test.dsp', 'r')

--- a/test/MSVS/vs-6.0-exec.py
+++ b/test/MSVS/vs-6.0-exec.py
@@ -54,9 +54,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-7.0-exec.py
+++ b/test/MSVS/vs-7.0-exec.py
@@ -54,9 +54,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-7.1-exec.py
+++ b/test/MSVS/vs-7.1-exec.py
@@ -54,9 +54,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-8.0-exec.py
+++ b/test/MSVS/vs-8.0-exec.py
@@ -55,8 +55,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-print("os.environ.update(%%s)" %% repr(env['ENV']))
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-8.0Exp-exec.py
+++ b/test/MSVS/vs-8.0Exp-exec.py
@@ -55,9 +55,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-9.0-exec.py
+++ b/test/MSVS/vs-9.0-exec.py
@@ -55,9 +55,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 

--- a/test/MSVS/vs-9.0Exp-exec.py
+++ b/test/MSVS/vs-9.0Exp-exec.py
@@ -55,9 +55,13 @@ if not msvs_version in test.msvs_versions():
 
 test.run(arguments = '-n -q -Q -f -', stdin = """\
 env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
-sconsEnv = repr(env['ENV'])
-print("os.environ.update(" + sconsEnv + ")")
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
 
 exec(test.stdout())
 


### PR DESCRIPTION
It is possible that the msvs selected by scons does not have a c++ compiler to build with. This PR will update SCons to check for a compiler before adding the MSVS version to the list of available versions.

Also this updates the MSVS tests to check for the compiler binary. In the case that you specifically request a certain version of MSVS, but there is not compiler installed, SCons will still setup the environment as requested but will issue a warning that the specific version requested doesn't have a compiler.

Mailing list:
https://pairlist2.pair.net/pipermail/scons-dev/2018-August/004728.html

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation