### PR TITLE
Improve scons docs regarding Default()

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -274,7 +274,7 @@ scons
 <para>will build all target files in or below the current directory.
 Explicit default targets
 (to be built when no targets are specified on the command line)
-may be defined the SConscript file(s)
+may be defined in the SConscript file(s)
 using the
 <emphasis role="bold">Default()</emphasis>
 function, described below.</para>

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -1987,17 +1987,16 @@ foo.c
 
       <para>
 
-      One of the most basic things you can control
-      is which targets &SCons; will build by default--that is,
+      You can control
+      which targets &SCons; will build by default - that is,
       when there are no targets specified on the command line.
       As mentioned previously,
       &SCons; will normally build every target
-      in or below the current directory
-      by default--that is, when you don't
+      in or below the current directory unless you
       explicitly specify one or more targets
       on the command line.
       Sometimes, however, you may want
-      to specify explicitly that only
+      to specify that only
       certain programs, or programs in certain directories,
       should be built by default.
       You do this with the &Default; function:
@@ -2193,7 +2192,8 @@ prog2.c
         <para>
 
         &SCons; supports a &DEFAULT_TARGETS; variable
-        that lets you get at the current list of default targets.
+        that lets you get at the current list of default targets
+        specified by calls to the &Default; function or method.
         The &DEFAULT_TARGETS; variable has
         two important differences from the &COMMAND_LINE_TARGETS; variable.
         First, the &DEFAULT_TARGETS; variable is a list of
@@ -2233,7 +2233,7 @@ prog1.c
         <para>
 
         Second,
-        the contents of the &DEFAULT_TARGETS; list change
+        the contents of the &DEFAULT_TARGETS; list changes
         in response to calls to the &Default; function,
         as you can see from the following &SConstruct; file:
 
@@ -2351,7 +2351,9 @@ prog2.c
 
       Notice how the value of &BUILD_TARGETS;
       changes depending on whether a target is
-      specified on the command line:
+      specified on the command line - &BUILD_TARGETS;
+      takes from  &DEFAULT_TARGETS;
+      only if there are no &COMMAND_LINE_TARGETS;:
 
       </para>
 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -16,6 +16,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       product from the default Visual Studio
     - Add TEMPFILESUFFIX to allow a customizable filename extension, as
       described in the patch attached to issue #2431.
+    - Doc updates around Default(), and the various *TARGETS variables.
 
   From Daniel Moody:
     - Improved support for VC14.1 and Visual Studio 2017, as well as arm and arm64 targets.
@@ -24,6 +25,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Tobias Herzog
     - Enhance cpp scanner regex logic to detect if/elif expressions without whitespaces but
       parenthesis like "#if(defined FOO)" or "#elif!(BAR)" correctly.
+
 
 RELEASE 3.0.3 - Mon, 07 Jan 2019 20:05:22 -0400
   NOTE: 3.0.2 release was dropped because there was a packaging bug. Please consider all 3.0.2

--- a/src/engine/SCons/Script/SConscript.xml
+++ b/src/engine/SCons/Script/SConscript.xml
@@ -38,6 +38,10 @@ Multiple calls to
 &f-Default;
 are legal,
 and add to the list of default targets.
+As noted above, both forms of this call affect the
+same global list of default targets; the
+construction environment method applies
+construction variable expansion to the targets.
 </para>
 
 <para>


### PR DESCRIPTION
An earlier change updated some examples, this makes some tweaks to the wording as well for `Default`, `DEFAULT_TARGETS`, etc. to clarify.

This is a doc-only change (no code or test impact). It represents an opinion on slightly clearer wording, but is not really fixing anything "broken".

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation