### PR TITLE
Fix GH issue #3136 No need to explicitly set file handles to non-sharable. Py 3.4 and above do this by default

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -55,6 +55,9 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       yielded trying to combine strings and bytes which threw exception.
     - Fix GH Issue #3225 SCons.Util.Flatten() doesn't handle MappingView's produced by dictionary as return
       values from dict().{items(), keys(), values()}.
+    - Fix GH Issue #3136 no longer wrap io.{BufferedReader,BufferedWriter,BufferedRWPair,BufferedRandom,TextIOWrapper
+      with logic to set HANDLE_FLAG_INHERIT flag on the file handle.  Python 3.4+ automatically sets this according
+      to Python docs: https://docs.python.org/3/library/os.html#fd-inheritance
 
   From Andrew Featherstone
     - Removed unused --warn options from the man page and source code.

--- a/src/engine/SCons/Platform/win32.py
+++ b/src/engine/SCons/Platform/win32.py
@@ -82,16 +82,8 @@ else:
                  win32con.HANDLE_FLAG_INHERIT, 0)
         file = _scons_file
     else:
-        import io
-        for io_class in ['BufferedReader', 'BufferedWriter', 'BufferedRWPair',
-                         'BufferedRandom', 'TextIOWrapper']:
-            _builtin_file = getattr(io, io_class)
-            class _scons_file(_builtin_file):
-                def __init__(self, *args, **kw):
-                    _builtin_file.__init__(self, *args, **kw)
-                    win32api.SetHandleInformation(msvcrt.get_osfhandle(self.fileno()),
-                        win32con.HANDLE_FLAG_INHERIT, 0)
-            setattr(io, io_class, _scons_file)
+        # No longer needed for python 3.4 and above. Files are opened non sharable
+        pass
 
 
 


### PR DESCRIPTION
Fix GH issue #3136 No need to explicitly set file handles to non-sharable. Py 3.4 and above do this by default

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation