### PR TITLE
Quiet Py3.6+ ResourceWarnings on tests

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -120,6 +120,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - quiet py3 warning in UtilTests.py
     - fix tests specifying octal constants for py3
     - fix must_contain tests for py3
+    - if test opens os.devnull, register with atexit so file opens do not leak.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -107,6 +107,7 @@ import sys
 import subprocess
 import itertools
 import inspect
+import atexit
 
 import SCons.Debug
 from SCons.Debug import logInstanceCreation
@@ -772,12 +773,15 @@ def _subproc(scons_env, cmd, error = 'ignore', **kw):
     io = kw.get('stdin')
     if is_String(io) and io == 'devnull':
         kw['stdin'] = open(os.devnull)
+        atexit.register(kw['stdin'].close)
     io = kw.get('stdout')
     if is_String(io) and io == 'devnull':
         kw['stdout'] = open(os.devnull, 'w')
+        atexit.register(kw['stdout'].close)
     io = kw.get('stderr')
     if is_String(io) and io == 'devnull':
         kw['stderr'] = open(os.devnull, 'w')
+        atexit.register(kw['stderr'].close)
 
     # Figure out what shell environment to use
     ENV = kw.get('env', None)


### PR DESCRIPTION
When a test calls _subproc to set up a subprocess.Popen call, if the
arg vector contains the string 'devnull' os.devnull is opened and the
resulting file object is stored in the kw vector prior to passing it to
Popen.  Reigster a close() call with atexit in this case.  Eliminates a
lot of Python 3.6+ ResourceWarning messages - 336 on this machine.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation (not applicable)