### PR TITLE
Add textfile tool to defaults

### DIFF
--- a/doc/generated/builders.gen
+++ b/doc/generated/builders.gen
@@ -2377,7 +2377,7 @@ and the result replaces the key.
 </para>
 
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">
-env = Environment(tools = ['default', 'textfile'])
+env = Environment(tools=['default'])
 
 env['prefix'] = '/usr/bin'
 script_dict = {'@prefix@': '/bin', '@exec_prefix@': '$prefix'}
@@ -2404,7 +2404,7 @@ env.Substfile('bar.in', SUBST_DICT = good_bar)
 
 # the SUBST_DICT may be in common (and not an override)
 substutions = {}
-subst = Environment(tools = ['textfile'], SUBST_DICT = substitutions)
+subst = Environment(tools=['textfile'], SUBST_DICT=substitutions)
 substitutions['@foo@'] = 'foo'
 subst['SUBST_DICT']['@bar@'] = 'bar'
 subst.Substfile('pgm1.c', [Value('#include "@foo@.h"'),

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -1197,6 +1197,10 @@ Multiple calls to
 <function xmlns="http://www.scons.org/dbxsd/v1.0">Default</function>
 are legal,
 and add to the list of default targets.
+As noted above, both forms of this call affect the
+same global list of default targets; the
+construction environment method applies
+construction variable expansion to the targets.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -23,6 +23,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by
       not using a context manager around Popen.stdout
+    - Add the textfile tool to the default tool list
 
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -1305,6 +1305,8 @@ def tool_list(platform, env):
         'tex', 'latex', 'pdflatex', 'pdftex',
         # Archivers
         'tar', 'zip',
+        # File builders (text)
+        'textfile',
     ], env)
 
     tools = ([linker, c_compiler, cxx_compiler,

--- a/src/engine/SCons/Tool/textfile.xml
+++ b/src/engine/SCons/Tool/textfile.xml
@@ -147,7 +147,7 @@ and the result replaces the key.
 </para>
 
 <example_commands>
-env = Environment(tools = ['default', 'textfile'])
+env = Environment(tools=['default'])
 
 env['prefix'] = '/usr/bin'
 script_dict = {'@prefix@': '/bin', '@exec_prefix@': '$prefix'}
@@ -174,7 +174,7 @@ env.Substfile('bar.in', SUBST_DICT = good_bar)
 
 # the SUBST_DICT may be in common (and not an override)
 substutions = {}
-subst = Environment(tools = ['textfile'], SUBST_DICT = substitutions)
+subst = Environment(tools=['textfile'], SUBST_DICT=substitutions)
 substitutions['@foo@'] = 'foo'
 subst['SUBST_DICT']['@bar@'] = 'bar'
 subst.Substfile('pgm1.c', [Value('#include "@foo@.h"'),

--- a/test/textfile.py
+++ b/test/textfile.py
@@ -115,6 +115,8 @@ test.write('foo2a.txt', foo2aText)
 test.write('bar2a.txt', foo2aText)
 check_times()
 
+# now that textfile is part of default tool list, run one testcase
+# without adding it explicitly as a tool to make sure.
 test.write('SConstruct', """
 textlist = ['This line has no substitutions',
             'This line has @subst@ substitutions',
@@ -125,7 +127,7 @@ sub1 = { '@subst@' : 'most' }
 sub2 = { '%subst%' : 'many' }
 sub3 = { '@subst@' : 'most' , '%subst%' : 'many' }
 
-env = Environment(tools = ['textfile'])
+env = Environment()
 
 t = env.Textfile('text', textlist)
 # no substitutions


### PR DESCRIPTION
PR #3242 added the `Textfile` and `Substfile` builders to the default builder list (for issue #3147), but didn't finish the job: the `textfile` tool needs to be added to the default list of tools as well.  This time
with a testcase that fails if the tool is not added. Minor doc tweak.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
