### PR TITLE
[PYPY] [PY 3.8] more context manager use in tests

### DIFF
--- a/test/Actions/pre-post.py
+++ b/test/Actions/pre-post.py
@@ -47,13 +47,11 @@ env = Environment(XXX='bar%(_exe)s')
 
 def before(env, target, source):
     a=str(target[0])
-    f=open(a, "wb")
-    f.write(b"Foo\\n")
-    f.close()
+    with open(a, "wb") as f:
+        f.write(b"Foo\\n")
     os.chmod(a, os.stat(a)[stat.ST_MODE] | stat.S_IXUSR)
-    f=open("before.txt", "ab")
-    f.write((os.path.splitext(str(target[0]))[0] + "\\n").encode())
-    f.close()
+    with open("before.txt", "ab") as f:
+        f.write((os.path.splitext(str(target[0]))[0] + "\\n").encode())
 
 def after(env, target, source):
     t = str(target[0])
@@ -106,9 +104,11 @@ test.must_match(['work3', 'dir', 'file'], "build()\n")
 # work4 start
 test.write(['work4', 'SConstruct'], """\
 def pre_action(target, source, env):
-    open(str(target[0]), 'ab').write(('pre %%s\\n' %% source[0]).encode())
+    with open(str(target[0]), 'ab') as f:
+        f.write(('pre %%s\\n' %% source[0]).encode())
 def post_action(target, source, env):
-    open(str(target[0]), 'ab').write(('post %%s\\n' %% source[0]).encode())
+    with open(str(target[0]), 'ab') as f:
+        f.write(('post %%s\\n' %% source[0]).encode())
 env = Environment()
 o = env.Command(['pre-post', 'file.out'],
                 'file.in',

--- a/test/SideEffect/basic.py
+++ b/test/SideEffect/basic.py
@@ -37,13 +37,14 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 def copy(source, target):
-    open(target, "wb").write(open(source, "rb").read())
+    with open(target, "wb") as f, open(source, "rb") as f2:
+        f.write(f2.read())
 
 def build(env, source, target):
     copy(str(source[0]), str(target[0]))
     if target[0].side_effects:
-        side_effect = open(str(target[0].side_effects[0]), "ab")
-        side_effect.write(('%%s -> %%s\\n'%%(str(source[0]), str(target[0]))).encode())
+        with open(str(target[0].side_effects[0]), "ab") as side_effect:
+            side_effect.write(('%%s -> %%s\\n'%%(str(source[0]), str(target[0]))).encode())
 
 Build = Builder(action=build)
 env = Environment(BUILDERS={'Build':Build}, SUBDIR='subdir')

--- a/test/SideEffect/variant_dir.py
+++ b/test/SideEffect/variant_dir.py
@@ -38,13 +38,14 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', 
 """
 def copy(source, target):
-    open(target, "wb").write(open(source, "rb").read())
+    with open(target, "wb") as f, open(source, "rb") as f2:
+        f.write(f2.read())
 
 def build(env, source, target):
     copy(str(source[0]), str(target[0]))
     if target[0].side_effects:
-        side_effect = open(str(target[0].side_effects[0]), "ab")
-        side_effect.write(('%s -> %s\\n'%(str(source[0]), str(target[0]))).encode())
+        with open(str(target[0].side_effects[0]), "ab") as side_effect:
+            side_effect.write(('%s -> %s\\n'%(str(source[0]), str(target[0]))).encode())
 
 Build = Builder(action=build)
 env = Environment(BUILDERS={'Build':Build})

--- a/test/VariantDir/errors.py
+++ b/test/VariantDir/errors.py
@@ -57,10 +57,10 @@ def fake_scan(node, env, target):
 
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as f2:
+                f.write(f2.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)},
                   SCANNERS=[Scanner(fake_scan, skeys = ['.in'])])
@@ -101,16 +101,15 @@ test.subdir(dir)
 SConscript = test.workpath(dir, 'SConscript')
 test.write(SConscript, '')
 os.chmod(SConscript, os.stat(SConscript)[stat.ST_MODE] & ~stat.S_IWUSR)
-f = open(SConscript, 'r')
-os.chmod(dir, os.stat(dir)[stat.ST_MODE] & ~stat.S_IWUSR)
+with open(SConscript, 'r'):
+    os.chmod(dir, os.stat(dir)[stat.ST_MODE] & ~stat.S_IWUSR)
 
-test.run(chdir = 'ro-SConscript',
-         arguments = ".",
-         status = 2,
-         stderr = "scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.\n" % os.path.join('src', 'SConscript'))
+    test.run(chdir = 'ro-SConscript',
+             arguments = ".",
+             status = 2,
+             stderr = "scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.\n" % os.path.join('src', 'SConscript'))
 
-os.chmod('ro-SConscript', os.stat('ro-SConscript')[stat.ST_MODE] | stat.S_IWUSR)
-f.close()
+    os.chmod('ro-SConscript', os.stat('ro-SConscript')[stat.ST_MODE] | stat.S_IWUSR)
 
 test.run(chdir = 'ro-SConscript',
          arguments = ".",
@@ -129,24 +128,22 @@ test.write([dir, 'SConscript'], '')
 file_in = test.workpath(dir, 'file.in')
 test.write(file_in, '')
 os.chmod(file_in, os.stat(file_in)[stat.ST_MODE] & ~stat.S_IWUSR)
-f = open(file_in, 'r')
-os.chmod(dir, os.stat(dir)[stat.ST_MODE] & ~stat.S_IWUSR)
+with open(file_in, 'r'):
+    os.chmod(dir, os.stat(dir)[stat.ST_MODE] & ~stat.S_IWUSR)
 
-test.run(chdir = 'ro-src',
-         arguments = ".",
-         status = 2,
-         stderr = """\
-scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
+    test.run(chdir = 'ro-src',
+             arguments = ".",
+             status = 2,
+             stderr = """\
+    scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
+    """ % (os.path.join('src', 'file.in')))
+
+    test.run(chdir = 'ro-src',
+             arguments = "-k .",
+             status = 2,
+             stderr = """\
+    scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
 """ % (os.path.join('src', 'file.in')))
-
-test.run(chdir = 'ro-src',
-         arguments = "-k .",
-         status = 2,
-         stderr = """\
-scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
-""" % (os.path.join('src', 'file.in')))
-
-f.close()
 
 # ensure that specifying multiple source directories for one
 # build directory results in an error message, rather

--- a/test/VariantDir/errors.py
+++ b/test/VariantDir/errors.py
@@ -135,14 +135,14 @@ with open(file_in, 'r'):
              arguments = ".",
              status = 2,
              stderr = """\
-    scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
-    """ % (os.path.join('src', 'file.in')))
+scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
+""" % (os.path.join('src', 'file.in')))
 
     test.run(chdir = 'ro-src',
              arguments = "-k .",
              status = 2,
              stderr = """\
-    scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
+scons: *** Cannot duplicate `%s' in `build': Permission denied.  Stop.
 """ % (os.path.join('src', 'file.in')))
 
 # ensure that specifying multiple source directories for one


### PR DESCRIPTION
Similar to #3319, add additional use of context managers inside written tests.  Fixes som PyPy3 fails and quiets matching warnings from Python 3.8.

These are test-only changes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
