### PR TITLE
Correct sheabangs in code snippets under test/

### DIFF
--- a/test/Builder/multi/different-environments.py
+++ b/test/Builder/multi/different-environments.py
@@ -36,15 +36,15 @@ test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 _python_ = TestSCons._python_
 
-test.write('build.py', r"""#!/usr/bin/env python
+test.write('build.py', r"""#!/usr/bin/env python%s
 import sys
 def build(num, target, source):
     file = open(str(target), 'wb')
-    file.write('%s\n'%num)
+    file.write('%%s\n' %% num)
     for s in source:
         file.write(open(str(s), 'rb').read())
 build(sys.argv[1],sys.argv[2],sys.argv[3:])
-""")
+""" % sys.version_info[0])
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])

--- a/test/Builder/multi/different-environments.py
+++ b/test/Builder/multi/different-environments.py
@@ -36,15 +36,15 @@ test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 _python_ = TestSCons._python_
 
-test.write('build.py', r"""#!/usr/bin/env python%s
+test.write('build.py', r"""\
 import sys
 def build(num, target, source):
     file = open(str(target), 'wb')
-    file.write('%%s\n' %% num)
+    file.write('%s\n' % num)
     for s in source:
         file.write(open(str(s), 'rb').read())
 build(sys.argv[1],sys.argv[2],sys.argv[3:])
-""" % sys.version_info[0])
+""")
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])

--- a/test/Builder/multi/same-overrides.py
+++ b/test/Builder/multi/same-overrides.py
@@ -29,20 +29,21 @@ Verify that everything works if two multi calls have the same overrides.
 """
 
 import TestSCons
+import sys
 
 test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 _python_ = TestSCons._python_
 
-test.write('build.py', r"""#!/usr/bin/env python
+test.write('build.py', r"""#!/usr/bin/env python%s
 import sys
 def build(num, target, source):
     file = open(str(target), 'wb')
-    file.write(bytearray('%s\n'%num,'utf-8'))
+    file.write(bytearray('%%s\n'%% num,'utf-8'))
     for s in source:
         file.write(open(str(s), 'rb').read())
 build(sys.argv[1],sys.argv[2],sys.argv[3:])
-""")
+""" % sys.version_info[0])
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])

--- a/test/Builder/multi/same-overrides.py
+++ b/test/Builder/multi/same-overrides.py
@@ -29,21 +29,20 @@ Verify that everything works if two multi calls have the same overrides.
 """
 
 import TestSCons
-import sys
 
 test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 _python_ = TestSCons._python_
 
-test.write('build.py', r"""#!/usr/bin/env python%s
+test.write('build.py', r"""\
 import sys
 def build(num, target, source):
     file = open(str(target), 'wb')
-    file.write(bytearray('%%s\n'%% num,'utf-8'))
+    file.write(bytearray('%s\n'% num,'utf-8'))
     for s in source:
         file.write(open(str(s), 'rb').read())
 build(sys.argv[1],sys.argv[2],sys.argv[3:])
-""" % sys.version_info[0])
+""")
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])

--- a/test/ENV.py
+++ b/test/ENV.py
@@ -25,7 +25,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import sys
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/ENV.py
+++ b/test/ENV.py
@@ -25,7 +25,7 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-
+import sys
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -47,12 +47,12 @@ env2.Bld(target = 'env2.out', source = 'input')
 """ % locals())
 
 test.write('build.py',
-r"""#!/usr/bin/env python
+r"""#!/usr/bin/env python%s
 import os
 import sys
 contents = open(sys.argv[2], 'r').read()
-open(sys.argv[1], 'w').write("build.py %s\n%s" % (os.environ['X'], contents))
-""")
+open(sys.argv[1], 'w').write("build.py %%s\n%%s" %% (os.environ['X'], contents))
+""" % sys.version_info[0])
 
 test.write('input', "input file\n")
 

--- a/test/ENV.py
+++ b/test/ENV.py
@@ -47,12 +47,12 @@ env2.Bld(target = 'env2.out', source = 'input')
 """ % locals())
 
 test.write('build.py',
-r"""#!/usr/bin/env python%s
+r"""\
 import os
 import sys
 contents = open(sys.argv[2], 'r').read()
-open(sys.argv[1], 'w').write("build.py %%s\n%%s" %% (os.environ['X'], contents))
-""" % sys.version_info[0])
+open(sys.argv[1], 'w').write("build.py %s\n%s" % (os.environ['X'], contents))
+""")
 
 test.write('input', "input file\n")
 

--- a/test/SWIG/build-dir.py
+++ b/test/SWIG/build-dir.py
@@ -139,9 +139,10 @@ public:
 };
 """)
 
+## _python_ = TestSCons._python_
 ## XXX: @ptomulik: looks like it was unused?
 ## test.write(['source', 'test.py'], """\
-## #!/usr/bin/env python%s
+## #!%(_python_)s
 ## from __future__ import print_function
 ##
 ## import linalg
@@ -158,7 +159,7 @@ public:
 ## for i, v in enumerate(x):
 ##     print("\tx[%%d] = %%g" %% (i, v))
 ##
-## """ % sys.version_info[0])
+## """ % locals())
 
 test.run(arguments = '.')
 

--- a/test/SWIG/build-dir.py
+++ b/test/SWIG/build-dir.py
@@ -139,25 +139,26 @@ public:
 };
 """)
 
-test.write(['source', 'test.py'], """\
-#!/usr/bin/env python%s
-from __future__ import print_function
-
-import linalg
-
-
-x = linalg.Vector(5)
-print(x)
-
-x[1] = 99.5
-x[3] = 8.3
-x[4] = 11.1
-
-
-for i, v in enumerate(x):
-    print("\tx[%%d] = %%g" %% (i, v))
-
-""" % sys.version_info[0])
+## XXX: @ptomulik: looks like it was unused?
+## test.write(['source', 'test.py'], """\
+## #!/usr/bin/env python%s
+## from __future__ import print_function
+##
+## import linalg
+##
+##
+## x = linalg.Vector(5)
+## print(x)
+##
+## x[1] = 99.5
+## x[3] = 8.3
+## x[4] = 11.1
+##
+##
+## for i, v in enumerate(x):
+##     print("\tx[%%d] = %%g" %% (i, v))
+##
+## """ % sys.version_info[0])
 
 test.run(arguments = '.')
 

--- a/test/SWIG/build-dir.py
+++ b/test/SWIG/build-dir.py
@@ -140,7 +140,7 @@ public:
 """)
 
 test.write(['source', 'test.py'], """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 from __future__ import print_function
 
 import linalg
@@ -155,9 +155,9 @@ x[4] = 11.1
 
 
 for i, v in enumerate(x):
-    print("\tx[%d] = %g" % (i, v))
+    print("\tx[%%d] = %%g" %% (i, v))
 
-""")
+""" % sys.version_info[0])
 
 test.run(arguments = '.')
 

--- a/test/Scanner/generated.py
+++ b/test/Scanner/generated.py
@@ -34,6 +34,7 @@ factors triggered the bug Scott saw, and partly because the real-world
 complexity is valuable in its own right.
 """
 
+import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -282,7 +283,7 @@ recurse_env.Command([lib_fullname] + lib_objs,
 """)
 
 test.write(['src', 'lib_geng', 'MAKE-HEADER.py'], """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 
 import os
 import os.path
@@ -293,7 +294,7 @@ os.chdir(os.path.split(sys.argv[0])[0])
 
 for h in ['libg_gx.h', 'libg_gy.h', 'libg_gz.h']:
     open(h, 'w').write('')
-""")
+""" % sys.version_info[0])
 
 test.write(['src', 'lib_geng', 'SConstruct'], """\
 import os

--- a/test/Scanner/generated.py
+++ b/test/Scanner/generated.py
@@ -34,8 +34,9 @@ factors triggered the bug Scott saw, and partly because the real-world
 complexity is valuable in its own right.
 """
 
-import sys
 import TestSCons
+
+_python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
@@ -283,7 +284,7 @@ recurse_env.Command([lib_fullname] + lib_objs,
 """)
 
 test.write(['src', 'lib_geng', 'MAKE-HEADER.py'], """\
-#!/usr/bin/env python%s
+#!%(_python_)s
 
 import os
 import os.path
@@ -294,7 +295,7 @@ os.chdir(os.path.split(sys.argv[0])[0])
 
 for h in ['libg_gx.h', 'libg_gy.h', 'libg_gz.h']:
     open(h, 'w').write('')
-""" % sys.version_info[0])
+""" % locals())
 
 test.write(['src', 'lib_geng', 'SConstruct'], """\
 import os

--- a/test/TEMPFILEPREFIX.py
+++ b/test/TEMPFILEPREFIX.py
@@ -30,7 +30,6 @@ beginning of the TEMPFILE invocation of a long command line.
 """
 
 import os
-import sys
 import stat
 
 import TestSCons
@@ -38,11 +37,10 @@ import TestSCons
 test = TestSCons.TestSCons(match = TestSCons.match_re)
 
 test.write('echo.py', """\
-#!/usr/bin/env python%s
 from __future__ import print_function
 import sys
 print(sys.argv)
-""" % sys.version_info[0])
+""")
 
 echo_py = test.workpath('echo.py')
 

--- a/test/TEMPFILEPREFIX.py
+++ b/test/TEMPFILEPREFIX.py
@@ -30,6 +30,7 @@ beginning of the TEMPFILE invocation of a long command line.
 """
 
 import os
+import sys
 import stat
 
 import TestSCons
@@ -37,11 +38,11 @@ import TestSCons
 test = TestSCons.TestSCons(match = TestSCons.match_re)
 
 test.write('echo.py', """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 from __future__ import print_function
 import sys
 print(sys.argv)
-""")
+""" % sys.version_info[0])
 
 echo_py = test.workpath('echo.py')
 

--- a/test/TEX/biber_biblatex.py
+++ b/test/TEX/biber_biblatex.py
@@ -32,6 +32,7 @@ Test courtesy Rob Managan.
 
 import TestSCons
 import os
+import sys
 
 test = TestSCons.TestSCons()
 
@@ -49,13 +50,13 @@ if not gloss==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 
 import os
 env = Environment(ENV=os.environ)
 env['BIBTEX'] = 'biber'
 main_output = env.PDF('bibertest.tex')
-""")
+""" % sys.version_info[0])
 
 
 sources_bib_content = r"""

--- a/test/TEX/biber_biblatex.py
+++ b/test/TEX/biber_biblatex.py
@@ -32,7 +32,6 @@ Test courtesy Rob Managan.
 
 import TestSCons
 import os
-import sys
 
 test = TestSCons.TestSCons()
 
@@ -50,13 +49,11 @@ if not gloss==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python%s
-
 import os
 env = Environment(ENV=os.environ)
 env['BIBTEX'] = 'biber'
 main_output = env.PDF('bibertest.tex')
-""" % sys.version_info[0])
+""")
 
 
 sources_bib_content = r"""

--- a/test/TEX/biber_biblatex2.py
+++ b/test/TEX/biber_biblatex2.py
@@ -34,7 +34,6 @@ Test courtesy Rob Managan.
 
 import TestSCons
 import os
-import sys
 
 test = TestSCons.TestSCons()
 
@@ -56,12 +55,10 @@ if not biblatex==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python%s
-
 import os
 env = Environment(ENV=os.environ)
 main_output = env.PDF('bibertest.tex')
-""" % sys.version_info[0])
+""")
 
 
 sources_bib_content = r"""

--- a/test/TEX/biber_biblatex2.py
+++ b/test/TEX/biber_biblatex2.py
@@ -34,6 +34,7 @@ Test courtesy Rob Managan.
 
 import TestSCons
 import os
+import sys
 
 test = TestSCons.TestSCons()
 
@@ -55,12 +56,12 @@ if not biblatex==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 
 import os
 env = Environment(ENV=os.environ)
 main_output = env.PDF('bibertest.tex')
-""")
+""" % sys.version_info[0])
 
 
 sources_bib_content = r"""

--- a/test/TEX/biblatex.py
+++ b/test/TEX/biblatex.py
@@ -31,6 +31,7 @@ Test courtesy Rob Managan.
 """
 
 import TestSCons
+import sys
 import os
 
 test = TestSCons.TestSCons()
@@ -45,12 +46,12 @@ if not biblatex==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 
 import os
 env = Environment(ENV=os.environ)
 main_output = env.PDF(target='biblatextest.pdf', source='biblatextest.tex')
-""")
+""" % sys.version_info[0])
 
 
 sources_bib_content = r"""

--- a/test/TEX/biblatex.py
+++ b/test/TEX/biblatex.py
@@ -31,7 +31,6 @@ Test courtesy Rob Managan.
 """
 
 import TestSCons
-import sys
 import os
 
 test = TestSCons.TestSCons()
@@ -46,12 +45,10 @@ if not biblatex==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python%s
-
 import os
 env = Environment(ENV=os.environ)
 main_output = env.PDF(target='biblatextest.pdf', source='biblatextest.tex')
-""" % sys.version_info[0])
+""")
 
 
 sources_bib_content = r"""

--- a/test/TEX/biblatex_plain.py
+++ b/test/TEX/biblatex_plain.py
@@ -32,6 +32,7 @@ Test courtesy Rob Managan.
 
 import TestSCons
 import os
+import sys
 
 test = TestSCons.TestSCons()
 
@@ -45,12 +46,12 @@ if not biblatex==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 
 import os
 env = Environment(ENV=os.environ)
 main_output = env.PDF(target='biblatextest.pdf', source='biblatextest.tex')
-""")
+""" % sys.version_info[0])
 
 test.write(['biblatextest.tex'],r"""
 \documentclass{article}

--- a/test/TEX/biblatex_plain.py
+++ b/test/TEX/biblatex_plain.py
@@ -32,7 +32,6 @@ Test courtesy Rob Managan.
 
 import TestSCons
 import os
-import sys
 
 test = TestSCons.TestSCons()
 

--- a/test/TEX/biblatex_plain.py
+++ b/test/TEX/biblatex_plain.py
@@ -46,12 +46,10 @@ if not biblatex==0:
 
 
 test.write(['SConstruct'], """\
-#!/usr/bin/env python%s
-
 import os
 env = Environment(ENV=os.environ)
 main_output = env.PDF(target='biblatextest.pdf', source='biblatextest.tex')
-""" % sys.version_info[0])
+""")
 
 test.write(['biblatextest.tex'],r"""
 \documentclass{article}

--- a/test/explain/basic.py
+++ b/test/explain/basic.py
@@ -51,7 +51,7 @@ inc_bbb_k = test.workpath('inc', 'bbb.k')
 
 
 
-test.write(cat_py, r"""
+test.write(cat_py, r"""\
 from __future__ import print_function
 
 import sys

--- a/test/explain/basic.py
+++ b/test/explain/basic.py
@@ -29,7 +29,6 @@ Verify a lot of the basic operation of the --debug=explain option.
 """
 
 import os
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -52,7 +51,7 @@ inc_bbb_k = test.workpath('inc', 'bbb.k')
 
 
 
-test.write(cat_py, r"""#!/usr/bin/env python%s
+test.write(cat_py, r"""
 from __future__ import print_function
 
 import sys
@@ -77,7 +76,7 @@ for f in sys.argv[2:]:
         process(outfp, open(f, 'r'))
 
 sys.exit(0)
-""" % sys.version_info[0])
+""")
 
 
 SConstruct_contents = """\

--- a/test/explain/basic.py
+++ b/test/explain/basic.py
@@ -29,7 +29,7 @@ Verify a lot of the basic operation of the --debug=explain option.
 """
 
 import os
-
+import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -52,7 +52,7 @@ inc_bbb_k = test.workpath('inc', 'bbb.k')
 
 
 
-test.write(cat_py, r"""#!/usr/bin/env python
+test.write(cat_py, r"""#!/usr/bin/env python%s
 from __future__ import print_function
 
 import sys
@@ -77,7 +77,7 @@ for f in sys.argv[2:]:
         process(outfp, open(f, 'r'))
 
 sys.exit(0)
-""")
+""" % sys.version_info[0])
 
 
 SConstruct_contents = """\

--- a/test/long-lines/signature.py
+++ b/test/long-lines/signature.py
@@ -30,7 +30,7 @@ surrounded by $( $) from the signature calculation.
 """
 
 import os
-
+import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -38,7 +38,7 @@ test = TestSCons.TestSCons()
 build_py = test.workpath('build.py')
 
 test.write(build_py, """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 import sys
 if sys.argv[1][0] == '@':
     args = open(sys.argv[1][1:], 'rb').read()
@@ -47,9 +47,9 @@ else:
     args = sys.argv[1:]
 fp = open(args[0], 'wb')
 fp.write(open(args[1], 'rb').read())
-fp.write('FILEFLAG=%s\\n' % args[2])
-fp.write('TIMESTAMP=%s\\n' % args[3])
-""")
+fp.write('FILEFLAG=%%s\\n' %% args[2])
+fp.write('TIMESTAMP=%%s\\n' %% args[3])
+""" % sys.version_info[0])
 
 os.chmod(build_py, 0o755)
 

--- a/test/long-lines/signature.py
+++ b/test/long-lines/signature.py
@@ -30,15 +30,16 @@ surrounded by $( $) from the signature calculation.
 """
 
 import os
-import sys
 import TestSCons
+
+_python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
 build_py = test.workpath('build.py')
 
 test.write(build_py, """\
-#!/usr/bin/env python%s
+#!%(_python_)s
 import sys
 if sys.argv[1][0] == '@':
     args = open(sys.argv[1][1:], 'rb').read()
@@ -49,7 +50,7 @@ fp = open(args[0], 'wb')
 fp.write(open(args[1], 'rb').read())
 fp.write('FILEFLAG=%%s\\n' %% args[2])
 fp.write('TIMESTAMP=%%s\\n' %% args[3])
-""" % sys.version_info[0])
+""" % locals())
 
 os.chmod(build_py, 0o755)
 

--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -29,9 +29,10 @@ Verify specifying an alternate Python executable in a config file.
 """
 
 import os
-import sys
 
 import TestSCons_time
+
+_python_ = TestSCons_time._python_
 
 test = TestSCons_time.TestSCons_time()
 
@@ -44,7 +45,7 @@ python = r'%(my_python_py)s'
 """ % locals())
 
 test.write(my_python_py, """\
-#!/usr/bin/env python%s
+#!%(_python_)s
 from __future__ import print_function
 import sys
 profile = ''
@@ -53,7 +54,7 @@ for arg in sys.argv[1:]:
         profile = arg[10:]
         break
 print('my_python.py: %%s' %% profile)
-""" % sys.version_info[0])
+""" % locals())
 
 os.chmod(my_python_py, 0o755)
 

--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -29,6 +29,7 @@ Verify specifying an alternate Python executable in a config file.
 """
 
 import os
+import sys
 
 import TestSCons_time
 
@@ -43,7 +44,7 @@ python = r'%(my_python_py)s'
 """ % locals())
 
 test.write(my_python_py, """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 from __future__ import print_function
 import sys
 profile = ''
@@ -51,8 +52,8 @@ for arg in sys.argv[1:]:
     if arg.startswith('--profile='):
         profile = arg[10:]
         break
-print('my_python.py: %s' % profile)
-""")
+print('my_python.py: %%s' %% profile)
+""" % sys.version_info[0])
 
 os.chmod(my_python_py, 0o755)
 

--- a/test/scons-time/run/option/python.py
+++ b/test/scons-time/run/option/python.py
@@ -29,9 +29,10 @@ Verify the run --python option to specify an alternatie Python executable.
 """
 
 import os
-import sys
 
 import TestSCons_time
+
+_python_ = TestSCons_time._python_
 
 test = TestSCons_time.TestSCons_time()
 
@@ -40,7 +41,7 @@ test.write_sample_project('foo.tar.gz')
 my_python_py = test.workpath('my_python.py')
 
 test.write(my_python_py, """\
-#!/usr/bin/env python%s
+#!%(_python_)s
 import sys
 profile = ''
 for arg in sys.argv[1:]:
@@ -48,7 +49,7 @@ for arg in sys.argv[1:]:
         profile = arg[10:]
         break
 sys.stdout.write('my_python.py: %%s\\n' %% profile)
-""" % sys.version_info[0])
+""" % locals())
 
 os.chmod(my_python_py, 0o755)
 

--- a/test/scons-time/run/option/python.py
+++ b/test/scons-time/run/option/python.py
@@ -29,6 +29,7 @@ Verify the run --python option to specify an alternatie Python executable.
 """
 
 import os
+import sys
 
 import TestSCons_time
 
@@ -39,15 +40,15 @@ test.write_sample_project('foo.tar.gz')
 my_python_py = test.workpath('my_python.py')
 
 test.write(my_python_py, """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 import sys
 profile = ''
 for arg in sys.argv[1:]:
     if arg.startswith('--profile='):
         profile = arg[10:]
         break
-sys.stdout.write('my_python.py: %s\\n' % profile)
-""")
+sys.stdout.write('my_python.py: %%s\\n' %% profile)
+""" % sys.version_info[0])
 
 os.chmod(my_python_py, 0o755)
 

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -30,7 +30,7 @@ using the signatures in an SConsignFile().
 """
 
 import re
-
+import sys
 import TestSCons
 import TestSConsign
 
@@ -41,7 +41,7 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, r"""#!/usr/bin/env python
+test.write(fake_cc_py, r"""#!/usr/bin/env python%s
 import os
 import re
 import sys
@@ -50,7 +50,7 @@ path = sys.argv[1].split()
 output = open(sys.argv[2], 'wb')
 input = open(sys.argv[3], 'rb')
 
-output.write('fake_cc.py:  %s\n' % sys.argv)
+output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
 def find_file(f):
     for dir in path:
@@ -71,20 +71,20 @@ def process(infp, outfp):
 process(input, output)
 
 sys.exit(0)
-""")
+""" % sys.version_info[0])
 
-test.write(fake_link_py, r"""#!/usr/bin/env python
+test.write(fake_link_py, r"""#!/usr/bin/env python%s
 import sys
 
 output = open(sys.argv[1], 'wb')
 input = open(sys.argv[2], 'rb')
 
-output.write('fake_link.py:  %s\n' % sys.argv)
+output.write('fake_link.py:  %%s\n' %% sys.argv)
 
 output.write(input.read())
 
 sys.exit(0)
-""")
+""" % sys.version_info[0])
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -30,9 +30,10 @@ using the signatures in an SConsignFile().
 """
 
 import re
-import sys
 import TestSCons
 import TestSConsign
+
+_python_ = TestSCons._python_
 
 test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
 
@@ -41,7 +42,7 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, r"""#!/usr/bin/env python%s
+test.write(fake_cc_py, r"""#!%(_python_)s
 import os
 import re
 import sys
@@ -71,9 +72,9 @@ def process(infp, outfp):
 process(input, output)
 
 sys.exit(0)
-""" % sys.version_info[0])
+""" % locals())
 
-test.write(fake_link_py, r"""#!/usr/bin/env python%s
+test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
 output = open(sys.argv[1], 'wb')
@@ -84,7 +85,7 @@ output.write('fake_link.py:  %%s\n' %% sys.argv)
 output.write(input.read())
 
 sys.exit(0)
-""" % sys.version_info[0])
+""" % locals())
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -35,7 +35,8 @@ SourceSignatures('timestamp') with TargetSignatures('content').
 
 import TestSCons
 import TestSConsign
-import sys
+
+_python_ = TestSCons._python_
 
 test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
 
@@ -61,7 +62,7 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, r"""#!/usr/bin/env python%s
+test.write(fake_cc_py, r"""#!%(_python_)s
 import os
 import re
 import sys
@@ -91,9 +92,9 @@ def process(infp, outfp):
 process(input, output)
 
 sys.exit(0)
-""" % sys.version_info[0])
+""" % locals())
 
-test.write(fake_link_py, r"""#!/usr/bin/env python%s
+test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
 output = open(sys.argv[1], 'wb')
@@ -104,7 +105,7 @@ output.write('fake_link.py:  %%s\n' %% sys.argv)
 output.write(input.read())
 
 sys.exit(0)
-""" % sys.version_info[0])
+""" % locals())
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -35,6 +35,7 @@ SourceSignatures('timestamp') with TargetSignatures('content').
 
 import TestSCons
 import TestSConsign
+import sys
 
 test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
 
@@ -60,7 +61,7 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, r"""#!/usr/bin/env python
+test.write(fake_cc_py, r"""#!/usr/bin/env python%s
 import os
 import re
 import sys
@@ -69,7 +70,7 @@ path = sys.argv[1].split()
 output = open(sys.argv[2], 'wb')
 input = open(sys.argv[3], 'rb')
 
-output.write('fake_cc.py:  %s\n' % sys.argv)
+output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
 def find_file(f):
     for dir in path:
@@ -90,20 +91,20 @@ def process(infp, outfp):
 process(input, output)
 
 sys.exit(0)
-""")
+""" % sys.version_info[0])
 
-test.write(fake_link_py, r"""#!/usr/bin/env python
+test.write(fake_link_py, r"""#!/usr/bin/env python%s
 import sys
 
 output = open(sys.argv[1], 'wb')
 input = open(sys.argv[2], 'rb')
 
-output.write('fake_link.py:  %s\n' % sys.argv)
+output.write('fake_link.py:  %%s\n' %% sys.argv)
 
 output.write(input.read())
 
 sys.exit(0)
-""")
+""" % sys.version_info[0])
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -31,6 +31,7 @@ Verify that the sconsign script works when using an individual
 
 import TestSCons
 import TestSConsign
+import sys
 
 test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
 
@@ -49,7 +50,7 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, r"""#!/usr/bin/env python
+test.write(fake_cc_py, r"""#!/usr/bin/env python%s
 import os
 import re
 import sys
@@ -58,7 +59,7 @@ path = sys.argv[1].split()
 output = open(sys.argv[2], 'wb')
 input = open(sys.argv[3], 'rb')
 
-output.write('fake_cc.py:  %s\n' % sys.argv)
+output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
 def find_file(f):
     for dir in path:
@@ -79,20 +80,20 @@ def process(infp, outfp):
 process(input, output)
 
 sys.exit(0)
-""")
+""" % sys.version_info[0])
 
-test.write(fake_link_py, r"""#!/usr/bin/env python
+test.write(fake_link_py, r"""#!/usr/bin/env python%s
 import sys
 
 output = open(sys.argv[1], 'wb')
 input = open(sys.argv[2], 'rb')
 
-output.write('fake_link.py:  %s\n' % sys.argv)
+output.write('fake_link.py:  %%s\n' %% sys.argv)
 
 output.write(input.read())
 
 sys.exit(0)
-""")
+""" % sys.version_info[0])
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -31,7 +31,8 @@ Verify that the sconsign script works when using an individual
 
 import TestSCons
 import TestSConsign
-import sys
+
+_python_ = TestSCons._python_
 
 test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
 
@@ -50,7 +51,7 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, r"""#!/usr/bin/env python%s
+test.write(fake_cc_py, r"""#!%(_python_)s
 import os
 import re
 import sys
@@ -80,9 +81,9 @@ def process(infp, outfp):
 process(input, output)
 
 sys.exit(0)
-""" % sys.version_info[0])
+""" % locals())
 
-test.write(fake_link_py, r"""#!/usr/bin/env python%s
+test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
 output = open(sys.argv[1], 'wb')
@@ -93,7 +94,7 @@ output.write('fake_link.py:  %%s\n' %% sys.argv)
 output.write(input.read())
 
 sys.exit(0)
-""" % sys.version_info[0])
+""" % locals())
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)

--- a/test/srcchange.py
+++ b/test/srcchange.py
@@ -34,7 +34,6 @@ TargetSignatures('content') but we now rely on the default behavior
 being the equivalent of Decider('content').
 """
 
-import sys
 import os.path
 
 import TestSCons
@@ -44,10 +43,9 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 
 test.write('getrevision', """
-#!/usr/bin/env python%s
 from __future__ import print_function
 print(open('revnum.in','r').read().strip(), end='')
-""" % sys.version_info[0])
+""")
 
 test.write('SConstruct', """
 import re

--- a/test/srcchange.py
+++ b/test/srcchange.py
@@ -34,6 +34,7 @@ TargetSignatures('content') but we now rely on the default behavior
 being the equivalent of Decider('content').
 """
 
+import sys
 import os.path
 
 import TestSCons
@@ -43,10 +44,10 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 
 test.write('getrevision', """
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 from __future__ import print_function
 print(open('revnum.in','r').read().strip(), end='')
-""")
+""" % sys.version_info[0])
 
 test.write('SConstruct', """
 import re

--- a/test/subdivide.py
+++ b/test/subdivide.py
@@ -36,7 +36,6 @@ being the equivalent of Decider('content').
 """
 
 import os
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -59,22 +58,20 @@ fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
 test.write(fake_cc_py, """\
-#!/usr/bin/env python%s
 import sys
 ofp = open(sys.argv[1], 'w')
-ofp.write('fake_cc.py:  %%s\\n' %% sys.argv)
+ofp.write('fake_cc.py:  %s\\n' % sys.argv)
 for s in sys.argv[2:]:
     ofp.write(open(s, 'r').read())
-""" % sys.version_info[0])
+""")
 
 test.write(fake_link_py, """\
-#!/usr/bin/env python%s
 import sys
 ofp = open(sys.argv[1], 'w')
-ofp.write('fake_link.py:  %%s\\n' %% sys.argv)
+ofp.write('fake_link.py:  %s\\n' % sys.argv)
 for s in sys.argv[2:]:
     ofp.write(open(s, 'r').read())
-""" % sys.version_info[0])
+""")
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)

--- a/test/subdivide.py
+++ b/test/subdivide.py
@@ -36,7 +36,7 @@ being the equivalent of Decider('content').
 """
 
 import os
-
+import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -59,22 +59,22 @@ fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
 test.write(fake_cc_py, """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 import sys
 ofp = open(sys.argv[1], 'w')
-ofp.write('fake_cc.py:  %s\\n' % sys.argv)
+ofp.write('fake_cc.py:  %%s\\n' %% sys.argv)
 for s in sys.argv[2:]:
     ofp.write(open(s, 'r').read())
-""")
+""" % sys.version_info[0])
 
 test.write(fake_link_py, """\
-#!/usr/bin/env python
+#!/usr/bin/env python%s
 import sys
 ofp = open(sys.argv[1], 'w')
-ofp.write('fake_link.py:  %s\\n' % sys.argv)
+ofp.write('fake_link.py:  %%s\\n' %% sys.argv)
 for s in sys.argv[2:]:
     ofp.write(open(s, 'r').read())
-""")
+""" % sys.version_info[0])
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)


### PR DESCRIPTION
According to [this thread](https://stackoverflow.com/a/19305076/2186051) and [PEP 394](https://www.python.org/dev/peps/pep-0394/#recommendation), scripts should use either ``python2`` or ``python3`` in sheabangs to avoid ambiguous use of python 2 or 3 on different platforms (on some ``python`` defaults to ``python2`` and on others to ``python3``).  In the context of scons tests, code snippets should specify the python version to be the one which is used to run ``runtest.py``. Otherwise it may happen that during the ``python3`` tests some scripts actually get executed under ``python2`` (and vice-versa). In the result, some python3 regressions may stay undiscovered because the corresponding code is actually executed on python2 (this seems to happend on travis currently).