### PR TITLE
Additional fixes for SWIG tests

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -139,7 +139,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
          to the specfile without adding specific logic for each one to scons.
     - The test for Python.h needed by swig tests is moved to get_python_platform
       so it does not have to be repeated in every test; picks up one failure
-      which did not make the (previously needed) check.
+      which did not make the (previously needed) check. Windows version
+      of get_python_platform needed some rework in case running in virtualenv.
     - If test opens os.devnull, register with atexit so file opens do not leak.
     - Fix bugs in Win32 process spawn logic to handle OSError exception correctly.
     - Use time.perf_counter instead of time.clock if it exists.

--- a/test/SWIG/remove-modules.py
+++ b/test/SWIG/remove-modules.py
@@ -65,7 +65,7 @@ test.write("module.i", """\
 test.write('SConstruct', """
 foo = Environment(SWIGFLAGS='-python',
                   %(swig_arch_var)s
-                  CPPPATH=['%(python_include)s'],
+                  CPPPATH=[r'%(python_include)s'],
                   LDMODULEPREFIX='%(ldmodule_prefix)s',
                   LDMODULESUFFIX='%(_dll)s',
                   SWIG=[r'%(swig)s'],

--- a/test/SWIG/subdir.py
+++ b/test/SWIG/subdir.py
@@ -63,7 +63,7 @@ else:
 test.write('SConstruct', """
 env = Environment(SWIGFLAGS='-python',
                   %(swig_arch_var)s
-                  CPPPATH=['%(python_include)s/'],
+                  CPPPATH=[r'%(python_include)s/'],
                   LDMODULEPREFIX='%(ldmodule_prefix)s',
                   LDMODULESUFFIX='%(_dll)s',
                   SWIG=r'%(swig)s',


### PR DESCRIPTION
Two tests were missing the raw-string marker when defining
the Python include path.

TestSCons:get_platform_python_info needed some rework for Windows,
it was failing to find the python library if running in a virtual
environment. Also removed a try-block; sys.version_info is standard
since Python 2.0 and so does not need wrapping.

Note the virtualenv stuff does not overlap the work in PR #3216 

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation