### PR TITLE
Fix no javac failures

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -51,6 +51,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fix Java tools to search reasonable default paths for Win32, Linux, macOS.  Add required paths
       for swig and java native interface to JAVAINCLUDES.  You should add these to your CPPPATH if you need
       to compile with them.  This handles spaces in paths in default Java paths on windows.
+    - Fix new logic which populates JAVAINCLUDES to handle the case where javac is not found.
       
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Tool/JavaCommon.py
+++ b/src/engine/SCons/Tool/JavaCommon.py
@@ -437,7 +437,10 @@ def get_java_include_paths(env, javac, version):
     :return:
     """
     paths = []
-    if env['PLATFORM'] == 'win32':
+    if not javac:
+        # there are no paths if we've not detected javac.
+        pass
+    elif env['PLATFORM'] == 'win32':
         javac_bin_dir = os.path.dirname(javac)
         java_inc_dir = os.path.normpath(os.path.join(javac_bin_dir, '..', 'include'))
         paths = [java_inc_dir, os.path.join(java_inc_dir, 'win32')]

--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -32,6 +32,10 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
+# Keep this logic because it skips the test if javac or jar not found.
+where_javac, java_version = test.java_where_javac()
+where_jar = test.java_where_jar()
+
 test.write('myjar.py', r"""
 import sys
 args = sys.argv[1:]

--- a/test/Java/JARCHDIR.py
+++ b/test/Java/JARCHDIR.py
@@ -38,6 +38,9 @@ import os
 import TestSCons
 
 test = TestSCons.TestSCons()
+# Keep this logic because it skips the test if javac or jar not found.
+where_javac, java_version = test.java_where_javac()
+where_jar = test.java_where_jar()
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])

--- a/test/Java/JARFLAGS.py
+++ b/test/Java/JARFLAGS.py
@@ -30,6 +30,10 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
+# Keep this logic because it skips the test if javac or jar not found.
+where_javac, java_version = test.java_where_javac()
+where_jar = test.java_where_jar()
+
 test.subdir('src')
 
 test.write('SConstruct', """

--- a/test/Java/source-files.py
+++ b/test/Java/source-files.py
@@ -35,6 +35,10 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
+# Keep this logic because it skips the test if javac or jar not found.
+where_javac, java_version = test.java_where_javac()
+where_jar = test.java_where_jar()
+
 test.write('SConstruct', """
 env = Environment(tools = ['javac', 'javah'])
 env.Java(target = 'class1', source = 'com/Example1.java')


### PR DESCRIPTION
Handle the case where there's no javac found when populating JAVAINCLUDES path.
Restore skipping some Java tests when there's no installed javac found (or jar)

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation