### PR TITLE
Fix win location yacc

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -16,6 +16,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       leaving TypeError Nonetype exception in config.log
     - Fix Issue #3303 - Handle --config=force overwriting the Environment passed into Configure()'s
       Decider and not clearing it when the configure context is completed.
+    - Add default paths for yacc tool on windows to include cygwin, mingw, and chocolatey
 
   From Daniel Moody:
     - Change the default for AppendENVPath to delete_existing=0, so path
@@ -23,7 +24,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed bug which threw error when running SCons on windows system with no MSVC installed.
     - Update link tool to convert target to node before accessing node member
     - Update mingw tool to remove MSVC like nologo CCFLAG
-    - Add default paths for lex tool on windows
+    - Add default paths for lex tool on windows to include cygwin, mingw, and chocolatey
     - Add lex construction variable LEXUNISTD for turning off unix headers on windows
     - Update lex tool to use win_flex on windows if available
 

--- a/test/YACC/live-check-output-cleaned.py
+++ b/test/YACC/live-check-output-cleaned.py
@@ -34,12 +34,13 @@ _exe = TestSCons._exe
 
 test = TestSCons.TestSCons()
 
-yacc = test.where_is('yacc') or test.where_is('bison')
+yacc = test.where_is('yacc') or test.where_is('bison') or test.where_is('win_bison')
 
 if not yacc:
     test.skip_test('No yacc or bison found; skipping test.\n')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 foo = Environment(YACCFLAGS='-v -d', tools = ['default', 'yacc'])
 foo.CFile(source = 'foo.y')
 """ % locals())

--- a/test/YACC/live.py
+++ b/test/YACC/live.py
@@ -37,18 +37,15 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-yacc = test.where_is('yacc') or test.where_is('bison')
+yacc = test.where_is('yacc') or test.where_is('bison') or test.where_is('win_bison')
 
 if not yacc:
     test.skip_test('No yacc or bison found; skipping test.\n')
 
-if sys.platform == 'win32':
-    if not test.where_is('gcc'):
-        test.skip_test('No gcc found on windows; skipping test.\n')
-
 test.file_fixture('wrapper.py')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 foo = Environment(YACCFLAGS='-d', tools = ['default', 'yacc'])
 yacc = foo.Dictionary('YACC')
 bar = Environment(YACC = r'%(_python_)s wrapper.py ' + yacc, tools = ['default', 'yacc'])


### PR DESCRIPTION
Add cygwin,mingw,and chocolaty paths for windows locations for yacc.
Also search for bison, yacc, and win_bison.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
