### PR TITLE
[PYPY] adjust two expect strings for PyPy msgs

### DIFF
--- a/test/Errors/SyntaxError.py
+++ b/test/Errors/SyntaxError.py
@@ -44,7 +44,7 @@ test.run(stdout = "scons: Reading SConscript files ...\n",
 
       \^
 
-SyntaxError: invalid syntax
+SyntaxError: (invalid syntax|Unknown character)
 
 """, status=2)
 

--- a/test/Subst/SyntaxError.py
+++ b/test/Subst/SyntaxError.py
@@ -34,7 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 
-expect_build = r"""scons: \*\*\*%s SyntaxError `invalid syntax( \((<string>, )?line 1\))?' trying to evaluate `%s'
+expect_build = r"""scons: \*\*\*%s SyntaxError `(invalid syntax|Unknown character)( \((<string>, )?line 1\))?' trying to evaluate `%s'
 """
 
 expect_read = "\n" + expect_build + TestSCons.file_expr


### PR DESCRIPTION
To help support pypy, two test expect-strings are adjusted to accept either the error message from CPython ("Syntax error: invalid syntax") and from PyPy ("Syntax error: Unknown character").

This is a test-only change, no doc or src/* changes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
