### PR TITLE
Fix test/Execute.py failing on windows with python 2.7.15. 

### DIFF
--- a/test/Execute.py
+++ b/test/Execute.py
@@ -27,7 +27,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 """
 Test the Execute() function for executing actions directly.
 """
-
+import sys
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -82,11 +82,12 @@ test.write('k.in', "k.in\n")
 test.write('l.in', "l.in\n")
 test.write('m.in', "m.in\n")
 
-import sys
 if sys.platform == 'win32' and sys.version_info[0] == 2:
+    # note that nonexistent.in will have a \ on windows with python < 2.7.15
+    # and a / on >= 2.7.15 (The third line below)
     expect = r"""scons: \*\*\* Error 1
 scons: \*\*\* Error 2
-scons: \*\*\* nonexistent.in/\*\.\*: (The system cannot find the path specified|Das System kann den angegebenen Pfad nicht finden)"""
+scons: \*\*\* nonexistent.in(/|\\)\*\.\*: (The system cannot find the path specified|Das System kann den angegebenen Pfad nicht finden)"""
 elif sys.platform == 'win32' and sys.version_info[0] == 3:
     expect = r"""scons: \*\*\* Error 1
 scons: \*\*\* Error 2


### PR DESCRIPTION
It worked fine with python 2.7.14 and below. The output message changed from / to \ and broke the test.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation