### PR TITLE
A few syntax cleanups

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -152,6 +152,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Stop using deprecated unittest asserts
     - messages in strip-install-dir test now os-neutral
     - Add xz compression format to packaging choices.
+    - Syntax cleanups - trailing blanks, use "is" to compare with None, etc.
+      Three uses of variables not defined are changed.
     
   From Hao Wu
     - typo in customized decider example in user guide 

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -843,8 +843,8 @@ class CommandAction(_ActionAction):
         _ActionAction.__init__(self, **kw)
         if is_List(cmd):
             if [c for c in cmd if is_List(c)]:
-                raise TypeError("CommandAction should be given only " \
-                      "a single command")
+                raise TypeError("CommandAction should be given only "
+                                "a single command")
         self.cmd_list = cmd
 
     def __str__(self):

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -150,7 +150,7 @@ def _set_BUILDERS(env, key, value):
         for k in list(bd.keys()):
             del bd[k]
     except KeyError:
-        bd = BuilderDict(kwbd, env)
+        bd = BuilderDict(bd, env)
         env._dict[key] = bd
     for k, v in value.items():
         if not SCons.Builder.is_a_Builder(v):
@@ -2258,7 +2258,7 @@ class Base(SubstitutionEnvironment):
             while (node != node.srcnode()):
               node = node.srcnode()
             return node
-        sources = list(map( final_source, sources ));
+        sources = list(map(final_source, sources))
         # remove duplicates
         return list(set(sources))
 

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -132,9 +132,9 @@ def initialize_do_splitdrive():
     global do_splitdrive
     global has_unc
     drive, path = os.path.splitdrive('X:/foo')
-    # splitunc is removed from python 3.7 and newer  
+    # splitunc is removed from python 3.7 and newer
     # so we can also just test if splitdrive works with UNC
-    has_unc = (hasattr(os.path, 'splitunc') 
+    has_unc = (hasattr(os.path, 'splitunc')
         or os.path.splitdrive(r'\\split\drive\test')[0] == r'\\split\drive')
 
     do_splitdrive = not not drive or has_unc
@@ -1397,10 +1397,10 @@ class FS(LocalFS):
             if not isinstance(d, SCons.Node.Node):
                 d = self.Dir(d)
             self.Top.addRepository(d)
-    
+
     def PyPackageDir(self, modulename):
         """Locate the directory of a given python module name
-		
+
         For example scons might resolve to
         Windows: C:\Python27\Lib\site-packages\scons-2.5.1
         Linux: /usr/lib/scons
@@ -3305,7 +3305,7 @@ class File(Base):
                 try: node = dir.entries[norm_name]
                 except KeyError: node = dir.file_on_disk(self.name)
                 if node and node.exists() and \
-                   (isinstance(node, File) or isinstance(node, Entry) \
+                   (isinstance(node, File) or isinstance(node, Entry)
                     or not node.is_derived()):
                         result = node
                         # Copy over our local attributes to the repository

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -155,7 +155,7 @@ def exists_file(node):
                     # The source file does not exist.  Make sure no old
                     # copy remains in the variant directory.
                     if print_duplicate:
-                        print("dup: no src for %s, unlinking old variant copy"%self)
+                        print("dup: no src for %s, unlinking old variant copy" % node)
                     if exists_base(node) or node.islink():
                         node.fs.unlink(node.get_internal_path())
                     # Return None explicitly because the Base.exists() call
@@ -665,7 +665,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
                 executor.cleanup()
 
     def reset_executor(self):
-        "Remove cached executor; forces recompute when needed."
+        """Remove cached executor; forces recompute when needed."""
         try:
             delattr(self, 'executor')
         except AttributeError:

--- a/src/engine/SCons/Platform/posix.py
+++ b/src/engine/SCons/Platform/posix.py
@@ -48,7 +48,7 @@ exitvalmap = {
 }
 
 def escape(arg):
-    "escape shell special characters" 
+    """escape shell special characters"""
     slash = '\\'
     special = '"$'
 

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -1000,7 +1000,7 @@ def CheckLib(context, library = None, symbol = "main",
     compiles without flags.
     """
 
-    if library == []:
+    if not library:
         library = [None]
 
     if not SCons.Util.is_List(library):

--- a/src/engine/SCons/Scanner/Fortran.py
+++ b/src/engine/SCons/Scanner/Fortran.py
@@ -78,7 +78,7 @@ class F90Scanner(SCons.Scanner.Classic):
     def scan(self, node, env, path=()):
 
         # cache the includes list in node so we only scan it once:
-        if node.includes != None:
+        if node.includes is not None:
             mods_and_includes = node.includes
         else:
             # retrieve all included filenames

--- a/src/engine/SCons/Scanner/LaTeX.py
+++ b/src/engine/SCons/Scanner/LaTeX.py
@@ -128,8 +128,8 @@ class LaTeX(SCons.Scanner.Base):
     Unlike most scanners, which use regular expressions that just
     return the included file name, this returns a tuple consisting
     of the keyword for the inclusion ("include", "includegraphics",
-    "input", or "bibliography"), and then the file name itself.  
-    Based on a quick look at LaTeX documentation, it seems that we 
+    "input", or "bibliography"), and then the file name itself.
+    Based on a quick look at LaTeX documentation, it seems that we
     should append .tex suffix for the "include" keywords, append .tex if
     there is no extension for the "input" keyword, and need to add .bib
     for the "bibliography" keyword that does not accept extensions by itself.
@@ -137,7 +137,7 @@ class LaTeX(SCons.Scanner.Base):
     Finally, if there is no extension for an "includegraphics" keyword
     latex will append .ps or .eps to find the file, while pdftex may use .pdf,
     .jpg, .tif, .mps, or .png.
-    
+
     The actual subset and search order may be altered by
     DeclareGraphicsExtensions command. This complication is ignored.
     The default order corresponds to experimentation with teTeX::
@@ -333,7 +333,7 @@ class LaTeX(SCons.Scanner.Base):
         line_continues_a_comment = False
         for line in text.splitlines():
             line,comment = self.comment_re.findall(line)[0]
-            if line_continues_a_comment == True:
+            if line_continues_a_comment:
                 out[-1] = out[-1] + line.lstrip()
             else:
                 out.append(line)
@@ -349,7 +349,7 @@ class LaTeX(SCons.Scanner.Base):
         # path_dict = dict(list(path))
         # add option for whitespace (\s) before the '['
         noopt_cre = re.compile('\s*\[.*$')
-        if node.includes != None:
+        if node.includes is not None:
             includes = node.includes
         else:
             text = self.canonical_text(node.get_text_contents())
@@ -386,8 +386,8 @@ class LaTeX(SCons.Scanner.Base):
         directory of the main file just as latex does"""
 
         path_dict = dict(list(path))
-        
-        queue = [] 
+
+        queue = []
         queue.extend( self.scan(node) )
         seen = {}
 
@@ -402,7 +402,7 @@ class LaTeX(SCons.Scanner.Base):
         source_dir = node.get_dir()
         #for include in includes:
         while queue:
-            
+
             include = queue.pop()
             inc_type, inc_subdir, inc_filename = include
 

--- a/src/engine/SCons/Tool/GettextCommon.py
+++ b/src/engine/SCons/Tool/GettextCommon.py
@@ -390,7 +390,7 @@ def _detect_xgettext(env):
     """ Detects *xgettext(1)* binary """
     if 'XGETTEXT' in env:
         return env['XGETTEXT']
-    xgettext = env.Detect('xgettext');
+    xgettext = env.Detect('xgettext')
     if xgettext:
         return xgettext
     raise SCons.Errors.StopError(XgettextNotFound, "Could not detect xgettext")
@@ -409,7 +409,7 @@ def _detect_msginit(env):
     """ Detects *msginit(1)* program. """
     if 'MSGINIT' in env:
         return env['MSGINIT']
-    msginit = env.Detect('msginit');
+    msginit = env.Detect('msginit')
     if msginit:
         return msginit
     raise SCons.Errors.StopError(MsginitNotFound, "Could not detect msginit")
@@ -428,7 +428,7 @@ def _detect_msgmerge(env):
     """ Detects *msgmerge(1)* program. """
     if 'MSGMERGE' in env:
         return env['MSGMERGE']
-    msgmerge = env.Detect('msgmerge');
+    msgmerge = env.Detect('msgmerge')
     if msgmerge:
         return msgmerge
     raise SCons.Errors.StopError(MsgmergeNotFound, "Could not detect msgmerge")

--- a/src/engine/SCons/Tool/JavaCommon.py
+++ b/src/engine/SCons/Tool/JavaCommon.py
@@ -389,7 +389,7 @@ else:
         is that the file name matches the public class name, and that
         the path to the file is the same as the package name.
         """
-        return os.path.split(file)
+        return os.path.split(fn)
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -238,7 +238,7 @@ class Tool(object):
                     setattr(SCons.Tool, self.name, module)
 
                 found_module = module
-            
+
             if found_module is not None:
                 sys.path = oldpythonpath
                 return found_module
@@ -1081,11 +1081,11 @@ class ToolInitializer(object):
                 env.Tool(tool)
                 return
 
-	# If we fall through here, there was no tool module found.
-	# This is where we can put an informative error message
-	# about the inability to find the tool.   We'll start doing
-	# this as we cut over more pre-defined Builder+Tools to use
-	# the ToolInitializer class.
+        # If we fall through here, there was no tool module found.
+        # This is where we can put an informative error message
+        # about the inability to find the tool.   We'll start doing
+        # this as we cut over more pre-defined Builder+Tools to use
+        # the ToolInitializer class.
 
 def Initializers(env):
     ToolInitializer(env, ['install'], ['_InternalInstall', '_InternalInstallAs', '_InternalInstallVersionedLib'])

--- a/src/engine/SCons/Tool/intelc.py
+++ b/src/engine/SCons/Tool/intelc.py
@@ -73,7 +73,7 @@ def linux_ver_normalize(vstr):
     m = re.match(r'([0-9]+)\.([0-9]+)\.([0-9]+)', vstr)
     if m:
         vmaj,vmin,build = m.groups()
-        return float(vmaj) * 10. + float(vmin) + float(build) / 1000.;
+        return float(vmaj) * 10. + float(vmin) + float(build) / 1000.
     else:
         f = float(vstr)
         if is_windows:

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -115,7 +115,7 @@ def Jar(env, target = None, source = [], *args, **kw):
         return jars
 
     # they passed no target so make a target implicitly
-    if target == None:
+    if target is None:
         try:
             # make target from the first source file
             target = os.path.splitext(str(source[0]))[0] + env.subst('$JARSUFFIX')

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -149,9 +149,9 @@ def splitFully(path):
     return [base]
 
 def makeHierarchy(sources):
-    '''Break a list of files into a hierarchy; for each value, if it is a string,
+    """Break a list of files into a hierarchy; for each value, if it is a string,
        then it is a file.  If it is a dictionary, it is a folder.  The string is
-       the original path of the file.'''
+       the original path of the file."""
 
     hierarchy = {}
     for file in sources:
@@ -189,7 +189,7 @@ class _UserGenerator(object):
         elif SCons.Util.is_List(env['variant']):
             variants = env['variant']
 
-        if 'DebugSettings' not in env or env['DebugSettings'] == None:
+        if 'DebugSettings' not in env or env['DebugSettings'] is None:
             dbg_settings = []
         elif SCons.Util.is_Dict(env['DebugSettings']):
             dbg_settings = [env['DebugSettings']]
@@ -1287,7 +1287,7 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
                       'Other Files': ''}
 
         cats = sorted([k for k in list(categories.keys()) if self.sources[k]],
-		              key = lambda a: a.lower())
+                      key = lambda a: a.lower())
 
         # print vcxproj.filters file first
         self.filters_file.write('\t<ItemGroup>\n')
@@ -1519,7 +1519,7 @@ class _GenerateV7DSW(_DSWGenerator):
                 name = base
             self.file.write('Project("%s") = "%s", "%s", "%s"\n'
                             % (external_makefile_guid, name, dspinfo['SLN_RELATIVE_FILE_PATH'], dspinfo['GUID']))
-            if self.version_num >= 7.1 and self.version_num < 8.0:
+            if 7.1 <= self.version_num < 8.0:
                 self.file.write('\tProjectSection(ProjectDependencies) = postProject\n'
                                 '\tEndProjectSection\n')
             self.file.write('EndProject\n')

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -107,7 +107,7 @@ def Package(env, target=None, source=None, **kw):
         from SCons.Script import GetOption
         kw['PACKAGETYPE'] = GetOption('package_type')
 
-    if kw['PACKAGETYPE'] == None:
+    if kw['PACKAGETYPE'] is None:
         if 'Tar' in env['BUILDERS']:
             kw['PACKAGETYPE']='targz'
         elif 'Zip' in env['BUILDERS']:
@@ -295,10 +295,8 @@ def stripinstallbuilder(target, source, env):
     It also warns about files which have no install builder attached.
     """
     def has_no_install_location(file):
-        return not (file.has_builder() and\
-            hasattr(file.builder, 'name') and\
-            (file.builder.name=="InstallBuilder" or\
-             file.builder.name=="InstallAsBuilder"))
+        return not file.has_builder() and hasattr(file.builder, 'name') \
+               and file.builder.name in ["InstallBuilder", "InstallAsBuilder"]
 
     if len([src for src in source if has_no_install_location(src)]):
         warn(Warning, "there are files to package which have no\

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -295,8 +295,9 @@ def stripinstallbuilder(target, source, env):
     It also warns about files which have no install builder attached.
     """
     def has_no_install_location(file):
-        return not file.has_builder() and hasattr(file.builder, 'name') \
-               and file.builder.name in ["InstallBuilder", "InstallAsBuilder"]
+        return not (file.has_builder() and hasattr(file.builder, 'name')
+                    and file.builder.name in ["InstallBuilder", "InstallAsBuilder"])
+
 
     if len([src for src in source if has_no_install_location(src)]):
         warn(Warning, "there are files to package which have no\

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -114,8 +114,7 @@ def gen_dos_short_file_name(file, filename_set):
     # thisis1.txt, thisis2.txt etc.
     duplicate, num = not None, 1
     while duplicate:
-        shortname = "%s%s" % (fname[:8-len(str(num))].upper(),\
-                              str(num))
+        shortname = "%s%s" % (fname[:8-len(str(num))].upper(), str(num))
         if len(ext) >= 2:
             shortname = "%s%s" % (shortname, ext[:4].upper())
 
@@ -301,7 +300,7 @@ def build_wxsfile_file_section(root, files, NAME, VERSION, VENDOR, filename_set,
                                if c.nodeName == 'Directory'
                                and c.attributes['LongName'].value == escape(d)] 
 
-            if already_created != []:
+            if already_created:
                 Directory = already_created[0]
                 dir_parts.remove(d)
                 upper_dir += d

--- a/src/engine/SCons/Tool/rpcgen.py
+++ b/src/engine/SCons/Tool/rpcgen.py
@@ -43,7 +43,7 @@ rpcgen_service  = cmd % ('m', '$RPCGENSERVICEFLAGS')
 rpcgen_xdr      = cmd % ('c', '$RPCGENXDRFLAGS')
 
 def generate(env):
-    "Add RPCGEN Builders and construction variables for an Environment."
+    """Add RPCGEN Builders and construction variables for an Environment."""
     
     client  = Builder(action=rpcgen_client,  suffix='_clnt.c', src_suffix='.x')
     header  = Builder(action=rpcgen_header,  suffix='.h',      src_suffix='.x')

--- a/src/engine/SCons/Tool/tex.py
+++ b/src/engine/SCons/Tool/tex.py
@@ -790,7 +790,7 @@ def tex_emitter_core(target, source, env, graphics_extensions):
                 for multibibmatch in multibib_re.finditer(content):
                     if Verbose:
                         print("multibib match ",multibibmatch.group(1))
-                    if multibibmatch != None:
+                    if multibibmatch is not None:
                         baselist = multibibmatch.group(1).split(',')
                         if Verbose:
                             print("multibib list ", baselist)

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -103,7 +103,7 @@ def containsOnly(str, set):
     return 1
 
 def splitext(path):
-    "Same as os.path.splitext() but faster."
+    """Same as os.path.splitext() but faster."""
     sep = rightmost_separator(path, os.sep)
     dot = path.rfind('.')
     # An ext is only real if it has at least one non-digit char
@@ -1370,8 +1370,8 @@ def make_path_relative(path):
 # The original idea for AddMethod() and RenameFunction() come from the
 # following post to the ActiveState Python Cookbook:
 #
-#	ASPN: Python Cookbook : Install bound methods in an instance
-#	http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/223613
+#   ASPN: Python Cookbook : Install bound methods in an instance
+#   http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/223613
 #
 # That code was a little fragile, though, so the following changes
 # have been wrung on it:
@@ -1388,8 +1388,8 @@ def make_path_relative(path):
 #   the "new" module, as alluded to in Alex Martelli's response to the
 #   following Cookbook post:
 #
-#	ASPN: Python Cookbook : Dynamically added methods to a class
-#	http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/81732
+#   ASPN: Python Cookbook : Dynamically added methods to a class
+#   http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/81732
 
 def AddMethod(obj, function, name=None):
     """

--- a/src/script/scons-time.py
+++ b/src/script/scons-time.py
@@ -58,12 +58,12 @@ def make_temp_file(**kw):
     return result
 
 def HACK_for_exec(cmd, *args):
-    '''
+    """
     For some reason, Python won't allow an exec() within a function
     that also declares an internal function (including lambda functions).
     This function is a hack that calls exec() in a function with no
     internal functions.
-    '''
+    """
     if not args:          exec(cmd)
     elif len(args) == 1:  exec(cmd, args[0])
     else:                 exec(cmd, args[0], args[1])
@@ -147,7 +147,7 @@ class Gnuplotter(Plotter):
         return line.plot_string()
 
     def vertical_bar(self, x, type, label, comment):
-        if self.get_min_x() <= x and x <= self.get_max_x():
+        if self.get_min_x() <= x <= self.get_max_x():
             points = [(x, 0), (x, self.max_graph_value(self.get_max_y()))]
             self.line(points, type, label, comment)
 

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -275,7 +275,7 @@ def map_bkids(entry, name):
     result = []
     for i in range(len(bkids)):
         result.append(nodeinfo_string(bkids[i], bkidsigs[i], "        "))
-    if result == []:
+    if not result:
         return None
     return "\n        ".join(result)
 


### PR DESCRIPTION
Suggested by PyCharm.  Includes three "real" changes:

1. src/engine/SCons/Node/__init__.py has a print statement in a function
   which references 'self', but there is no 'self' defined (it is not
   a method in a class). Guessing it should have been 'node'.
2. src/engine/SCons/Environment.py makes a call using 'kwbd' which is not
   defined, looks like a copy-paste error and should be 'bd'.
3. src/engine/SCons/Tool/JavaCommon.py splits 'file', which is not
   defined, was evidently supposed to be 'fn'.

These should be double-checked.

The rest are purely syntax: whitespace, dropping trailing semicolons,
using "is" to test for None, simplifying comparisons, normalizing
docstring commenting ("always triple double quotes"), unneeded
backslashes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation