### PR TITLE
attempt fixing tests failing due to binary mode

### DIFF
--- a/test/long-lines/signature.py
+++ b/test/long-lines/signature.py
@@ -42,12 +42,12 @@ test.write(build_py, """\
 #!%(_python_)s
 import sys
 if sys.argv[1][0] == '@':
-    args = open(sys.argv[1][1:], 'rb').read()
+    args = open(sys.argv[1][1:], 'r').read()
     args = args.split()
 else:
     args = sys.argv[1:]
-fp = open(args[0], 'wb')
-fp.write(open(args[1], 'rb').read())
+fp = open(args[0], 'w')
+fp.write(open(args[1], 'r').read())
 fp.write('FILEFLAG=%%s\\n' %% args[2])
 fp.write('TIMESTAMP=%%s\\n' %% args[3])
 """ % locals())
@@ -75,17 +75,17 @@ env.Command('file.out', 'file.in',
             '${TEMPFILE(FILECOM)}')
 """ % locals())
 
-test.write('file.in', "file.in\n")
+test.write('file.in', "file.in\n", mode='w')
 
 test.run(arguments='FILEFLAG=first TIMESTAMP=20090207 .')
 
-test.must_match('file.out', "file.in\nFILEFLAG=first\nTIMESTAMP=20090207\n")
+test.must_match('file.out', "file.in\nFILEFLAG=first\nTIMESTAMP=20090207\n", mode='r')
 
 test.up_to_date(options='FILEFLAG=first TIMESTAMP=20090208', arguments = '.')
 
 test.run(arguments='FILEFLAG=second TIMESTAMP=20090208 .')
 
-test.must_match('file.out', "file.in\nFILEFLAG=second\nTIMESTAMP=20090208\n")
+test.must_match('file.out', "file.in\nFILEFLAG=second\nTIMESTAMP=20090208\n", mode='r')
 
 test.up_to_date(options='FILEFLAG=second TIMESTAMP=20090209', arguments = '.')
 

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -48,8 +48,8 @@ import re
 import sys
 
 path = sys.argv[1].split()
-output = open(sys.argv[2], 'wb')
-input = open(sys.argv[3], 'rb')
+output = open(sys.argv[2], 'w')
+input = open(sys.argv[3], 'r')
 
 output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
@@ -57,7 +57,7 @@ def find_file(f):
     for dir in path:
         p = dir + os.sep + f
         if os.path.exists(p):
-            return open(p, 'rb')
+            return open(p, 'r')
     return None
 
 def process(infp, outfp):
@@ -77,8 +77,8 @@ sys.exit(0)
 test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
-output = open(sys.argv[1], 'wb')
-input = open(sys.argv[2], 'rb')
+output = open(sys.argv[1], 'w')
+input = open(sys.argv[2], 'r')
 
 output.write('fake_link.py:  %%s\n' %% sys.argv)
 

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -68,8 +68,8 @@ import re
 import sys
 
 path = sys.argv[1].split()
-output = open(sys.argv[2], 'wb')
-input = open(sys.argv[3], 'rb')
+output = open(sys.argv[2], 'w')
+input = open(sys.argv[3], 'r')
 
 output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
@@ -77,7 +77,7 @@ def find_file(f):
     for dir in path:
         p = dir + os.sep + f
         if os.path.exists(p):
-            return open(p, 'rb')
+            return open(p, 'r')
     return None
 
 def process(infp, outfp):
@@ -97,8 +97,8 @@ sys.exit(0)
 test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
-output = open(sys.argv[1], 'wb')
-input = open(sys.argv[2], 'rb')
+output = open(sys.argv[1], 'w')
+input = open(sys.argv[2], 'r')
 
 output.write('fake_link.py:  %%s\n' %% sys.argv)
 

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -57,8 +57,8 @@ import re
 import sys
 
 path = sys.argv[1].split()
-output = open(sys.argv[2], 'wb')
-input = open(sys.argv[3], 'rb')
+output = open(sys.argv[2], 'w')
+input = open(sys.argv[3], 'r')
 
 output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
@@ -66,7 +66,7 @@ def find_file(f):
     for dir in path:
         p = dir + os.sep + f
         if os.path.exists(p):
-            return open(p, 'rb')
+            return open(p, 'r')
     return None
 
 def process(infp, outfp):
@@ -86,8 +86,8 @@ sys.exit(0)
 test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
-output = open(sys.argv[1], 'wb')
-input = open(sys.argv[2], 'rb')
+output = open(sys.argv[1], 'w')
+input = open(sys.argv[2], 'r')
 
 output.write('fake_link.py:  %%s\n' %% sys.argv)
 


### PR DESCRIPTION
Some tests may fail under python3, due to (improper/unnecessary?) use of binary mode when opening files. This PR attempts to fix the issue.