### PR TITLE
Add windows default paths to lex tool

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,12 +18,12 @@ install:
   - cmd: "C:\\%WINPYTHON%\\python.exe --version"
   - cmd: for /F "tokens=*" %%g in ('C:\\%WINPYTHON%\\python.exe -m site --user-site') do (set PYSITEDIR=%%g)
   # use mingw 32 bit until #3291 is resolved
-  - cmd: "set PATH=C:\\%WINPYTHON%;C:\\%WINPYTHON%\\Scripts;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin;C:\\cygwin\\bin;C:\\ProgramData\\chocolatey\\bin;%PATH%"
+  - cmd: "set PATH=C:\\%WINPYTHON%;C:\\%WINPYTHON%\\Scripts;C:\\ProgramData\\chocolatey\\bin;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin;C:\\cygwin\\bin;%PATH%"
   - cmd: "C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off pip setuptools wheel "
   - cmd: "C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off pypiwin32 coverage codecov"
   - cmd: set STATIC_DEPS=true & C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off lxml
   # install 3rd party tools to test with
-  - cmd: choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc
+  - cmd: choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc winflexbison
   - cmd: set
 
   ### LINUX ###

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -19,6 +19,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Change the default for AppendENVPath to delete_existing=0, so path
       order will not be changed, unless explicitly set (Issue #3276)
     - Fixed bug which threw error when running SCons on windows system with no MSVC installed.
+    - Update link tool to convert target to node before accessing node member
+    - Update mingw tool to remove MSVC like nologo CCFLAG
+    - Update lex tool to work in mingw environments
 
   From Mats Wichmann:
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by
@@ -42,8 +45,6 @@ RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000
       Issues #3268 & Issue #3222
     - Initial support for ARM targets with Visual Studio 2017 - Issue #3182 (You must set TARGET_ARCH for this to work)
     - Update TempFileMunge class to use PRINT_CMD_LINE_FUNC
-    - Update link tool to convert target to node before accessing node member
-    - Update mingw tool to remove MSVC like nologo CCFLAG
 
   From Tobias Herzog
     - Enhance cpp scanner regex logic to detect if/elif expressions without whitespaces but

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -21,7 +21,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed bug which threw error when running SCons on windows system with no MSVC installed.
     - Update link tool to convert target to node before accessing node member
     - Update mingw tool to remove MSVC like nologo CCFLAG
-    - Update lex tool to work in mingw environments
+    - Add default paths for lex tool on windows
+    - Add lex construction variable LEXUNISTD for turning off unix headers on windows
+    - Update lex tool to use win_flex on windows if available
 
   From Mats Wichmann:
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by

--- a/src/engine/SCons/Platform/win32.py
+++ b/src/engine/SCons/Platform/win32.py
@@ -43,6 +43,10 @@ from SCons.Platform.virtualenv import ImportVirtualenv
 from SCons.Platform.virtualenv import ignore_virtualenv, enable_virtualenv
 import SCons.Util
 
+CHOCO_DEFAULT_PATH = [
+    r'C:\ProgramData\chocolatey\bin'
+]
+
 try:
     import msvcrt
     import win32api

--- a/src/engine/SCons/Tool/lex.py
+++ b/src/engine/SCons/Tool/lex.py
@@ -74,26 +74,18 @@ def get_lex_path(env, append_paths=False):
     """
     # save existing path to reset if we don't want to append any paths
     envPath = env['ENV']['PATH']
-    
-    lex = SCons.Tool.find_program_path(env, 'lex', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
-    if lex:
-        if not append_paths:
-            env['ENV']['PATH'] = envPath
-        else:
-            lex_bin_dir = os.path.dirname(lex)
-            env.AppendENVPath('PATH', lex_bin_dir)
-        return lex
+    bins = ['lex', 'flex']
 
-    flex = SCons.Tool.find_program_path(env, 'flex', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
-    if flex:
-        if not append_paths:
-            env['ENV']['PATH'] = envPath
-        else:
-            flex_bin_dir = os.path.dirname(flex)
-            env.AppendENVPath('PATH', flex_bin_dir)
-        return flex
-    else:
-        SCons.Warnings.Warning('lex tool requested, but lex or flex binary not found in ENV PATH')
+    for prog in bins:
+        bin_path = SCons.Tool.find_program_path(env, prog, default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
+        if bin_path:
+            if not append_paths:
+                env['ENV']['PATH'] = envPath
+            else:
+                env.AppendENVPath('PATH', os.path.dirname(bin_path))
+            return bin_path
+
+    SCons.Warnings.Warning('lex tool requested, but lex or flex binary not found in ENV PATH')
 
 
 def generate(env):

--- a/src/engine/SCons/Tool/lex.py
+++ b/src/engine/SCons/Tool/lex.py
@@ -75,7 +75,7 @@ def get_lex_path(env, append_paths=False):
     """
     # save existing path to reset if we don't want to append any paths
     envPath = env['ENV']['PATH']
-    bins = ['win_flex', 'lex', 'flex']
+    bins = ['flex', 'lex', 'win_flex']
 
     for prog in bins:
         bin_path = SCons.Tool.find_program_path(
@@ -110,14 +110,16 @@ def generate(env):
     cxx_file.add_action(".ll", LexAction)
     cxx_file.add_emitter(".ll", lexEmitter)
 
+    env["LEXFLAGS"] = SCons.Util.CLVar("")
+
     if sys.platform == 'win32':
         get_lex_path(env, append_paths=True)
-        env["LEX"] = env.Detect(['win_flex', 'lex', 'flex'])
-        env["LEXUNISTD"] = SCons.Util.CLVar("--nounistd")
+        env["LEX"] = env.Detect(['flex', 'lex', 'win_flex'])
+        if not env.get("LEXUNISTD"):
+            env["LEXUNISTD"] = SCons.Util.CLVar("")
         env["LEXCOM"] = "$LEX $LEXUNISTD $LEXFLAGS -t $SOURCES > $TARGET"
     else:
         env["LEX"] = env.Detect(["flex", "lex"])
-        env["LEXFLAGS"] = SCons.Util.CLVar("")
         env["LEXCOM"] = "$LEX $LEXFLAGS -t $SOURCES > $TARGET"
 
 def exists(env):

--- a/src/engine/SCons/Tool/lex.xml
+++ b/src/engine/SCons/Tool/lex.xml
@@ -33,6 +33,7 @@ Sets construction variables for the &lex; lexical analyser.
 <item>LEX</item>
 <item>LEXFLAGS</item>
 <item>LEXCOM</item>
+<item>LEXUNISTD</item>
 </sets>
 <uses>
 <item>LEXCOMSTR</item>
@@ -74,6 +75,14 @@ env = Environment(LEXCOMSTR = "Lex'ing $TARGET from $SOURCES")
 <summary>
 <para>
 General options passed to the lexical analyzer generator.
+</para>
+</summary>
+</cvar>
+
+<cvar name="LEXUNISTD">
+<summary>
+<para>
+Used only on windows environments to set a lex flag to prevent 'unistd.h' from being included. The default value is '--nounistd'.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/msvc.py
+++ b/src/engine/SCons/Tool/msvc.py
@@ -271,6 +271,10 @@ def generate(env):
     env['SHOBJPREFIX']    = '$OBJPREFIX'
     env['SHOBJSUFFIX']    = '$OBJSUFFIX'
 
+    # MSVC probably wont support unistd.h so default
+    # without it for lex generation
+    env["LEXUNISTD"] = SCons.Util.CLVar("--nounistd")
+
     # Set-up ms tools paths
     msvc_setup_env_once(env)
 

--- a/test/CXX/CXXFILESUFFIX.py
+++ b/test/CXX/CXXFILESUFFIX.py
@@ -35,7 +35,11 @@ test = TestSCons.TestSCons()
 test.write('mylex.py', """
 import getopt
 import sys
-cmd_opts, args = getopt.getopt(sys.argv[1:], 't', [])
+if sys.platform == 'win32':
+    longopts = ['nounistd']
+else:
+    longopts = []
+cmd_opts, args = getopt.getopt(sys.argv[1:], 't', longopts)
 for a in args:
     contents = open(a, 'r').read()
     sys.stdout.write(contents.replace('LEX', 'mylex.py'))

--- a/test/LEX/LEX.py
+++ b/test/LEX/LEX.py
@@ -38,7 +38,11 @@ test = TestSCons.TestSCons()
 test.write('mylex.py', """
 import getopt
 import sys
-cmd_opts, args = getopt.getopt(sys.argv[1:], 't', [])
+if sys.platform == 'win32':
+    longopts = ['nounistd']
+else:
+    longopts = []
+cmd_opts, args = getopt.getopt(sys.argv[1:], 't', longopts)
 for a in args:
     contents = open(a, 'rb').read()
     sys.stdout.write(contents.replace(b'LEX', b'mylex.py').decode())

--- a/test/packaging/multiple-packages-at-once.py
+++ b/test/packaging/multiple-packages-at-once.py
@@ -38,9 +38,13 @@ python = TestSCons.python
 test = TestSCons.TestSCons()
 
 zip = test.detect('ZIP', 'zip')
+tar = test.detect('TAR', 'tar')
 
 if not zip:
     test.skip_test('zip not found, skipping test\n')
+
+if not tar:
+    test.skip_test('tar not found, skipping test\n')
 
 test.subdir('src')
 


### PR DESCRIPTION

I discovered this issue when testing #3270. Lex tool needs to use --nounistd flag on windows to prevent including 'unistd.h'.

This PR:
* adds default paths for the lex tool on windows
* adds chocolatey/bin as a default path to win32 platform
* adds check for 'win_flex' binary on windows
* adds --nounistd as default flag on windows in the LEXUNISTD construction variable
* updates lex tests to handle --nounistd
* add a test for making sure Environments can be constructed when no lex is found
* add live mingw test, to make sure 'unistd.h' can be used with lex tool in mingw environments
* add documentation for LEXUNISTD construction variable

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
