### PR TITLE
Fix some problems found if no MS compiler at all

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -165,6 +165,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       Three uses of variables not defined are changed.
     - Some script changes in trying to find scons engine
     - Update (pep8) configure-cache script, add a --show option.
+    - Fix for a couple of "what if tool not found" exceptions in framework.
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1590,7 +1590,10 @@ class TestCmd(object):
         elif run < 0:
             run = len(self._stdout) + run
         run = run - 1
-        return self._stdout[run]
+        try:
+            return self._stdout[run]
+        except IndexError:
+            return None
 
     def subdir(self, *subdirs):
         """Create new subdirectories under the temporary working

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1579,11 +1579,18 @@ class TestCmd(object):
         return self._stderr[run]
 
     def stdout(self, run=None):
-        """Returns the standard output from the specified run number.
-        If there is no specified run number, then returns the standard
-        output of the last run.  If the run number is less than zero,
-        then returns the standard output from that many runs back from
-        the current run.
+        """
+        Returns the stored standard output from a given run.
+
+        Args:
+            run: run number to select.  If run number is omitted,
+            return the standard output of the most recent run.
+            If negative, use as a relative offset, so that -2
+            means the run two prior to the most recent.
+
+        Returns:
+            selected stdout string or None if there are no
+            stored runs.
         """
         if not run:
             run = len(self._stdout)

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -293,16 +293,25 @@ class TestSCons(TestCommon):
 
     def detect(self, var, prog=None, ENV=None, norm=None):
         """
-        Detect a program named 'prog' by first checking the construction
-        variable named 'var' and finally searching the path used by
-        SCons. If either method fails to detect the program, then false
-        is returned, otherwise the full path to prog is returned. If
-        prog is None, then the value of the environment variable will be
-        used as prog.
+        Return the detected path to a tool program.
+
+        Searches first the named construction variable, then
+        the SCons path.
+
+        Args:
+            var: name of construction variable to check for tool name.
+            prog: tool program to check for.
+            ENV: if present, kwargs to initialize an environment that
+                will be created to perform the lookup.
+            norm: if true, normalize any returned path looked up in
+                the environment to use UNIX-style path separators.
+
+        Returns: full path to the tool, or None.
+
         """
         env = self.Environment(ENV)
         if env:
-            v = env.subst('$'+var)
+            v = env.subst('$' + var)
             if not v:
                 return None
             if prog is None:

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -310,7 +310,7 @@ class TestSCons(TestCommon):
             if v != prog:
                 return None
             result = env.WhereIs(prog)
-            if norm and os.sep != '/':
+            if result and norm and os.sep != '/':
                 result = result.replace(os.sep, '/')
             return result
 


### PR DESCRIPTION
A few tests blew up with exceptions (AttributeError, IndexError) if no compiler is installed on Windows - from where they are it could possibly happen on other platforms as well.  Changes are to the test harness.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation