### PR TITLE
[WIP] Add error-on-warning control

### DIFF
--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -846,11 +846,15 @@ def _main(parser):
     default_warnings = [ SCons.Warnings.WarningOnByDefault,
                          SCons.Warnings.DeprecatedWarning,
                        ]
+    default_werrors = []
 
     for warning in default_warnings:
         SCons.Warnings.enableWarningClass(warning)
+    for werror in default_werrors:
+        SCons.Warnings.enableWarningClassException(werror)
     SCons.Warnings._warningOut = _scons_internal_warning
     SCons.Warnings.process_warn_strings(options.warn)
+    SCons.Warnings.process_werror_strings(options.werror)
 
     # Now that we have the warnings configuration set up, we can actually
     # issue (or suppress) any warnings about warning-worthy things that
@@ -1040,6 +1044,7 @@ def _main(parser):
     # first and not issue the warning.
     #SCons.Warnings.enableWarningClass(SCons.Warnings.PythonVersionWarning)
     SCons.Warnings.process_warn_strings(options.warn)
+    SCons.Warnings.process_werror_strings(options.werror)
 
     # Now that we've read the SConscript files, we can check for the
     # warning about deprecated Python versions--delayed until here

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -140,6 +140,7 @@ class SConsValues(optparse.Values):
         'random',
         'stack_size',
         'warn',
+        'werror',
         'silent'
     ]
 
@@ -197,6 +198,11 @@ class SConsValues(optparse.Values):
                 value = [value]
             value = self.__SConscript_settings__.get(name, []) + value
             SCons.Warnings.process_warn_strings(value)
+        elif name == 'werror':
+            if SCons.Util.is_String(value):
+                value = [value]
+            value = self.__SConscript_settings__.get(name, []) + value
+            SCons.Warnings.process_werror_strings(value)
 
         self.__SConscript_settings__[name] = value
 
@@ -910,6 +916,18 @@ def Parser(version):
                   dest="warn", default=[],
                   action="callback", callback=opt_warn,
                   help="Enable or disable warnings.",
+                  metavar="WARNING-SPEC")
+
+    def opt_werror(option, opt, value, parser, tree_options=tree_options):
+        if SCons.Util.is_String(value):
+            value = value.split(',')
+        parser.values.werror.extend(value)
+
+    op.add_option('--werr', '--werror',
+                  nargs=1, type="string",
+                  dest="werror", default=[],
+                  action="callback", callback=opt_werror,
+                  help="Enable or disable exceptions on warnings.",
                   metavar="WARNING-SPEC")
 
     op.add_option('-Y', '--repository', '--srcdir',


### PR DESCRIPTION
Add `--werror` to allow specified warnings to be treated as errors (exceptions).  Syntax is the same as `--warn`.  Warnings have defaults built-in based on subclassing; scons maintains a list of tuples as an override to hold explicit requests to warn or not warn, populated from command line, `SetOption`, and a built-in table. The list is looked up using a first-find basis, so it is sufficient to insert a new value at the front.  The override list is not changed to add warning-errors, but a new flag value (2) is added to mean raise exception - there was already logic to raise the exception based on the value of a global flag.

This is not ready for merge, it's more a proof of concept to generate some discussion. The logic needs thinking through further.  The fact that warnings are classes which may be heirarchical suggests that maybe more examination should done on where exceptions are/are not generated. There are no tests, and no documentation.  The messages are not great. Here's an example where the message from the warning ends up being deceptive:
```
  scons: *** ("Ignoring missing SConscript 'tizen/SConscript'",)
```
that is, it quits with a message which says it's ignoring a particular problem, so it isn't ignoring it at all.

Signed-off-by: Mats Wichmann <mats@linux.com>

all of the checklist items still need doing:

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation