### PR TITLE
Fix issue # 2580 applelink frameworkpath

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -47,6 +47,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fixed issue causing stack trace when python Action function contains a unicode string when being
       run with Python 2.7
     - Add alternate path to QT install for Centos in qt tool: /usr/lib64/qt-3.3/bin
+    - Fix GH Issue #2580 - # in FRAMEWORKPATH doesn't get properly expanded. The # is left in the
+      command line.
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Defaults.py
+++ b/src/engine/SCons/Defaults.py
@@ -342,6 +342,7 @@ Touch = ActionFactory(touch_func,
 
 # Internal utility functions
 
+
 def _concat(prefix, list, suffix, env, f=lambda x: x, target=None, source=None):
     """
     Creates a new list from 'list' by first interpolating each element
@@ -357,6 +358,7 @@ def _concat(prefix, list, suffix, env, f=lambda x: x, target=None, source=None):
         list = l
 
     return _concat_ixes(prefix, list, suffix, env)
+
 
 def _concat_ixes(prefix, list, suffix, env):
     """
@@ -394,6 +396,7 @@ def _concat_ixes(prefix, list, suffix, env):
                     result[-1] = result[-1]+suffix
 
     return result
+
 
 def _stripixes(prefix, itms, suffix, stripprefixes, stripsuffixes, env, c=None):
     """

--- a/src/engine/SCons/Tool/applelink.py
+++ b/src/engine/SCons/Tool/applelink.py
@@ -45,7 +45,8 @@ def generate(env):
     link.generate(env)
 
     env['FRAMEWORKPATHPREFIX'] = '-F'
-    env['_FRAMEWORKPATH'] = '${_concat(FRAMEWORKPATHPREFIX, FRAMEWORKPATH, "", __env__)}'
+    env['_FRAMEWORKPATH'] = '${_concat(FRAMEWORKPATHPREFIX, FRAMEWORKPATH, "", __env__, RDirs)}'
+
     env['_FRAMEWORKS'] = '${_concat("-framework ", FRAMEWORKS, "", __env__)}'
     env['LINKCOM'] = env['LINKCOM'] + ' $_FRAMEWORKPATH $_FRAMEWORKS $FRAMEWORKSFLAGS'
     env['SHLINKFLAGS'] = SCons.Util.CLVar('$LINKFLAGS -dynamiclib')

--- a/src/engine/SCons/Tool/applelink.py
+++ b/src/engine/SCons/Tool/applelink.py
@@ -39,6 +39,7 @@ import SCons.Util
 # the -rpath option, so we use the "link" tool instead of "gnulink".
 from . import link
 
+
 def generate(env):
     """Add Builders and construction variables for applelink to an
     Environment."""
@@ -67,8 +68,6 @@ def generate(env):
     env['LDMODULESUFFIX'] = '' 
     env['LDMODULEFLAGS'] = SCons.Util.CLVar('$LINKFLAGS -bundle')
     env['LDMODULECOM'] = '$LDMODULE -o ${TARGET} $LDMODULEFLAGS $SOURCES $_LIBDIRFLAGS $_LIBFLAGS $_FRAMEWORKPATH $_FRAMEWORKS $FRAMEWORKSFLAGS'
-
-
 
 def exists(env):
     return env['PLATFORM'] == 'darwin'

--- a/test/LINK/applelink.py
+++ b/test/LINK/applelink.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+import os
+
+import TestSCons
+
+_python_ = TestSCons._python_
+_exe   = TestSCons._exe
+
+test = TestSCons.TestSCons()
+
+
+test.write('foo.c', r"""
+#include <stdio.h>
+#include <stdlib.h>
+int
+main(int argc, char *argv[])
+{
+        argv[argc++] = "--";
+        printf("foo.c\n");
+        exit (0);
+}
+""")
+
+#  Test issue # 2580
+test.write('SConstruct', """
+DefaultEnvironment(tools=[])
+env = Environment()
+                  
+env.Object(
+	target = '#foo.o',
+	source = ['foo.c'],
+	FRAMEWORKS = ['Ogre'],
+	FRAMEWORKPATH = ['#frameworks']
+)
+""" % locals())
+
+test.run(arguments='-Q', stdout='gcc -o foo.o -c -Fframeworks foo.c\n')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/LINK/applelink.py
+++ b/test/LINK/applelink.py
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
 #  Test issue # 2580
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
-env = Environment()
+env = Environment(PLATFORM='darwin')
                   
 env.Object(
 	target = '#foo.o',


### PR DESCRIPTION
Hash marks in FRAMEWORKPATH weren't being properly evaluated.
Credit to @acmorrow for the patch.

Fixes issue #2580 

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation