### PR TITLE
Some fixes to sconsign

### DIFF
--- a/doc/man/sconsign.xml
+++ b/doc/man/sconsign.xml
@@ -25,7 +25,7 @@
 -->
 
 <!-- lifted from troff+man by doclifter -->
-<refentry id='sconsign1' 
+<refentry id='sconsign1'
           xmlns="http://www.scons.org/dbxsd/v1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
@@ -42,7 +42,7 @@
 <!-- body begins here -->
 <refsynopsisdiv id='synopsis'>
 <cmdsynopsis>
-  <command>sconsign</command>    
+  <command>sconsign</command>
     <arg choice='opt' rep='repeat'><replaceable>options</replaceable></arg>
     <arg choice='plain'><replaceable>file</replaceable></arg>
     <arg choice='opt'><replaceable>...</replaceable></arg>
@@ -51,7 +51,7 @@
 
 
 <refsect1 id='description'><title>DESCRIPTION</title>
-<para>The 
+<para>The
 <command>sconsign</command>
 command
 displays the contents of one or more
@@ -94,17 +94,21 @@ was specified by the
 function).
 Any
 <emphasis>file</emphasis>
-argument that does not end in
-<markup>.dbm</markup>
+argument that ends in
+<markup>.dblite</markup>
 is assumed to be a traditional
 <markup>.sconsign</markup>
 file containing the signature entries
 for a single directory.
+If neither of those is true,
+<command>sconsign</command>
+attempts to guess the format (but will
+probably get it wrong).
 An explicit format
 may be specified using the
 <option>-f</option>
 or
-<option>--file=</option>
+<option>--format=</option>
 options.</para>
 
 </refsect1>

--- a/doc/man/sconsign.xml
+++ b/doc/man/sconsign.xml
@@ -102,9 +102,9 @@ file containing the signature entries
 for a single directory.
 If neither of those is true,
 <command>sconsign</command>
-attempts to guess the format (but will
-probably get it wrong).
-An explicit format
+attempts to guess the format.
+If that does not work, 
+an explicit format
 may be specified using the
 <option>-f</option>
 or

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -176,6 +176,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Update (pep8) configure-cache script, add a --show option.
     - Fix for a couple of "what if tool not found" exceptions in framework.
     - Add Textfile/Substfile to default environment. (issue #3147)
+    - sconsign: a couple of python3 fixes; be more tolerant of implicit
+      entries which have no signatures; minor PEP8 changes.
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -453,7 +453,10 @@ class Do_SConsignDB(object):
 
     @staticmethod
     def printentries(dir, val):
-        print('=== ' + dir.decode() + ':')
+        try:
+            print('=== ' + dir + ':')
+        except TypeError:
+            print('=== ' + dir.decode() + ':')
         printentries(pickle.loads(val), dir)
 
 

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -283,9 +283,8 @@ def map_bkids(entry, _):
         bkidsigs = entry.bsourcesigs + entry.bdependsigs + entry.bimplicitsigs
     except AttributeError:
         return None
-    result = []
-    for bkid, bkidsig in zip(bkids, bkidsigs):
-        result.append(nodeinfo_string(bkid, bkidsig, "        "))
+    result = [nodeinfo_string(bkid, bkidsig, "        ")
+              for bkid, bkidsig in zip(bkids, bkidsigs)]
     if not result:
         return None
     return "\n        ".join(result)

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -164,7 +164,7 @@ else:
         pass
     else:
         # Split /usr/libfoo/python*/os.py to /usr/libfoo/python*.
-        libpath, tail = os.path.split(libpath)
+        libpath, _ = os.path.split(libpath)
         # Split /usr/libfoo/python* to /usr/libfoo
         libpath, tail = os.path.split(libpath)
         # Check /usr/libfoo/scons*.
@@ -194,6 +194,7 @@ import pickle
 import imp
 
 import SCons.SConsign
+
 
 def my_whichdb(filename):
     if filename[-7:] == ".dblite":
@@ -225,13 +226,17 @@ def my_import(mname):
         fp, pathname, description = imp.find_module(mname)
     return imp.load_module(mname, fp, pathname, description)
 
+
 class Flagger(object):
     default_value = 1
+
     def __setitem__(self, item, value):
         self.__dict__[item] = value
         self.default_value = 0
+
     def __getitem__(self, item):
         return self.__dict__.get(item, self.default_value)
+
 
 Do_Call = None
 Print_Directories = []
@@ -240,9 +245,10 @@ Print_Flags = Flagger()
 Verbose = 0
 Readable = 0
 
+
 def default_mapper(entry, name):
     try:
-        val = eval("entry."+name)
+        val = eval("entry." + name)
     except:
         val = None
     if sys.version_info.major >= 3 and isinstance(val, bytes):
@@ -252,6 +258,7 @@ def default_mapper(entry, name):
         val = val.decode()
     return str(val)
 
+
 def map_action(entry, name):
     try:
         bact = entry.bact
@@ -260,7 +267,7 @@ def map_action(entry, name):
         return None
     return '%s [%s]' % (bactsig, bact)
 
-def map_timestamp(entry, name):
+def map_timestamp(entry, _):
     try:
         timestamp = entry.timestamp
     except AttributeError:
@@ -270,18 +277,19 @@ def map_timestamp(entry, name):
     else:
         return str(timestamp)
 
-def map_bkids(entry, name):
+def map_bkids(entry, _):
     try:
         bkids = entry.bsources + entry.bdepends + entry.bimplicit
         bkidsigs = entry.bsourcesigs + entry.bdependsigs + entry.bimplicitsigs
     except AttributeError:
         return None
     result = []
-    for i in range(len(bkids)):
-        result.append(nodeinfo_string(bkids[i], bkidsigs[i], "        "))
+    for bkid, bkidsig in zip(bkids, bkidsigs):
+        result.append(nodeinfo_string(bkid, bkidsig, "        "))
     if not result:
         return None
     return "\n        ".join(result)
+
 
 map_field = {
     'action'    : map_action,
@@ -293,6 +301,7 @@ map_name = {
     'implicit'  : 'bkids',
 }
 
+
 def field(name, entry, verbose=Verbose):
     if not Print_Flags[name]:
         return None
@@ -302,6 +311,7 @@ def field(name, entry, verbose=Verbose):
     if verbose:
         val = name + ": " + val
     return val
+
 
 def nodeinfo_raw(name, ninfo, prefix=""):
     # This just formats the dictionary, which we would normally use str()
@@ -318,6 +328,7 @@ def nodeinfo_raw(name, ninfo, prefix=""):
         name = repr(name)
     return name + ': {' + ', '.join(l) + '}'
 
+
 def nodeinfo_cooked(name, ninfo, prefix=""):
     try:
         field_list = ninfo.field_list
@@ -325,14 +336,18 @@ def nodeinfo_cooked(name, ninfo, prefix=""):
         field_list = []
     if '\n' in name:
         name = repr(name)
-    outlist = [name+':'] + [_f for _f in [field(x, ninfo, Verbose) for x in field_list] if _f]
+    outlist = [name + ':'] + [
+        f for f in [field(x, ninfo, Verbose) for x in field_list] if f
+    ]
     if Verbose:
         sep = '\n    ' + prefix
     else:
         sep = ' '
     return sep.join(outlist)
 
+
 nodeinfo_string = nodeinfo_cooked
+
 
 def printfield(name, entry, prefix=""):
     outlist = field("implicit", entry, 0)
@@ -347,13 +362,15 @@ def printfield(name, entry, prefix=""):
         else:
             print("        " + outact)
 
+
 def printentries(entries, location):
     if Print_Entries:
         for name in Print_Entries:
             try:
                 entry = entries[name]
             except KeyError:
-                sys.stderr.write("sconsign: no entry `%s' in `%s'\n" % (name, location))
+                err = "sconsign: no entry `%s' in `%s'\n" % (name, location)
+                sys.stderr.write(err)
             else:
                 try:
                     ninfo = entry.ninfo
@@ -372,6 +389,7 @@ def printentries(entries, location):
             else:
                 print(nodeinfo_string(name, entry.ninfo))
             printfield(name, entry.binfo)
+
 
 class Do_SConsignDB(object):
     def __init__(self, dbm_name, dbm):
@@ -407,15 +425,17 @@ class Do_SConsignDB(object):
                     # Nope, that file doesn't even exist, so report that
                     # fact back.
                     print_e = e
-                sys.stderr.write("sconsign: %s\n" % (print_e))
+                sys.stderr.write("sconsign: %s\n" % print_e)
                 return
         except KeyboardInterrupt:
             raise
         except pickle.UnpicklingError:
-            sys.stderr.write("sconsign: ignoring invalid `%s' file `%s'\n" % (self.dbm_name, fname))
+            sys.stderr.write("sconsign: ignoring invalid `%s' file `%s'\n"
+                             % (self.dbm_name, fname))
             return
         except Exception as e:
-            sys.stderr.write("sconsign: ignoring invalid `%s' file `%s': %s\n" % (self.dbm_name, fname, e))
+            sys.stderr.write("sconsign: ignoring invalid `%s' file `%s': %s\n"
+                             % (self.dbm_name, fname, e))
             return
 
         if Print_Directories:
@@ -423,34 +443,40 @@ class Do_SConsignDB(object):
                 try:
                     val = db[dir]
                 except KeyError:
-                    sys.stderr.write("sconsign: no dir `%s' in `%s'\n" % (dir, args[0]))
+                    err = "sconsign: no dir `%s' in `%s'\n" % (dir, args[0])
+                    sys.stderr.write(err)
                 else:
                     self.printentries(dir, val)
         else:
             for dir in sorted(db.keys()):
                 self.printentries(dir, db[dir])
 
-    def printentries(self, dir, val):
-        print('=== ' + dir + ':')
+    @staticmethod
+    def printentries(dir, val):
+        print('=== ' + dir.decode() + ':')
         printentries(pickle.loads(val), dir)
+
 
 def Do_SConsignDir(name):
     try:
         fp = open(name, 'rb')
     except (IOError, OSError) as e:
-        sys.stderr.write("sconsign: %s\n" % (e))
+        sys.stderr.write("sconsign: %s\n" % e)
         return
     try:
         sconsign = SCons.SConsign.Dir(fp)
     except KeyboardInterrupt:
         raise
     except pickle.UnpicklingError:
-        sys.stderr.write("sconsign: ignoring invalid .sconsign file `%s'\n" % (name))
+        err = "sconsign: ignoring invalid .sconsign file `%s'\n" % (name)
+        sys.stderr.write(err)
         return
     except Exception as e:
-        sys.stderr.write("sconsign: ignoring invalid .sconsign file `%s': %s\n" % (name, e))
+        err = "sconsign: ignoring invalid .sconsign file `%s': %s\n" % (name, e)
+        sys.stderr.write(err)
         return
     printentries(sconsign.entries, args[0])
+
 
 ##############################################################################
 
@@ -493,8 +519,7 @@ for o, a in opts:
     elif o in ('-f', '--format'):
         # Try to map the given DB format to a known module
         # name, that we can then try to import...
-        Module_Map = {'dblite'   : 'SCons.dblite',
-                      'sconsign' : None}
+        Module_Map = {'dblite': 'SCons.dblite', 'sconsign': None}
         dbm_name = Module_Map.get(a, a)
         if dbm_name:
             try:
@@ -502,6 +527,7 @@ for o, a in opts:
                     dbm = my_import(dbm_name)
                 else:
                     import SCons.dblite
+
                     dbm = SCons.dblite
                     # Ensure that we don't ignore corrupt DB files,
                     # this was handled by calling my_import('SCons.dblite')
@@ -530,7 +556,6 @@ for o, a in opts:
     elif o in ('-v', '--verbose'):
         Verbose = 1
 
-
 if Do_Call:
     for a in args:
         Do_Call(a)
@@ -538,11 +563,12 @@ else:
     for a in args:
         dbm_name = whichdb(a)
         if dbm_name:
-            Map_Module = {'SCons.dblite' : 'dblite'}
+            Map_Module = {'SCons.dblite': 'dblite'}
             if dbm_name != "SCons.dblite":
                 dbm = my_import(dbm_name)
             else:
                 import SCons.dblite
+
                 dbm = SCons.dblite
                 # Ensure that we don't ignore corrupt DB files,
                 # this was handled by calling my_import('SCons.dblite')


### PR DESCRIPTION
Two locations which attempt to directly print an item tipped over on py3, so they now decode().

There seem to be cases where implicit dependencies do not have signatures, so instead of looping through the dep list and indexing into the signature list (IndexError), the two lists are now zipped, which means nothing is printed, but sconsign does not die (the zip technique is used in FS.py in the engine).

Minor PEP8 changes: spaces around operators; shorter lines; two-blanks rule around classes/functions. Also unused args changed to _ to show it was intentional.

Manpage updated slightly - the internal whichdb function explicitly looks for the .dblite suffix, so the claim that if it's not .dbm it is assumed to be dblite was not true.

sconsign still will not work on a dblite file which is not suffixed .dblite, but that is an existing problem, not a newly introduced one.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation