### PR TITLE
Fix path to qt install for centos. It's not in the default posix PATH set by scons.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -46,6 +46,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fix GH Issue #3141 unicode string in a TryAction() with python 2.7 crashes.
     - Fixed issue causing stack trace when python Action function contains a unicode string when being
       run with Python 2.7
+    - Add alternate path to QT install for Centos in qt tool: /usr/lib64/qt-3.3/bin
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Tool/qt.py
+++ b/src/engine/SCons/Tool/qt.py
@@ -37,6 +37,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import re
+import glob
 
 import SCons.Action
 import SCons.Builder
@@ -44,6 +45,8 @@ import SCons.Defaults
 import SCons.Scanner
 import SCons.Tool
 import SCons.Util
+import SCons.Tool.cxx
+cplusplus = SCons.Tool.cxx
 
 class ToolQtWarning(SCons.Warnings.Warning):
     pass
@@ -60,11 +63,32 @@ header_extensions = [".h", ".hxx", ".hpp", ".hh"]
 if SCons.Util.case_sensitive_suffixes('.h', '.H'):
     header_extensions.append('.H')
 
-import SCons.Tool.cxx
-cplusplus = SCons.Tool.cxx
-#cplusplus = __import__('cxx', globals(), locals(), [])
-
 cxx_suffixes = cplusplus.CXXSuffixes
+
+
+#
+def find_platform_specific_qt_paths():
+    """
+    If the platform has non-standard paths which it installs QT in,return the likely default path
+    :return:
+    """
+
+    # qt_bin_dirs = []
+    qt_bin_dir = None
+    if os.path.isfile('/etc/redhat-release'):
+        with open('/etc/redhat-release','r') as rr:
+            lines = rr.readlines()
+            distro = lines[0].split()[0]
+        if distro == 'CentOS':
+            # Centos installs QT under /usr/{lib,lib64}/qt{4,5,-3.3}/bin
+            # so we need to handle this differently
+            # qt_bin_dirs = glob.glob('/usr/lib64/qt*/bin')
+            qt_bin_dir = '/usr/lib64/qt-3.3/bin'
+
+    return qt_bin_dir
+
+
+QT_BIN_DIR = find_platform_specific_qt_paths()
 
 def checkMocIncluded(target, source, env):
     moc = target[0]
@@ -188,13 +212,13 @@ AutomocStatic = _Automoc('StaticObject')
 
 def _detect(env):
     """Not really safe, but fast method to detect the QT library"""
-    QTDIR = None
-    if not QTDIR:
-        QTDIR = env.get('QTDIR',None)
+
+    QTDIR = env.get('QTDIR',None)
     if not QTDIR:
         QTDIR = os.environ.get('QTDIR',None)
     if not QTDIR:
-        moc = env.WhereIs('moc')
+        try_paths = os.pathsep.join([env['ENV']['PATH'],QT_BIN_DIR])
+        moc = env.WhereIs('moc',try_paths)
         if moc:
             QTDIR = os.path.dirname(os.path.dirname(moc))
             SCons.Warnings.warn(

--- a/src/engine/SCons/Tool/qt.py
+++ b/src/engine/SCons/Tool/qt.py
@@ -217,8 +217,7 @@ def _detect(env):
     if not QTDIR:
         QTDIR = os.environ.get('QTDIR',None)
     if not QTDIR:
-        try_paths = os.pathsep.join([env['ENV']['PATH'],QT_BIN_DIR])
-        moc = env.WhereIs('moc',try_paths)
+        moc = env.WhereIs('moc') or env.WhereIs('moc',QT_BIN_DIR)
         if moc:
             QTDIR = os.path.dirname(os.path.dirname(moc))
             SCons.Warnings.warn(


### PR DESCRIPTION
Add centos specific likely qt path to moc as it's not in the default PATH defined by SCons

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [] I have updated the appropriate documentation