### PR TITLE
Speedup tests on Windows platform - Part 1 (more to come)

### DIFF
--- a/test/Clean/Option.py
+++ b/test/Clean/Option.py
@@ -46,8 +46,9 @@ file.close()
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
+env = Environment(tools=[], BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 
 mode = ARGUMENTS.get('MODE')

--- a/test/Clean/basic.py
+++ b/test/Clean/basic.py
@@ -45,8 +45,9 @@ file.close()
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
+env = Environment(tools=[], BUILDERS = { 'B' : B })
 env.B(target = 'foo1.out', source = 'foo1.in')
 env.B(target = 'foo2.out', source = 'foo2.xxx')
 env.B(target = 'foo2.xxx', source = 'foo2.in')

--- a/test/Clean/function.py
+++ b/test/Clean/function.py
@@ -51,8 +51,9 @@ subd_foon_in = os.path.join('subd', 'foon.in')
 subd_foox_in = os.path.join('subd', 'foox.in')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B }, FOO = 'foo2')
+env = Environment(tools=[], BUILDERS = { 'B' : B }, FOO = 'foo2')
 env.B(target = 'foo1.out', source = 'foo1.in')
 env.B(target = 'foo2.out', source = 'foo2.xxx')
 foo2_xxx = env.B(target = 'foo2.xxx', source = 'foo2.in')

--- a/test/Climb/explicit-parent--D.py
+++ b/test/Climb/explicit-parent--D.py
@@ -36,13 +36,14 @@ test = TestSCons.TestSCons()
 test.subdir(['subdir'])
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     f = open(target, "wb")
     for src in source:
         f.write(open(str(src), "rb").read())
     f.close()
-env = Environment(BUILDERS={'Cat':Builder(action=cat)})
+env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('f1.out', 'f1.in')
 f2 = env.Cat('f2.out', 'f2.in')
 Default(f2)

--- a/test/Climb/filename--D.py
+++ b/test/Climb/filename--D.py
@@ -36,6 +36,7 @@ test = TestSCons.TestSCons()
 test.subdir('subdir', 'other')
 
 test.write('main.scons', """\
+DefaultEnvironment(tools=[])
 print("main.scons")
 SConscript('subdir/sub.scons')
 """)

--- a/test/Climb/filename--U.py
+++ b/test/Climb/filename--U.py
@@ -36,6 +36,7 @@ test = TestSCons.TestSCons()
 test.subdir('subdir', 'other')
 
 test.write('main.scons', """\
+DefaultEnvironment(tools=[])
 print("main.scons")
 SConscript('subdir/sub.scons')
 """)

--- a/test/Climb/filename-u.py
+++ b/test/Climb/filename-u.py
@@ -36,6 +36,7 @@ test = TestSCons.TestSCons()
 test.subdir('subdir', 'other')
 
 test.write('main.scons', """\
+DefaultEnvironment(tools=[])
 print("main.scons")
 SConscript('subdir/sub.scons')
 """)

--- a/test/Climb/option--D.py
+++ b/test/Climb/option--D.py
@@ -41,9 +41,10 @@ file.close()
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 import SCons.Defaults
 B = Builder(action=r'%(_python_)s build.py $TARGET $SOURCES')
-env = Environment()
+env = Environment(tools=[])
 env['BUILDERS']['B'] = B
 env.B(target = 'sub1/foo.out', source = 'sub1/foo.in')
 Export('env')

--- a/test/Climb/option--U.py
+++ b/test/Climb/option--U.py
@@ -43,8 +43,9 @@ file.close()
 """)
 
 test.write('SConstruct', r"""
+DefaultEnvironment(tools=[])
 import SCons.Defaults
-env = Environment()
+env = Environment(tools=[])
 env['BUILDERS']['B'] = Builder(action=r'%(_python_)s build.py $TARGET $SOURCES', multi=1)
 Default(env.B(target = 'sub1/foo.out', source = 'sub1/foo.in'))
 Export('env')
@@ -83,7 +84,7 @@ test.must_not_exist(test.workpath('sub2/xxx.out'))
 test.unlink(['sub1', 'foo.out'])
 
 test.write('SConscript', """\
-env = Environment()
+env = Environment(tools=[], )
 assert env.GetLaunchDir() == r'%s'
 """%test.workpath('sub1'))
 test.run(arguments = '-U',

--- a/test/Climb/option-u.py
+++ b/test/Climb/option-u.py
@@ -41,13 +41,14 @@ test.subdir('sub1',
             'sub4', ['sub4', 'dir'])
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     f = open(target, "wb")
     for src in source:
         f.write(open(str(src), "rb").read())
     f.close()
-env = Environment()
+env = Environment(tools=[])
 env.Append(BUILDERS = {'Cat' : Builder(action=cat)})
 env.Cat(target = 'sub1/f1a.out', source = 'sub1/f1a.in')
 env.Cat(target = 'sub1/f1b.out', source = 'sub1/f1b.in')

--- a/test/GetBuildFailures/option-k.py
+++ b/test/GetBuildFailures/option-k.py
@@ -57,6 +57,7 @@ test.write('mypass.py', contents)
 test.write('myfail.py', contents)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 Command('f3', 'f3.in', r'@%(_python_)s mypass.py -  f3 $TARGET $SOURCE')
 Command('f4', 'f4.in', r'@%(_python_)s myfail.py f3 f4 $TARGET $SOURCE')
 Command('f5', 'f5.in', r'@%(_python_)s myfail.py f4 f5 $TARGET $SOURCE')

--- a/test/GetBuildFailures/parallel.py
+++ b/test/GetBuildFailures/parallel.py
@@ -73,6 +73,7 @@ test.write('mypass.py', contents)
 test.write('myfail.py', contents)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 Command('f3', 'f3.in', r'@%(_python_)s mypass.py -  f3 $TARGET $SOURCE')
 Command('f4', 'f4.in', r'@%(_python_)s myfail.py f3 f4 $TARGET $SOURCE')
 Command('f5', 'f5.in', r'@%(_python_)s myfail.py f4 f5 $TARGET $SOURCE')

--- a/test/GetBuildFailures/serial.py
+++ b/test/GetBuildFailures/serial.py
@@ -60,6 +60,7 @@ test.write('mypass.py', contents)
 test.write('myfail.py', contents)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 Command('f03', 'f03.in', r'@%(_python_)s mypass.py -   f03 $TARGET $SOURCE')
 Command('f04', 'f04.in', r'@%(_python_)s myfail.py f03 f04 $TARGET $SOURCE')
 Command('f05', 'f05.in', r'@%(_python_)s myfail.py f04 f05 $TARGET $SOURCE')

--- a/test/GetOption/help.py
+++ b/test/GetOption/help.py
@@ -33,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 if GetOption('help'):
    print("GetOption('help') set")
 else:

--- a/test/Glob/Repository.py
+++ b/test/Glob/Repository.py
@@ -47,6 +47,7 @@ work_src_yyy = test.workpath('work', 'src', 'yyy')
 opts = "-Y " + test.workpath('repository')
 
 test.write(['repository', 'SConstruct'], """\
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     f = open(target, "wb")
@@ -60,7 +61,7 @@ File('../repository/mmm.in')
 m = Glob('m*.in')
 assert str(m[0]) == 'mmm.in'
 
-env = Environment(BUILDERS={'Build':Builder(action=cat)})
+env = Environment(tools=[], BUILDERS={'Build':Builder(action=cat)})
 env.Build('aaa.out', Glob('a*.in'))
 env.Build('bbb.out', Glob('b*.in'))
 env.Build('ccc.out', Glob('c*.in'))

--- a/test/Glob/VariantDir.py
+++ b/test/Glob/VariantDir.py
@@ -37,6 +37,7 @@ test.subdir('src')
 test.subdir('src/sub1')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 VariantDir('var1', 'src')
 VariantDir('var2', 'src')
 
@@ -48,7 +49,7 @@ SConscript('src/sub1/SConscript', src_dir = 'src', variant_dir = 'var3', duplica
 """)
 
 test.write(['src', 'SConscript'], """\
-env = Environment() 
+env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
     fp = open(str(target[0]), 'wb')
@@ -63,7 +64,7 @@ env.Concatenate('fex.out', sorted(Glob('f*.in', exclude = 'f1.in'), key=lambda t
 """)
 
 test.write(['src', 'sub1', 'SConscript'], """\
-env = Environment()
+env = Environment(tools=[])
 
 def concatenate(target, source, env):
     fp = open(str(target[0]), 'wb')

--- a/test/Glob/basic.py
+++ b/test/Glob/basic.py
@@ -33,7 +33,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment() 
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
     fp = open(str(target[0]), 'wb')

--- a/test/Glob/exclude.py
+++ b/test/Glob/exclude.py
@@ -36,7 +36,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment() 
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
     fp = open(str(target[0]), 'wb')

--- a/test/Glob/source.py
+++ b/test/Glob/source.py
@@ -37,7 +37,8 @@ test = TestSCons.TestSCons()
 test.subdir('src', 'var1', 'var2')
 
 test.write('SConstruct', """\
-env = Environment() 
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
     fp = open(str(target[0]), 'wb')

--- a/test/Glob/strings.py
+++ b/test/Glob/strings.py
@@ -37,6 +37,7 @@ test = TestSCons.TestSCons()
 test.subdir('src')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 VariantDir('var1', 'src')
 VariantDir('var2', 'src')
 
@@ -45,7 +46,7 @@ SConscript('var2/SConscript')
 """)
 
 test.write(['src', 'SConscript'], """\
-env = Environment() 
+env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
     fp = open(str(target[0]), 'wb')

--- a/test/Glob/subdir.py
+++ b/test/Glob/subdir.py
@@ -36,7 +36,8 @@ test = TestSCons.TestSCons()
 test.subdir('subdir')
 
 test.write('SConstruct', """\
-env = Environment() 
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
     fp = open(str(target[0]), 'wb')

--- a/test/Glob/subst.py
+++ b/test/Glob/subst.py
@@ -34,7 +34,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment(PATTERN = 'f*.in')
+DefaultEnvironment(tools=[])
+env = Environment(tools=[], PATTERN = 'f*.in')
 
 def copy(target, source, env):
     fp = open(str(target[0]), 'wb')

--- a/test/Install/Clone.py
+++ b/test/Install/Clone.py
@@ -34,6 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env1 = Environment(DESTDIR='sub1', tools=[])
 
 # Call env1.Install() but not env1.InstallAs() *before* we clone it.

--- a/test/Install/INSTALLSTR.py
+++ b/test/Install/INSTALLSTR.py
@@ -37,7 +37,8 @@ test = TestSCons.TestSCons()
 test.subdir('install')
 
 test.write('SConstruct', """\
-env = Environment(INSTALLSTR = 'INSTALL $SOURCE => $TARGET!')
+DefaultEnvironment(tools=[])
+env = Environment(tools=[], INSTALLSTR = 'INSTALL $SOURCE => $TARGET!')
 env.Install('install', 'file')
 """)
 

--- a/test/Install/Install.py
+++ b/test/Install/Install.py
@@ -48,6 +48,7 @@ f6_sep = f6_txt.replace(os.sep, '/')
 _SUBDIR_f4_out = os.path.join('$SUBDIR', 'f4.out')
 
 test.write(['work', 'SConstruct'], """\
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     f = open(target, "w")
@@ -60,7 +61,7 @@ def my_install(dest, source, env):
     shutil.copy2(source, dest)
     open('my_install.out', 'a').write(dest)
 
-env1 = Environment()
+env1 = Environment(tools=[])
 env1.Append(BUILDERS={'Cat':Builder(action=cat)})
 env3 = env1.Clone(INSTALL = my_install)
 

--- a/test/Install/InstallAs.py
+++ b/test/Install/InstallAs.py
@@ -47,7 +47,8 @@ _SUBDIR_file3_in = os.path.join('$SUBDIR', 'file3.in')
 
 #
 test.write('SConstruct', r"""
-env = Environment(INSTALLDIR=r'%(install)s', SUBDIR='subdir')
+DefaultEnvironment(tools=[])
+env = Environment(tools=[], INSTALLDIR=r'%(install)s', SUBDIR='subdir')
 InstallAs(r'%(install_file1_out)s', 'file1.in')
 env.InstallAs([r'%(_INSTALLDIR_file2_out)s', r'%(install_file3_out)s'],
               ['file2.in', r'%(_SUBDIR_file3_in)s'])

--- a/test/Install/dir-exists.py
+++ b/test/Install/dir-exists.py
@@ -35,6 +35,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 Execute(Mkdir('a'))
 Execute(Mkdir('b'))
 f=Command('a/f', None, 'echo hi > $TARGET')

--- a/test/Install/directories.py
+++ b/test/Install/directories.py
@@ -46,10 +46,12 @@ test.subdir('outside',
             ['work', 'dir4', 'sub'])
 
 test.write(['work', 'SConstruct'], """\
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
+
 Install('../outside',  'dir1')
 InstallAs('../outside/d2', 'dir2')
 
-env = Environment()
 env.Install('../outside',  'dir3')
 env.InstallAs('../outside/d4',  'dir4')
 """)

--- a/test/Install/multi-dir/src/SConstruct
+++ b/test/Install/multi-dir/src/SConstruct
@@ -2,7 +2,8 @@
 # outside the source tree can cause SCons to fail to create the dest
 # dir.
 import os, os.path, shutil
-env=Environment()
+DefaultEnvironment(tools=[])
+env=Environment(tools=[])
 dst='../build'
 env.Install(os.path.join(dst,'__foo/bar/baz'), 'a')
 env.Install(os.path.join(dst,'__foo/bar/baz/a/b'), 'x/y')

--- a/test/Install/multi.py
+++ b/test/Install/multi.py
@@ -34,7 +34,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
 env.Install('install', 'file1')
 env.Install('install', 'file1')
 """)

--- a/test/Install/no-top-relative.py
+++ b/test/Install/no-top-relative.py
@@ -39,7 +39,8 @@ test = TestSCons.TestSCons()
 test.subdir(['test'])
 
 test.write(['SConstruct'], """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
 i = env.Install("#/install", "#/test/#testfile.txt#");
 env.Default(i);
 """)

--- a/test/Install/non-ascii-name.py
+++ b/test/Install/non-ascii-name.py
@@ -39,6 +39,7 @@ test.write('中文.txt',
            "test stuff here in file 中文.txt.\n")
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 InstallAs("b", Glob("*.txt"))
 """)
 test.run(arguments='.')

--- a/test/Install/option--install-sandbox.py
+++ b/test/Install/option--install-sandbox.py
@@ -49,7 +49,8 @@ file1_out       = target+os.path.join( target,
 
 #
 test.write('SConstruct', r"""
-env = Environment(SUBDIR='subdir')
+DefaultEnvironment(tools=[])
+env = Environment(tools=[], SUBDIR='subdir')
 f1 = env.Install(r'%(destdir)s', 'file1.out')
 f2 = env.InstallAs(['file2.out', r'%(_SUBDIR_file3_out)s'],
                    ['file2.in', r'%(_SUBDIR_file3_in)s'])

--- a/test/Install/tool.py
+++ b/test/Install/tool.py
@@ -36,6 +36,7 @@ test = TestSCons.TestSCons()
 test.subdir('iii')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(tools = [])
 env.Install('iii', 'foo.in')
 env.InstallAs('foo.out', 'foo.in')

--- a/test/Install/wrap-by-attribute.py
+++ b/test/Install/wrap-by-attribute.py
@@ -42,6 +42,7 @@ test = TestSCons.TestSCons()
 test.subdir('outside', 'sub')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 import os.path
 
 def cat(env, source, target):
@@ -51,7 +52,7 @@ def cat(env, source, target):
         f.write(open(str(src), "rb").read())
     f.close()
 
-env = Environment(DESTDIR='dest')
+env = Environment(tools=[], DESTDIR='dest')
 env.Append(BUILDERS={'Cat':Builder(action=cat)})
 
 env.SconsInternalInstallFunc = env.Install

--- a/test/M4/M4.py
+++ b/test/M4/M4.py
@@ -46,7 +46,8 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'm4'],
+DefaultEnvironment(tools=[])
+env = Environment(tools=['m4'],
                   M4 = r'%(_python_)s mym4.py')
 env.M4(target = 'aaa.x', source = 'aaa.x.m4')
 """ % locals())
@@ -76,10 +77,11 @@ if m4:
     test.file_fixture('wrapper.py')
 
     test.write('SConstruct', """
-foo = Environment(tools=['default', 'm4'],
+DefaultEnvironment(tools=[])
+foo = Environment(tools=['m4'],
                   M4=r'%(m4)s', M4FLAGS='-DFFF=fff')
 m4 = foo.Dictionary('M4')
-bar = Environment(tools=['default', 'm4'],
+bar = Environment(tools=['m4'],
                   M4 = r'%(_python_)s wrapper.py ' + m4, M4FLAGS='-DBBB=bbb')
 foo.M4(target = 'foo.x', source = 'foo.x.m4')
 bar.M4(target = 'bar', source = 'bar.m4')

--- a/test/M4/M4COM.py
+++ b/test/M4/M4COM.py
@@ -47,7 +47,8 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'm4'],
+DefaultEnvironment(tools=[])
+env = Environment(tools=['m4'],
                   M4COM = r'%(_python_)s mym4.py $TARGET $SOURCES')
 env.M4(target = 'aaa.out', source = 'aaa.in')
 """ % locals())

--- a/test/M4/M4COMSTR.py
+++ b/test/M4/M4COMSTR.py
@@ -48,7 +48,8 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'm4'],
+DefaultEnvironment(tools=[])
+env = Environment(tools=['m4'],
                   M4COM = r'%(_python_)s mym4.py $TARGET $SOURCES',
                   M4COMSTR = 'M4ing $TARGET from $SOURCE')
 env.M4(target = 'aaa.out', source = 'aaa.in')

--- a/test/explain/alias-order.py
+++ b/test/explain/alias-order.py
@@ -38,7 +38,8 @@ args = '--debug=explain target2.dat'
 
 test.subdir('src')
 test.write(['src', 'SConstruct'],"""
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 
 def action( source, target, env ):
     f = open( str(target[0]), 'wb' )

--- a/test/explain/basic.py
+++ b/test/explain/basic.py
@@ -81,6 +81,7 @@ sys.exit(0)
 
 
 SConstruct_contents = """\
+DefaultEnvironment(tools=[])
 import re
 
 include_re = re.compile(r'^include\s+(\S+)$', re.M)
@@ -98,7 +99,7 @@ kscan = Scanner(name = 'kfile',
 cat = Builder(action = [[r'%(python)s', r'%(cat_py)s', '$TARGET', '$SOURCES']])
 one_cat = Builder( action = [[r'%(python)s', r'%(cat_py)s', '$TARGET', '${SOURCES[0]}']])
 
-env = Environment()
+env = Environment(tools=[])
 env.Append(BUILDERS = {'Cat':cat, 'OneCat':one_cat},
            SCANNERS = kscan)
 env.PrependENVPath('PATHEXT', '.PY')

--- a/test/explain/function-actions.py
+++ b/test/explain/function-actions.py
@@ -38,9 +38,10 @@ test = TestSCons.TestSCons()
 
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 import shutil
 
-env = Environment()
+env = Environment(tools=[])
 mode = int(ARGUMENTS.get('mode'))
 if mode:
     def DifferentCopy(target, source, env):

--- a/test/explain/get_csig.py
+++ b/test/explain/get_csig.py
@@ -39,7 +39,8 @@ test = TestSCons.TestSCons()
 args = "--debug=explain"
 
 test.write('SConstruct', """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 
 def action( source, target, env ):
     target[0].get_csig()

--- a/test/explain/save-info.py
+++ b/test/explain/save-info.py
@@ -69,6 +69,7 @@ sys.exit(0)
 """)
 
 test.write(['src', 'SConstruct'], """\
+DefaultEnvironment(tools=[])
 import re
 
 include_re = re.compile(r'^include\s+(\S+)$', re.M)
@@ -85,7 +86,7 @@ kscan = Scanner(name = 'kfile',
 
 cat = Builder(action = r'%(_python_)s %(cat_py)s $TARGET $SOURCES')
 
-env = Environment()
+env = Environment(tools=[])
 env.Append(BUILDERS = {'Cat':cat},
            SCANNERS = kscan)
 

--- a/test/implicit-cache/DualTargets.py
+++ b/test/implicit-cache/DualTargets.py
@@ -34,6 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 import os.path
 
 def emitter(target, source, env):
@@ -49,7 +50,7 @@ def source_scan(node, env, path):
     return [base + '.lib']
 
 
-env = Environment()
+env = Environment(tools=[])
 env['BUILDERS']['DualTarget'] = Builder(
     action = Action(
         [ 

--- a/test/implicit-cache/GetOption.py
+++ b/test/implicit-cache/GetOption.py
@@ -34,6 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 assert not GetOption('implicit_cache')
 SetOption('implicit_cache', 1)
 assert GetOption('implicit_cache')
@@ -42,6 +43,7 @@ assert GetOption('implicit_cache')
 test.run()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 assert GetOption('implicit_cache')
 SetOption('implicit_cache', 0)
 assert GetOption('implicit_cache')

--- a/test/implicit-cache/RemoveImplicitDep.py
+++ b/test/implicit-cache/RemoveImplicitDep.py
@@ -37,11 +37,12 @@ test = TestSCons.TestSCons()
 test.subdir(['src'])
 
 SConstruct_contents = """\
+DefaultEnvironment(tools=[])
 import SCons.Script
 
 SetOption( 'implicit_cache', 1 )
 
-env = Environment()
+env = Environment(tools=[])
 act = Action([Touch('${TARGETS[0]}'),Touch('${TARGETS[1]}')])
 env.Append(BUILDERS = {'BuildMe':Builder(action=act,source_scanner=SCons.Script.SourceFileScanner)} )
 

--- a/test/implicit-cache/SetOption.py
+++ b/test/implicit-cache/SetOption.py
@@ -36,6 +36,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 SetOption('implicit_cache', 1)
 env=Environment(CPPPATH=['i1', 'i2'])
 env.Object('foo.c')

--- a/test/implicit-cache/basic.py
+++ b/test/implicit-cache/basic.py
@@ -53,6 +53,7 @@ test = TestSCons.TestSCons()
 test.subdir('include', 'subdir', ['subdir', 'include'], 'inc2')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(CPPPATH = Split('inc2 include'))
 obj = env.Object(target='prog', source='subdir/prog.c')
 env.Program(target='prog', source=obj)

--- a/test/implicit/IMPLICIT_COMMAND_DEPENDENCIES.py
+++ b/test/implicit/IMPLICIT_COMMAND_DEPENDENCIES.py
@@ -64,9 +64,11 @@ extra = ''
 test.write('generate_build_py.py', generate_build_py_py_contents % locals())
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 generate = Builder(action = r'%(_python_)s $GENERATE $TARGET')
 build = Builder(action = r'$BUILD_PY $TARGET $SOURCES')
-env = Environment(BUILDERS = {
+env = Environment(tools=[],
+                  BUILDERS = {
                         'GenerateBuild' : generate,
                         'BuildFile' : build,
                   },

--- a/test/implicit/asynchronous-modification.py
+++ b/test/implicit/asynchronous-modification.py
@@ -39,7 +39,8 @@ test = TestSCons.TestSCons()
 
 test.write(['SConstruct'], """\
 import SCons.Defaults
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[]) 
 env['BUILDERS']['C'] = Builder(action = Copy('$TARGET', '$SOURCE'),
                                source_scanner = SCons.Defaults.CScan)
 env['BUILDERS']['Mod'] = Builder(action = r'%(_python_)s mod.py')

--- a/test/implicit/changed-node.py
+++ b/test/implicit/changed-node.py
@@ -40,6 +40,7 @@ test.subdir('d',
             ['d', '3'])
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 SetOption('implicit_cache', 1)
 SetOption('max_drift', 1)
 

--- a/test/import.py
+++ b/test/import.py
@@ -63,6 +63,7 @@ platforms = [
 
 for platform in platforms:
     test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 print("Platform %(platform)s")
 env = Environment(platform = '%(platform)s', tools=[])
 import SCons.Platform.%(platform)s
@@ -152,22 +153,24 @@ error_output = {
 # An SConstruct for importing Tool names that have illegal characters
 # for Python variable names.
 indirect_import = """\
+DefaultEnvironment(tools=[])
 print("Tool %(tool)s (indirect)")
 env = Environment(tools = ['%(tool)s'])
 
 SCons = __import__('SCons.Tool.%(tool)s', globals(), locals(), [])
 m = getattr(SCons.Tool, '%(tool)s')
-env = Environment()
+env = Environment(tools=[])
 m.generate(env)
 """
 
 # An SConstruct for importing Tool names "normally."
 direct_import = """\
+DefaultEnvironment(tools=[])
 print("Tool %(tool)s (direct)")
 env = Environment(tools = ['%(tool)s'])
 
 import SCons.Tool.%(tool)s
-env = Environment()
+env = Environment(tools=[])
 SCons.Tool.%(tool)s.exists(env)
 SCons.Tool.%(tool)s.generate(env)
 """

--- a/test/long-lines/signature.py
+++ b/test/long-lines/signature.py
@@ -54,11 +54,13 @@ fp.write('TIMESTAMP=%s\\n' % args[3])
 os.chmod(build_py, 0o755)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 arg = 'a_long_ignored_argument'
 extra_arguments = arg
 while len(extra_arguments) <= 1024:
     extra_arguments = extra_arguments + ' ' + arg
-env = Environment(FILECOM=[r'%(build_py)s',
+env = Environment(tools=[],
+                  FILECOM=[r'%(build_py)s',
                            '$TARGET', '$SOURCE',
                            '$FILEFLAG',
                            '$(', '$TIMESTAMP', '$)',

--- a/test/option/d.py
+++ b/test/option/d.py
@@ -32,7 +32,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', "")
+test.write('SConstruct', "DefaultEnvironment(tools=[])\n")
 
 test.run(arguments = '-d .',
          stderr = "Warning:  ignoring -d option\n")
@@ -44,6 +44,7 @@ test.pass_test()
 test.subdir('subdir')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment()
 env.Program(target = 'aaa', source = 'aaa.c')
 env.Program(target = 'bbb', source = 'bbb.c')

--- a/test/option/debug-count.py
+++ b/test/option/debug-count.py
@@ -44,6 +44,7 @@ except ImportError:
 
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def cat(target, source, env):
     open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
 env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})

--- a/test/option/debug-duplicate.py
+++ b/test/option/debug-duplicate.py
@@ -33,7 +33,8 @@ test = TestSCons.TestSCons()
 test.subdir('sub1')
 
 test.write('SConstruct', """\
-env=Environment()
+DefaultEnvironment(tools=[])
+env=Environment(tools=[])
 Export('env')
 env.SConscript('SConscript', variant_dir='Build')
 """)

--- a/test/option/debug-findlibs.py
+++ b/test/option/debug-findlibs.py
@@ -42,6 +42,7 @@ ofp.close()
 """)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment(OBJSUFFIX = '.ooo', PROGSUFFIX = '.xxx',
                   LIBPATH = ['sub1', 'sub2', '.'],
                   LIBS = ['iii', 'jjj', 'kkk', 'lll', 'mmm'],

--- a/test/option/debug-includes.py
+++ b/test/option/debug-includes.py
@@ -34,6 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(OBJSUFFIX = '.obj',
                   SHOBJSUFFIX = '.shobj',
                   LIBPREFIX = '',

--- a/test/option/debug-memoizer.py
+++ b/test/option/debug-memoizer.py
@@ -36,9 +36,10 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def cat(target, source, env):
     open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
-env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
+env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)
 

--- a/test/option/debug-memory.py
+++ b/test/option/debug-memory.py
@@ -47,9 +47,10 @@ except ImportError:
 
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def cat(target, source, env):
     open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
-env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
+env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)
 

--- a/test/option/debug-multiple.py
+++ b/test/option/debug-multiple.py
@@ -36,6 +36,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def cat(target, source, env):
     open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
 env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})

--- a/test/option/debug-objects.py
+++ b/test/option/debug-objects.py
@@ -41,9 +41,10 @@ except ImportError:
 
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def cat(target, source, env):
     open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
-env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
+env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)
 

--- a/test/option/debug-pdb.py
+++ b/test/option/debug-pdb.py
@@ -29,7 +29,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 """)
 
 test.run(arguments = "--debug=pdb", stdin = "n\ns\nq\n")

--- a/test/option/debug-prepare.py
+++ b/test/option/debug-prepare.py
@@ -31,7 +31,8 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env=Environment()
+DefaultEnvironment(tools=[])
+env=Environment(tools=[])
 dest=env.Command('foo.out', 'SConstruct',
    [Copy('$TARGET', '$SOURCE'),
     Copy('${TARGET}.extra', '$SOURCE')])

--- a/test/option/debug-presub.py
+++ b/test/option/debug-presub.py
@@ -37,6 +37,7 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     f = open(target, "wb")
@@ -47,7 +48,8 @@ FILE = Builder(action="$FILECOM")
 TEMP = Builder(action="$TEMPCOM")
 LIST = Builder(action="$LISTCOM")
 FUNC = Builder(action=cat)
-env = Environment(PYTHON=r'%(_python_)s',
+env = Environment(tools=[],
+                  PYTHON=r'%(_python_)s',
                   BUILDERS = {'FILE':FILE, 'TEMP':TEMP, 'LIST':LIST, 'FUNC':FUNC},
                   FILECOM="$PYTHON cat.py $SOURCES $TARGET",
                   TEMPCOM="$PYTHON cat.py $SOURCES temp\\n$PYTHON cat.py temp $TARGET",

--- a/test/option/debug-stacktrace.py
+++ b/test/option/debug-stacktrace.py
@@ -33,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 def kfile_scan(node, env, target):
     raise Exception("kfile_scan error")
 
@@ -40,7 +41,7 @@ kscan = Scanner(name = 'kfile',
                 function = kfile_scan,
                 skeys = ['.k'])
 
-env = Environment()
+env = Environment(tools=[])
 env.Append(SCANNERS = [kscan])
 
 env.Command('foo', 'foo.k', Copy('$TARGET', '$SOURCE'))

--- a/test/option/debug-time.py
+++ b/test/option/debug-time.py
@@ -44,7 +44,9 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment(PYTHON = r'%(_python_)s',
+DefaultEnvironment(tools=[])
+env = Environment(tools=[],
+                  PYTHON = r'%(_python_)s',
                   SLEEP_CAT = r'sleep_cat.py',
                   CATCOM = '$PYTHON $SLEEP_CAT $SECONDS $TARGET $SOURCES',
                   SECONDS = ARGUMENTS.get('SLEEP', '0'))

--- a/test/option/environment-overrides.py
+++ b/test/option/environment-overrides.py
@@ -32,7 +32,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', "")
+test.write('SConstruct', "DefaultEnvironment(tools=[])\n")
 
 test.run(arguments = '-e .',
          stderr = "Warning:  ignoring -e option\n")

--- a/test/option/help-options.py
+++ b/test/option/help-options.py
@@ -34,7 +34,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', "")
+test.write('SConstruct', "DefaultEnvironment(tools=[])\n")
 
 test.run(arguments = '-H')
 

--- a/test/option/md5-chunksize.py
+++ b/test/option/md5-chunksize.py
@@ -39,9 +39,10 @@ file.close()
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 SetOption('md5_chunksize', 128)
 B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
+env = Environment(tools=[], BUILDERS = { 'B' : B })
 f1 = env.B(target = 'f1.out', source = 'f1.in')
 f2 = env.B(target = 'f2.out', source = 'f2.in')
 Requires(f2, f1)
@@ -102,13 +103,14 @@ get_stat(["test.stat"], ["test.big"])
 """)
 
 test2.write('SConstruct', """
+DefaultEnvironment(tools=[])
 import os
 def get_stat(target, source, env):
     stat = os.stat(source[0].get_abspath())
     dest = open(target[0].get_abspath(),'w')
     dest.write(str(stat))
     dest.close()
-env = Environment()
+env = Environment(tools=[])
 env.Command('test.big', 'SConstruct', 'dd if=/dev/zero of=test.big seek=100 bs=1M count=0 2>/dev/null')
 env.AlwaysBuild('test.big')
 env.Command('test.stat', 'test.big', Action(get_stat))

--- a/test/option/no-print-directory.py
+++ b/test/option/no-print-directory.py
@@ -32,7 +32,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', "")
+test.write('SConstruct', "DefaultEnvironment(tools=[])\n")
 
 test.run(arguments = '--no-print-directory .',
          stderr = "Warning:  ignoring --no-print-directory option\n")

--- a/test/option/option_profile.py
+++ b/test/option/option_profile.py
@@ -48,6 +48,7 @@ except ImportError:
     test.skip_test('No pstats module, skipping test.\n')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 Command('file.out', 'file.in', Copy("$TARGET", "$SOURCE"))
 """)
 

--- a/test/option/print-directory.py
+++ b/test/option/print-directory.py
@@ -32,7 +32,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', "")
+test.write('SConstruct', "DefaultEnvironment(tools=[])\n")
 
 test.run(arguments = '-w .',
          stderr = "Warning:  ignoring -w option\n")

--- a/test/option/repository.py
+++ b/test/option/repository.py
@@ -37,7 +37,8 @@ test.subdir('repository', 'work1')
 repository = test.workpath('repository')
 
 test.write(['repository', 'SConstruct'], """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env.Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
 """)
 

--- a/test/option/srcdir.py
+++ b/test/option/srcdir.py
@@ -37,7 +37,8 @@ test.subdir('repository', 'work1')
 repository = test.workpath('repository')
 
 test.write(['repository', 'SConstruct'], r"""
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env.Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
 """)
 

--- a/test/option/stack-size.py
+++ b/test/option/stack-size.py
@@ -49,8 +49,9 @@ file.close()
 
 
 test.write(['work1', 'SConstruct'], """
+DefaultEnvironment(tools=[])
 B = Builder(action = r'%(_python_)s ../build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
+env = Environment(tools=[], BUILDERS = { 'B' : B })
 f1 = env.B(target = 'f1.out', source = 'f1.in')
 f2 = env.B(target = 'f2.out', source = 'f2.in')
 Requires(f2, f1)

--- a/test/option/taskmastertrace.py
+++ b/test/option/taskmastertrace.py
@@ -33,7 +33,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 
 # We name the files 'Tfile' so that they will sort after the SConstruct
 # file regardless of whether the test is being run on a case-sensitive

--- a/test/option/tree-all.py
+++ b/test/option/tree-all.py
@@ -39,6 +39,7 @@ LINK = test.detect('LINK')
 if LINK is None: LINK = CC
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(OBJSUFFIX = '.ooo', PROGSUFFIX = '.xxx')
 env.Program('Foo', Split('Foo.c Bar.c'))
 """)

--- a/test/option/tree-derived.py
+++ b/test/option/tree-derived.py
@@ -34,6 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(OBJSUFFIX = '.ooo', PROGSUFFIX = '.xxx')
 env.Program('foo', Split('foo.c bar.c'))
 """)

--- a/test/option/tree-lib.py
+++ b/test/option/tree-lib.py
@@ -38,6 +38,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(LIBPREFIX='',
                   LIBSUFFIX='.lib',
                   OBJSUFFIX='.obj',

--- a/test/option/warn-dependency.py
+++ b/test/option/warn-dependency.py
@@ -34,12 +34,13 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 
 test.write("SConstruct", """\
+DefaultEnvironment(tools=[])
 import SCons.Defaults
 
 def build(target, source, env):
     pass
 
-env=Environment()
+env=Environment(tools=[])
 env['BUILDERS']['test'] = Builder(action=build,
                                   source_scanner=SCons.Defaults.ObjSourceScan)
 env.test(target='foo', source='foo.c')

--- a/test/option/warn-duplicate-environment.py
+++ b/test/option/warn-duplicate-environment.py
@@ -34,6 +34,7 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def build(env, target, source):
     file = open(str(target[0]), 'wb')
     for s in source:
@@ -44,7 +45,7 @@ if WARN:
     SetOption('warn', WARN)
 
 B = Builder(action=build, multi=1)
-env = Environment(BUILDERS = { 'B' : B })
+env = Environment(tools=[], BUILDERS = { 'B' : B })
 env2 = env.Clone(DIFFERENT_VARIABLE = 'true')
 env.B(target = 'file1.out', source = 'file1a.in')
 env2.B(target = 'file1.out', source = 'file1b.in')

--- a/test/option/warn-misleading-keywords.py
+++ b/test/option/warn-misleading-keywords.py
@@ -34,6 +34,7 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def build(env, target, source):
     file = open(str(target[0]), 'wb')
     for s in source:
@@ -44,7 +45,7 @@ if WARN:
     SetOption('warn', WARN)
 
 B = Builder(action=build, multi=1)
-env = Environment(BUILDERS = { 'B' : B })
+env = Environment(tools=[], BUILDERS = { 'B' : B })
 env.B(targets = 'file3a.out', source = 'file3a.in')
 env.B(target = 'file3b.out', sources = 'file3b.in')
 """)

--- a/test/option/warn-missing-sconscript.py
+++ b/test/option/warn-missing-sconscript.py
@@ -34,10 +34,11 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 
 test.write("SConstruct", """\
+DefaultEnvironment(tools=[])
 def build(target, source, env):
     pass
 
-env=Environment()
+env=Environment(tools=[])
 env['BUILDERS']['test'] = Builder(action=build)
 env.test(target='foo', source='foo.c')
 WARN = ARGUMENTS.get('WARN')


### PR DESCRIPTION
In many cases specifying tools=[] in some or all of the Environment() statements in the tests and/or  adding

DefaultEnvironment(tools=[])

Will speed up the tests. This shortcuts looking for MSVC and/or MSVS installs which can be several seconds depending how many versions of MSVC are installed on the system.

These changes should not change the functionality of the test.

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation