### PR TITLE
update find_program_path to leave the env un-altered

### DIFF
--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -1314,7 +1314,7 @@ def tool_list(platform, env):
     return [x for x in tools if x]
 
 
-def find_program_path(env, key_program, default_paths=[]):
+def find_program_path(env, key_program, default_paths=[], append=False):
     """
     Find the location of key_program and then return the path it was located at.
     Checking the default install locations.
@@ -1336,7 +1336,8 @@ def find_program_path(env, key_program, default_paths=[]):
     for p in default_paths:
         env.AppendENVPath('PATH', p)
     path = env.WhereIs(key_program)
-    env['ENV']['PATH'] = save_path
+    if not append or not path:
+        env['ENV']['PATH'] = save_path
     return path
 
 # Local Variables:

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -1331,13 +1331,12 @@ def find_program_path(env, key_program, default_paths=[]):
     if (path):
         return path
 
-    # If that doesn't work try default location for mingw
+    # If that doesn't work try default location
     save_path = env['ENV']['PATH']
     for p in default_paths:
         env.AppendENVPath('PATH', p)
     path = env.WhereIs(key_program)
-    if not path:
-        env['ENV']['PATH'] = save_path
+    env['ENV']['PATH'] = save_path
     return path
 
 # Local Variables:


### PR DESCRIPTION
The find_program_path should not alter the environment passed in. It should find the paths that the tool exists in and then let the caller decide if they want to append it, discard, store the paths, or etc.

The usage through the tools is to find the path from this function and then use a separate AppendENVPath call to append it. 

This was also appending all paths to the PATH, when only one is needed.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
