### PR TITLE
Improvements to tarball packager testing

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -129,13 +129,16 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
        - Document and comment cleanup.
        - Added new Environment Value X_RPM_EXTRADEFS to supply custom settings
          to the specfile without adding specific logic for each one to scons.
-    - One swig test now checks for Python.h instead of failing
+    - The test for Python.h needed by swig tests is moved to get_python_platform
+      so it does not have to be repeated in every test; picks up one failure
+      which did not make the (previously needed) check.
     - If test opens os.devnull, register with atexit so file opens do not leak.
     - Fix bugs in Win32 process spawn logic to handle OSError exception correctly.
     - Use time.perf_counter instead of time.clock if it exists.
       time.clock deprecated since py3.3, due to remove in 3.8. deprecation
       warnings from py3.7 were failing a bunch of tests on Windows since they
       mess up expected stderr.
+    - tar packaging test fixups
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/test/packaging/tar/bz2_packaging.py
+++ b/test/packaging/tar/bz2_packaging.py
@@ -36,18 +36,23 @@ python = TestSCons.python
 test = TestSCons.TestSCons()
 
 tar = test.detect('TAR', 'tar')
+if not tar:
+    test.skip_test('tar not found, skipping test\n')
 
-if tar:
-  test.subdir('src')
+bz2 = test.where_is('bzip2')
+if not bz2:
+    test.skip_test('tar found, but helper bzip2 not found, skipping test\n')
 
-  test.write( [ 'src', 'main.c' ], r"""
+test.subdir('src')
+
+test.write([ 'src', 'main.c'], r"""
 int main( int argc, char* argv[] )
 {
   return 0;
 }
 """)
 
-  test.write('SConstruct', """
+test.write('SConstruct', """
 Program( 'src/main.c' )
 env=Environment(tools=['default', 'packaging'])
 env.Package( PACKAGETYPE  = 'src_tarbz2',
@@ -56,9 +61,9 @@ env.Package( PACKAGETYPE  = 'src_tarbz2',
              source       = [ 'src/main.c', 'SConstruct' ] )
 """)
 
-  test.run(arguments='', stderr = None)
+test.run(arguments='', stderr=None)
 
-  test.must_exist( 'src.tar.bz2' )
+test.must_exist('src.tar.bz2')
 
 test.pass_test()
 

--- a/test/packaging/tar/gz.py
+++ b/test/packaging/tar/gz.py
@@ -36,18 +36,19 @@ python = TestSCons.python
 test = TestSCons.TestSCons()
 
 tar = test.detect('TAR', 'tar')
+if not tar:
+    test.skip_test('tar not found, skipping test\n')
 
-if tar:
-  test.subdir('src')
+test.subdir('src')
 
-  test.write( [ 'src', 'main.c' ], r"""
+test.write(['src', 'main.c'], r"""
 int main( int argc, char* argv[] )
 {
   return 0;
 }
 """)
 
-  test.write('SConstruct', """
+test.write('SConstruct', """
 Program( 'src/main.c' )
 env=Environment(tools=['default', 'packaging'])
 env.Package( PACKAGETYPE  = 'src_targz',
@@ -56,9 +57,9 @@ env.Package( PACKAGETYPE  = 'src_targz',
              source       = [ 'src/main.c', 'SConstruct' ] )
 """)
 
-  test.run(arguments='', stderr = None)
+test.run(arguments='', stderr=None)
 
-  test.must_exist( 'src.tar.gz' )
+test.must_exist('src.tar.gz')
 
 test.pass_test()
 


### PR DESCRIPTION
Both gz and bzip2 now skip the test if tar is not found (previously they
would not test, but mark the test OK).

Since tar is now found on recent Windows 10, but the helper program
bzip2 is not, check for bzip2 as well.  This is actually a correct test
for other systems as well, they have just been very unlikely to not have
had bzip2 provisioned so it has not bitten us.

Note: on Windows, with cygwin installed, the test may well find bzip2
but c:\Windows\System32\tar.exe does not find it and the test fails
anyway. Work needed on this "finds too much" issue (not unique to
this test).

note: earlier description about swig tests in CHANGES.txt was fixed up, that patch evolved before merge but changelog was never updated.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:
test change only

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation