### PR TITLE
Fix rpm tests for newer rpmbuild (fixes #3164)

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -121,9 +121,12 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - fix tests specifying octal constants for py3
     - fix must_contain tests for py3
     - rpm package generation: fix supplying a build architecture; disable
-      auto debug package generation on certain rpmbuild versions; adjust some tests
-      to be resistant to automatic supplying of build-id file on certain rpmbuild
-      versions; a little doc and comment cleanup.
+      auto debug package generation on certain rpmbuild versions; adjust some
+      tests to be resistant to automatic supplying of build-id file on
+      certain rpmbuild versions; tests now use a file fixture for the 
+      repeated (trivial) main.c program. A little doc and comment cleanup.
+      A new tag is added, X_RPM_EXTRADEFS, to allow supplying custom settings
+      to the specfile without adding specific logic for each one to scons.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -120,6 +120,10 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - quiet py3 warning in UtilTests.py
     - fix tests specifying octal constants for py3
     - fix must_contain tests for py3
+    - rpm package generation: fix supplying a build architecture; disable
+      auto debug package generation on certain rpmbuild versions; adjust some tests
+      to be resistant to automatic supplying of build-id file on certain rpmbuild
+      versions; a little doc and comment cleanup.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/Tool/packaging/__init__.xml
+++ b/src/engine/SCons/Tool/packaging/__init__.xml
@@ -106,7 +106,9 @@ This is used to fill in the
 <literal>Architecture:</literal>
 field in an Ipkg
 <filename>control</filename> file,
-and as part of the name of a generated RPM file.
+and the <literal>BuildArch:</literal> field
+in the RPM <filename>.spec</filename> file,
+as well as forming part of the name of a generated RPM package file.
 </para>
 </summary>
 </cvar>
@@ -120,7 +122,6 @@ the <filename>control</filename> for Ipkg,
 the <filename>.wxs</filename> for MSI).
 If set, the function will be called
 after the SCons template for the file has been written.
-XXX
 </para>
 </summary>
 </cvar>
@@ -164,10 +165,10 @@ section of an RPM
 <cvar name="LICENSE">
 <summary>
 <para>
-The abbreviated name of the license under which
-this project is released (gpl, lpgl, bsd etc.).
+The abbreviated name, preferably the SPDX code, of the license under which
+this project is released (GPL-3.0, LGPL-2.1, BSD-2-Clause etc.).
 See http://www.opensource.org/licenses/alphabetical
-for a list of license names.
+for a list of license names and SPDX codes.
 </para>
 </summary>
 </cvar>
@@ -383,6 +384,7 @@ This is used to fill in the
 <literal>BuildRequires:</literal>
 field in the RPM
 <filename>.spec</filename> file.
+Note this should only be used on a host managed by rpm as the dependencies will not be resolvable at build time otherwise.
 </para>
 </summary>
 </cvar>
@@ -441,7 +443,8 @@ field in the RPM
 <para>
 This is used to fill in the
 <literal>Epoch:</literal>
-field in the controlling information for RPM packages.
+field in the RPM
+<filename>.spec</filename> file.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/packaging/__init__.xml
+++ b/src/engine/SCons/Tool/packaging/__init__.xml
@@ -471,6 +471,38 @@ field in the RPM
 </summary>
 </cvar>
 
+<cvar name="X_RPM_EXTRADEFS">
+<summary>
+<para>
+A list used to supply extra defintions or flags
+to be added to the RPM <filename>.spec<filename> file.
+Each item is added as-is with a carriage return appended.
+This is useful if some specific RPM feature not otherwise
+anticipated by SCons needs to be turned on or off.
+Note if this variable is omitted, SCons will by
+default supply the value
+<literal>'%global debug_package %{nil}'</literal>
+to disable debug package generation.
+To enable debug package generation, include this
+variable set either to None, or to a custom
+list that does not include the default line.
+Added in version 3.1.
+</para>
+
+<example_commands>
+env.Package(
+    NAME             = 'foo',
+...
+    X_RPM_EXTRADEFS = [
+        '%define _unpackaged_files_terminate_build 0'
+        '%define _missing_doc_files_terminate_build 0'
+    ],
+... )
+</example_commands>
+
+</summary>
+</cvar>
+
 <cvar name="X_RPM_GROUP">
 <summary>
 <para>

--- a/src/engine/SCons/Tool/packaging/rpm.py
+++ b/src/engine/SCons/Tool/packaging/rpm.py
@@ -198,7 +198,8 @@ def build_specfile_header(spec):
         'PACKAGEVERSION' : '%%define release %s\nRelease: %%{release}\n',
         'X_RPM_GROUP'    : 'Group: %s\n',
         'SUMMARY'        : 'Summary: %s\n',
-        'LICENSE'        : 'License: %s\n', }
+        'LICENSE'        : 'License: %s\n',
+    }
 
     str = str + SimpleTagCompiler(mandatory_header_fields).compile( spec )
 
@@ -227,7 +228,8 @@ def build_specfile_header(spec):
         'X_RPM_PREFIX'        : 'Prefix: %s\n',
 
         # internal use
-        'X_RPM_BUILDROOT'     : 'BuildRoot: %s\n', }
+        'X_RPM_BUILDROOT'     : 'BuildRoot: %s\n',
+    }
 
     # fill in default values:
     # Adding a BuildRequires renders the .rpm unbuildable under systems which
@@ -241,11 +243,17 @@ def build_specfile_header(spec):
 
     str = str + SimpleTagCompiler(optional_header_fields, mandatory=0).compile( spec )
 
+    # Add any extra specfile definitions the user may have supplied.
+    # These flags get no processing, they are just added.
     # github #3164: if we don't turn off debug package generation
-    # the tests which build packages all fail.  This just slams
-    # a flag into the specfile header, could make it an X_RPM_NODEBUGPKGS
-    # which is controllable by an environment setting.
-    str += '%global debug_package %{nil}\n'
+    # the tests which build packages all fail.  If there are no
+    # extra flags, default to adding this one. If the user wants
+    # to turn this back on, supply the flag set to None.
+
+    if 'X_RPM_EXTRADEFS' not in spec:
+        spec['X_RPM_EXTRADEFS'] = ['%global debug_package %{nil}']
+    for extra in spec['X_RPM_EXTRADEFS']:
+        str += extra + '\n'
 
     return str
 

--- a/src/engine/SCons/Tool/packaging/tarbz2.py
+++ b/src/engine/SCons/Tool/packaging/tarbz2.py
@@ -32,7 +32,7 @@ from SCons.Tool.packaging import stripinstallbuilder, putintopackageroot
 
 def package(env, target, source, PACKAGEROOT, **kw):
     bld = env['BUILDERS']['Tar']
-    bld.set_suffix('.tar.gz')
+    bld.set_suffix('.tar.bz2')
     target, source = putintopackageroot(target, source, env, PACKAGEROOT)
     target, source = stripinstallbuilder(target, source, env)
     return bld(env, target, source, TARFLAGS='-jc')

--- a/test/packaging/option--package-type.py
+++ b/test/packaging/option--package-type.py
@@ -26,6 +26,9 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the --package-type option.
+
+Side effect: also tests that we can produce a noarch package
+by supplying the ARCHITECTURE tag.
 """
 
 import TestSCons
@@ -63,12 +66,13 @@ env.Package( NAME           = 'foo',
              X_RPM_INSTALL  = r'%(_python_)s %(scons)s --install-sandbox="$RPM_BUILD_ROOT" "$RPM_BUILD_ROOT"',
              DESCRIPTION    = 'this should be really long',
              source         = [ prog ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz'
+             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz',
+             ARCHITECTURE   = 'noarch'
             )
 """ % locals())
 
 src_rpm = 'foo-1.2.3-0.src.rpm'
-machine_rpm = 'foo-1.2.3-0.%s.rpm' % SCons.Tool.rpmutils.defaultMachine()
+machine_rpm = 'foo-1.2.3-0.noarch.rpm'
 
 test.run(arguments='package PACKAGETYPE=rpm', stderr = None)
 

--- a/test/packaging/rpm/cleanup.py
+++ b/test/packaging/rpm/cleanup.py
@@ -28,6 +28,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Assert that files created by the RPM packager will be removed by 'scons -c'.
 """
 
+import os
 import TestSCons
 import SCons.Tool.rpmutils
 
@@ -47,13 +48,8 @@ if not rpm:
 rpm_build_root = test.workpath('rpm_build_root')
 
 test.subdir('src')
-
-test.write( [ 'src', 'main.c' ], r"""
-int main( int argc, char* argv[] )
-{
-  return 0;
-}
-""")
+mainpath = os.path.join('src', 'main.c')
+test.file_fixture(mainpath, mainpath)
 
 test.write('SConstruct', """
 env=Environment(tools=['default', 'packaging'])

--- a/test/packaging/rpm/explicit-target.py
+++ b/test/packaging/rpm/explicit-target.py
@@ -28,6 +28,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test the ability to create a rpm package from a explicit target name.
 """
 
+import os
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -44,13 +45,8 @@ if not rpm:
 rpm_build_root = test.workpath('rpm_build_root')
 
 test.subdir('src')
-
-test.write( [ 'src', 'main.c' ], r"""
-int main( int argc, char* argv[] )
-{
-  return 0;
-}
-""")
+mainpath = os.path.join('src', 'main.c')
+test.file_fixture(mainpath, mainpath)
 
 test.write('SConstruct', """
 import os

--- a/test/packaging/rpm/internationalization.py
+++ b/test/packaging/rpm/internationalization.py
@@ -33,7 +33,6 @@ These are x-rpm-Group, description, summary and the lang_xx file tag.
 
 import os
 import SCons.Tool.rpmutils
-
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -52,12 +51,7 @@ rpm_build_root = test.workpath('rpm_build_root')
 #
 # test INTERNATIONAL PACKAGE META-DATA
 #
-test.write( [ 'main.c' ], r"""
-int main( int argc, char* argv[] )
-{
-  return 0;
-}
-""")
+test.file_fixture('src/main.c', 'main.c')
 
 test.write('SConstruct', """
 # -*- coding: utf-8 -*-
@@ -123,13 +117,8 @@ test.fail_test( out != 'Application/office-hello-this should be really long' )
 #
 # test INTERNATIONAL PACKAGE TAGS
 #
-
-test.write( [ 'main.c' ], r"""
-int main( int argc, char* argv[] )
-{
-  return 0;
-}
-""")
+mainpath = os.path.join('src', 'main.c')
+test.file_fixture(mainpath)
 
 test.write( ['man.de'], '' )
 test.write( ['man.en'], '' )

--- a/test/packaging/rpm/multipackage.py
+++ b/test/packaging/rpm/multipackage.py
@@ -47,13 +47,8 @@ if not rpm:
 rpm_build_root = test.workpath('rpm_build_root')
 
 test.subdir('src')
-
-test.write( [ 'src', 'main.c' ], r"""
-int main( int argc, char* argv[] )
-{
-  return 0;
-}
-""")
+mainpath = os.path.join('src', 'main.c')
+test.file_fixture(mainpath, mainpath)
 
 test.write('SConstruct', """
 import os

--- a/test/packaging/rpm/multipackage.py
+++ b/test/packaging/rpm/multipackage.py
@@ -109,8 +109,10 @@ test.must_exist( machine_rpm2 )
 test.must_exist( src_rpm2 )
 
 test.must_not_exist( 'bin/main' )
-test.fail_test( not os.popen('rpm -qpl %s' % machine_rpm).read()=='/bin/main\n')
-test.fail_test( not os.popen('rpm -qpl %s' % src_rpm).read()=='foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
+out = os.popen( 'rpm -qpl %s' % machine_rpm).read()
+test.must_contain_all_lines( out, '/bin/main')
+out = os.popen( 'rpm -qpl %s' % src_rpm).read()
+test.fail_test( not out == 'foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
 
 test.pass_test()
 

--- a/test/packaging/rpm/package.py
+++ b/test/packaging/rpm/package.py
@@ -46,13 +46,8 @@ if not rpm:
 rpm_build_root = test.workpath('rpm_build_root')
 
 test.subdir('src')
-
-test.write( [ 'src', 'main.c' ], r"""
-int main( int argc, char* argv[] )
-{
-  return 0;
-}
-""")
+mainpath = os.path.join('src', 'main.c')
+test.file_fixture(mainpath, mainpath)
 
 test.write('SConstruct', """
 import os

--- a/test/packaging/rpm/package.py
+++ b/test/packaging/rpm/package.py
@@ -88,8 +88,10 @@ machine_rpm = 'foo-1.2.3-0.%s.rpm' % SCons.Tool.rpmutils.defaultMachine()
 test.must_exist( machine_rpm )
 test.must_exist( src_rpm )
 test.must_not_exist( 'bin/main' )
-test.fail_test( not os.popen('rpm -qpl %s' % machine_rpm).read()=='/bin/main\n')
-test.fail_test( not os.popen('rpm -qpl %s' % src_rpm).read()=='foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
+out = os.popen( 'rpm -qpl %s' % machine_rpm).read()
+test.must_contain_all_lines( out, '/bin/main')
+out = os.popen( 'rpm -qpl %s' % src_rpm).read()
+test.fail_test( not out == 'foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
 
 test.pass_test()
 

--- a/test/packaging/rpm/src/main.c
+++ b/test/packaging/rpm/src/main.c
@@ -1,0 +1,5 @@
+
+int main( int argc, char* argv[] )
+{
+  return 0;
+}

--- a/test/packaging/rpm/tagging.py
+++ b/test/packaging/rpm/tagging.py
@@ -91,9 +91,12 @@ src_rpm = 'foo-1.2.3-0.src.rpm'
 machine_rpm = 'foo-1.2.3-0.%s.rpm' % SCons.Tool.rpmutils.defaultMachine()
 
 test.must_exist( machine_rpm )
+out = os.popen('rpm -qpl %s' % machine_rpm).read()
+test.must_contain_all_lines( out, '/bin/main')
+
 test.must_exist( src_rpm )
-test.fail_test( not os.popen('rpm -qpl %s' % machine_rpm).read()=='/bin/main\n')
-test.fail_test( not os.popen('rpm -qpl %s' % src_rpm).read()=='foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
+out = os.popen('rpm -qpl %s' % src_rpm).read()
+test.fail_test( not out == 'foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
 
 expect = '(0755, root, users) /bin/main'
 test.must_contain_all_lines(test.read('foo-1.2.3.spec',mode='r'), [expect])

--- a/test/packaging/rpm/tagging.py
+++ b/test/packaging/rpm/tagging.py
@@ -30,7 +30,6 @@ Test the ability to add file tags
 
 import os
 import SCons.Tool.rpmutils
-
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -50,13 +49,8 @@ rpm_build_root = test.workpath('rpm_build_root')
 # Test adding an attr tag to the built program.
 #
 test.subdir('src')
-
-test.write( [ 'src', 'main.c' ], r"""
-int main( int argc, char* argv[] )
-{
-return 0;
-}
-""")
+mainpath = os.path.join('src', 'main.c')
+test.file_fixture(mainpath, mainpath)
 
 test.write('SConstruct', """
 import os


### PR DESCRIPTION
Two issues: (1) ARCHITECTURE, if supplied, actually needs to be set
in the specfile BuildArch: field (or passed on the command line).
(2) rpmbuild on Fedora builds all kind of debug stuff behind the
scenes (it makes packages not requested by the specfile!). This
causes scons rpm tests to fail, so force in a flag to turn off this
generation. That is done unconditionally at the moment by writing

`  %global debug_package %{nil}\n`

to the specfile.  If anyone eventually ends up needing to produce
these debug packages through scons, we can add a flag to allow
it by omitting the above setting.

Some doc and comment cleanup done, and one of the tests now builds
a noarch package to test actually supplying an ARCHITECTURE value
that is not the machine default. Also, one of the tools called by
rpm packaging did not supply the right suffix for the Tar builder,
presumably a copy-paste error in a place that is not stressed by
any test.

Fedora packaging now also generates a file containing the build id
and puts it into the package (another behind the scenes bit of magic -
this does not appear in our %files section but is still added to the
package). It is possible to turn this behavior off as well, but for the
tests affected, the choice was made instead to have them now check the
files in the generated package /contain/ the expected filenames rather
than /exactly-match/ the expected filenames.

Testing: on recent Fedora all the rpm-related tests now pass after six
failed previously; on a Centos 7.4 system which did not fail any tests,
the modified code still passes - did not introduce regressions. At
the moment do not believe any of the CI setup will cause rpm tests
to be run.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation