### PR TITLE
tools should not override existing path order

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -11,6 +11,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Whatever John Doe did.
 
+  From Daniel Moody:
+    - Update tools to not delete existing paths in the PATH when 
+      appending a tool path (Issue #3276)
+
   From Mats Wichmann:
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by
       not using a context manager around Popen.stdout

--- a/src/engine/SCons/Tool/JavaCommon.py
+++ b/src/engine/SCons/Tool/JavaCommon.py
@@ -463,7 +463,6 @@ def get_java_include_paths(env, javac, version):
         for p in base_paths:
             paths.extend([p, os.path.join(p,'linux')])
             
-    #print("PATHS:%s"%paths)
     return paths
 
 

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -1336,8 +1336,8 @@ def find_program_path(env, key_program, default_paths=[]):
     for p in default_paths:
         env.AppendENVPath('PATH', p)
     path = env.WhereIs(key_program)
-    if not path:
-        env['ENV']['PATH'] = save_path
+    # replace the env as it was and return the path the program was found in
+    env['ENV']['PATH'] = save_path
     return path
 
 # Local Variables:

--- a/src/engine/SCons/Tool/clang.py
+++ b/src/engine/SCons/Tool/clang.py
@@ -60,7 +60,7 @@ def generate(env):
                                              default_paths=get_clang_install_dirs(env['PLATFORM']))
         if clang:
             clang_bin_dir = os.path.dirname(clang)
-            env.AppendENVPath('PATH', clang_bin_dir)
+            env.AppendENVPath('PATH', clang_bin_dir, delete_existing=0)
 
     env['CC'] = env.Detect(compilers) or 'clang'
     if env['PLATFORM'] in ['cygwin', 'win32']:

--- a/src/engine/SCons/Tool/clangxx.py
+++ b/src/engine/SCons/Tool/clangxx.py
@@ -73,7 +73,7 @@ def generate(env):
         clangxx = SCons.Tool.find_program_path(env, compilers[0], default_paths=get_clang_install_dirs(env['PLATFORM']))
         if clangxx:
             clangxx_bin_dir = os.path.dirname(clangxx)
-            env.AppendENVPath('PATH', clangxx_bin_dir)
+            env.AppendENVPath('PATH', clangxx_bin_dir, delete_existing=0)
 
     # determine compiler version
     if env['CXX']:

--- a/src/engine/SCons/Tool/gettext_tool.py
+++ b/src/engine/SCons/Tool/gettext_tool.py
@@ -40,7 +40,7 @@ def generate(env,**kw):
         tool = SCons.Tool.find_program_path(env, t, default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
         if tool:
             tool_bin_dir = os.path.dirname(tool)
-            env.AppendENVPath('PATH', tool_bin_dir)
+            env.AppendENVPath('PATH', tool_bin_dir, delete_existing=0)
         else:
             SCons.Warnings.Warning(t + ' tool requested, but binary not found in ENV PATH')
     env.Tool(t)

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -214,7 +214,7 @@ def generate(env):
                                              default_paths=get_java_install_dirs(env['PLATFORM']))
         if jar:
             jar_bin_dir = os.path.dirname(jar)
-            env.AppendENVPath('PATH', jar_bin_dir)
+            env.AppendENVPath('PATH', jar_bin_dir, delete_existing=0)
 
     env['JAR']        = 'jar'
     env['JARFLAGS']   = SCons.Util.CLVar('cf')

--- a/src/engine/SCons/Tool/javac.py
+++ b/src/engine/SCons/Tool/javac.py
@@ -218,7 +218,7 @@ def generate(env):
                                              default_paths=paths)
         if javac:
             javac_bin_dir = os.path.dirname(javac)
-            env.AppendENVPath('PATH', javac_bin_dir)
+            env.AppendENVPath('PATH', javac_bin_dir, delete_existing=0)
 
     env['JAVAINCLUDES'] = get_java_include_paths(env, javac, version)
 

--- a/src/engine/SCons/Tool/javah.py
+++ b/src/engine/SCons/Tool/javah.py
@@ -128,7 +128,7 @@ def generate(env):
                                              default_paths=get_java_install_dirs(env['PLATFORM']))
         if javah:
             javah_bin_dir = os.path.dirname(javah)
-            env.AppendENVPath('PATH', javah_bin_dir)
+            env.AppendENVPath('PATH', javah_bin_dir, delete_existing=0)
 
     env['_JAVAHOUTFLAG']    = JavaHOutFlagGenerator
     env['JAVAH']            = 'javah'

--- a/src/engine/SCons/Tool/mingw.py
+++ b/src/engine/SCons/Tool/mingw.py
@@ -141,7 +141,7 @@ def generate(env):
     mingw = SCons.Tool.find_program_path(env, key_program, default_paths=mingw_paths)
     if mingw:
         mingw_bin_dir = os.path.dirname(mingw)
-        env.AppendENVPath('PATH', mingw_bin_dir)
+        env.AppendENVPath('PATH', mingw_bin_dir, delete_existing=0)
 
     # Most of mingw is the same as gcc and friends...
     gnu_tools = ['gcc', 'g++', 'gnulink', 'ar', 'gas', 'gfortran', 'm4']
@@ -186,7 +186,7 @@ def exists(env):
     mingw = SCons.Tool.find_program_path(env, key_program, default_paths=mingw_paths)
     if mingw:
         mingw_bin_dir = os.path.dirname(mingw)
-        env.AppendENVPath('PATH', mingw_bin_dir)
+        env.AppendENVPath('PATH', mingw_bin_dir, delete_existing=0)
 
     return mingw
 

--- a/src/engine/SCons/Tool/msgfmt.py
+++ b/src/engine/SCons/Tool/msgfmt.py
@@ -87,7 +87,7 @@ def generate(env,**kw):
       msgfmt = SCons.Tool.find_program_path(env, 'msgfmt', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
       if msgfmt:
           msgfmt_bin_dir = os.path.dirname(msgfmt)
-          env.AppendENVPath('PATH', msgfmt_bin_dir)
+          env.AppendENVPath('PATH', msgfmt_bin_dir, delete_existing=0)
       else:
           SCons.Warnings.Warning('msgfmt tool requested, but binary not found in ENV PATH')
 

--- a/src/engine/SCons/Tool/msginit.py
+++ b/src/engine/SCons/Tool/msginit.py
@@ -89,7 +89,7 @@ def generate(env,**kw):
       msginit = SCons.Tool.find_program_path(env, 'msginit', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
       if msginit:
           msginit_bin_dir = os.path.dirname(msginit)
-          env.AppendENVPath('PATH', msginit_bin_dir)
+          env.AppendENVPath('PATH', msginit_bin_dir, delete_existing=0)
       else:
           SCons.Warnings.Warning('msginit tool requested, but binary not found in ENV PATH')
 

--- a/src/engine/SCons/Tool/msgmerge.py
+++ b/src/engine/SCons/Tool/msgmerge.py
@@ -80,7 +80,7 @@ def generate(env,**kw):
       msgmerge = SCons.Tool.find_program_path(env, 'msgmerge', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
       if msgmerge:
           msgmerge_bin_dir = os.path.dirname(msgmerge)
-          env.AppendENVPath('PATH', msgmerge_bin_dir)
+          env.AppendENVPath('PATH', msgmerge_bin_dir, delete_existing=0)
       else:
           SCons.Warnings.Warning('msgmerge tool requested, but binary not found in ENV PATH')
   try:

--- a/src/engine/SCons/Tool/rmic.py
+++ b/src/engine/SCons/Tool/rmic.py
@@ -118,7 +118,7 @@ def generate(env):
         # print("RMIC: %s"%rmic)
         if rmic:
             rmic_bin_dir = os.path.dirname(rmic)
-            env.AppendENVPath('PATH', rmic_bin_dir)
+            env.AppendENVPath('PATH', rmic_bin_dir, delete_existing=0)
 
     env['RMIC']            = 'rmic'
     env['RMICFLAGS']       = SCons.Util.CLVar('')

--- a/src/engine/SCons/Tool/swig.py
+++ b/src/engine/SCons/Tool/swig.py
@@ -187,7 +187,7 @@ def generate(env):
         swig = SCons.Tool.find_program_path(env, 'swig', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS + [r'C:\ProgramData\chocolatey\bin'] )
         if swig:
             swig_bin_dir = os.path.dirname(swig)
-            env.AppendENVPath('PATH', swig_bin_dir)
+            env.AppendENVPath('PATH', swig_bin_dir, delete_existing=0)
         else:
             SCons.Warnings.Warning('swig tool requested, but binary not found in ENV PATH')
 

--- a/src/engine/SCons/Tool/tex.py
+++ b/src/engine/SCons/Tool/tex.py
@@ -861,7 +861,7 @@ def generate_darwin(env):
         except:
             ospath = None
         if ospath:
-            env.AppendENVPath('PATH', ospath)
+            env.AppendENVPath('PATH', ospath, delete_existing=0)
 
 def generate_common(env):
     """Add internal Builders and construction variables for LaTeX to an Environment."""

--- a/src/engine/SCons/Tool/xgettext.py
+++ b/src/engine/SCons/Tool/xgettext.py
@@ -300,7 +300,7 @@ def generate(env, **kw):
         xgettext = SCons.Tool.find_program_path(env, 'xgettext', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
         if xgettext:
             xgettext_bin_dir = os.path.dirname(xgettext)
-            env.AppendENVPath('PATH', xgettext_bin_dir)
+            env.AppendENVPath('PATH', xgettext_bin_dir, delete_existing=0)
         else:
             SCons.Warnings.Warning('xgettext tool requested, but binary not found in ENV PATH')
     try:

--- a/src/engine/SCons/Tool/yacc.py
+++ b/src/engine/SCons/Tool/yacc.py
@@ -120,7 +120,7 @@ def generate(env):
         bison = SCons.Tool.find_program_path(env, 'bison', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
         if bison:
             bison_bin_dir = os.path.dirname(bison)
-            env.AppendENVPath('PATH', bison_bin_dir)
+            env.AppendENVPath('PATH', bison_bin_dir, delete_existing=0)
         else:
             SCons.Warnings.Warning('yacc tool requested, but bison binary not found in ENV PATH')
 


### PR DESCRIPTION
This is a potential solution to https://github.com/SCons/scons/issues/3276.

This sets all tools to not delete existing paths, maintaining the original environment.

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
