### PR TITLE
Redo fix for file closing in SCons.Action._subproc

### DIFF
--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -819,7 +819,6 @@ def _subproc(scons_env, cmd, error = 'ignore', **kw):
         pobj = dummyPopen(e)
     finally:
         # clean up open file handles stored in parent's kw
-        import io
         for k, v in kw.items():
             if hasattr(v, 'close'):
                 v.close()


### PR DESCRIPTION
When the _subproc wrapper is called, a keyword dictionary is used to
hold open file objects if any were indicated as being redirected to
os.devull.  These objects just go missing when SCons.Action._subproc
is done.  A previous iteration registered the close method of the object
with atexit, which made Python 3 happy the open file resources were not
leaking, but has some unexpected side effects. Apparently Action cannot
import either atexit or the SCons equivalent, SCons.exitfuncs without
triggering these effects.

As an alternative, close the objects in the parent's kw dictionary that
have close methods after the subprocess.Popen object has been created.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

update of previous commit, no impact on existing changelog or docs.