### PR TITLE
For Issue#3222: improve ms build finding

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -180,7 +180,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       in case 2017 Build Tools only is installed as it is considered a separate
       product from the default Visual Studio; search for cl.exe in located
       path instead of just looking for a couple of built-in locations as
-      2017 products are putting cl.exe deeper down the heirarchy.
+      2017 products are putting cl.exe deeper down the hierarchy.
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -177,8 +177,10 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fix for a couple of "what if tool not found" exceptions in framework.
     - Add Textfile/Substfile to default environment. (issue #3147)
     - Improve finding of Microsoft compiler: add a 'products' wildcard
-      in case Build Tools only is installed; search for cl.exe in located
-      path instead of just looking for a couple of built-in locations.
+      in case 2017 Build Tools only is installed as it is considered a separate
+      product from the default Visual Studio; search for cl.exe in located
+      path instead of just looking for a couple of built-in locations as
+      2017 products are putting cl.exe deeper down the heirarchy.
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -176,6 +176,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Update (pep8) configure-cache script, add a --show option.
     - Fix for a couple of "what if tool not found" exceptions in framework.
     - Add Textfile/Substfile to default environment. (issue #3147)
+    - Improve finding of Microsoft compiler: add a 'products' wildcard
+      in case Build Tools only is installed; search for cl.exe in located
+      path instead of just looking for a couple of built-in locations.
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/src/engine/SCons/Tool/MSCommon/common.py
+++ b/src/engine/SCons/Tool/MSCommon/common.py
@@ -46,7 +46,7 @@ elif LOGFILE:
         debug = lambda message: open(LOGFILE, 'a').write(message + '\n')
     else:
         logging.basicConfig(filename=LOGFILE, level=logging.DEBUG)
-        debug = logging.debug
+        debug = logging.getLogger(name=__name__).debug
 else:
     debug = lambda x: None
 

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -500,7 +500,7 @@ def msvc_find_valid_batch_script(env,version):
     platforms = get_host_target(env)
     debug("vc.py: msvs_find_valid_batch_script(): host_platform %s, target_platform %s req_target_platform:%s" % platforms)
 
-    host_platform, target_platform, req_target_platform) = platforms
+    host_platform, target_platform, req_target_platform = platforms
     try_target_archs = [target_platform]
 
     # VS2012 has a "cross compile" environment to build 64 bit


### PR DESCRIPTION
Broaden the search to also include Build Tools (the compiler without the whole Visual Studio works).  Also in the initial search to see if a suite is valid or not, don't just look for a couple of locations within a given path, do a search.

This is tested with a clean Windows which has only the build tools installed. The tests refused to find a compiler, as noted in the issue. After the change they are happy. However, there is no specific test for this scenario - "testing" depends on a specific provisioning scenario, which is to have Build Tools installed and Visual Studio not installed.

Fixes issue #3222 

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation