### PR TITLE
[PYPY] fix way exit status is retrieved in main

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -33,6 +33,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       not using a context manager around Popen.stdout
     - Add the textfile tool to the default tool list
     - Fix syntax on is/is not clauses: should not use with a literal
+    - Properly retrieve exit code when catching SystemExit
 
   From Bernhard M. Wiedemann:
     - Do not store build host+user name if reproducible builds are wanted

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -1376,7 +1376,7 @@ def main():
             revert_io()
     except SystemExit as s:
         if s:
-            exit_status = s
+            exit_status = s.code
     except KeyboardInterrupt:
         print("scons: Build interrupted.")
         sys.exit(2)


### PR DESCRIPTION
When scons exits, it wants to take the opportunity to print any diagnostics and statistics that may have been requested, so the main routine traps the various ways it can quit.  If code somewhere calls `sys.exit()`, that generates a `SystemExit` exception. The handling of that has not been quite correct - it simply takes the exception instance, saves it, and later quits with `sys.exit(saved)`. This seemingly works fine for all other tested versions of Python, but has interesting side effects with PyPy3.

Per the Python documentation:

> If the value is an integer, it specifies the system exit status (passed to C’s `exit()` function); if it is `None`, the exit status is zero; if it has another type (such as a string), the object’s value is printed and the exit status is one.

And in fact, PyPy3 does this: if the original call to` sys.exit()` took a value of 2, then the `SystemExit` exception triggers with a class instance which does have an exit code of 2, which turns up if you take the string repr of the instance, but when passed to the final `sys.exit`, as it's not an integer it *prints* the 2, and returns with an exit code of 1, just as in the documentation snip.

Not really sure if PyPy3 is wrong here, or the other Pythons are letting something slide, but it's an easy fix: save off the code stored in the exception instance for later use as the exit code, instead of using the instance itself for that.

The existing tests catch this case - if you use pypy3.  There is no doc impact.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
