### PR TITLE
M4 test line endings change for windows

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -161,6 +161,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Syntax cleanups - trailing blanks, use "is" to compare with None, etc.
       Three uses of variables not defined are changed.
     - Some script changes in trying to find scons engine
+    - fix M4 test for Windows line endings
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/test/M4/M4.py
+++ b/test/M4/M4.py
@@ -86,23 +86,23 @@ bar.M4(target = 'bar', source = 'bar.m4')
 
     test.write('foo.x.m4', "line 1\n"
                            "FFF\n"
-                           "line 3\n")
+                           "line 3\n", mode='w')
 
     test.write('bar.m4', "line 1\n"
                          "BBB\n"
-                         "line 3\n")
+                         "line 3\n", mode='w')
 
     test.run(arguments = '.')
 
     test.up_to_date(arguments = '.')
 
-    expect = "wrapper.py\n".replace("\n", os.linesep)
+    expect = "wrapper.py\n"
     test.must_match('wrapper.out', expect)
 
-    expect = "line 1\nfff\nline 3\n".replace("\n", os.linesep)
+    expect = "line 1\nfff\nline 3\n"
     test.must_match('foo.x', expect)
 
-    expect = "line 1\nbbb\nline 3\n".replace("\n", os.linesep)
+    expect = "line 1\nbbb\nline 3\n"
     test.must_match('bar', expect)
 
 test.pass_test()

--- a/test/M4/M4.py
+++ b/test/M4/M4.py
@@ -62,11 +62,8 @@ test.run()
 
 import sys
 
-if sys.platform == 'win32':
-    # Handle carriage returns.
-    test.must_match(test.workpath('aaa.x'), "line 1\r\nmym4.py\r\nline 3\r\n")
-else:
-    test.must_match(test.workpath('aaa.x'), "line 1\nmym4.py\nline 3\n")
+expect = "line 1\nmym4.py\nline 3\n".replace("\n", os.linesep)
+test.must_match(test.workpath('aaa.x'), expect)
 
 
 
@@ -99,11 +96,14 @@ bar.M4(target = 'bar', source = 'bar.m4')
 
     test.up_to_date(arguments = '.')
 
-    test.must_match('wrapper.out', "wrapper.py\n")
+    expect = "wrapper.py\n".replace("\n", os.linesep)
+    test.must_match('wrapper.out', expect)
 
-    test.must_match('foo.x', "line 1\nfff\nline 3\n")
+    expect = "line 1\nfff\nline 3\n".replace("\n", os.linesep)
+    test.must_match('foo.x', expect)
 
-    test.must_match('bar', "line 1\nbbb\nline 3\n")
+    expect = "line 1\nbbb\nline 3\n".replace("\n", os.linesep)
+    test.must_match('bar', expect)
 
 test.pass_test()
 


### PR DESCRIPTION
Ugly fix for M4 test: when checking strings written for files, account
for line endings, was failing on Windows.  There should be something
cleaner coming but for now let's not keep failing the test.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation