### PR TITLE
customizable tempfile extension (issue #2431)

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -14,8 +14,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improve finding of Microsoft compiler: add a 'products' wildcard
       in case 2017 Build Tools only is installed as it is considered a separate
       product from the default Visual Studio
-    - Add TEMPFILEEXTENSION as in the patch attached to issue #2431,
-      updated to current codebase.
+    - Add TEMPFILESUFFIX to allow a customizable filename extension, as
+      described in the patch attached to issue #2431.
 
   From Daniel Moody:
     - Improved support for VC14.1 and Visual Studio 2017, as well as arm and arm64 targets.

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -14,6 +14,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improve finding of Microsoft compiler: add a 'products' wildcard
       in case 2017 Build Tools only is installed as it is considered a separate
       product from the default Visual Studio
+    - Add TEMPFILEEXTENSION as in the patch attached to issue #2431,
+      updated to current codebase.
 
   From Daniel Moody:
     - Improved support for VC14.1 and Visual Studio 2017, as well as arm and arm64 targets.

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -144,15 +144,20 @@ class TempFileMunge(object):
     line limitation.
 
     Example usage:
-    env["TEMPFILE"] = TempFileMunge
-    env["LINKCOM"] = "${TEMPFILE('$LINK $TARGET $SOURCES','$LINKCOMSTR')}"
+        env["TEMPFILE"] = TempFileMunge
+        env["LINKCOM"] = "${TEMPFILE('$LINK $TARGET $SOURCES','$LINKCOMSTR')}"
 
     By default, the name of the temporary file used begins with a
-    prefix of '@'.  This may be configred for other tool chains by
-    setting '$TEMPFILEPREFIX'.
+    prefix of '@'.  This may be configured for other tool chains by
+    setting '$TEMPFILEPREFIX':
+        env["TEMPFILEPREFIX"] = '-@'        # diab compiler
+        env["TEMPFILEPREFIX"] = '-via'      # arm tool chain
+        env["TEMPFILEPREFIX"] = ''          # (the empty string) PC Lint
 
-    env["TEMPFILEPREFIX"] = '-@'        # diab compiler
-    env["TEMPFILEPREFIX"] = '-via'      # arm tool chain
+    You can configure the extension of the temporary file through the
+    TEMPFILEEXTENSION variable, which defaults to '.lnk' (see comments
+    in the code below):
+        env["TEMPFILEEXTENSION"] = '.lnt'   # PC Lint
     """
     def __init__(self, cmd, cmdstr = None):
         self.cmd = cmd
@@ -194,16 +199,21 @@ class TempFileMunge(object):
 
         # We do a normpath because mktemp() has what appears to be
         # a bug in Windows that will use a forward slash as a path
-        # delimiter.  Windows's link mistakes that for a command line
+        # delimiter.  Windows' link mistakes that for a command line
         # switch and barfs.
         #
         # We use the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if
         # none is given.
-        (fd, tmp) = tempfile.mkstemp('.lnk', text=True)
+        if env.has_key('TEMPFILEEXTENSION'):
+            extension = env.subst('$TEMPFILEEXTENSION')
+        else:
+            extension = '.lnk'  # TODO: better way to pick default?
+        (fd, tmp) = tempfile.mkstemp(extension, text=True)
+
         native_tmp = SCons.Util.get_native_path(os.path.normpath(tmp))
 
-        if env.get('SHELL',None) == 'sh':
+        if env.get('SHELL', None) == 'sh':
             # The sh shell will try to escape the backslashes in the
             # path, so unescape them.
             native_tmp = native_tmp.replace('\\', r'\\\\')
@@ -216,8 +226,9 @@ class TempFileMunge(object):
             # Windows path names.
             rm = 'del'
 
-        prefix = env.subst('$TEMPFILEPREFIX')
-        if not prefix:
+        if env.has_key('TEMPFILEPREFIX'):
+            prefix = env.subst('$TEMPFILEPREFIX')
+        else:
             prefix = '@'
 
         args = list(map(SCons.Subst.quote_spaces, cmd[1:]))

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -205,11 +205,11 @@ class TempFileMunge(object):
         # We use the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if
         # none is given.
-        if env.has_key('TEMPFILEEXTENSION'):
-            extension = env.subst('$TEMPFILEEXTENSION')
+        if env.has_key('TEMPFILESUFFIX'):
+            suffix = env.subst('$TEMPFILESUFFIX')
         else:
-            extension = '.lnk'  # TODO: better way to pick default?
-        (fd, tmp) = tempfile.mkstemp(extension, text=True)
+            suffix = '.lnk'  # TODO: better way to pick default?
+        fd, tmp = tempfile.mkstemp(suffix, text=True)
 
         native_tmp = SCons.Util.get_native_path(os.path.normpath(tmp))
 

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -205,12 +205,11 @@ class TempFileMunge(object):
         # We use the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if
         # none is given.
-        if env.has_key('TEMPFILESUFFIX'):
-            suffix = env.subst('$TEMPFILESUFFIX')
-        else:
-            suffix = '.lnk'  # TODO: better way to pick default?
-        fd, tmp = tempfile.mkstemp(suffix, text=True)
+        suffix = env.subst('$TEMPFILESUFFIX')
+        if not suffix:
+            suffix = '.lnk'
 
+        fd, tmp = tempfile.mkstemp(suffix, text=True)
         native_tmp = SCons.Util.get_native_path(os.path.normpath(tmp))
 
         if env.get('SHELL', None) == 'sh':
@@ -226,9 +225,8 @@ class TempFileMunge(object):
             # Windows path names.
             rm = 'del'
 
-        if env.has_key('TEMPFILEPREFIX'):
-            prefix = env.subst('$TEMPFILEPREFIX')
-        else:
+        prefix = env.subst('$TEMPFILEPREFIX')
+        if not prefix:
             prefix = '@'
 
         args = list(map(SCons.Subst.quote_spaces, cmd[1:]))

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -194,7 +194,7 @@ class TempFileMunge(object):
         node = target[0] if SCons.Util.is_List(target) else target
         cmdlist = getattr(node.attributes, 'tempfile_cmdlist', None) \
                     if node is not None else None
-        if cmdlist is not None :
+        if cmdlist is not None:
             return cmdlist
 
         # We do a normpath because mktemp() has what appears to be
@@ -202,11 +202,12 @@ class TempFileMunge(object):
         # delimiter.  Windows' link mistakes that for a command line
         # switch and barfs.
         #
-        # We use the .lnk suffix for the benefit of the Phar Lap
+        # Default to the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if
         # none is given.
-        suffix = env.subst('$TEMPFILESUFFIX')
-        if not suffix:
+        if env.has_key('TEMPFILESUFFIX'):
+            suffix = env.subst('$TEMPFILESUFFIX')
+        else:
             suffix = '.lnk'
 
         fd, tmp = tempfile.mkstemp(suffix, text=True)

--- a/src/engine/SCons/Platform/__init__.xml
+++ b/src/engine/SCons/Platform/__init__.xml
@@ -232,11 +232,27 @@ The suffix used for shared object file names.
 <summary>
 <para>
 The prefix for a temporary file used
-to execute lines longer than $MAXLINELENGTH.
-The default is '@'.
-This may be set for toolchains that use other values,
-such as '-@' for the diab compiler
+to store lines lines longer than $MAXLINELENGTH
+as operations which call out to a shell will fail
+if the line is too long, which particularly
+impacts linking.
+The default is '@', which works for the Microsoft
+and GNU toolchains on Windows.
+Set this appropriately for other toolchains,
+for example '-@' for the diab compiler
 or '-via' for ARM toolchain.
+</para>
+</summary>
+</cvar>
+
+<cvar name="TEMPFILESUFFIX">
+<summary>
+<para>
+The suffix used for the temporary file name
+used for long command lines. The name should
+include the dot ('.') if one is wanted as
+it will not be added automatically.
+The default is '.lnk'.
 </para>
 </summary>
 </cvar>

--- a/test/TEMPFILESUFFIX.py
+++ b/test/TEMPFILESUFFIX.py
@@ -25,8 +25,8 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Verify that setting the $TEMPFILEPREFIX variable will cause
-it to appear at the front of name of the generated tempfile
+Verify that setting the $TEMPFILESUFFIX variable will cause
+it to appear at the end of name of the generated tempfile
 used for long command lines.
 """
 
@@ -35,7 +35,7 @@ import stat
 
 import TestSCons
 
-test = TestSCons.TestSCons(match = TestSCons.match_re)
+test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 test.write('echo.py', """\
 from __future__ import print_function
@@ -46,14 +46,14 @@ print(sys.argv)
 echo_py = test.workpath('echo.py')
 
 st = os.stat(echo_py)
-os.chmod(echo_py, st[stat.ST_MODE]|0o111)
+os.chmod(echo_py, st[stat.ST_MODE] | 0o111)
 
 test.write('SConstruct', """
 import os
 env = Environment(
     BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
     MAXLINELENGTH = 16,
-    TEMPFILEPREFIX = '-via',
+    TEMPFILESUFFIX = '.foo',
 )
 env.AppendENVPath('PATH', os.curdir)
 env.Command('foo.out', 'foo.in', '$BUILDCOM')
@@ -65,7 +65,7 @@ test.run(arguments = '-n -Q .',
          stdout = """\
 Using tempfile \\S+ for command line:
 xxx.py foo.out foo.in
-xxx.py -via\\S+
+xxx.py \\S+
 """)
 
 test.write('SConstruct', """
@@ -77,7 +77,7 @@ def print_cmd_line(s, targets, sources, env):
 env = Environment(
     BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
     MAXLINELENGTH = 16,
-    TEMPFILEPREFIX = '-via',
+    TEMPFILESUFFIX = '.foo',
     PRINT_CMD_LINE_FUNC=print_cmd_line
 )
 env.AppendENVPath('PATH', os.curdir)
@@ -103,7 +103,7 @@ env = Environment(
     TEMPFILE = TestTempFileMunge,
     BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
     MAXLINELENGTH = 16,
-    TEMPFILEPREFIX = '-via',
+    TEMPFILESUFFIX = '.foo',
 
 )
 env.AppendENVPath('PATH', os.curdir)
@@ -114,7 +114,7 @@ test.run(arguments = '-n -Q .',
          stdout = """\
 Using tempfile \\S+ for command line:
 xxx.py foo.out foo.in
-xxx.py -via\\S+
+xxx.py \\S+
 """)
 
 test.pass_test()


### PR DESCRIPTION
Apply the patch (adjusted) from issue #2341: instead of hardcoding the filename extenstion for the tempfile to help with linking on Windows targets, allow variability.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
