### PR TITLE
attempt fixing TestSCons.where_is() for win32

### DIFF
--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -333,7 +333,7 @@ class TestSCons(TestCommon):
             return None
         return env.Detect([prog])
 
-    def where_is(self, prog, path=None):
+    def where_is(self, prog, path=None, pathext=None):
         """
         Given a program, search for it in the specified external PATH,
         or in the actual external PATH if none is specified.
@@ -343,26 +343,14 @@ class TestSCons(TestCommon):
         if self.external:
             if isinstance(prog, str):
                 prog = [prog]
-            import stat
-            paths = path.split(os.pathsep)
             for p in prog:
-                for d in paths:
-                    f = os.path.join(d, p)
-                    if os.path.isfile(f):
-                        try:
-                            st = os.stat(f)
-                        except OSError:
-                            # os.stat() raises OSError, not IOError if the file
-                            # doesn't exist, so in this case we let IOError get
-                            # raised so as to not mask possibly serious disk or
-                            # network issues.
-                            continue
-                        if stat.S_IMODE(st[stat.ST_MODE]) & 0o111:
-                            return os.path.normpath(f)
+                result = TestCmd.where_is(self, p, path, pathext)
+                if result:
+                    return os.path.normpath(result)
         else:
             import SCons.Environment
             env = SCons.Environment.Environment()
-            return env.WhereIs(prog, path)
+            return env.WhereIs(prog, path, pathext)
 
         return None
 


### PR DESCRIPTION
When using testing framework for external tests (``-e``), the method ``TestSCons.where_is()`` seems to always return ``None`` under win32. This PR fixes this. Tested with one of my projects on appveyor.