### PR TITLE
Get a little smarter about finding the scons engine.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -160,6 +160,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Add xz compression format to packaging choices.
     - Syntax cleanups - trailing blanks, use "is" to compare with None, etc.
       Three uses of variables not defined are changed.
+    - Some script changes in trying to find scons engine
 
   From Hao Wu
     - typo in customized decider example in user guide

--- a/src/script/scons.py
+++ b/src/script/scons.py
@@ -37,9 +37,17 @@ __date__ = "__DATE__"
 
 __developer__ = "__DEVELOPER__"
 
+# This is the entry point to the SCons program.
+# The only job of this script is to work out where the guts of the program
+# could be and import them, where the real work begins.
+# SCons can be invoked several different ways
+# - from an installed location
+# - from a "local install" copy
+# - from a source tree, which has a different dir struture than the other two
+# Try to account for all those possibilities.
+
 import os
 import sys
-
 
 ##############################################################################
 # BEGIN STANDARD SCons SCRIPT HEADER
@@ -50,57 +58,53 @@ import sys
 # should also change other scripts that use this same header.
 ##############################################################################
 
-# Strip the script directory from sys.path() so on case-insensitive
-# (WIN32) systems Python doesn't think that the "scons" script is the
-# "SCons" package.  Replace it with our own library directories
-# (version-specific first, in case they installed by hand there,
-# followed by generic) so we pick up the right version of the build
-# engine modules if they're in either directory.
-
-
+# compatibility check
 if (3,0,0) < sys.version_info < (3,5,0) or sys.version_info < (2,7,0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python < 3.5 is not yet supported.\n"
+Python 2.7 or >= 3.5 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 
-
-script_dir = os.path.dirname(os.path.realpath(__file__))
-
-if script_dir in sys.path:
-    sys.path.remove(script_dir)
+# Strip the script directory from sys.path so on case-insensitive
+# (WIN32) systems Python doesn't think that the "scons" script is the
+# "SCons" package.
+script_dir = os.path.dirname(__file__)
+script_path = os.path.realpath(os.path.dirname(__file__))
+if script_path in sys.path:
+    sys.path.remove(script_path)
 
 libs = []
 
 if "SCONS_LIB_DIR" in os.environ:
     libs.append(os.environ["SCONS_LIB_DIR"])
 
-# - running from source takes priority (since 2.3.2), excluding SCONS_LIB_DIR settings
-script_path = os.path.abspath(os.path.dirname(__file__))
-source_path = os.path.join(script_path, '..', 'engine')
-libs.append(source_path)
+# running from source takes 2nd priority (since 2.3.2), following SCONS_LIB_DIR
+source_path = os.path.join(script_path, os.pardir, 'engine')
+if os.path.isdir(source_path):
+    libs.append(source_path)
 
+# add local-install locations
 local_version = 'scons-local-' + __version__
 local = 'scons-local'
 if script_dir:
     local_version = os.path.join(script_dir, local_version)
     local = os.path.join(script_dir, local)
-libs.append(os.path.abspath(local_version))
-libs.append(os.path.abspath(local))
+if os.path.isdir(local_version):
+    libs.append(os.path.abspath(local_version))
+if os.path.isdir(local):
+    libs.append(os.path.abspath(local))
 
 scons_version = 'scons-%s' % __version__
 
 # preferred order of scons lookup paths
 prefs = []
 
-
-# - running from egg check
+# if we can find package information, use it
 try:
     import pkg_resources
 except ImportError:
     pass
 else:
-    # when running from an egg add the egg's directory
     try:
         d = pkg_resources.get_distribution('scons')
     except pkg_resources.DistributionNotFound:
@@ -109,18 +113,18 @@ else:
         prefs.append(d.location)
 
 if sys.platform == 'win32':
-    # sys.prefix is (likely) C:\Python*;
-    # check only C:\Python*.
+    # Use only sys.prefix on Windows
     prefs.append(sys.prefix)
     prefs.append(os.path.join(sys.prefix, 'Lib', 'site-packages'))
 else:
     # On other (POSIX) platforms, things are more complicated due to
-    # the variety of path names and library locations.  Try to be smart
-    # about it.
+    # the variety of path names and library locations.
+    # Build up some possibilities, then transform them into candidates
+    temp = []
     if script_dir == 'bin':
         # script_dir is `pwd`/bin;
         # check `pwd`/lib/scons*.
-        prefs.append(os.getcwd())
+        temp.append(os.getcwd())
     else:
         if script_dir == '.' or script_dir == '':
             script_dir = os.getcwd()
@@ -128,42 +132,41 @@ else:
         if tail == "bin":
             # script_dir is /foo/bin;
             # check /foo/lib/scons*.
-            prefs.append(head)
+            temp.append(head)
 
     head, tail = os.path.split(sys.prefix)
     if tail == "usr":
         # sys.prefix is /foo/usr;
         # check /foo/usr/lib/scons* first,
         # then /foo/usr/local/lib/scons*.
-        prefs.append(sys.prefix)
-        prefs.append(os.path.join(sys.prefix, "local"))
+        temp.append(sys.prefix)
+        temp.append(os.path.join(sys.prefix, "local"))
     elif tail == "local":
         h, t = os.path.split(head)
         if t == "usr":
             # sys.prefix is /foo/usr/local;
             # check /foo/usr/local/lib/scons* first,
             # then /foo/usr/lib/scons*.
-            prefs.append(sys.prefix)
-            prefs.append(head)
+            temp.append(sys.prefix)
+            temp.append(head)
         else:
             # sys.prefix is /foo/local;
             # check only /foo/local/lib/scons*.
-            prefs.append(sys.prefix)
+            temp.append(sys.prefix)
     else:
         # sys.prefix is /foo (ends in neither /usr or /local);
         # check only /foo/lib/scons*.
-        prefs.append(sys.prefix)
+        temp.append(sys.prefix)
 
-    temp = [os.path.join(x, 'lib') for x in prefs]
-    temp.extend([os.path.join(x,
-                                           'lib',
-                                           'python' + sys.version[:3],
-                                           'site-packages') for x in prefs])
-    prefs = temp
+    # suffix these to add to our original prefs:
+    prefs.extend([os.path.join(x, 'lib') for x in temp])
+    prefs.extend([os.path.join(x, 'lib', 'python' + sys.version[:3],
+                               'site-packages') for x in temp])
+
 
     # Add the parent directory of the current python's library to the
-    # preferences.  On SuSE-91/AMD64, for example, this is /usr/lib64,
-    # not /usr/lib.
+    # preferences.  This picks up differences between, e.g., lib and lib64,
+    # and finds the base location in case of a non-copying virtualenv.
     try:
         libpath = os.__file__
     except AttributeError:
@@ -177,9 +180,9 @@ else:
         prefs.append(libpath)
 
 # Look first for 'scons-__version__' in all of our preference libs,
-# then for 'scons'.
-libs.extend([os.path.join(x, scons_version) for x in prefs])
-libs.extend([os.path.join(x, 'scons') for x in prefs])
+# then for 'scons'.  Skip paths that do not exist.
+libs.extend([os.path.join(x, scons_version) for x in prefs if os.path.isdir(x)])
+libs.extend([os.path.join(x, 'scons') for x in prefs if os.path.isdir(x)])
 
 sys.path = libs + sys.path
 
@@ -191,9 +194,9 @@ if __name__ == "__main__":
     try:
         import SCons.Script
     except ImportError:
-        print("SCons import failed. Unable to find engine files in:")
+        sys.stderr.write("SCons import failed. Unable to find engine files in:\n")
         for path in libs:
-            print("  {}".format(path))
+            sys.stderr.write("  {}\n".format(path))
         raise
 
     # this does all the work, and calls sys.exit

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -49,48 +49,53 @@ import sys
 # should also change other scripts that use this same header.
 ##############################################################################
 
-# Strip the script directory from sys.path() so on case-insensitive
+# compatibility check
+if (3,0,0) < sys.version_info < (3,5,0) or sys.version_info < (2,7,0):
+    msg = "scons: *** SCons version %s does not run under Python version %s.\n\
+Python 2.7 or >= 3.5 is required.\n"
+    sys.stderr.write(msg % (__version__, sys.version.split()[0]))
+    sys.exit(1)
+
+# Strip the script directory from sys.path so on case-insensitive
 # (WIN32) systems Python doesn't think that the "scons" script is the
-# "SCons" package.  Replace it with our own library directories
-# (version-specific first, in case they installed by hand there,
-# followed by generic) so we pick up the right version of the build
-# engine modules if they're in either directory.
-
-
-script_dir = os.path.dirname(os.path.realpath(__file__))
-
-if script_dir in sys.path:
-    sys.path.remove(script_dir)
+# "SCons" package.
+script_dir = os.path.dirname(__file__)
+script_path = os.path.realpath(os.path.dirname(__file__))
+if script_path in sys.path:
+    sys.path.remove(script_path)
 
 libs = []
 
 if "SCONS_LIB_DIR" in os.environ:
     libs.append(os.environ["SCONS_LIB_DIR"])
 
-# - running from source takes priority (since 2.3.2), excluding SCONS_LIB_DIR settings
-script_path = os.path.abspath(os.path.dirname(__file__))
-source_path = os.path.join(script_path, '..', 'engine')
-libs.append(source_path)
+# running from source takes 2nd priority (since 2.3.2), following SCONS_LIB_DIR
+source_path = os.path.join(script_path, os.pardir, 'engine')
+if os.path.isdir(source_path):
+    libs.append(source_path)
 
+# add local-install locations
 local_version = 'scons-local-' + __version__
 local = 'scons-local'
 if script_dir:
     local_version = os.path.join(script_dir, local_version)
     local = os.path.join(script_dir, local)
-libs.append(os.path.abspath(local_version))
-libs.append(os.path.abspath(local))
+if os.path.isdir(local_version):
+    libs.append(os.path.abspath(local_version))
+if os.path.isdir(local):
+    libs.append(os.path.abspath(local))
 
 scons_version = 'scons-%s' % __version__
 
 # preferred order of scons lookup paths
 prefs = []
 
+# if we can find package information, use it
 try:
     import pkg_resources
 except ImportError:
     pass
 else:
-    # when running from an egg add the egg's directory
     try:
         d = pkg_resources.get_distribution('scons')
     except pkg_resources.DistributionNotFound:
@@ -99,18 +104,18 @@ else:
         prefs.append(d.location)
 
 if sys.platform == 'win32':
-    # sys.prefix is (likely) C:\Python*;
-    # check only C:\Python*.
+    # Use only sys.prefix on Windows
     prefs.append(sys.prefix)
     prefs.append(os.path.join(sys.prefix, 'Lib', 'site-packages'))
 else:
     # On other (POSIX) platforms, things are more complicated due to
-    # the variety of path names and library locations.  Try to be smart
-    # about it.
+    # the variety of path names and library locations.
+    # Build up some possibilities, then transform them into candidates
+    temp = []
     if script_dir == 'bin':
         # script_dir is `pwd`/bin;
         # check `pwd`/lib/scons*.
-        prefs.append(os.getcwd())
+        temp.append(os.getcwd())
     else:
         if script_dir == '.' or script_dir == '':
             script_dir = os.getcwd()
@@ -118,42 +123,41 @@ else:
         if tail == "bin":
             # script_dir is /foo/bin;
             # check /foo/lib/scons*.
-            prefs.append(head)
+            temp.append(head)
 
     head, tail = os.path.split(sys.prefix)
     if tail == "usr":
         # sys.prefix is /foo/usr;
         # check /foo/usr/lib/scons* first,
         # then /foo/usr/local/lib/scons*.
-        prefs.append(sys.prefix)
-        prefs.append(os.path.join(sys.prefix, "local"))
+        temp.append(sys.prefix)
+        temp.append(os.path.join(sys.prefix, "local"))
     elif tail == "local":
         h, t = os.path.split(head)
         if t == "usr":
             # sys.prefix is /foo/usr/local;
             # check /foo/usr/local/lib/scons* first,
             # then /foo/usr/lib/scons*.
-            prefs.append(sys.prefix)
-            prefs.append(head)
+            temp.append(sys.prefix)
+            temp.append(head)
         else:
             # sys.prefix is /foo/local;
             # check only /foo/local/lib/scons*.
-            prefs.append(sys.prefix)
+            temp.append(sys.prefix)
     else:
         # sys.prefix is /foo (ends in neither /usr or /local);
         # check only /foo/lib/scons*.
-        prefs.append(sys.prefix)
+        temp.append(sys.prefix)
 
-    temp = [os.path.join(x, 'lib') for x in prefs]
-    temp.extend([os.path.join(x,
-                                           'lib',
-                                           'python' + sys.version[:3],
-                                           'site-packages') for x in prefs])
-    prefs = temp
+    # suffix these to add to our original prefs:
+    prefs.extend([os.path.join(x, 'lib') for x in temp])
+    prefs.extend([os.path.join(x, 'lib', 'python' + sys.version[:3],
+                               'site-packages') for x in temp])
+
 
     # Add the parent directory of the current python's library to the
-    # preferences.  On SuSE-91/AMD64, for example, this is /usr/lib64,
-    # not /usr/lib.
+    # preferences.  This picks up differences between, e.g., lib and lib64,
+    # and finds the base location in case of a non-copying virtualenv.
     try:
         libpath = os.__file__
     except AttributeError:
@@ -167,9 +171,9 @@ else:
         prefs.append(libpath)
 
 # Look first for 'scons-__version__' in all of our preference libs,
-# then for 'scons'.
-libs.extend([os.path.join(x, scons_version) for x in prefs])
-libs.extend([os.path.join(x, 'scons') for x in prefs])
+# then for 'scons'.  Skip paths that do not exist.
+libs.extend([os.path.join(x, scons_version) for x in prefs if os.path.isdir(x)])
+libs.extend([os.path.join(x, 'scons') for x in prefs if os.path.isdir(x)])
 
 sys.path = libs + sys.path
 


### PR DESCRIPTION
In the common script stanza, previous version was generating some paths
that were not useful.  Make sure the path pulled from package info is
not mangled into unsuability. General cleanup.

Write error message to stderr instead of stdout in scons.py.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://scons.org/guidelines.html


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation