### PR TITLE
Add java 11

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -101,7 +101,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       This changes SCons to better comply with normal Python installation practices.
 
   From Mats Wichmann:
-    - Recognize new java 9, 10 (as 9.0 and 10.0)
+    - Recognize new java 9, 10, 11 (as 9.0 and 10.0, 11.0)
     - Updated manpage scons.xml to fix a nested list problem
     - Updated doc terminiology: use prepend instead of append as appropriate
     - XML validity fixes from SConstruct.py change

--- a/src/engine/SCons/Tool/JavaCommon.py
+++ b/src/engine/SCons/Tool/JavaCommon.py
@@ -69,7 +69,7 @@ if java_parsing:
         def __init__(self, version=default_java_version):
 
             if not version in ('1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7',
-                               '1.8', '5', '6', '9.0', '10.0'):
+                               '1.8', '5', '6', '9.0', '10.0', '11.0'):
 
                 msg = "Java version %s not supported" % version
                 raise NotImplementedError(msg)
@@ -177,7 +177,7 @@ if java_parsing:
             if self.version in ('1.1', '1.2', '1.3', '1.4'):
                 clazz = self.listClasses[0]
                 self.listOutputs.append('%s$%d' % (clazz, self.nextAnon))
-            elif self.version in ('1.5', '1.6', '1.7', '1.8', '5', '6', '9.0', '10.0'):
+            elif self.version in ('1.5', '1.6', '1.7', '1.8', '5', '6', '9.0', '10.0', '11.0'):
                 self.stackAnonClassBrackets.append(self.brackets)
                 className = []
                 className.extend(self.listClasses)


### PR DESCRIPTION
jdk 11.0 is almost at GA, and it will be the first edition designated
as Long Term Support (LTS), with commercial support until Sept 2023,
so we might as well add support to scons.

Going forward, is it worth continuing to check for individual versions
as being "supported"?

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:
No doc impact; tests just depend on the updated core check for version.

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation