### PR TITLE
fix Value node tests to expect a string and not bytes

### DIFF
--- a/src/engine/SCons/Node/PythonTests.py
+++ b/src/engine/SCons/Node/PythonTests.py
@@ -88,15 +88,15 @@ class ValueTestCase(unittest.TestCase):
         """
         v1 = SCons.Node.Python.Value('aaa')
         csig = v1.get_csig(None)
-        assert csig.decode() == 'aaa', csig
+        assert csig == 'aaa', csig
 
         v2 = SCons.Node.Python.Value(7)
         csig = v2.get_csig(None)
-        assert csig.decode() == '7', csig
+        assert csig == '7', csig
 
         v3 = SCons.Node.Python.Value(None)
         csig = v3.get_csig(None)
-        assert csig.decode() == 'None', csig
+        assert csig == 'None', csig
 
 class ValueNodeInfoTestCase(unittest.TestCase):
     def test___init__(self):


### PR DESCRIPTION

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation