### PR TITLE
Fix packaging strip-install-dir test

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -150,6 +150,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Remove obsoleted internal implementaiton of OrderedDict.
     - Test for tar packaging fixups
     - Stop using deprecated unittest asserts
+    - messages in strip-install-dir test now os-neutral
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/test/packaging/strip-install-dir.py
+++ b/test/packaging/strip-install-dir.py
@@ -27,6 +27,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 """
 Test stripping the InstallBuilder of the Package source file.
 """
+import os
 
 import TestSCons
 
@@ -52,10 +53,10 @@ env.Package( NAME    = 'foo',
 expected = """scons: Reading SConscript files ...
 scons: done reading SConscript files.
 scons: Building targets ...
-Copy file(s): "main.c" to "foo-1.2.3/bin/main.c"
-tar -zc -f foo-1.2.3.tar.gz foo-1.2.3/bin/main.c
+Copy file(s): "main.c" to "foo-1.2.3{os_sep}bin{os_sep}main.c"
+tar -zc -f foo-1.2.3.tar.gz foo-1.2.3{os_sep}bin{os_sep}main.c
 scons: done building targets.
-"""
+""".format(os_sep=os.sep)
 
 test.run(arguments='', stderr = None, stdout=expected)
 


### PR DESCRIPTION
The expected message was not OS-neutral, failing on Windows due
to backslashes. Now that Windows has tar this turned up. Interpolate
os.sep to fix.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation