### PR TITLE
Fix bytes->string decoding issue as subprocess returned stdout is bytes in py3 [ci skip]

### DIFF
--- a/test/AS/nasm.py
+++ b/test/AS/nasm.py
@@ -52,6 +52,7 @@ try:
 except OSError:
     test.skip_test('could not determine nasm version; skipping test\n')
 else:
+    stdout = stdout.decode()
     version = stdout.split()[2].split('.')
     if int(version[0]) ==0 and int(version[1]) < 98:
         test.skip_test("skipping test of nasm version %s\n" % version)


### PR DESCRIPTION

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation