### PR TITLE
Stop using custom OrderedDict

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -128,6 +128,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       time.clock deprecated since py3.3, due to remove in 3.8. deprecation
       warnings from py3.7 were failing a bunch of tests on Windows since they
       mess up expected stderr.
+    - Remove obsoleted internal implementaiton of OrderedDict.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -107,6 +107,7 @@ import sys
 import subprocess
 import itertools
 import inspect
+from collections import OrderedDict
 
 import SCons.Debug
 from SCons.Debug import logInstanceCreation
@@ -1294,7 +1295,7 @@ class ListAction(ActionBase):
         return result
 
     def get_varlist(self, target, source, env, executor=None):
-        result = SCons.Util.OrderedDict()
+        result = OrderedDict()
         for act in self.list:
             for var in act.get_varlist(target, source, env, executor):
                 result[var] = True

--- a/src/engine/SCons/Tool/javac.py
+++ b/src/engine/SCons/Tool/javac.py
@@ -34,6 +34,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import os.path
+from collections import OrderedDict
 
 import SCons.Action
 import SCons.Builder
@@ -70,7 +71,7 @@ def emit_java_classes(target, source, env):
         if isinstance(entry, SCons.Node.FS.File):
             slist.append(entry)
         elif isinstance(entry, SCons.Node.FS.Dir):
-            result = SCons.Util.OrderedDict()
+            result = OrderedDict()
             dirnode = entry.rdir()
             def find_java_files(arg, dirpath, filenames):
                 java_files = sorted([n for n in filenames

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -37,21 +37,18 @@ import pprint
 PY3 = sys.version_info[0] == 3
 
 try:
+    from collections import UserDict, UserList, UserString
+except ImportError:
     from UserDict import UserDict
-except ImportError as e:
-    from collections import UserDict
-
-try:
     from UserList import UserList
-except ImportError as e:
-    from collections import UserList
-
-from collections import Iterable
+    from UserString import UserString
 
 try:
-    from UserString import UserString
-except ImportError as e:
-    from collections import UserString
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
+from collections import OrderedDict
 
 # Don't "from types import ..." these because we need to get at the
 # types module later to look for UnicodeType.
@@ -63,7 +60,7 @@ MethodType      = types.MethodType
 FunctionType    = types.FunctionType
 
 try:
-    unicode
+    _ = type(unicode)
 except NameError:
     UnicodeType = str
 else:
@@ -1032,59 +1029,6 @@ class CLVar(UserList):
     def __str__(self):
         return ' '.join(self.data)
 
-# A dictionary that preserves the order in which items are added.
-# Submitted by David Benjamin to ActiveState's Python Cookbook web site:
-#     http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/107747
-# Including fixes/enhancements from the follow-on discussions.
-class OrderedDict(UserDict):
-    def __init__(self, dict = None):
-        self._keys = []
-        UserDict.__init__(self, dict)
-
-    def __delitem__(self, key):
-        UserDict.__delitem__(self, key)
-        self._keys.remove(key)
-
-    def __setitem__(self, key, item):
-        UserDict.__setitem__(self, key, item)
-        if key not in self._keys: self._keys.append(key)
-
-    def clear(self):
-        UserDict.clear(self)
-        self._keys = []
-
-    def copy(self):
-        dict = OrderedDict()
-        dict.update(self)
-        return dict
-
-    def items(self):
-        return list(zip(self._keys, list(self.values())))
-
-    def keys(self):
-        return self._keys[:]
-
-    def popitem(self):
-        try:
-            key = self._keys[-1]
-        except IndexError:
-            raise KeyError('dictionary is empty')
-
-        val = self[key]
-        del self[key]
-
-        return (key, val)
-
-    def setdefault(self, key, failobj = None):
-        UserDict.setdefault(self, key, failobj)
-        if key not in self._keys: self._keys.append(key)
-
-    def update(self, dict):
-        for (key, val) in dict.items():
-            self.__setitem__(key, val)
-
-    def values(self):
-        return list(map(self.get, self._keys))
 
 class Selector(OrderedDict):
     """A callable ordered dictionary that maps file suffixes to


### PR DESCRIPTION
OrdredDict is in the standard library for all supported Python versions
(2.7 and 3.5+) and has improvements over the ActiveState recipe version
of OrderedDict we have been using. Switch to importing from collections
instead of getting it from SCons.Util (tests already did this).

At the same time, reorganize the Util.py imports - import Iterable
from collections.abc if possible (it is deprecated to import
it from collections, will stop working in 3.8); try getting the
User{Dict,List,String} from collections if possible - that is, try the
3.x way first.  Fixes #3185.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation

Tests referencing OrderedDict already imported the stdlib one from collections, so no impact. There is no doc mention of this type.