### PR TITLE
Add correct archiver tool for clang on win32

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -176,7 +176,6 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Update (pep8) configure-cache script, add a --show option.
     - Fix for a couple of "what if tool not found" exceptions in framework.
     - Add Textfile/Substfile to default environment. (issue #3147)
-    - Make the clang StaticLibrary tests work on win32.
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -176,6 +176,7 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Update (pep8) configure-cache script, add a --show option.
     - Fix for a couple of "what if tool not found" exceptions in framework.
     - Add Textfile/Substfile to default environment. (issue #3147)
+    - Make the clang StaticLibrary tests work on win32.
 
   From Bernhard M. Wiedemann:
     - Update SCons' internal scons build logic to allow overriding build date 

--- a/test/Clang/clang_static_library.py
+++ b/test/Clang/clang_static_library.py
@@ -24,8 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
-
 import TestSCons
 
 _exe = TestSCons._exe
@@ -34,13 +32,12 @@ test = TestSCons.TestSCons()
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang', skipping test.\n")
 
-if sys.platform == 'win32':
+if test.IS_WINDOWS:
     foo_lib = 'foo.lib'
     archiver = 'mslib'
-    import SCons.Tool.MSCommon as msc
-    if not msc.msvc_exists():
-        foo_lib = 'libfoo.a'
-        archiver = 'ar'
+    # TODO: other Windows combinations exist (not depending on
+    # mslib (lib.exe) from MS Build Tools / Visual Studio).
+    # Expand this if there is demand.
 else:
     foo_lib = 'libfoo.a'
     archiver = 'ar'

--- a/test/Clang/clang_static_library.py
+++ b/test/Clang/clang_static_library.py
@@ -24,6 +24,8 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
+import sys
+
 import TestSCons
 
 _exe = TestSCons._exe
@@ -32,11 +34,23 @@ test = TestSCons.TestSCons()
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang', skipping test.\n")
 
+if sys.platform == 'win32':
+    foo_lib = 'foo.lib'
+    archiver = 'mslib'
+    import SCons.Tool.MSCommon as msc
+    if not msc.msvc_exists():
+        foo_lib = 'libfoo.a'
+        archiver = 'ar'
+else:
+    foo_lib = 'libfoo.a'
+    archiver = 'ar'
+
+
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=['mingw','clang', 'ar'])
+env = Environment(tools=['mingw','clang', '%s'])
 env.StaticLibrary('foo', 'foo.c')
-""")
+""" % archiver)
 
 test.write('foo.c', """\
 int bar() {
@@ -46,7 +60,7 @@ int bar() {
 
 test.run()
 
-test.must_exist(test.workpath('libfoo.a'))
+test.must_exist(test.workpath(foo_lib))
 
 test.pass_test()
 

--- a/test/Clang/clangxx_static_library.py
+++ b/test/Clang/clangxx_static_library.py
@@ -24,6 +24,8 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
+import sys
+
 import TestSCons
 
 _exe = TestSCons._exe
@@ -32,11 +34,23 @@ test = TestSCons.TestSCons()
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang++', skipping test.\n")
 
+if sys.platform == 'win32':
+    foo_lib = 'foo.lib'
+    archiver = 'mslib'
+    import SCons.Tool.MSCommon as msc
+    if not msc.msvc_exists():
+        foo_lib = 'libfoo.a'
+        archiver = 'ar'
+else:
+    foo_lib = 'libfoo.a'
+    archiver = 'ar'
+
+
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=['mingw','clang++', 'ar'])
+env = Environment(tools=['mingw','clang++', '%s'])
 env.StaticLibrary('foo', 'foo.cpp')
-""")
+""" % archiver)
 
 test.write('foo.cpp', """\
 int bar() {
@@ -46,7 +60,7 @@ int bar() {
 
 test.run()
 
-test.must_exist(test.workpath('libfoo.a'))
+test.must_exist(test.workpath(foo_lib))
 
 test.pass_test()
 

--- a/test/Clang/clangxx_static_library.py
+++ b/test/Clang/clangxx_static_library.py
@@ -24,8 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
-
 import TestSCons
 
 _exe = TestSCons._exe
@@ -34,13 +32,12 @@ test = TestSCons.TestSCons()
 if not test.where_is('clang'):
     test.skip_test("Could not find 'clang++', skipping test.\n")
 
-if sys.platform == 'win32':
+if test.IS_WINDOWS:
     foo_lib = 'foo.lib'
     archiver = 'mslib'
-    import SCons.Tool.MSCommon as msc
-    if not msc.msvc_exists():
-        foo_lib = 'libfoo.a'
-        archiver = 'ar'
+    # TODO: other Windows combinations exist (not depending on
+    # mslib (lib.exe) from MS Build Tools / Visual Studio).
+    # Expand this if there is demand.
 else:
     foo_lib = 'libfoo.a'
     archiver = 'ar'


### PR DESCRIPTION
Do some work to figure out which tool to initialize with so that StaticLibrary works out for clang.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation