### PR TITLE
Modifications for deprecated getargspec

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -136,6 +136,11 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       time.clock deprecated since py3.3, due to remove in 3.8. deprecation
       warnings from py3.7 were failing a bunch of tests on Windows since they
       mess up expected stderr.
+    - Prefer Py3's inspect.getfullargspec over deprecated inspect.getargspec.
+      Switched to "new" (standard in Py2.7) usage of receiving a namedtuple -
+      we were unpacking to a four-tuple, two of the items of which were unused;
+      getfullargspec returns a named tuple with seven elements so it is a
+      cleaner drop-in replacement using the namedtuple.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -163,15 +163,21 @@ def Package(env, target=None, source=None, **kw):
         # this exception means that a needed argument for the packager is
         # missing. As our packagers get their "tags" as named function
         # arguments we need to find out which one is missing.
-        from inspect import getargspec
-        args,varargs,varkw,defaults=getargspec(packager.package)
-        if defaults!=None:
-            args=args[:-len(defaults)] # throw away arguments with default values
+        #TODO: getargspec deprecated in Py3. cleanup when Py2.7 dropped.
+        try:
+            from inspect import getfullargspec
+        except ImportError:
+            from inspect import getargspec
+        argspec = getargspec(packager.package)
+        args = argspec.args
+        if argspec.defaults:
+            # throw away arguments with default values
+            args = args[:-len(argspec.defaults)]
         args.remove('env')
         args.remove('target')
         args.remove('source')
         # now remove any args for which we have a value in kw.
-        args=[x for x in args if x not in kw]
+        args = [x for x in args if x not in kw]
 
         if len(args)==0:
             raise # must be a different error, so re-raise

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -27,14 +27,15 @@ SCons Packaging Tool.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
+import SCons.Defaults
 import SCons.Environment
 from SCons.Variables import *
 from SCons.Errors import *
 from SCons.Util import is_List, make_path_relative
 from SCons.Warnings import warn, Warning
 
-import os, imp
-import SCons.Defaults
+import os
+import imp
 
 __all__ = [ 'src_targz', 'src_tarbz2', 'src_zip', 'tarbz2', 'targz', 'zip', 'rpm', 'msi', 'ipk' ]
 
@@ -166,9 +167,10 @@ def Package(env, target=None, source=None, **kw):
         #TODO: getargspec deprecated in Py3. cleanup when Py2.7 dropped.
         try:
             from inspect import getfullargspec
+            argspec = getfullargspec(packager.package)
         except ImportError:
             from inspect import getargspec
-        argspec = getargspec(packager.package)
+            argspec = getargspec(packager.package)
         args = argspec.args
         if argspec.defaults:
             # throw away arguments with default values


### PR DESCRIPTION
Py3 deprecated inspect.getargspec, prefer getfullargspec which is a drop-in replacement.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:
No test changes or user-visible code changes.
* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation