### PR TITLE
fix for case where nothing is returned from vswhere

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -18,6 +18,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Daniel Moody:
     - Change the default for AppendENVPath to delete_existing=0, so path
       order will not be changed, unless explicitly set (Issue #3276)
+    - fix bug where no msvc's are found and an empty list is indexed
 
   From Mats Wichmann:
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -298,13 +298,14 @@ def find_vc_pdir_vswhere(msvc_version):
     if os.path.exists(vswhere_path):
         sp = subprocess.Popen(vswhere_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         vsdir, err = sp.communicate()
-        vsdir = vsdir.decode("mbcs").splitlines()
-        # vswhere could easily return multiple lines
-        # we could define a way to pick the one we prefer, but since
-        # this data is currently only used to make a check for existence,
-        # returning the first hit should be good enough for now.
-        vc_pdir = os.path.join(vsdir[0], 'VC')
-        return vc_pdir
+        if vsdir:
+            vsdir = vsdir.decode("mbcs").splitlines()
+            # vswhere could easily return multiple lines
+            # we could define a way to pick the one we prefer, but since
+            # this data is currently only used to make a check for existence,
+            # returning the first hit should be good enough for now.
+            vc_pdir = os.path.join(vsdir[0], 'VC')
+            return vc_pdir
     else:
         # No vswhere on system, no install info available
         return None

--- a/test/MSVC/no_msvc.py
+++ b/test/MSVC/no_msvc.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Test scons when no MSVCs are present.
+"""
+
+import sys
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+if sys.platform != 'win32':
+    test.skip_test("Not win32 platform. Skipping test\n")
+
+# test find_vc_pdir_vswhere by removing all other VS's reg keys
+test.file_fixture('no_msvc/no_regs_sconstruct.py', 'SConstruct')
+test.run(arguments='-Q -s', stdout='')
+
+# test no msvc's
+test.file_fixture('no_msvc/no_msvcs_sconstruct.py', 'SConstruct')
+test.run(arguments='-Q -s')
+
+if 'MSVC_VERSION=None' not in test.stdout():
+    test.fail_test()
+
+test.pass_test()

--- a/test/fixture/no_msvc/no_msvcs_sconstruct.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct.py
@@ -1,0 +1,15 @@
+import SCons
+import SCons.Tool.MSCommon
+
+def DummyVsWhere(msvc_version):
+    # not testing versions with vswhere, so return none
+    return None
+
+for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+
+SCons.Tool.MSCommon.vc.find_vc_pdir_vswhere = DummyVsWhere
+
+env = SCons.Environment.Environment()
+
+print('MSVC_VERSION='+str(env.get('MSVC_VERSION')))

--- a/test/fixture/no_msvc/no_regs_sconstruct.py
+++ b/test/fixture/no_msvc/no_regs_sconstruct.py
@@ -1,0 +1,7 @@
+import SCons
+import SCons.Tool.MSCommon
+
+for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+
+env = SCons.Environment.Environment()


### PR DESCRIPTION
Small change to protect against the case that no msvc is installed.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
