### PR TITLE
[WIP] try to improve debug=explain

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -148,6 +148,8 @@ RELEASE 3.0.2 - Mon, 31 Dec 2018 16:00:12 -0700
       pickled with the previous lower protocal.
     - Updated FS.py to handle removal of splitunc function from python 3.7
     - Updated the vc.py to ignore MSVS versions where not compiler could be found
+    - Avoid the --debug=explain problem where nodes are reported as
+      removed, then added (sometiems even if the file itself did not change).
 
   From Gary Oberbrunner:
     - Fix bug when Installing multiple subdirs outside the source tree

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -14,6 +14,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by
       not using a context manager around Popen.stdout
+    - Avoid the --debug=explain problem where nodes are reported as
+      removed, then added (sometiems even if the file itself did not change).
 
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000
@@ -148,8 +150,6 @@ RELEASE 3.0.2 - Mon, 31 Dec 2018 16:00:12 -0700
       pickled with the previous lower protocal.
     - Updated FS.py to handle removal of splitunc function from python 3.7
     - Updated the vc.py to ignore MSVS versions where not compiler could be found
-    - Avoid the --debug=explain problem where nodes are reported as
-      removed, then added (sometiems even if the file itself did not change).
 
   From Gary Oberbrunner:
     - Fix bug when Installing multiple subdirs outside the source tree

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1625,15 +1625,15 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             old_bkids    = old.bsources    + old.bdepends    + old.bimplicit
             old_bkidsigs = old.bsourcesigs + old.bdependsigs + old.bimplicitsigs
         except AttributeError:
-            return "Cannot explain why `%s' is being rebuilt: No previous build information found\n" % self
+            return "Cannot explain why `%s' is being rebuilt: No previous build information available.\n" % self
 
         new = self.get_binfo()
 
         new_bkids    = new.bsources    + new.bdepends    + new.bimplicit
         new_bkidsigs = new.bsourcesigs + new.bdependsigs + new.bimplicitsigs
 
-        osig = dict(list(zip(old_bkids, old_bkidsigs)))
-        nsig = dict(list(zip(new_bkids, new_bkidsigs)))
+        osig = {k: v for k, v in zip(old_bkids, old_bkidsigs)}
+        nsig = {k: v for k, v in zip(new_bkids, new_bkidsigs)}
 
         def stringify( s, E=self.dir.Entry):
             """


### PR DESCRIPTION
When variant dir with no duplicating is in effect, some deceptive reporting can happen. In some circumstances, a file may be reported as no longer a dependency, then added as a dependency, when neither is true. The file appears to always be the actual source file, and it does not matter if the file itself is changed or not.

This phenomenon is mentioned in at least #2932, #2935, #2936.

There are several contributing factors for the problem; the main one seems to be that the nodes are different despite the same filename if these conditions are met - the source file has a saved entry in sconsign (has been built previously), and the operating mode is variant directory with duplicate=0, and the source file needs to be rebuilt.

these changes attempt to let explain behave more reasonably.

Along the way, implement the suggestion from issue #2996 - don't exclude report for changed action even if other rebuild reason was already found.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation