### PR TITLE
[PYPY] [PY 3.8] CacheDir tests use context managers

### DIFF
--- a/test/CacheDir/CacheDir.py
+++ b/test/CacheDir/CacheDir.py
@@ -53,11 +53,12 @@ SConscript('SConscript')
 test.write(['src', 'SConscript'], """\
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')
 env.Cat('bbb.out', 'bbb.in')

--- a/test/CacheDir/SideEffect.py
+++ b/test/CacheDir/SideEffect.py
@@ -39,15 +39,16 @@ cache = test.workpath('cache')
 test.write(['work', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
 def copy(source, target):
-    open(target, "w").write(open(source, "r").read())
+    with open(target, "w") as f, open(source, "r") as f2:
+        f.write(f2.read())
 
 def build(env, source, target):
     s = str(source[0])
     t = str(target[0])
     copy(s, t)
     if target[0].side_effects:
-        side_effect = open(str(target[0].side_effects[0]), "a")
-        side_effect.write(s + ' -> ' + t + '\\n')
+        with open(str(target[0].side_effects[0]), "a") as side_effect:
+            side_effect.write(s + ' -> ' + t + '\\n')
 
 CacheDir(r'%(cache)s')
 

--- a/test/CacheDir/VariantDir.py
+++ b/test/CacheDir/VariantDir.py
@@ -42,11 +42,12 @@ cat_out = test.workpath('cat.out')
 test.write(['src', 'SConscript'], """\
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')
 env.Cat('bbb.out', 'bbb.in')

--- a/test/CacheDir/debug.py
+++ b/test/CacheDir/debug.py
@@ -53,11 +53,12 @@ SConscript('SConscript')
 test.write(['src', 'SConscript'], """\
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')
 env.Cat('bbb.out', 'bbb.in')

--- a/test/CacheDir/environment.py
+++ b/test/CacheDir/environment.py
@@ -54,11 +54,12 @@ SConscript('SConscript')
 test.write(['src', 'SConscript'], """\
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env_cache = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env_nocache = env_cache.Clone()
 env_nocache.CacheDir(None)

--- a/test/CacheDir/multi-targets.py
+++ b/test/CacheDir/multi-targets.py
@@ -42,8 +42,10 @@ multiple_foo = test.workpath('multiple', 'foo')
 test.write(['multiple', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
 def touch(env, source, target):
-    open('foo', 'w').write("")
-    open('bar', 'w').write("")
+    with open('foo', 'w') as f:
+        f.write("")
+    with open('bar', 'w') as f:
+        f.write("")
 CacheDir(r'%(cache)s')
 env = Environment(tools=[])
 env.Command(['foo', 'bar'], ['input'], touch)

--- a/test/CacheDir/multiple-targets.py
+++ b/test/CacheDir/multiple-targets.py
@@ -40,8 +40,10 @@ test.subdir('cache')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def touch(env, source, target):
-    open('foo', 'w').write("")
-    open('bar', 'w').write("")
+    with open('foo', 'w') as f:
+        f.write("")
+    with open('bar', 'w') as f:
+        f.write("")
 CacheDir(r'%s')
 env = Environment(tools=[], )
 env.Command(['foo', 'bar'], ['input'], touch)

--- a/test/CacheDir/option--cd.py
+++ b/test/CacheDir/option--cd.py
@@ -42,11 +42,12 @@ test.write(['src', 'SConstruct'], """
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')
 env.Cat('bbb.out', 'bbb.in')

--- a/test/CacheDir/option--cf.py
+++ b/test/CacheDir/option--cf.py
@@ -41,11 +41,12 @@ test.write(['src', 'SConstruct'], """
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')
 env.Cat('bbb.out', 'bbb.in')

--- a/test/CacheDir/option--cr.py
+++ b/test/CacheDir/option--cr.py
@@ -42,11 +42,12 @@ test.write(['src', 'SConstruct'], """
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')
 env.Cat('bbb.out', 'bbb.in')

--- a/test/CacheDir/option--cs.py
+++ b/test/CacheDir/option--cs.py
@@ -45,11 +45,12 @@ test.subdir('cache', 'src1', 'src2')
 
 test.write(['src1', 'build.py'], r"""
 import sys
-open('cat.out', 'a').write(sys.argv[1] + "\n")
-file = open(sys.argv[1], 'w')
-for src in sys.argv[2:]:
-    file.write(open(src, 'r').read())
-file.close()
+with open('cat.out', 'a') as f:
+    f.write(sys.argv[1] + "\n")
+with open(sys.argv[1], 'w') as f:
+    for src in sys.argv[2:]:
+        with open(src, 'r') as f2:
+            f.write(f2.read())
 """)
 
 cache = test.workpath('cache')
@@ -58,11 +59,12 @@ test.write(['src1', 'SConstruct'], """
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    open('cat.out', 'a').write(target + "\\n")
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open('cat.out', 'a') as f:
+        f.write(target + "\\n")
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 env = Environment(tools=[], 
                   BUILDERS={'Internal':Builder(action=cat),
                             'External':Builder(action=r'%(_python_)s build.py $TARGET $SOURCES')})

--- a/test/CacheDir/scanner-target.py
+++ b/test/CacheDir/scanner-target.py
@@ -48,9 +48,8 @@ CacheDir(r'%s')
 
 def docopy(target,source,env):
     data = source[0].get_contents()
-    f = open(target[0].rfile().get_abspath(), "wb")
-    f.write(data)
-    f.close()
+    with open(target[0].rfile().get_abspath(), "wb") as f:
+        f.write(data)
 
 def sillyScanner(node, env, dirs):
     print('This is never called (unless we build file.out)')

--- a/test/CacheDir/source-scanner.py
+++ b/test/CacheDir/source-scanner.py
@@ -50,9 +50,8 @@ CacheDir(r'%(cache)s')
 
 def docopy(target,source,env):
     data = source[0].get_contents()
-    f = open(target[0].rfile().get_abspath(), "wb")
-    f.write(data)
-    f.close()
+    with open(target[0].rfile().get_abspath(), "wb") as f:
+        f.write(data)
 
 def sillyScanner(node, env, dirs):
     print('This is never called (unless we build file.out)')


### PR DESCRIPTION
Python 3.8 complains about unclosed files on nearly all of the CacheDir tests. PyPy3 fails 8 of the 20 tests for the same reason, though since it's based on an earlier version of Python (3.5 at the moment) it does not display the resourcewarning messages.

Update sequences of `open().write()` which are the primary problem area to use context managers for automatic closing, and for consistency, the rest of the `open`/`read`/`write` stuff as well. With this change, all these tests pass in PyPy3. Python 3.8 does not, as it is spewing other warning messages which also end up in the stderr, which is fatal to this set of tests, but it has quieted the warnings from the CacheDir tests themselves.

This is a test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
