### PR TITLE
s/get_bool_envvar/get_os_env_bool/

### DIFF
--- a/src/engine/SCons/Platform/virtualenv.py
+++ b/src/engine/SCons/Platform/virtualenv.py
@@ -37,11 +37,11 @@ virtualenv_enabled_by_default = False
 
 
 def _enable_virtualenv_default():
-    return SCons.Util.get_bool_envvar('SCONS_ENABLE_VIRTUALENV', virtualenv_enabled_by_default)
+    return SCons.Util.get_os_env_bool('SCONS_ENABLE_VIRTUALENV', virtualenv_enabled_by_default)
 
 
 def _ignore_virtualenv_default():
-    return SCons.Util.get_bool_envvar('SCONS_IGNORE_VIRTUALENV', False)
+    return SCons.Util.get_os_env_bool('SCONS_IGNORE_VIRTUALENV', False)
 
 
 enable_virtualenv = _enable_virtualenv_default()

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -1598,16 +1598,16 @@ def cmp(a, b):
 
 
 def get_env_bool(env, name, default=False):
-    """
-    Get a value of an environment variable converting it to boolean.
+    """Get a value of env[name] converted to boolean. The value of env[name] is
+    interpreted as follows: 'true', 'yes', 'y', 'on' (case insensitive) and
+    anything convertible to int that yields non-zero integer are True values;
+    '0', 'false', 'no', 'n' and 'off' (case insensitive) are False values. For
+    all other cases, default value is returned.
 
-    - FOO=1, FOO=123, FOO=true, FOO=yes, FOO=y, FOO=on are examples of ``True``
-      values.
-    - FOO=0, FOO=false, FOO=no, FOO=n, FOO=off are examples of ``False``
-      values.
-
-    If a variable can't be converted to a boolean, default value is returned
-    (``False`` by default).
+    :Parameters:
+        - `env`     - dict or dict-like object, a convainer with variables
+        - `name`    - name of the variable in env to be returned
+        - `default` - returned when env[name] does not exist or can't be converted to bool
     """
     try:
         var = env[name]

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -1597,9 +1597,9 @@ def cmp(a, b):
     return (a > b) - (a < b)
 
 
-def get_bool_envvar(name, default=False):
+def get_env_bool(env, name, default=False):
     """
-    Get a value of OS environment variable converting it to boolean.
+    Get a value of an environment variable converting it to boolean.
 
     - FOO=1, FOO=123, FOO=true, FOO=yes, FOO=y, FOO=on are examples of ``True``
       values.
@@ -1607,10 +1607,10 @@ def get_bool_envvar(name, default=False):
       values.
 
     If a variable can't be converted to a boolean, default value is returned
-    (``False`` by default)
+    (``False`` by default).
     """
     try:
-        var = os.environ[name]
+        var = env[name]
     except KeyError:
         return default
     try:
@@ -1622,6 +1622,11 @@ def get_bool_envvar(name, default=False):
             return False
         else:
             return default
+
+
+def get_os_env_bool(name, default=False):
+    """Same as get_env_bool(os.environ, name, default)."""
+    return get_env_bool(os.environ, name, default)
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/UtilTests.py
+++ b/src/engine/SCons/UtilTests.py
@@ -905,13 +905,50 @@ class OsEnviron(object):
         self.stop()
 
 
-class get_bool_envvarTestCase(unittest.TestCase):
+class get_env_boolTestCase(unittest.TestCase):
+    def test_missing(self):
+        env = dict()
+        var = get_env_bool(env, 'FOO')
+        assert var is False, "var should be False, not %s" % repr(var)
+        env = {'FOO': '1'}
+        var = get_env_bool(env, 'BAR')
+        assert var is False, "var should be False, not %s" % repr(var)
+
+    def test_true(self):
+        for foo in [ 'TRUE', 'True', 'true',
+                     'YES', 'Yes', 'yes',
+                     'Y', 'y',
+                     'ON', 'On', 'on',
+                     '1', '20', '-1']:
+            env = {'FOO': foo}
+            var = get_env_bool(env, 'FOO')
+            assert var is True, 'var should be True, not %s' % repr(var)
+
+    def test_false(self):
+        for foo in [ 'FALSE', 'False', 'false',
+                     'NO', 'No', 'no',
+                     'N', 'n',
+                     'OFF', 'Off', 'off',
+                     '0']:
+            env = {'FOO': foo}
+            var = get_env_bool(env, 'FOO', True)
+            assert var is False, 'var should be True, not %s' % repr(var)
+
+    def test_default(self):
+        env = {'FOO': 'other'}
+        var = get_env_bool(env, 'FOO', True)
+        assert var is True, 'var should be True, not %s' % repr(var)
+        var = get_env_bool(env, 'FOO', False)
+        assert var is False, 'var should be False, not %s' % repr(var)
+
+
+class get_os_env_boolTestCase(unittest.TestCase):
     def test_missing(self):
         with OsEnviron(dict()):
-            var = get_bool_envvar('FOO')
+            var = get_os_env_bool('FOO')
             assert var is False, "var should be False, not %s" % repr(var)
         with OsEnviron({'FOO': '1'}):
-            var = get_bool_envvar('BAR')
+            var = get_os_env_bool('BAR')
             assert var is False, "var should be False, not %s" % repr(var)
 
     def test_true(self):
@@ -921,7 +958,7 @@ class get_bool_envvarTestCase(unittest.TestCase):
                      'ON', 'On', 'on',
                      '1', '20', '-1']:
             with OsEnviron({'FOO': foo}):
-                var = get_bool_envvar('FOO')
+                var = get_os_env_bool('FOO')
                 assert var is True, 'var should be True, not %s' % repr(var)
 
     def test_false(self):
@@ -931,14 +968,14 @@ class get_bool_envvarTestCase(unittest.TestCase):
                      'OFF', 'Off', 'off',
                      '0']:
             with OsEnviron({'FOO': foo}):
-                var = get_bool_envvar('FOO', True)
+                var = get_os_env_bool('FOO', True)
                 assert var is False, 'var should be True, not %s' % repr(var)
 
     def test_default(self):
         with OsEnviron({'FOO': 'other'}):
-            var = get_bool_envvar('FOO', True)
+            var = get_os_env_bool('FOO', True)
             assert var is True, 'var should be True, not %s' % repr(var)
-            var = get_bool_envvar('FOO', False)
+            var = get_os_env_bool('FOO', False)
             assert var is False, 'var should be False, not %s' % repr(var)
 
 


### PR DESCRIPTION
This introduces ``get_env_bool()``, which allows to retrieve boolean values of environment variables from any dictionary-like objects. I've also renamed ``get_bool_envvar()`` to ``get_os_env_bool()``.