### PR TITLE
for #3304: drop use of -tt if py3

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -46,8 +46,6 @@ import time
 import socket
 import textwrap
 
-
-
 import bootstrap
 
 project = 'scons'
@@ -55,7 +53,6 @@ default_version = '3.0.4'
 copyright = "Copyright (c) %s The SCons Foundation" % copyright_years
 
 SConsignFile()
-
 
 #
 # We let the presence or absence of various utilities determine whether
@@ -128,9 +125,6 @@ if build_id is None:
         build_id = generate_build_id(revision)
     else:
         build_id = ''
-
-
-python_ver = sys.version[0:3]
 
 #
 # Adding some paths to sys.path, this is mainly needed

--- a/runtest.py
+++ b/runtest.py
@@ -797,7 +797,7 @@ tests_failing = 0
 def run_test(t, io_lock, run_async=True):
     global tests_completed, tests_passing, tests_failing
     header = ""
-    command_args = ['-tt']
+    command_args = []
     if debug:
         command_args.append(debug)
     command_args.append(t.path)

--- a/runtest.py
+++ b/runtest.py
@@ -798,6 +798,8 @@ def run_test(t, io_lock, run_async=True):
     global tests_completed, tests_passing, tests_failing
     header = ""
     command_args = []
+    if sys.version_info[0] < 3:
+        command_args.append('-tt')
     if debug:
         command_args.append(debug)
     command_args.append(t.path)

--- a/test/runtest/baseline/combined.py
+++ b/test/runtest/baseline/combined.py
@@ -34,6 +34,7 @@ import os
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 test_fail_py = os.path.join('test', 'fail.py')
 test_no_result_py = os.path.join('test', 'no_result.py')
 test_pass_py = os.path.join('test', 'pass.py')
@@ -49,11 +50,11 @@ test.write_no_result_test(['test', 'no_result.py'])
 test.write_passing_test(['test', 'pass.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt %(test_fail_py)s
+%(pythonstring)s%(pythonflags)s %(test_fail_py)s
 FAILING TEST STDOUT
-%(pythonstring)s -tt %(test_no_result_py)s
+%(pythonstring)s%(pythonflags)s %(test_no_result_py)s
 NO RESULT TEST STDOUT
-%(pythonstring)s -tt %(test_pass_py)s
+%(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 
 Failed the following test:

--- a/test/runtest/baseline/fail.py
+++ b/test/runtest/baseline/fail.py
@@ -31,6 +31,7 @@ Test how we handle a failing test specified on the command line.
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 
 test = TestRuntest.TestRuntest()
 
@@ -39,7 +40,7 @@ test.subdir('test')
 test.write_failing_test(['test', 'fail.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt test/fail.py
+%(pythonstring)s%(pythonflags)s test/fail.py
 FAILING TEST STDOUT
 """ % locals()
 

--- a/test/runtest/baseline/no_result.py
+++ b/test/runtest/baseline/no_result.py
@@ -31,6 +31,7 @@ Test how we handle a no-results test specified on the command line.
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 
 test = TestRuntest.TestRuntest()
 
@@ -39,7 +40,7 @@ test.subdir('test')
 test.write_no_result_test(['test', 'no_result.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt test/no_result.py
+%(pythonstring)s%(pythonflags)s test/no_result.py
 NO RESULT TEST STDOUT
 """ % locals()
 

--- a/test/runtest/baseline/pass.py
+++ b/test/runtest/baseline/pass.py
@@ -33,6 +33,7 @@ import os
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 test_pass_py = os.path.join('test', 'pass.py')
 
 test = TestRuntest.TestRuntest()
@@ -42,7 +43,7 @@ test.subdir('test')
 test.write_passing_test(['test', 'pass.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt %(test_pass_py)s
+%(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 """ % locals()
 

--- a/test/runtest/fallback.py
+++ b/test/runtest/fallback.py
@@ -34,6 +34,7 @@ import os
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 
 test = TestRuntest.TestRuntest()
 
@@ -56,11 +57,11 @@ test.write_no_result_test(test_no_result_py)
 test.write_passing_test(test_pass_py)
 
 expect_stdout = """\
-%(pythonstring)s -tt %(test_fail_py)s
+%(pythonstring)s%(pythonflags)s %(test_fail_py)s
 FAILING TEST STDOUT
-%(pythonstring)s -tt %(test_no_result_py)s
+%(pythonstring)s%(pythonflags)s %(test_no_result_py)s
 NO RESULT TEST STDOUT
-%(pythonstring)s -tt %(test_pass_py)s
+%(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 
 Failed the following test:

--- a/test/runtest/noqmtest.py
+++ b/test/runtest/noqmtest.py
@@ -34,6 +34,7 @@ import os
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 
 test = TestRuntest.TestRuntest()
 
@@ -48,11 +49,11 @@ test.write_no_result_test(test_no_result_py)
 test.write_passing_test(test_pass_py)
 
 expect_stdout = """\
-%(pythonstring)s -tt %(test_fail_py)s
+%(pythonstring)s%(pythonflags)s %(test_fail_py)s
 FAILING TEST STDOUT
-%(pythonstring)s -tt %(test_no_result_py)s
+%(pythonstring)s%(pythonflags)s %(test_no_result_py)s
 NO RESULT TEST STDOUT
-%(pythonstring)s -tt %(test_pass_py)s
+%(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 
 Failed the following test:

--- a/test/runtest/print_time.py
+++ b/test/runtest/print_time.py
@@ -36,6 +36,7 @@ import TestCmd
 import TestRuntest
 
 pythonstring = re.escape(TestRuntest.pythonstring)
+pythonflags = TestRuntest.pythonflags
 test_fail_py = re.escape(os.path.join('test', 'fail.py'))
 test_no_result_py = re.escape(os.path.join('test', 'no_result.py'))
 test_pass_py = re.escape(os.path.join('test', 'pass.py'))
@@ -51,13 +52,13 @@ test.write_no_result_test(['test', 'no_result.py'])
 test.write_passing_test(['test', 'pass.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt %(test_fail_py)s
+%(pythonstring)s%(pythonflags)s %(test_fail_py)s
 FAILING TEST STDOUT
 Test execution time: \\d+.\\d seconds
-%(pythonstring)s -tt %(test_no_result_py)s
+%(pythonstring)s%(pythonflags)s %(test_no_result_py)s
 NO RESULT TEST STDOUT
 Test execution time: \\d+.\\d seconds
-%(pythonstring)s -tt %(test_pass_py)s
+%(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 Test execution time: \\d+.\\d seconds
 Total execution time for all tests: \\d+.\\d seconds

--- a/test/runtest/python.py
+++ b/test/runtest/python.py
@@ -43,6 +43,11 @@ test_pass_py = os.path.join('test', 'pass.py')
 head, python = os.path.split(TestRuntest.python)
 head, dir = os.path.split(head)
 
+# deciding whether or not to use -tt flag here is dicey.
+# we'll go ahead and use TestRuntest.pythonflags, but it uses the
+# python version then in use, which could be different
+pythonflags = TestRuntest.pythonflags
+
 # We have to normalize the python path here, because some installations don't like
 # getting called with "/bin/../bin/python" as first argument, e.g. Fedora 17 Desktop.
 mypython = os.path.normpath(os.path.join(head, dir, os.path.pardir, dir, python))
@@ -60,7 +65,7 @@ test.subdir('test')
 test.write_passing_test(['test', 'pass.py'])
 
 expect_stdout = """\
-%(mypythonstring)s -tt %(test_pass_py)s
+%(mypythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 """ % locals()
 

--- a/test/runtest/simple/combined.py
+++ b/test/runtest/simple/combined.py
@@ -37,6 +37,7 @@ import TestRuntest
 test = TestRuntest.TestRuntest()
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 test_fail_py = os.path.join('test', 'fail.py')
 test_no_result_py = os.path.join('test', 'no_result.py')
 test_pass_py = os.path.join('test', 'pass.py')
@@ -50,11 +51,11 @@ test.write_no_result_test(['test', 'no_result.py'])
 test.write_passing_test(['test', 'pass.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt %(test_fail_py)s
+%(pythonstring)s%(pythonflags)s %(test_fail_py)s
 FAILING TEST STDOUT
-%(pythonstring)s -tt %(test_no_result_py)s
+%(pythonstring)s%(pythonflags)s %(test_no_result_py)s
 NO RESULT TEST STDOUT
-%(pythonstring)s -tt %(test_pass_py)s
+%(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 
 Failed the following test:

--- a/test/runtest/simple/fail.py
+++ b/test/runtest/simple/fail.py
@@ -31,6 +31,7 @@ Test how we handle a failing test specified on the command line.
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 
 test = TestRuntest.TestRuntest()
 
@@ -39,7 +40,7 @@ test.subdir('test')
 test.write_failing_test(['test', 'fail.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt test/fail.py
+%(pythonstring)s%(pythonflags)s test/fail.py
 FAILING TEST STDOUT
 """ % locals()
 

--- a/test/runtest/simple/no_result.py
+++ b/test/runtest/simple/no_result.py
@@ -31,6 +31,7 @@ Test how we handle a no-results test specified on the command line.
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 
 test = TestRuntest.TestRuntest()
 
@@ -39,7 +40,7 @@ test.subdir('test')
 test.write_no_result_test(['test', 'no_result.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt test/no_result.py
+%(pythonstring)s%(pythonflags)s test/no_result.py
 NO RESULT TEST STDOUT
 """ % locals()
 

--- a/test/runtest/simple/pass.py
+++ b/test/runtest/simple/pass.py
@@ -31,6 +31,7 @@ Test how we handle a passing test specified on the command line.
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 
 test = TestRuntest.TestRuntest()
 
@@ -39,7 +40,7 @@ test.subdir('test')
 test.write_passing_test(['test', 'pass.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt test/pass.py
+%(pythonstring)s%(pythonflags)s test/pass.py
 PASSING TEST STDOUT
 """ % locals()
 

--- a/test/runtest/src.py
+++ b/test/runtest/src.py
@@ -39,6 +39,7 @@ test.subdir(['src'],
             ['src', 'suite'])
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 src_passTests_py = os.path.join('src', 'passTests.py')
 src_suite_passTests_py = os.path.join('src', 'suite', 'passTests.py')
 
@@ -51,9 +52,9 @@ test.write_passing_test(['src', 'suite', 'pass.py'])
 test.write_passing_test(['src', 'suite', 'passTests.py'])
 
 expect_stdout = """\
-%(pythonstring)s -tt %(src_passTests_py)s
+%(pythonstring)s%(pythonflags)s %(src_passTests_py)s
 PASSING TEST STDOUT
-%(pythonstring)s -tt %(src_suite_passTests_py)s
+%(pythonstring)s%(pythonflags)s %(src_suite_passTests_py)s
 PASSING TEST STDOUT
 """ % locals()
 

--- a/test/runtest/testargv.py
+++ b/test/runtest/testargv.py
@@ -40,6 +40,7 @@ test.subdir('test', ['test', 'subdir'])
 
 files = {}
 files['pythonstring'] = TestRuntest.pythonstring
+files['pythonflags'] = TestRuntest.pythonflags
 
 files['one'] = os.path.join('test/subdir', 'test_one.py')
 files['two'] = os.path.join('test/subdir', 'two.py')
@@ -50,9 +51,9 @@ test.write_passing_test(files['two'])
 test.write_passing_test(files['three'])
 
 expect_stdout = """\
-%(pythonstring)s -tt %(one)s
+%(pythonstring)s%(pythonflags)s %(one)s
 PASSING TEST STDOUT
-%(pythonstring)s -tt %(two)s
+%(pythonstring)s%(pythonflags)s %(two)s
 PASSING TEST STDOUT
 """ % files
 

--- a/test/runtest/testlistfile.py
+++ b/test/runtest/testlistfile.py
@@ -34,6 +34,7 @@ import re
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
+pythonflags = TestRuntest.pythonflags
 test_fail_py = os.path.join('test', 'fail.py')
 test_no_result_py = os.path.join('test', 'no_result.py')
 test_pass_py = os.path.join('test', 'pass.py')
@@ -54,7 +55,7 @@ test.write('t.txt', """\
 """ % locals())
 
 expect_stdout = """\
-%(pythonstring)s -tt %(test_pass_py)s
+%(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 """ % locals()
 

--- a/test/runtest/xml/output.py
+++ b/test/runtest/xml/output.py
@@ -38,6 +38,7 @@ test = TestRuntest.TestRuntest(match = TestCmd.match_re,
                                diff = TestCmd.diff_re)
 
 pythonstring = re.escape(TestRuntest.pythonstring)
+pythonflags = TestRuntest.pythonflags
 test_fail_py = re.escape(os.path.join('test', 'fail.py'))
 test_no_result_py = re.escape(os.path.join('test', 'no_result.py'))
 test_pass_py = re.escape(os.path.join('test', 'pass.py'))
@@ -58,7 +59,7 @@ expect = """\
   <results>
     <test>
       <file_name>%(test_fail_py)s</file_name>
-      <command_line>%(pythonstring)s -tt %(test_fail_py)s</command_line>
+      <command_line>%(pythonstring)s%(pythonflags)s %(test_fail_py)s</command_line>
       <exit_status>1</exit_status>
       <stdout>FAILING TEST STDOUT
 </stdout>
@@ -68,7 +69,7 @@ expect = """\
     </test>
     <test>
       <file_name>%(test_no_result_py)s</file_name>
-      <command_line>%(pythonstring)s -tt %(test_no_result_py)s</command_line>
+      <command_line>%(pythonstring)s%(pythonflags)s %(test_no_result_py)s</command_line>
       <exit_status>2</exit_status>
       <stdout>NO RESULT TEST STDOUT
 </stdout>
@@ -78,7 +79,7 @@ expect = """\
     </test>
     <test>
       <file_name>%(test_pass_py)s</file_name>
-      <command_line>%(pythonstring)s -tt %(test_pass_py)s</command_line>
+      <command_line>%(pythonstring)s%(pythonflags)s %(test_pass_py)s</command_line>
       <exit_status>0</exit_status>
       <stdout>PASSING TEST STDOUT
 </stdout>

--- a/testing/framework/TestRuntest.py
+++ b/testing/framework/TestRuntest.py
@@ -27,6 +27,7 @@ from TestCommon import __all__
 
 __all__.extend([ 'TestRuntest',
                  'pythonstring',
+                 'pythonflags',
                ])
 
 if re.search('\s', python):
@@ -34,7 +35,9 @@ if re.search('\s', python):
 else:
     pythonstring = python
 pythonstring = pythonstring.replace('\\', '\\\\')
-
+pythonflags = ''
+if sys.version_info[0] < 3:
+    pythonflags = ' -tt'
 
 failing_test_template = """\
 import sys
@@ -104,7 +107,10 @@ class TestRuntest(TestCommon):
         if 'program' not in kw:
             kw['program'] = 'runtest.py'
         if 'interpreter' not in kw:
-            kw['interpreter'] = [python, '-tt']
+            kw['interpreter'] = [python,]
+            if sys.version_info[0] < 3:
+                kw['interpreter'].append('-tt')
+
         if 'match' not in kw:
             kw['match'] = match_exact
         if 'workdir' not in kw:

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -247,7 +247,9 @@ class TestSCons(TestCommon):
             elif not self.external and not os.path.isabs(kw['program']):
                 kw['program'] = os.path.join(self.orig_cwd, kw['program'])
         if 'interpreter' not in kw and not os.environ.get('SCONS_EXEC'):
-            kw['interpreter'] = [python, '-tt']
+            kw['interpreter'] = [python,]
+            if sys.version_info[0] < 3:
+                kw['interpreter'].append('-tt')
         if 'match' not in kw:
             kw['match'] = match_exact
         if 'workdir' not in kw:

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -186,7 +186,9 @@ class TestSCons_time(TestCommon):
             kw['program'] = p
 
         if 'interpreter' not in kw:
-            kw['interpreter'] = [python, '-tt']
+            kw['interpreter'] = [python,]
+            if sys.version_info[0] < 3:
+                kw['interpreter'].append('-tt')
 
         if 'match' not in kw:
             kw['match'] = match_exact


### PR DESCRIPTION
As noted in issue #3304, the Python flag to warn/error on inconsistent tabs/spaces has been dropped for Python 3 interpreters; while CPython still accepts it, silently ignoring it, PyPy3 errors out.  This change adds the flag throughout the testsuite run only if using a Python2 interpreter.
    
TODO: the current method of pasting in the flags from TestRuntest leaves an extra space in "expected" strings, so some tests are failing after the change due to that. Probably include the space in pythonflags instead of in the expected strings.
    
Signed-off-by: Mats Wichmann <mats@linux.com>


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
