### PR TITLE
fix missing code contents that should be included in signature of a f…

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -112,6 +112,11 @@ RELEASE 3.1.0.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       Specifically, this fixes the test cases use by Configure.CheckCC() which
       would fail when using -Wstrict-prototypes.
 
+  From Zachary Tessler:
+    - Fix calculation of signatures for FunctionActions that contain list (or set,...)
+      comprehensions whose expressions involve constant literals. Those constants had
+      been ignored in signatures, so changing them did not cause targets to be rebuilt.
+
   From Paweł Tomulik:
     - In the testing framework, module TestCommon, fixed must_contain(),
       must_not_contain(), and related methods of TestCommon class to work with

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -258,8 +258,7 @@ def _code_contents(code, docstring=None):
     # function. Note that we have to call _object_contents on each
     # constants because the code object of nested functions can
     # show-up among the constants.
-
-    z = [_object_contents(cc) for cc in code.co_consts[1:]]
+    z = [_object_contents(cc) for cc in code.co_consts if cc != docstring]
     contents.extend(b',(')
     contents.extend(bytearray(',', 'utf-8').join(z))
     contents.extend(b')')

--- a/src/engine/SCons/ActionTests.py
+++ b/src/engine/SCons/ActionTests.py
@@ -2252,14 +2252,14 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (2, 7): bytearray(b'0, 0, 0, 0,(N.),(),(d\x00\x00GHd\x01\x00S)'),
-            (3, 5): bytearray(b'0, 0, 0, 0,(N.),(print),(e\x00\x00d\x00\x00\x83\x01\x00\x01d\x01\x00S)'),
-            (3, 6): bytearray(b'0, 0, 0, 0,(N.),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
-            (3, 7): bytearray(b'0, 0, 0, 0,(N.),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
+            (2, 7): bytearray(b'0, 0, 0, 0,(Hello, World!),(),(d\x00\x00GHd\x01\x00S)'),
+            (3, 5): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00\x00d\x00\x00\x83\x01\x00\x01d\x01\x00S)'),
+            (3, 6): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
+            (3, 7): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
         }
 
-        assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + expected[
-            sys.version_info[:2]]
+        assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(expected[
+            sys.version_info[:2]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…unction action

The code of a python function that is used as a build action is inspected and included in the sconsign signature so the target can be rebuilt if the function changes. However, scons currently does not notice if a constant value in the expression of a list comprehension is changed. This PR fixes that.

In this example:
```
def test(source, target, env):
    xs = [2*x for x in range(5)]
    with open(str(target[0])) as out:
        out.write(str(xs))

env = Environment()
env.Command(
    source=None,
    target='out.txt',
    action=test)
```
changing the `2` in the list comprehension in `test()` would (incorrectly) not cause a rebuild.

The existing code that computes contents of a function (in `_code_contents()`) strips off the first item from the `co_consts` tuple. In a function, this first item is the docstring (or `None` if there is no docstring). List comprehension code is not included directly in a function's `co_code`, but appears as an object in the `co_consts` tuple, and is processed on a later recursive invocation of `_code_contents()`.  List comprehensions also have their own `co_consts` tuple, though theirs do not have a docstring (or a `None` placeholder). Removing the first object from their `co_consts` effectively ignores a real constant from the code. This PR changes the logic to only remove values from the `co_consts` tuple that equal the docstring, if any.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation