### PR TITLE
Typefixes

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -190,6 +190,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Add Textfile/Substfile to default environment. (issue #3147)
     - sconsign: a couple of python3 fixes; be more tolerant of implicit
       entries which have no signatures; minor PEP8 changes.
+    - Fix a couple of type mistakes (list-> string, filter type -> list)
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -191,6 +191,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - sconsign: a couple of python3 fixes; be more tolerant of implicit
       entries which have no signatures; minor PEP8 changes.
     - Fix a couple of type mistakes (list-> string, filter type -> list)
+    - Fix a couple of type mistakes in packaging tools: list-> string in msi,
+      filter type -> list in ipk
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/src/engine/SCons/Tool/packaging/ipk.py
+++ b/src/engine/SCons/Tool/packaging/ipk.py
@@ -26,9 +26,11 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
+import os
+
 import SCons.Builder
 import SCons.Node.FS
-import os
+import SCons.Util
 
 from SCons.Tool.packaging import stripinstallbuilder, putintopackageroot
 
@@ -119,7 +121,9 @@ def build_specfiles(source, target, env):
         try:
             return opened_files[needle]
         except KeyError:
-            file=filter(lambda x: x.get_path().rfind(needle)!=-1, haystack)[0]
+            files = filter(lambda x: x.get_path().rfind(needle) != -1, haystack)
+            # Py3: filter returns an iterable, not a list
+            file = list(files)[0]
             opened_files[needle]=open(file.get_abspath(), 'w')
             return opened_files[needle]
 

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -63,8 +63,8 @@ def convert_to_id(s, id_set):
     """
     charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYabcdefghijklmnopqrstuvwxyz0123456789_.'
     if s[0] in '0123456789.':
-        s += '_'+s
-    id = [c for c in s if c in charset]
+        s = '_' + s
+    id = ''.join([c for c in s if c in charset])
 
     # did we already generate an id for this file?
     try:
@@ -108,7 +108,7 @@ def gen_dos_short_file_name(file, filename_set):
 
     # strip forbidden characters.
     forbidden = '."/[]:;=, '
-    fname = [c for c in fname if c not in forbidden]
+    fname = ''.join([c for c in fname if c not in forbidden])
 
     # check if we already generated a filename with the same number:
     # thisis1.txt, thisis2.txt etc.


### PR DESCRIPTION
    small type-related cleanups
    
    Two files in packaging:
    ipk.py indexed off the result of running filter, but in Python 3
    filter returns an iterable, not a list. Convert to a list first.
    
    msi.py removes forbidden characters using a list comprehension,
    but the result is a list, so when it then calls upper() on it
    that's a method that does not exist on a list. Join it back into
    a string. Found another place in the same file that also assumed
    the list comprehension leaves a string, not a list, although it
    doesn't then call a nonexistent method on it.

## Contributor Checklist:
test/docs N/A

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation