### PR TITLE
Fix cpp scanner regex logic to treat ifndef. This is a PY3.5+ only issue.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -186,8 +186,8 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Replace usage of unittest.TestSuite with unittest.main() (fix #3113)
 
   From Arda Fu
-    - Fix cpp scanner regex logic to treat ifndef. Previously it was not properly 
-      differentiating between if, ifdef, and ifndef
+    - Fix cpp scanner regex logic to treat ifndef for py3.5+. Previously it was 
+      not properly differentiating between if, ifdef, and ifndef.
 
 
 RELEASE 3.0.1 - Mon, 12 Nov 2017 15:31:33 -0700

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -185,6 +185,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Typo in customized decider example in user guide
     - Replace usage of unittest.TestSuite with unittest.main() (fix #3113)
 
+  From Arda Fu
+    - Fix cpp scanner regex logic to treat ifndef. Previously it was not properly 
+      differentiating between if, ifdef, and ifndef
 
 
 RELEASE 3.0.1 - Mon, 12 Nov 2017 15:31:33 -0700

--- a/src/engine/SCons/cpp.py
+++ b/src/engine/SCons/cpp.py
@@ -82,9 +82,9 @@ del op_list
 # Create a list of the expressions we'll use to match all of the
 # preprocessor directives.  These are the same as the directives
 # themselves *except* that we must use a negative lookahead assertion
-# when matching "if" so it doesn't match the "if" in "ifdef."
+# when matching "if" so it doesn't match the "if" in "ifdef" or "ifndef".
 override = {
-    'if'                        : 'if(?!def)',
+    'if'                        : 'if(?!n?def)',
 }
 l = [override.get(x, x) for x in list(Table.keys())]
 

--- a/src/engine/SCons/cppTests.py
+++ b/src/engine/SCons/cppTests.py
@@ -346,6 +346,24 @@ nested_ifs_input = """
 
 
 
+ifndef_input = """
+#define DEFINED 0
+
+#ifndef	DEFINED
+#include "file45-no"
+#else
+#include "file45-yes"
+#endif
+
+#ifndef	NOT_DEFINED
+#include <file46-yes>
+#else
+#include <file46-no>
+#endif
+"""
+
+
+
 #    pp_class = PreProcessor
 #    #pp_class = DumbPreProcessor
 
@@ -424,6 +442,12 @@ class cppTestCase(unittest.TestCase):
     def test_nested_ifs(self):
         expect = self.nested_ifs_expect
         result = self.cpp.process_contents(nested_ifs_input)
+        assert expect == result, (expect, result)
+
+    def test_ifndef(self):
+        """Test basic #ifndef processing"""
+        expect = self.ifndef_expect
+        result = self.cpp.process_contents(ifndef_input)
         assert expect == result, (expect, result)
 
 class cppAllTestCase(cppTestCase):
@@ -513,6 +537,11 @@ class PreProcessorTestCase(cppAllTestCase):
         ('include', '"', 'file7-yes'),
     ]
 
+    ifndef_expect = [
+        ('include', '"', 'file45-yes'),
+        ('include', '<', 'file46-yes'),
+    ]
+    
 class DumbPreProcessorTestCase(cppAllTestCase):
     cpp_class = cpp.DumbPreProcessor
 
@@ -626,6 +655,12 @@ class DumbPreProcessorTestCase(cppAllTestCase):
     ]
 
 
+    ifndef_expect = [
+        ('include', '"', 'file45-no'),
+        ('include', '"', 'file45-yes'),
+        ('include', '<', 'file46-yes'),
+        ('include', '<', 'file46-no'),
+    ]
 
 import os
 import re


### PR DESCRIPTION
Previously it was not properly differentiating between if, ifdef, and ifndef

[following last PR 3237](https://github.com/SCons/scons/pull/3237)

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation