### PR TITLE
Fix is/is not syntax

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -24,6 +24,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Quiet open file ResourceWarnings on Python >= 3.6 caused by
       not using a context manager around Popen.stdout
     - Add the textfile tool to the default tool list
+    - Fix syntax on is/is not cluases: should not use with a literal
 
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000

--- a/src/engine/SCons/ActionTests.py
+++ b/src/engine/SCons/ActionTests.py
@@ -490,7 +490,7 @@ class _ActionActionTestCase(unittest.TestCase):
 
         a = SCons.Action._ActionAction(cmdstr='cmdstr')
         assert not hasattr(a, 'strfunction')
-        assert a.cmdstr is 'cmdstr', a.cmdstr
+        assert a.cmdstr == 'cmdstr', a.cmdstr
 
         a = SCons.Action._ActionAction(cmdstr=None)
         assert not hasattr(a, 'strfunction')
@@ -504,7 +504,7 @@ class _ActionActionTestCase(unittest.TestCase):
         assert a.presub is func1, a.presub
 
         a = SCons.Action._ActionAction(chdir=1)
-        assert a.chdir is 1, a.chdir
+        assert a.chdir == 1, a.chdir
 
         a = SCons.Action._ActionAction(exitstatfunc=func1)
         assert a.exitstatfunc is func1, a.exitstatfunc
@@ -518,8 +518,8 @@ class _ActionActionTestCase(unittest.TestCase):
             strfunction=func1,
             varlist=t,
         )
-        assert a.chdir is 'x', a.chdir
-        assert a.cmdstr is 'cmdstr', a.cmdstr
+        assert a.chdir == 'x', a.chdir
+        assert a.cmdstr == 'cmdstr', a.cmdstr
         assert a.exitstatfunc is func3, a.exitstatfunc
         assert a.presub is func2, a.presub
         assert a.strfunction is func1, a.strfunction

--- a/src/engine/SCons/Defaults.py
+++ b/src/engine/SCons/Defaults.py
@@ -210,7 +210,7 @@ def chmod_func(dest, mode):
             else:
                 raise SyntaxError("Could not find +, - or =")
             operation_list = operation.split(operator)
-            if len(operation_list) is not 2:
+            if len(operation_list) != 2:
                 raise SyntaxError("More than one operator found")
             user = operation_list[0].strip().replace("a", "ugo")
             permission = operation_list[1].strip()

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -963,7 +963,7 @@ class BaseTestCase(unittest.TestCase,TestEnvironmentFixture):
 
         self.assertRaises(AttributeError, getattr, bw, 'foobar')
         bw.foobar = 42
-        assert bw.foobar is 42
+        assert bw.foobar == 42
 
     # This unit test is currently disabled because we don't think the
     # underlying method it tests (Environment.BuilderWrapper.execute())
@@ -1777,15 +1777,15 @@ def exists(env):
         env2 = env1.Clone()
         env3 = env1.Clone(tools=[bar, baz])
 
-        assert env1.get('FOO') is 1
+        assert env1.get('FOO') == 1
         assert env1.get('BAR') is None
         assert env1.get('BAZ') is None
-        assert env2.get('FOO') is 1
+        assert env2.get('FOO') == 1
         assert env2.get('BAR') is None
         assert env2.get('BAZ') is None
-        assert env3.get('FOO') is 1
-        assert env3.get('BAR') is 2
-        assert env3.get('BAZ') is 3
+        assert env3.get('FOO') == 1
+        assert env3.get('BAR') == 2
+        assert env3.get('BAZ') == 3
 
         # Ensure that recursive variable substitution when copying
         # environments works properly.

--- a/test/MSVC/TARGET_ARCH.py
+++ b/test/MSVC/TARGET_ARCH.py
@@ -63,7 +63,7 @@ if env.Detect('cl'):
     env.Command('checkarm', [], 'cl')
 """ % locals())
 test.run(arguments = ".", stderr = None)
-if test.stderr().strip() is not "" and "ARM" not in test.stderr():
+if test.stderr().strip() != "" and "ARM" not in test.stderr():
     test.fail_test()
 
 test.write('SConstruct', """
@@ -73,7 +73,7 @@ if env.Detect('cl'):
     env.Command('checkarm64', [], 'cl')
 """ % locals())
 test.run(arguments = ".", stderr = None)
-if test.stderr().strip() is not "" and "ARM64" not in test.stderr():
+if test.stderr().strip() != "" and "ARM64" not in test.stderr():
     test.fail_test()
 
 test.pass_test()

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1227,7 +1227,7 @@ class TestCmd(object):
         the temporary working directories to be preserved for all
         conditions.
         """
-        if conditions is ():
+        if not conditions:
             conditions = ('pass_test', 'fail_test', 'no_result')
         for cond in conditions:
             self._preserve[cond] = 1


### PR DESCRIPTION
In a few places, `is` and `is not` are used to compare with a string or integer literal.  Python 3.8 flags these with a `SyntaxWarning`.  Changed to `==` and `!=`

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
