### PR TITLE
Do not use time.clock for Py3 in runtest

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -95,10 +95,8 @@ import time
 import threading
 try:                        # python3
     from queue import Queue
-    PY3=True
 except ImportError as e:    # python2
     from Queue import Queue
-    PY3=False
 import subprocess
 
 cwd = os.getcwd()
@@ -771,7 +769,8 @@ os.environ["python_executable"] = python
 # but time.time() does a better job on Linux systems, so let that be
 # the non-Windows default.
 
-if PY3:
+#TODO: clean up when py2 support is dropped
+try:
     time_func = time.perf_counter
 else:
     if sys.platform == 'win32':

--- a/runtest.py
+++ b/runtest.py
@@ -95,10 +95,11 @@ import time
 import threading
 try:                        # python3
     from queue import Queue
+    PY3=True
 except ImportError as e:    # python2
     from Queue import Queue
+    PY3=False
 import subprocess
-
 
 cwd = os.getcwd()
 
@@ -770,10 +771,13 @@ os.environ["python_executable"] = python
 # but time.time() does a better job on Linux systems, so let that be
 # the non-Windows default.
 
-if sys.platform == 'win32':
-    time_func = time.clock
+if PY3:
+    time_func = time.perf_counter
 else:
-    time_func = time.time
+    if sys.platform == 'win32':
+        time_func = time.clock
+    else:
+        time_func = time.time
 
 if print_times:
     print_time_func = lambda fmt, time: sys.stdout.write(fmt % time)

--- a/runtest.py
+++ b/runtest.py
@@ -772,7 +772,7 @@ os.environ["python_executable"] = python
 #TODO: clean up when py2 support is dropped
 try:
     time_func = time.perf_counter
-else:
+except AttributeError:
     if sys.platform == 'win32':
         time_func = time.clock
     else:

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -123,9 +123,10 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - fix must_contain tests for py3
     - one swig test now checks for Python.h instead of failing
     - if test opens os.devnull, register with atexit so file opens do not leak.
-    - for py3, use time.perf_counter instead of depr time.clock, which is
-      used in win32 case for py2. py37 depr warnings were failing a bunch
-      of tests on windows since warn messes up expected stderr.
+    - use time.perf_counter instead of time.clock if it exists.
+      time.clock deprecated since py3.3, due to remove in 3.8. deprecation
+      warnings from py3.7 were failing a bunch of tests on Windows since they
+      mess up expected stderr.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -123,6 +123,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - fix must_contain tests for py3
     - one swig test now checks for Python.h instead of failing
     - if test opens os.devnull, register with atexit so file opens do not leak.
+    - for py3, use time.perf_counter instead of depr time.clock, which is
+      used in win32 case for py2. py37 depr warnings were failing a bunch
+      of tests on windows since warn messes up expected stderr.
     
   From Hao Wu
     - typo in customized decider example in user guide 


### PR DESCRIPTION
time.clock is deprecated since Python 3.3 and will be removed in
Python 3.8.  3.7 started issuing DeprecationWarning, which
fails about 16 tests in AppVeyor CI (and running manually),
since the warning appears in stderr stream and so real vs expected
does not match any longer.  Arguably the tests could be fixed to
do a different check (contains rather than exactly-equal), but
a change needs to be made anyway.

use time.perf_counter as the time function for Python 3.  This
works for Windows and non-Windows; however since this function
did not exist in 2.7 (added for 3.3), the Py2 case is left, which
selects between time.clock and time.time depending on OS.

Note this addresses runtest.py, but not code in bench/, which
need attention also.  Suggest that be a separate change since
it's not failing tests.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:
tests/docs do not need changes; this is a change to make some tests pass.
* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation