### PR TITLE
Quiet Py3 resource warnings

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -11,6 +11,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Whatever John Doe did.
 
+  From Mats Wichmann:
+    - Quiet open file ResourceWarnings on Python >= 3.6 caused by
+      not using a context manager around Popen.stdout
+
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000
 

--- a/src/engine/SCons/Tool/swig.py
+++ b/src/engine/SCons/Tool/swig.py
@@ -135,21 +135,31 @@ def _swigEmitter(target, source, env):
 
 def _get_swig_version(env, swig):
     """Run the SWIG command line tool to get and return the version number"""
+    version = None
     swig = env.subst(swig)
+    if not swig:
+        return version
     pipe = SCons.Action._subproc(env, SCons.Util.CLVar(swig) + ['-version'],
                                  stdin = 'devnull',
                                  stderr = 'devnull',
                                  stdout = subprocess.PIPE)
-    if pipe.wait() != 0: return
+    if pipe.wait() != 0:
+        return version
 
     # MAYBE:   out = SCons.Util.to_str (pipe.stdout.read())
-    out = SCons.Util.to_str(pipe.stdout.read())
+    with pipe.stdout:
+        out = SCons.Util.to_str(pipe.stdout.read())
+
     match = re.search('SWIG Version\s+(\S+).*', out, re.MULTILINE)
     if match:
-        if verbose: print("Version is:%s"%match.group(1))
-        return match.group(1)
+        version = match.group(1)
+        if verbose:
+            print("Version is: %s" % version)
     else:
-        if verbose: print("Unable to detect version: [%s]"%out)
+        if verbose:
+            print("Unable to detect version: [%s]" % out)
+
+    return version
 
 def generate(env):
     """Add Builders and construction variables for swig to an Environment."""


### PR DESCRIPTION
Later Pythons (3.6+) enable warnings by default (needed a command
line option before then), so some tools give off warnings now.
This change quiets the warnings from the gcc, g++ and swig tools.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [n/a] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
