### PR TITLE
Add xz compression to tar packaging choices.

### DIFF
--- a/bin/scons_dev_master.py
+++ b/bin/scons_dev_master.py
@@ -11,11 +11,12 @@ import sys
 from Command import CommandRunner, Usage
 
 INITIAL_PACKAGES = [
-    'mercurial',
+    'git',
 ]
 
 INSTALL_PACKAGES = [
     'wget',
+    'xz-utils',
 ]
 
 PYTHON_PACKAGES = [
@@ -60,8 +61,7 @@ DOCUMENTATION_PACKAGES = [
     'gcc-doc',
     'pkg-config',
     'python-doc',
-    'sun-java5-doc',
-    'sun-java6-doc',
+    'openjdk-8-doc',
     'swig-doc',
     'texlive-doc',
 ]
@@ -70,21 +70,22 @@ TESTING_PACKAGES = [
     'bison',
     'cssc',
     'cvs',
+    'hg',
     'flex',
     'g++',
     'gcc',
     'gcj',
     'ghostscript',
-#    'libgcj7-dev',
     'm4',
     'openssh-client',
     'openssh-server',
     'python-profiler',
     'python-all-dev',
+    'python3-all-dev',
+    'pypy-dev',
     'rcs',
     'rpm',
-#    'sun-java5-jdk',
-    'sun-java6-jdk',
+    'openjdk-8-jdk',
     'swig',
     'texlive-base-bin',
     'texlive-extra-utils',
@@ -131,7 +132,7 @@ Usage:  scons_dev_master.py [-hnqy] [--password PASSWORD] [--username USER]
         buildbot                Install packages for running BuildBot
 """
 
-    scons_url = 'https://bdbaddog@bitbucket.org/scons/scons'
+    scons_url = 'https://github.com/SCons/scons.git'
     sudo = 'sudo'
     password = '""'
     username = 'guest'
@@ -180,13 +181,15 @@ Usage:  scons_dev_master.py [-hnqy] [--password PASSWORD] [--username USER]
             cmd.run('%(sudo)s apt-get %(yesflag)s upgrade')
         elif arg == 'checkout':
             cmd.run('%(sudo)s apt-get %(yesflag)s install %(initial_packages)s')
-            cmd.run('hg clone" %(scons_url)s')
+            cmd.run('git clone" %(scons_url)s')
         elif arg == 'building':
             cmd.run('%(sudo)s apt-get %(yesflag)s install %(building_packages)s')
         elif arg == 'docs':
             cmd.run('%(sudo)s apt-get %(yesflag)s install %(doc_packages)s')
         elif arg == 'testing':
             cmd.run('%(sudo)s apt-get %(yesflag)s install %(testing_packages)s')
+            #TODO: maybe copy ipkg-build from openwrt git
+            #cmd.run('%(sudo)s wget https://raw.githubusercontent.com/openwrt/openwrt/master/scripts/ipkg-build SOMEWHERE')
         elif arg == 'buildbot':
             cmd.run('%(sudo)s apt-get %(yesflag)s install %(buildbot_packages)s')
         elif arg == 'python-versions':

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -151,6 +151,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Test for tar packaging fixups
     - Stop using deprecated unittest asserts
     - messages in strip-install-dir test now os-neutral
+    - Add xz compression format to packaging choices.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -37,7 +37,11 @@ from SCons.Warnings import warn, Warning
 import os
 import imp
 
-__all__ = [ 'src_targz', 'src_tarbz2', 'src_zip', 'tarbz2', 'targz', 'zip', 'rpm', 'msi', 'ipk' ]
+__all__ = [
+    'src_targz', 'src_tarbz2', 'src_xz', 'src_zip',
+    'targz', 'tarbz2', 'xz', 'zip',
+    'rpm', 'msi', 'ipk',
+]
 
 #
 # Utility and Builder function

--- a/src/engine/SCons/Tool/packaging/__init__.xml
+++ b/src/engine/SCons/Tool/packaging/__init__.xml
@@ -64,13 +64,15 @@ the following packagers available:
 
 <para>
  * msi - Microsoft Installer
- * rpm - Redhat Package Manger
+ * rpm - RPM Package Manger
  * ipkg - Itsy Package Management System
- * tarbz2 - compressed tar
- * targz - compressed tar
+ * tarbz2 - bzip2 compressed tar
+ * targz - gzip compressed tar
+ * tarxz - xz compressed tar
  * zip - zip file
- * src_tarbz2 - compressed tar source
- * src_targz - compressed tar source
+ * src_tarbz2 - bzip2 compressed tar source
+ * src_targz - gzip compressed tar source
+ * src_tarxz - xz compressed tar source
  * src_zip - zip file source
 </para>
 

--- a/src/engine/SCons/Tool/packaging/src_tarbz2.py
+++ b/src/engine/SCons/Tool/packaging/src_tarbz2.py
@@ -1,4 +1,4 @@
-"""SCons.Tool.Packaging.tarbz2
+"""SCons.Tool.Packaging.src_tarbz2
 
 The tarbz2 SRC packager.
 """

--- a/src/engine/SCons/Tool/packaging/src_targz.py
+++ b/src/engine/SCons/Tool/packaging/src_targz.py
@@ -1,4 +1,4 @@
-"""SCons.Tool.Packaging.targz
+"""SCons.Tool.Packaging.src_targz
 
 The targz SRC packager.
 """

--- a/src/engine/SCons/Tool/packaging/src_tarxz.py
+++ b/src/engine/SCons/Tool/packaging/src_tarxz.py
@@ -1,11 +1,11 @@
-"""SCons.Tool.Packaging.tarbz2
+"""SCons.Tool.Packaging.src_tarxz
 
-The tarbz2 packager.
+The tarxz SRC packager.
 """
 
 #
 # __COPYRIGHT__
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -28,14 +28,13 @@ The tarbz2 packager.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-from SCons.Tool.packaging import stripinstallbuilder, putintopackageroot
+from SCons.Tool.packaging import putintopackageroot
 
 def package(env, target, source, PACKAGEROOT, **kw):
     bld = env['BUILDERS']['Tar']
-    bld.set_suffix('.tar.bz2')
-    target, source = putintopackageroot(target, source, env, PACKAGEROOT)
-    target, source = stripinstallbuilder(target, source, env)
-    return bld(env, target, source, TARFLAGS='-jc')
+    bld.set_suffix('.tar.xz')
+    target, source = putintopackageroot(target, source, env, PACKAGEROOT, honor_install_location=0)
+    return bld(env, target, source, TARFLAGS='-Jc')
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Tool/packaging/targz.py
+++ b/src/engine/SCons/Tool/packaging/targz.py
@@ -1,6 +1,6 @@
 """SCons.Tool.Packaging.targz
 
-The targz SRC packager.
+The targz packager.
 """
 
 #

--- a/src/engine/SCons/Tool/packaging/tarxz.py
+++ b/src/engine/SCons/Tool/packaging/tarxz.py
@@ -1,11 +1,11 @@
-"""SCons.Tool.Packaging.tarbz2
+"""SCons.Tool.Packaging.tarxz
 
-The tarbz2 packager.
+The tarxz packager.
 """
 
 #
 # __COPYRIGHT__
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -32,10 +32,10 @@ from SCons.Tool.packaging import stripinstallbuilder, putintopackageroot
 
 def package(env, target, source, PACKAGEROOT, **kw):
     bld = env['BUILDERS']['Tar']
-    bld.set_suffix('.tar.bz2')
+    bld.set_suffix('.tar.xz')
     target, source = putintopackageroot(target, source, env, PACKAGEROOT)
     target, source = stripinstallbuilder(target, source, env)
-    return bld(env, target, source, TARFLAGS='-jc')
+    return bld(env, target, source, TARFLAGS='-Jc')
 
 # Local Variables:
 # tab-width:4

--- a/test/packaging/guess-package-name.py
+++ b/test/packaging/guess-package-name.py
@@ -81,9 +81,9 @@ env.Package( NAME        = 'libfoo',
              source      = [ 'src/main.c', 'SConstruct' ] )
 """)
 
-test.run(stderr = None)
+test.run(stderr=None)
 
-test.must_exist( 'src.tar.gz' )
+test.must_exist('src.tar.gz')
 
 #
 # TEST: default package name creation with overridden packager.
@@ -98,9 +98,26 @@ env.Package( NAME        = 'libfoo',
              source      = [ 'src/main.c', 'SConstruct' ] )
 """)
 
-test.run(stderr = None)
+test.run(stderr=None)
 
-test.must_exist( 'libfoo-1.2.3.tar.bz2' )
+test.must_exist('libfoo-1.2.3.tar.bz2')
+
+#
+# TEST: default package name creation with another packager.
+#
+
+test.write('SConstruct', """
+env=Environment(tools=['default', 'packaging'])
+env.Program( 'src/main.c' )
+env.Package( NAME        = 'libfoo',
+             VERSION     = '1.2.3',
+             PACKAGETYPE = 'src_tarxz',
+             source      = [ 'src/main.c', 'SConstruct' ] )
+""")
+
+test.run(stderr=None)
+
+test.must_exist('libfoo-1.2.3.tar.xz')
 
 test.pass_test()
 


### PR DESCRIPTION
A few tweaks to scons_dev_master.py which needed to have xz added anyway:
changed mercurial to git in initial setup, install different java,
more pythons.  Note about adding ipkg-build.

Docs updated slightly for wording in addition to adding the new tar packager.

This is near-trivial: the actual code is basically identical to the tar.bz2 case, just swapping bz2 for xz.
The changes to scons_dev_master are not strictly related except the add of xz, could be left to a separate change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation