### PR TITLE
Fix java install location for centos 7 to resolve failing Java/multi-step.py test

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -51,6 +51,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Fix Java tools to search reasonable default paths for Win32, Linux, macOS.  Add required paths
       for swig and java native interface to JAVAINCLUDES.  You should add these to your CPPPATH if you need
       to compile with them.  This handles spaces in paths in default Java paths on windows.
+    - Added more java paths to match install for Centos 7 of openjdk
       
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Tool/JavaCommon.py
+++ b/src/engine/SCons/Tool/JavaCommon.py
@@ -401,7 +401,9 @@ java_macos_include_dir = '/System/Library/Frameworks/JavaVM.framework/Headers/'
 java_macos_version_include_dir = '/System/Library/Frameworks/JavaVM.framework/Versions/%s*/Headers/'
 
 java_linux_include_dirs = ['/usr/lib/jvm/default-java/include',
-                        '/usr/lib/jvm/java-*-oracle/include']
+                        '/usr/lib/jvm/java-*/include']
+# Need to match path like below (from Centos 7)
+# /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.191.b12-0.el7_5.x86_64/include/
 java_linux_version_include_dirs = ['/usr/lib/jvm/java-*-sun-%s*/include',
                                    '/usr/lib/jvm/java-%s*-openjdk*/include',
                                    '/usr/java/jdk%s*/include']


### PR DESCRIPTION
Fix java install location for centos 7 to resolve failing Java/multi-step.py test


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation