### PR TITLE
Update some doc examples

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -3014,7 +3014,7 @@ function to get at the path name for each Node.</para>
 
 <literallayout class="monospaced">
 print(str(DEFAULT_TARGETS[0]))
-if 'foo' in map(str, DEFAULT_TARGETS):
+if 'foo' in [str(t) for t in DEFAULT_TARGETS]:
     print("Don't forget to test the `foo' program!")
 </literallayout>
   </listitem>
@@ -3028,13 +3028,13 @@ list change on on each successive call to the
 function:</para>
 
 <literallayout class="monospaced">
-print(map(str, DEFAULT_TARGETS))   # originally []
+print([str(t) for t in DEFAULT_TARGETS])   # originally []
 Default('foo')
-print(map(str, DEFAULT_TARGETS))   # now a node ['foo']
+print([str(t) for t in DEFAULT_TARGETS])   # now a node ['foo']
 Default('bar')
-print(map(str, DEFAULT_TARGETS))   # now a node ['foo', 'bar']
+print([str(t) for t in DEFAULT_TARGETS])   # now a node ['foo', 'bar']
 Default(None)
-print(map(str, DEFAULT_TARGETS))   # back to []
+print([str(t) for t in DEFAULT_TARGETS])   # back to []
 </literallayout>
 
 <para>Consequently, be sure to use
@@ -5279,11 +5279,11 @@ arguments may be lists of Node objects if there is
 more than one target file or source file.
 The actual target and source file name(s) may
 be retrieved from their Node objects
-via the built-in Python str() function:</para>
+via the built-in Python <function>str</function> function:</para>
 
 <literallayout class="monospaced">
 target_file_name = str(target)
-source_file_names = map(lambda x: str(x), source)
+source_file_names = [str(x) for x in source]
 </literallayout>
 
 <para>The function should return

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -2200,9 +2200,8 @@ prog2.c
         internal &SCons; nodes,
         so you need to convert the list elements to strings
         if you want to print them or look for a specific target name.
-        Fortunately, you can do this easily
-        by using the Python <function>map</function> function
-        to run the list through <function>str</function>:
+        You can do this easily by calling the <function>str</function>
+        on the elements in a list comprehension:
 
         </para>
 
@@ -2210,7 +2209,7 @@ prog2.c
            <file name="SConstruct" printme="1">
 prog1 = Program('prog1.c')
 Default(prog1)
-print("DEFAULT_TARGETS is %s"%map(str, DEFAULT_TARGETS))
+print("DEFAULT_TARGETS is %s" % [str(t) for t in DEFAULT_TARGETS])
            </file>
            <file name="prog1.c">
 prog1.c
@@ -2244,10 +2243,10 @@ prog1.c
            <file name="SConstruct" printme="1">
 prog1 = Program('prog1.c')
 Default(prog1)
-print("DEFAULT_TARGETS is now %s"%map(str, DEFAULT_TARGETS))
+print("DEFAULT_TARGETS is now %s" % [str(t) for t in DEFAULT_TARGETS])
 prog2 = Program('prog2.c')
 Default(prog2)
-print("DEFAULT_TARGETS is now %s"%map(str, DEFAULT_TARGETS))
+print("DEFAULT_TARGETS is now %s" % [str(t) for t in DEFAULT_TARGETS])
            </file>
            <file name="prog1.c">
 prog1.c
@@ -2338,7 +2337,7 @@ else:
 prog1 = Program('prog1.c')
 Program('prog2.c')
 Default(prog1)
-print ("BUILD_TARGETS is %s"%map(str, BUILD_TARGETS))
+print ("BUILD_TARGETS is %s" % [str(t) for t in BUILD_TARGETS])
         </file>
         <file name="prog1.c">
 prog1.c

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -11,6 +11,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Whatever John Doe did.
 
+  From Mats Wichmann:
+    - Update some doc examples for Py3: map() now returns an interable
+      instead of a list.
+
 
 RELEASE 3.0.2 - Mon, 31 Dec 2018 16:00:12 -0700
 


### PR DESCRIPTION
`map()` now returns an interable instead of a list, update examples which assumed they could just `print()` the result of a `map()`. Use a comprehension here for readability.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation

This is a doc-only change, so there are in fact no test changes (or rather tests have already made changes for this, as they were affected by the Py3 transition)