### PR TITLE
Minor manpage bugfix

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2321,12 +2321,12 @@ that are not absolute path names
 <emphasis role="bold">/</emphasis>
 on POSIX systems
 or
-<emphasis role="bold">\fR
+<emphasis role="bold">\</emphasis>
 on Windows systems,
 with or without
 an optional drive letter)
 are interpreted relative to the directory containing the
-SConscript</emphasis>
+<emphasis role="bold">SConscript</emphasis>
 file being read.
 An initial
 <emphasis role="bold">#</emphasis>


### PR DESCRIPTION
Syntax problem in existing manpage in section **Builder Methods**:

Target and source file names that are not absolute path names (that is, do not begin with **/** on POSIX systems or **\fR on Windows systems, with or without an optional drive letter) are interpreted relative to the directory containing the SConscript** file being read.

Corrected.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
