### PR TITLE
win32 handle exception object correctly

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -123,6 +123,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - fix must_contain tests for py3
     - one swig test now checks for Python.h instead of failing
     - if test opens os.devnull, register with atexit so file opens do not leak.
+    - win32.py handle exception object appropriately for class
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/Platform/win32.py
+++ b/src/engine/SCons/Platform/win32.py
@@ -202,9 +202,9 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
             try:
                 ret = exitvalmap[e[0]]
             except KeyError:
-                sys.stderr.write("scons: unknown OSError exception code %d - %s: %s\n" % (e[0], cmd, e[1]))
+                sys.stderr.write("scons: unknown OSError exception code %d - %s: %s\n" % (e.errno, cmd, e.strerror))
             if stderr is not None:
-                stderr.write("scons: %s: %s\n" % (cmd, e[1]))
+                stderr.write("scons: %s: %s\n" % (cmd, e.strerror))
         # copy child output from tempfiles to our streams
         # and do clean up stuff
         if stdout is not None and stdoutRedirected == 0:

--- a/src/engine/SCons/Platform/win32.py
+++ b/src/engine/SCons/Platform/win32.py
@@ -200,7 +200,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         except OSError as e:
             # catch any error
             try:
-                ret = exitvalmap[e[0]]
+                ret = exitvalmap[e.errno]
             except KeyError:
                 sys.stderr.write("scons: unknown OSError exception code %d - %s: %s\n" % (e.errno, cmd, e.strerror))
             if stderr is not None:


### PR DESCRIPTION
Code inspection reveals this problem (4 instances):
Class 'OSError' does not define '__getitem__' so the [] operator cannot be used on its instances.
Use e.errno for e[0] and e.strerror for e[1].

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:
Tests/docs N/A
* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation