### PR TITLE
Stop using deprecated unittest asserts

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -149,6 +149,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Updated the test-framework.rst documentation.
     - Remove obsoleted internal implementaiton of OrderedDict.
     - Test for tar packaging fixups
+    - Stop using deprecated unittest asserts
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/JobTests.py
+++ b/src/engine/SCons/JobTests.py
@@ -98,7 +98,7 @@ class Task(object):
         return True
 
     def execute(self):
-        self.taskmaster.test_case.failUnless(self.was_prepared,
+        self.taskmaster.test_case.assertTrue(self.was_prepared,
                                   "the task wasn't prepared")
 
         self.taskmaster.guard.acquire()
@@ -126,17 +126,17 @@ class Task(object):
     def executed(self):
         self.taskmaster.num_executed = self.taskmaster.num_executed + 1
 
-        self.taskmaster.test_case.failUnless(self.was_prepared,
+        self.taskmaster.test_case.assertTrue(self.was_prepared,
                                   "the task wasn't prepared")
-        self.taskmaster.test_case.failUnless(self.was_executed,
+        self.taskmaster.test_case.assertTrue(self.was_executed,
                                   "the task wasn't really executed")
-        self.taskmaster.test_case.failUnless(isinstance(self, Task),
+        self.taskmaster.test_case.assertTrue(isinstance(self, Task),
                                   "the task wasn't really a Task instance")
 
     def failed(self):
         self.taskmaster.num_failed = self.taskmaster.num_failed + 1
         self.taskmaster.stop = 1
-        self.taskmaster.test_case.failUnless(self.was_prepared,
+        self.taskmaster.test_case.assertTrue(self.was_prepared,
                                   "the task wasn't prepared")
 
     def postprocess(self):
@@ -171,17 +171,17 @@ class ExceptionTask(object):
     def executed(self):
         self.taskmaster.num_executed = self.taskmaster.num_executed + 1
 
-        self.taskmaster.test_case.failUnless(self.was_prepared,
+        self.taskmaster.test_case.assertTrue(self.was_prepared,
                                   "the task wasn't prepared")
-        self.taskmaster.test_case.failUnless(self.was_executed,
+        self.taskmaster.test_case.assertTrue(self.was_executed,
                                   "the task wasn't really executed")
-        self.taskmaster.test_case.failUnless(self.__class__ is Task,
+        self.taskmaster.test_case.assertTrue(self.__class__ is Task,
                                   "the task wasn't really a Task instance")
 
     def failed(self):
         self.taskmaster.num_failed = self.taskmaster.num_failed + 1
         self.taskmaster.stop = 1
-        self.taskmaster.test_case.failUnless(self.was_prepared,
+        self.taskmaster.test_case.assertTrue(self.was_prepared,
                                   "the task wasn't prepared")
 
     def postprocess(self):
@@ -262,15 +262,15 @@ class ParallelTestCase(unittest.TestCase):
         jobs = SCons.Job.Jobs(num_jobs, taskmaster)
         jobs.run()
 
-        self.failUnless(not taskmaster.tasks_were_serial(),
+        self.assertTrue(not taskmaster.tasks_were_serial(),
                         "the tasks were not executed in parallel")
-        self.failUnless(taskmaster.all_tasks_are_executed(),
+        self.assertTrue(taskmaster.all_tasks_are_executed(),
                         "all the tests were not executed")
-        self.failUnless(taskmaster.all_tasks_are_iterated(),
+        self.assertTrue(taskmaster.all_tasks_are_iterated(),
                         "all the tests were not iterated over")
-        self.failUnless(taskmaster.all_tasks_are_postprocessed(),
+        self.assertTrue(taskmaster.all_tasks_are_postprocessed(),
                         "all the tests were not postprocessed")
-        self.failIf(taskmaster.num_failed,
+        self.assertFalse(taskmaster.num_failed,
                     "some task(s) failed to execute")
 
         # Verify that parallel jobs will pull all of the completed tasks
@@ -325,15 +325,15 @@ class SerialTestCase(unittest.TestCase):
         jobs = SCons.Job.Jobs(1, taskmaster)
         jobs.run()
 
-        self.failUnless(taskmaster.tasks_were_serial(),
+        self.assertTrue(taskmaster.tasks_were_serial(),
                         "the tasks were not executed in series")
-        self.failUnless(taskmaster.all_tasks_are_executed(),
+        self.assertTrue(taskmaster.all_tasks_are_executed(),
                         "all the tests were not executed")
-        self.failUnless(taskmaster.all_tasks_are_iterated(),
+        self.assertTrue(taskmaster.all_tasks_are_iterated(),
                         "all the tests were not iterated over")
-        self.failUnless(taskmaster.all_tasks_are_postprocessed(),
+        self.assertTrue(taskmaster.all_tasks_are_postprocessed(),
                         "all the tests were not postprocessed")
-        self.failIf(taskmaster.num_failed,
+        self.assertFalse(taskmaster.num_failed,
                     "some task(s) failed to execute")
 
 class NoParallelTestCase(unittest.TestCase):
@@ -346,18 +346,18 @@ class NoParallelTestCase(unittest.TestCase):
         try:
             taskmaster = Taskmaster(num_tasks, self, RandomTask)
             jobs = SCons.Job.Jobs(2, taskmaster)
-            self.failUnless(jobs.num_jobs == 1,
+            self.assertTrue(jobs.num_jobs == 1,
                             "unexpected number of jobs %d" % jobs.num_jobs)
             jobs.run()
-            self.failUnless(taskmaster.tasks_were_serial(),
+            self.assertTrue(taskmaster.tasks_were_serial(),
                             "the tasks were not executed in series")
-            self.failUnless(taskmaster.all_tasks_are_executed(),
+            self.assertTrue(taskmaster.all_tasks_are_executed(),
                             "all the tests were not executed")
-            self.failUnless(taskmaster.all_tasks_are_iterated(),
+            self.assertTrue(taskmaster.all_tasks_are_iterated(),
                             "all the tests were not iterated over")
-            self.failUnless(taskmaster.all_tasks_are_postprocessed(),
+            self.assertTrue(taskmaster.all_tasks_are_postprocessed(),
                             "all the tests were not postprocessed")
-            self.failIf(taskmaster.num_failed,
+            self.assertFalse(taskmaster.num_failed,
                         "some task(s) failed to execute")
         finally:
             SCons.Job.Parallel = save_Parallel
@@ -371,13 +371,13 @@ class SerialExceptionTestCase(unittest.TestCase):
         jobs = SCons.Job.Jobs(1, taskmaster)
         jobs.run()
 
-        self.failIf(taskmaster.num_executed,
+        self.assertFalse(taskmaster.num_executed,
                     "a task was executed")
-        self.failUnless(taskmaster.num_iterated == 1,
+        self.assertTrue(taskmaster.num_iterated == 1,
                     "exactly one task should have been iterated")
-        self.failUnless(taskmaster.num_failed == 1,
+        self.assertTrue(taskmaster.num_failed == 1,
                     "exactly one task should have failed")
-        self.failUnless(taskmaster.num_postprocessed == 1,
+        self.assertTrue(taskmaster.num_postprocessed == 1,
                     "exactly one task should have been postprocessed")
 
 class ParallelExceptionTestCase(unittest.TestCase):
@@ -388,13 +388,13 @@ class ParallelExceptionTestCase(unittest.TestCase):
         jobs = SCons.Job.Jobs(num_jobs, taskmaster)
         jobs.run()
 
-        self.failIf(taskmaster.num_executed,
+        self.assertFalse(taskmaster.num_executed,
                     "a task was executed")
-        self.failUnless(taskmaster.num_iterated >= 1,
+        self.assertTrue(taskmaster.num_iterated >= 1,
                     "one or more task should have been iterated")
-        self.failUnless(taskmaster.num_failed >= 1,
+        self.assertTrue(taskmaster.num_failed >= 1,
                     "one or more tasks should have failed")
-        self.failUnless(taskmaster.num_postprocessed >= 1,
+        self.assertTrue(taskmaster.num_postprocessed >= 1,
                     "one or more tasks should have been postprocessed")
 
 #---------------------------------------------------------------------
@@ -525,10 +525,10 @@ class _SConsTaskTest(unittest.TestCase):
 
         for N in testnodes:
             state = N.get_state()
-            self.failUnless(state in [SCons.Node.no_state, N.expect_to_be],
+            self.assertTrue(state in [SCons.Node.no_state, N.expect_to_be],
                             "Node %s got unexpected result: %s" % (N, state))
 
-        self.failUnless([N for N in testnodes if N.get_state()],
+        self.assertTrue([N for N in testnodes if N.get_state()],
                         "no nodes ran at all.")
 
 

--- a/src/engine/SCons/Scanner/CTests.py
+++ b/src/engine/SCons/Scanner/CTests.py
@@ -218,7 +218,7 @@ def deps_match(self, deps, headers):
     global my_normpath
     scanned = list(map(my_normpath, list(map(str, deps))))
     expect = list(map(my_normpath, headers))
-    self.failUnless(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
+    self.assertTrue(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
 
 # define some tests:
 

--- a/src/engine/SCons/Scanner/DTests.py
+++ b/src/engine/SCons/Scanner/DTests.py
@@ -79,7 +79,7 @@ def deps_match(self, deps, headers):
     global my_normpath
     scanned = list(map(my_normpath, list(map(str, deps))))
     expect = list(map(my_normpath, headers))
-    self.failUnless(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
+    self.assertTrue(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
 
 """
 Examples from https://dlang.org/spec/module.html

--- a/src/engine/SCons/Scanner/FortranTests.py
+++ b/src/engine/SCons/Scanner/FortranTests.py
@@ -258,7 +258,7 @@ class DummyEnvironment(object):
 def deps_match(self, deps, headers):
     scanned = list(map(os.path.normpath, list(map(str, deps))))
     expect = list(map(os.path.normpath, headers))
-    self.failUnless(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
+    self.assertTrue(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
 
 # define some tests:
 

--- a/src/engine/SCons/Scanner/IDLTests.py
+++ b/src/engine/SCons/Scanner/IDLTests.py
@@ -243,7 +243,7 @@ if os.path.normcase('foo') == os.path.normcase('FOO'):
 def deps_match(self, deps, headers):
     scanned = list(map(my_normpath, list(map(str, deps))))
     expect = list(map(my_normpath, headers))
-    self.failUnless(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
+    self.assertTrue(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
 
 # define some tests:
 

--- a/src/engine/SCons/Scanner/LaTeXTests.py
+++ b/src/engine/SCons/Scanner/LaTeXTests.py
@@ -122,7 +122,7 @@ def deps_match(self, deps, headers):
     global my_normpath
     scanned = list(map(my_normpath, list(map(str, deps))))
     expect = list(map(my_normpath, headers))
-    self.failUnless(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
+    self.assertTrue(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
 
 
 class LaTeXScannerTestCase1(unittest.TestCase):

--- a/src/engine/SCons/Scanner/RCTests.py
+++ b/src/engine/SCons/Scanner/RCTests.py
@@ -116,7 +116,7 @@ if os.path.normcase('foo') == os.path.normcase('FOO'):
 def deps_match(self, deps, headers):
     scanned = sorted(map(my_normpath, list(map(str, deps))))
     expect = sorted(map(my_normpath, headers))
-    self.failUnless(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
+    self.assertTrue(scanned == expect, "expect %s != scanned %s" % (expect, scanned))
 
 # define some tests:
 

--- a/src/engine/SCons/Scanner/ScannerTests.py
+++ b/src/engine/SCons/Scanner/ScannerTests.py
@@ -132,16 +132,16 @@ class BaseTestCase(unittest.TestCase):
         scanned = scanner(filename, env, path)
         scanned_strs = [str(x) for x in scanned]
 
-        self.failUnless(self.filename == filename, "the filename was passed incorrectly")
-        self.failUnless(self.env == env, "the environment was passed incorrectly")
-        self.failUnless(scanned_strs == deps, "the dependencies were returned incorrectly")
+        self.assertTrue(self.filename == filename, "the filename was passed incorrectly")
+        self.assertTrue(self.env == env, "the environment was passed incorrectly")
+        self.assertTrue(scanned_strs == deps, "the dependencies were returned incorrectly")
         for d in scanned:
-            self.failUnless(not isinstance(d, str), "got a string in the dependencies")
+            self.assertTrue(not isinstance(d, str), "got a string in the dependencies")
 
         if len(args) > 0:
-            self.failUnless(self.arg == args[0], "the argument was passed incorrectly")
+            self.assertTrue(self.arg == args[0], "the argument was passed incorrectly")
         else:
-            self.failIf(hasattr(self, "arg"), "an argument was given when it shouldn't have been")
+            self.assertFalse(hasattr(self, "arg"), "an argument was given when it shouldn't have been")
 
     def test___call__dict(self):
         """Test calling Scanner.Base objects with a dictionary"""
@@ -245,7 +245,7 @@ class BaseTestCase(unittest.TestCase):
         dict[s] = 777
         i = hash(id(s))
         h = hash(list(dict.keys())[0])
-        self.failUnless(h == i,
+        self.assertTrue(h == i,
                         "hash Scanner base class expected %s, got %s" % (i, h))
 
     def test_scan_check(self):
@@ -260,7 +260,7 @@ class BaseTestCase(unittest.TestCase):
         self.checked = {}
         path = s.path(env)
         scanned = s(DummyNode('x'), env, path)
-        self.failUnless(self.checked['x'] == 1,
+        self.assertTrue(self.checked['x'] == 1,
                         "did not call check function")
 
     def test_recursive(self):
@@ -269,42 +269,42 @@ class BaseTestCase(unittest.TestCase):
 
         s = SCons.Scanner.Base(function = self.func)
         n = s.recurse_nodes(nodes)
-        self.failUnless(n == [],
+        self.assertTrue(n == [],
                         "default behavior returned nodes: %s" % n)
 
         s = SCons.Scanner.Base(function = self.func, recursive = None)
         n = s.recurse_nodes(nodes)
-        self.failUnless(n == [],
+        self.assertTrue(n == [],
                         "recursive = None returned nodes: %s" % n)
 
         s = SCons.Scanner.Base(function = self.func, recursive = 1)
         n = s.recurse_nodes(nodes)
-        self.failUnless(n == n,
+        self.assertTrue(n == n,
                         "recursive = 1 didn't return all nodes: %s" % n)
 
         def odd_only(nodes):
             return [n for n in nodes if n % 2]
         s = SCons.Scanner.Base(function = self.func, recursive = odd_only)
         n = s.recurse_nodes(nodes)
-        self.failUnless(n == [1, 3],
+        self.assertTrue(n == [1, 3],
                         "recursive = 1 didn't return all nodes: %s" % n)
 
     def test_get_skeys(self):
         """Test the Scanner.Base get_skeys() method"""
         s = SCons.Scanner.Base(function = self.func)
         sk = s.get_skeys()
-        self.failUnless(sk == [],
+        self.assertTrue(sk == [],
                         "did not initialize to expected []")
 
         s = SCons.Scanner.Base(function = self.func, skeys = ['.1', '.2'])
         sk = s.get_skeys()
-        self.failUnless(sk == ['.1', '.2'],
+        self.assertTrue(sk == ['.1', '.2'],
                         "sk was %s, not ['.1', '.2']")
 
         s = SCons.Scanner.Base(function = self.func, skeys = '$LIST')
         env = DummyEnvironment(LIST = ['.3', '.4'])
         sk = s.get_skeys(env)
-        self.failUnless(sk == ['.3', '.4'],
+        self.assertTrue(sk == ['.3', '.4'],
                         "sk was %s, not ['.3', '.4']")
 
     def test_select(self):
@@ -432,19 +432,19 @@ class CurrentTestCase(unittest.TestCase):
         path = s.path(env)
         hnb = HasNoBuilder()
         s(hnb, env, path)
-        self.failUnless(hnb.called_has_builder, "did not call has_builder()")
-        self.failUnless(not hnb.called_is_up_to_date, "did call is_up_to_date()")
-        self.failUnless(hnb.func_called, "did not call func()")
+        self.assertTrue(hnb.called_has_builder, "did not call has_builder()")
+        self.assertTrue(not hnb.called_is_up_to_date, "did call is_up_to_date()")
+        self.assertTrue(hnb.func_called, "did not call func()")
         inc = IsNotCurrent()
         s(inc, env, path)
-        self.failUnless(inc.called_has_builder, "did not call has_builder()")
-        self.failUnless(inc.called_is_up_to_date, "did not call is_up_to_date()")
-        self.failUnless(not inc.func_called, "did call func()")
+        self.assertTrue(inc.called_has_builder, "did not call has_builder()")
+        self.assertTrue(inc.called_is_up_to_date, "did not call is_up_to_date()")
+        self.assertTrue(not inc.func_called, "did call func()")
         ic = IsCurrent()
         s(ic, env, path)
-        self.failUnless(ic.called_has_builder, "did not call has_builder()")
-        self.failUnless(ic.called_is_up_to_date, "did not call is_up_to_date()")
-        self.failUnless(ic.func_called, "did not call func()")
+        self.assertTrue(ic.called_has_builder, "did not call has_builder()")
+        self.assertTrue(ic.called_is_up_to_date, "did not call is_up_to_date()")
+        self.assertTrue(ic.func_called, "did not call func()")
 
 class ClassicTestCase(unittest.TestCase):
 
@@ -566,7 +566,7 @@ class ClassicTestCase(unittest.TestCase):
 
         s = SCons.Scanner.Classic("Test", [], None, "", function=self.func, recursive=1)
         n = s.recurse_nodes(nodes)
-        self.failUnless(n == n,
+        self.assertTrue(n == n,
                         "recursive = 1 didn't return all nodes: %s" % n)
 
         def odd_only(nodes):
@@ -574,7 +574,7 @@ class ClassicTestCase(unittest.TestCase):
 
         s = SCons.Scanner.Classic("Test", [], None, "", function=self.func, recursive=odd_only)
         n = s.recurse_nodes(nodes)
-        self.failUnless(n == [1, 3],
+        self.assertTrue(n == [1, 3],
                         "recursive = 1 didn't return all nodes: %s" % n)
 
 


### PR DESCRIPTION
failUnless and failIf have been deprecated since 2.7 and 3.1,
the docs call them aliases that exist for historical reasons.
In Python 3.7, the default DeprecationWarnings make things
very noisy, so flip these to assertTrue and assertFalse.

This is a trivial replace on unit-test files.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation