### PR TITLE
Switch stages around to get correct build failures from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,17 @@ os:
 install:
     - ./.travis/install.sh
 
-# pypy is not passing, but allow failures for coverage stage to be reached
+# pypy is not passing atm, but still report build success for now
+# allow coverage to fail, so we can still do testing for all platforms
 matrix:
   allow_failures:
-    - stage: Test
+    - python: pypy
+    - stage: Coverage
+
+# run coverage first as its still useful to collect
+stages:
+  - Coverage
+  - Test
 
 jobs:
   include:


### PR DESCRIPTION
Small follow on patch to #3275, which fixes an issue where Travis will report a pass when one of the platform test runs could have failed.

Example here shows 3.6 failing, but since the last stage is Coverage and it passed, then the build reported pass:
https://travis-ci.org/SCons/scons/builds/486015577 

This PR:
* switches the order the Travis stages are run, so that Coverage is run first and collected, then the platform tests are run last and the result of the Test stage determines the result of entire run.
* pypi still is allowed to fail because it is not in a working state, but is still useful to run 
