### PR TITLE
MD5-Timestamp was causing build failures on windows only. (Mesa Project affected)

### DIFF
--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3338,17 +3338,29 @@ class File(Base):
 
         # First try the simple name for node
         c_str = str(self)
+        df = dmap.get(c_str, None)
+        if df:
+            return df
+        
         if os.altsep:
             c_str = c_str.replace(os.sep, os.altsep)
-        df = dmap.get(c_str, None)
+            df = dmap.get(c_str, None)
+            if df:
+                return df
+
         if not df:
             try:
                 # this should yield a path which matches what's in the sconsign
                 c_str = self.get_path()
+                df = dmap.get(c_str, None)
+                if df:
+                    return df
+
                 if os.altsep:
                     c_str = c_str.replace(os.sep, os.altsep)
-
-                df = dmap.get(c_str, None)
+                    df = dmap.get(c_str, None)
+                    if df:
+                        return df
 
             except AttributeError as e:
                 raise FileBuildInfoFileToCsigMappingError("No mapping from file name to content signature for :%s"%c_str)
@@ -3388,16 +3400,23 @@ class File(Base):
             dependency_map = self._build_dependency_map(bi)
             rebuilt = True
 
-        prev_ni = self._get_previous_signatures(dependency_map)
+        new_prev_ni = self._get_previous_signatures(dependency_map)
+        new = self.changed_timestamp_match(target, new_prev_ni)
+        old = self.changed_timestamp_match(target, prev_ni)
 
-        if not self.changed_timestamp_match(target, prev_ni):
+        if old != new:
+            print("Mismatch self.changed_timestamp_match(%s, prev_ni) old:%s new:%s"%(str(target), old, new))
+            new_prev_ni = self._get_previous_signatures(dependency_map)
+
+
+        if not new:
             try:
                 # NOTE: We're modifying the current node's csig in a query.
-                self.get_ninfo().csig = prev_ni.csig
+                self.get_ninfo().csig = new_prev_ni.csig
             except AttributeError:
                 pass
             return False
-        return self.changed_content(target, prev_ni)
+        return self.changed_content(target, new_prev_ni)
 
     def changed_timestamp_newer(self, target, prev_ni):
         try:

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3417,7 +3417,12 @@ class File(Base):
             # prev_ni as there aren't any
             # shortcut the rest of the logic
             if MD5_TIMESTAMP_DEBUG: print("Skipping checks len(dmap)=0")
+
+            # We still need to get the current file's csig
+            # This should be slightly faster than calling self.changed_content(target, new_prev_ni)
+            self.get_csig()
             return True
+
         new_prev_ni = self._get_previous_signatures(dependency_map)
         new = self.changed_timestamp_match(target, new_prev_ni)
 

