### PR TITLE
Fix issue #3303 - --config=force overwriting environment passed to Configure()

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -47,4 +47,6 @@ else
         tar xzf rel-3.0.12.tar.gz
         cd swig-rel-3.0.12 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ..
     fi
+
+    which dvipdf
 fi

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -14,6 +14,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       The Configure logic directly calls the decider when using --config=force but wasn't handling
       that exception.  This would yield minimally configure tests using TryLink() not running and
       leaving TypeError Nonetype exception in config.log
+    - Fix Issue #3303 - Handle --config=force overwriting the Environment passed into Configure()'s
+      Decider and not clearing it when the configure context is completed.
 
   From Daniel Moody:
     - Change the default for AppendENVPath to delete_existing=0, so path

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -2372,6 +2372,7 @@ class OverrideEnvironment(Base):
         kw = copy_non_reserved_keywords(kw)
         self.__dict__['overrides'].update(semi_deepcopy(kw))
 
+
 # The entry point that will be used by the external world
 # to refer to a construction environment.  This allows the wrapper
 # interface to extend a construction environment for its own purposes

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -324,24 +324,6 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
             s = sys.stdout = sys.stderr = Streamer(sys.stdout)
             try:
                 env = self.targets[0].get_build_env()
-                if cache_mode == FORCE:
-                    # Set up the Decider() to force rebuilds by saying
-                    # that every source has changed.  Note that we still
-                    # call the environment's underlying source decider so
-                    # that the correct .sconsign info will get calculated
-                    # and keep the build state consistent.
-                    def force_build(dependency, target, prev_ni,
-                                    env_decider=env.decide_source,
-                                    node=None):
-                        try:
-                            env_decider(dependency, target, prev_ni)
-                        except DeciderNeedsNode as e:
-                            e.decider(target, prev_ni, node=target)
-                        except Exception as e:
-                            raise e
-                        return True
-                    if env.decide_source.__code__ is not force_build.__code__:
-                        env.Decider(force_build)
                 env['PSTDOUT'] = env['PSTDERR'] = s
                 try:
                     sconf.cached = 0
@@ -412,12 +394,42 @@ class SConfBase(object):
         build tests in the VariantDir, not in the SourceDir)
         """
         global SConfFS
+
+        # Now create isolated override so setting source_decider doesn't affect parent Environment
+        if cache_mode == FORCE:
+            self.original_env = env
+            self.env = env.Clone()
+
+            # Set up the Decider() to force rebuilds by saying
+            # that every source has changed.  Note that we still
+            # call the environment's underlying source decider so
+            # that the correct .sconsign info will get calculated
+            # and keep the build state consistent.
+            def force_build(dependency, target, prev_ni,
+                            env_decider=env.decide_source,
+                            node=None):
+                try:
+                    env_decider(dependency, target, prev_ni)
+                except DeciderNeedsNode as e:
+                    e.decider(target, prev_ni, node=target)
+                except Exception as e:
+                    raise e
+                return True
+
+            if self.env.decide_source.__code__ is not force_build.__code__:
+                self.env.Decider(force_build)
+
+        else:
+            self.env = env
+
+        # print("Override env:%s"%env)
+
         if not SConfFS:
             SConfFS = SCons.Node.FS.default_fs or \
                       SCons.Node.FS.FS(env.fs.pathTop)
         if sconf_global is not None:
             raise SCons.Errors.UserError
-        self.env = env
+
         if log_file is not None:
             log_file = SConfFS.File(env.subst(log_file))
         self.logfile = log_file
@@ -456,6 +468,7 @@ class SConfBase(object):
                 env = sconf.Finish()
         """
         self._shutdown()
+
         return self.env
 
     def Define(self, name, value = None, comment = None):
@@ -509,6 +522,20 @@ class SConfBase(object):
             if not hasattr(n, 'attributes'):
                 n.attributes = SCons.Node.Node.Attrs()
             n.attributes.keep_targetinfo = 1
+
+            if True:
+                # Some checkers have intermediate files (for example anything that compiles a c file into a program to run
+                # Those files need to be set to not release their target info, otherwise taskmaster will throw a
+                # Nonetype not callable
+                for c in n.children(scan=False):
+                    # Keep debug code here.
+                    # print("Checking [%s] for builders and then setting keep_targetinfo"%c)
+                    if  c.has_builder():
+                        n.store_info = 0
+                        if not hasattr(c, 'attributes'):
+                            c.attributes = SCons.Node.Node.Attrs()
+                        c.attributes.keep_targetinfo = 1
+                    # pass
 
         ret = 1
 
@@ -746,10 +773,18 @@ class SConfBase(object):
             self.logstream.write("\n")
             self.logstream.close()
             self.logstream = None
-        # remove the SConfSourceBuilder from the environment
-        blds = self.env['BUILDERS']
-        del blds['SConfSourceBuilder']
-        self.env.Replace( BUILDERS=blds )
+
+        # Now reset the decider if we changed it due to --config=force
+        # We saved original Environment passed in and cloned it to isolate
+        # it from being changed.
+        if cache_mode == FORCE:
+            self.env.Decider(self.original_env.decide_source)
+
+            # remove the SConfSourceBuilder from the environment
+            blds = self.env['BUILDERS']
+            del blds['SConfSourceBuilder']
+            self.env.Replace( BUILDERS=blds )
+
         self.active = 0
         sconf_global = None
         if not self.config_h is None:

--- a/src/engine/SCons/SConfTests.py
+++ b/src/engine/SCons/SConfTests.py
@@ -194,7 +194,7 @@ class SConfTestCase(unittest.TestCase):
                         pass
                     def add_post_action(self, *actions):
                         pass
-                    def children(self):
+                    def children(self, scan = 1):
                         return []
                     def get_state(self):
                         return self.state

--- a/test/fixture/test_main.c
+++ b/test/fixture/test_main.c
@@ -1,0 +1,4 @@
+int main( int argc, char* argv[] )
+{
+  return 0;
+}


### PR DESCRIPTION
--config=force overwriting environment passed to Configure()

In the case --config=force, Configure logic will clone the passed environment and then if conf.Finish() is called the decider is restore to that of the passed in environment and Configure specific builders are removed in environment passed in.

If some logic depends on the Environment() object being returned is the exact same object returned from env.Finish() that will no longer be true when --config=force is set.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
