### PR TITLE
Fix problem where API doc gen misses some files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -335,7 +335,7 @@ python_scons = {
         'debian_deps'   : [
                             'debian/changelog',
                             'debian/compat',
-                            'debian/control',	    
+                            'debian/control',
                             'debian/copyright',
                             'debian/dirs',
                             'debian/docs',
@@ -499,8 +499,7 @@ for p in [ scons ]:
     # destination files.
     #
     manifest_in = File(os.path.join(src, 'MANIFEST.in')).rstr()
-    manifest_in_lines = open(manifest_in).readlines()
-    src_files = bootstrap.parseManifestLines(src, manifest_in_lines)
+    src_files = bootstrap.parseManifestLines(src, manifest_in)
     raw_files = src_files[:]
     dst_files = src_files[:]
 
@@ -520,12 +519,11 @@ for p in [ scons ]:
 
             MANIFEST_in = File(os.path.join(src, ssubdir, 'MANIFEST.in')).rstr()
             MANIFEST_in_list.append(MANIFEST_in)
-            files = bootstrap.parseManifestLines(os.path.join(src, ssubdir), open(MANIFEST_in).readlines())
+            files = bootstrap.parseManifestLines(os.path.join(src, ssubdir), MANIFEST_in)
 
             raw_files.extend(files)
             src_files.extend([os.path.join(ssubdir, x) for x in files])
 
-               
             files = [os.path.join(isubdir, x) for x in files]
             dst_files.extend(files)
             for k, f in sp['filemap'].items():

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -326,7 +326,7 @@ else:
     # get included by the document XML files in the subdirectories.
     #
     manifest = File('MANIFEST').rstr()
-    src_files = bootstrap.parseManifestLines('.', open(manifest).readlines())
+    src_files = bootstrap.parseManifestLines('.', manifest)
     for s in src_files:
         if not s:
             continue
@@ -351,7 +351,7 @@ else:
         if not os.path.exists(os.path.join(build, doc, 'titlepage')):
             env.Execute(Mkdir(os.path.join(build, doc, 'titlepage')))
         manifest = File(os.path.join(doc, 'MANIFEST')).rstr()
-        src_files = bootstrap.parseManifestLines(doc, open(manifest).readlines())
+        src_files = bootstrap.parseManifestLines(doc, manifest)
         for s in src_files:
             if not s:
                 continue
@@ -571,14 +571,15 @@ if not epydoc_cli and not epydoc:
 else:
     # XXX Should be in common with reading the same thing in
     # the SConstruct file.
-    e = os.path.join('#src', 'engine')
-    manifest_in = File(os.path.join(e, 'MANIFEST.in')).rstr()
-    sources = bootstrap.parseManifestLines(e, open(manifest_in).readlines())
-    
-    # Don't omit this as we need Platform.virtualenv for the examples to be run
+    # bootstrap.py runs outside of SCons, so need to process the path
+    e = Dir(os.path.join('#src', 'engine')).rstr()
+    sources = bootstrap.parseManifestLines(e, os.path.join(e, 'MANIFEST.in'))
+
+    # Omit some files:
+    #
+    # Don't omit Platform as we need Platform.virtualenv for the examples to be run
     # sources = [x for x in sources if x.find('Platform') == -1]
     sources = [x for x in sources if x.find('Tool') == -1]
-    # XXX
     sources = [x for x in sources if x.find('Options') == -1]
 
     e = os.path.join(build, '..', 'scons', 'engine')


### PR DESCRIPTION
In `doc/SConscript`, the function in `bootstrap.py` to parse a manifest was called with an scons path (`#src/engine`) but bootstrap does not run in an scons context, it is run via `subprocess.Popen`. As a result, the glob matching failed to match files. The resulting list is passed to `epydoc` (at the moment) to generate the API docs, so the list should be correct (it was actually missing very little, since 14 of the missed files are later eliminated when the list is cleaned)

Preprocess the path before the call. Along the way, change the function to open the file itself instead of being passed a list already read from the file, update the comment, and clean some whitespace issues.

Did not updates src/CHANGES.txt since there was no change to scons source.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
