### PR TITLE
Attempt to fix py37 java falures. Which are likely caused by newer oracle java echoing values in  _JAVA_OPTIONS env variable to stderr.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ jobs:
       python: 3.7
       env: 
         - PYVER=37
-        - _JAVA_OPTIONS=
       sudo: required
       dist: xenial  # required for Python 3.7 (travis-ci/travis-ci#9069)
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -33,3 +33,7 @@ if [[ "$PYVER" == 27 ]]; then
     tar xzf rel-3.0.12.tar.gz
     cd swig-rel-3.0.12 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ..
 fi
+
+# Clear this flag as newer Oracle Java's will echo to stderr any values set in it which breaks several java
+# tests
+unset _JAVA_OPTIONS

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -33,7 +33,3 @@ if [[ "$PYVER" == 27 ]]; then
     tar xzf rel-3.0.12.tar.gz
     cd swig-rel-3.0.12 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ..
 fi
-
-# Clear this flag as newer Oracle Java's will echo to stderr any values set in it which breaks several java
-# tests
-unset _JAVA_OPTIONS

--- a/runtest.py
+++ b/runtest.py
@@ -618,6 +618,10 @@ os.environ['SCONS_VERSION'] = version
 
 old_pythonpath = os.environ.get('PYTHONPATH')
 
+# Clear _JAVA_OPTIONS which java tools output to stderr when run breaking tests
+if '_JAVA_OPTIONS' in os.environ:
+    del os.environ['_JAVA_OPTIONS']
+
 # FIXME: the following is necessary to pull in half of the testing
 #        harness from $srcdir/etc. Those modules should be transfered
 #        to testing/, in which case this manipulation of PYTHONPATH


### PR DESCRIPTION
When using py37 in travis, it seems to pick up a newer version of Oracle Java which outputs the value of the environment variable _JAVA_OPTIONS to stderr breaking several java tests which expect no output to stderr.

This PR unsets _JAVA_OPTIONS in the .travis/install.sh script.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation