### PR TITLE
rpcgen test accomodate distros using tirpc

### DIFF
--- a/test/Rpcgen/live.py
+++ b/test/Rpcgen/live.py
@@ -49,6 +49,14 @@ if env['PLATFORM'] == 'darwin':
     # #include <stdlib.h> to get the declarations right.  Suppress the
     # warnings so the test passes.
     env.Append(CCFLAGS=['-w'])
+
+# on some Linux systems, RPC support has moved to libtirpc. Check for that.
+conf = Configure(env)
+env.Append(CPPPATH=['/usr/include/tirpc'])
+if conf.CheckLibWithHeader('tirpc', 'rpc/rpc.h', 'c'):
+    env.Append(LIBS=['tirpc'])
+env = conf.Finish()
+
 env.Program('rpcclnt', ['rpcclnt.c', 'do_rpcgen/rpcif_clnt.c'])
 env.RPCGenHeader('do_rpcgen/rpcif')
 env.RPCGenClient('do_rpcgen/rpcif')


### PR DESCRIPTION
Fedora since 28 has removed SunRPC support from glibc and switched to using tirpc.  Adjust a test to accomodate the new usage - adds an include path and if configure check passes, add libtirpc to link.

This is a test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