--- a/test/Decider/MD5-winonly-firstbuild.py
+++ b/test/Decider/MD5-winonly-firstbuild.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Test but which only shows on windows when one generated file depends on another generated file
+In this case flex and yacc are an example.
+"""
+
+import os
+import stat
+
+import TestSCons
+from TestCmd import IS_WINDOWS
+
+
+test = TestSCons.TestSCons()
+
+if IS_WINDOWS:
+    yacc = test.where_is('yacc') or test.where_is('bison') or test.where_is('win_bison')
+    lex = test.where_is('flex') or test.where_is('lex') or test.where_is('win_flex')
+    # print("Lex:%s yacc:%s"%(lex,yacc))
+    if not yacc or not lex:
+        test.skip("On windows but no flex/lex/win_flex and yacc/bison/win_bison required for test")
+else:
+    test.skip("Windows only test")
+
+
+test.dir_fixture('MD5-winonly-fixture')
+test.run()
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Decider/MD5-winonly-firstbuild.py
+++ b/test/Decider/MD5-winonly-firstbuild.py
@@ -43,9 +43,9 @@ if IS_WINDOWS:
     lex = test.where_is('flex') or test.where_is('lex') or test.where_is('win_flex')
     # print("Lex:%s yacc:%s"%(lex,yacc))
     if not yacc or not lex:
-        test.skip_test("On windows but no flex/lex/win_flex and yacc/bison/win_bison required for test")
+        test.skip_test("On windows but no flex/lex/win_flex and yacc/bison/win_bison required for test\n")
 else:
-    test.skip_test("Windows only test")
+    test.skip_test("Windows only test\n")
 
 
 test.dir_fixture('MD5-winonly-fixture')

--- a/test/Decider/MD5-winonly-firstbuild.py
+++ b/test/Decider/MD5-winonly-firstbuild.py
@@ -43,9 +43,9 @@ if IS_WINDOWS:
     lex = test.where_is('flex') or test.where_is('lex') or test.where_is('win_flex')
     # print("Lex:%s yacc:%s"%(lex,yacc))
     if not yacc or not lex:
-        test.skip("On windows but no flex/lex/win_flex and yacc/bison/win_bison required for test")
+        test.skip_test("On windows but no flex/lex/win_flex and yacc/bison/win_bison required for test")
 else:
-    test.skip("Windows only test")
+    test.skip_test("Windows only test")
 
 
 test.dir_fixture('MD5-winonly-fixture')

--- a/test/Decider/MD5-winonly-fixture/SConstruct
+++ b/test/Decider/MD5-winonly-fixture/SConstruct
@@ -5,5 +5,6 @@ env.AppendENVPath('PATH', r'd:\mesa\flexbison')
 env.Tool('lex')
 env.Tool('yacc')
 env['YACCFLAGS'] = '-d'
-env.Append(LEXFLAGS = ['--wincompat'])
+if env['YACC'] == 'win_flex':
+    env.Append(LEXFLAGS = ['--wincompat'])
 env.SharedLibrary('dummy',['test_lex.l','test_parse.y'])

--- a/test/Decider/MD5-winonly-fixture/SConstruct
+++ b/test/Decider/MD5-winonly-fixture/SConstruct
@@ -1,0 +1,9 @@
+DefaultEnvironment(tools=[])
+env=Environment()
+env.Decider('MD5-timestamp')
+env.AppendENVPath('PATH', r'd:\mesa\flexbison')
+env.Tool('lex')
+env.Tool('yacc')
+env['YACCFLAGS'] = '-d'
+env.Append(LEXFLAGS = ['--wincompat'])
+env.SharedLibrary('dummy',['test_lex.l','test_parse.y'])

--- a/test/Decider/MD5-winonly-fixture/test_lex.l
+++ b/test/Decider/MD5-winonly-fixture/test_lex.l
@@ -1,0 +1,10 @@
+%{
+
+#include <stdio.h>
+#include "test_parse.h"
+int c;
+%}
+%%
+
+%%
+

--- a/test/Decider/MD5-winonly-fixture/test_parse.y
+++ b/test/Decider/MD5-winonly-fixture/test_parse.y
@@ -1,0 +1,43 @@
+%{
+#include<stdio.h>
+
+int regs[26];
+int base;
+
+%}
+
+%start digit
+
+%union { int a; }
+
+
+%token DIGIT LETTER
+
+%left '|'
+%left '&'
+%left '+' '-'
+%left '*' '/' '%'
+%left UMINUS  /*supplies precedence for unary minus */
+
+%%                   /* beginning of rules section */
+
+digit: DIGIT;
+
+
+%%
+main()
+{
+ return(yyparse());
+}
+
+yyerror(s)
+char *s;
+{
+  fprintf(stderr, "%s\n",s);
+  return(0);
+}
+
+yywrap()
+{
+  return(1);
+}


### PR DESCRIPTION
On windows first try with native file paths with \ then swap path to normalized path string with / separators. On a fresh windows build the node string will have windows dirsep and not normalized. This yielded broken builds for the Mesa project

Also added code to shortcut to avoid stringifying nodes if there is no previous build info to compare against.
This should speed up the initial clean MD5-timestamp build (on any platform)

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
