### PR TITLE
[ci skip] correct TempFileMunge docstring

### DIFF
--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -155,9 +155,9 @@ class TempFileMunge(object):
         env["TEMPFILEPREFIX"] = ''          # (the empty string) PC Lint
 
     You can configure the extension of the temporary file through the
-    TEMPFILEEXTENSION variable, which defaults to '.lnk' (see comments
+    TEMPFILESUFFIX variable, which defaults to '.lnk' (see comments
     in the code below):
-        env["TEMPFILEEXTENSION"] = '.lnt'   # PC Lint
+        env["TEMPFILESUFFIX"] = '.lnt'   # PC Lint
     """
     def __init__(self, cmd, cmdstr = None):
         self.cmd = cmd


### PR DESCRIPTION
`TEMPFILEEXTENSION` in class `TempFileMunge` docstring should be `TEMPFILESUFFIX` to match the code (issue #2431 describd the original change that introduced this problem). Doc (docstring) only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
