### PR TITLE
Fix issue #3135. Type Bound procedures in Fortran submodules

### DIFF
--- a/src/engine/SCons/Scanner/Fortran.py
+++ b/src/engine/SCons/Scanner/Fortran.py
@@ -285,21 +285,26 @@ def FortranScan(path_variable="FORTRANPATH"):
 #   but *not* the following:
 #
 #   MODULE PROCEDURE procedure_name
+#   MODULE SUBROUTINE subroutine_name
+#   MODULE FUNCTION function_name
 #
 #   Here is a breakdown of the regex:
 #
-#   (?i)               : regex is case insensitive
-#   ^\s*               : any amount of white space
-#   MODULE             : match the string MODULE, case insensitive
-#   \s+                : match one or more white space characters
-#   (?!PROCEDURE)      : but *don't* match if the next word matches
-#                        PROCEDURE (negative lookahead assertion),
-#                        case insensitive
-#   (\w+)              : match one or more alphanumeric characters
-#                        that make up the defined module name and
-#                        save it in a group
+#   (?i)                               : regex is case insensitive
+#   ^\s*                               : any amount of white space
+#   MODULE                             : match the string MODULE, case
+#                                        insensitive
+#   \s+                                : match one or more white space
+#                                        characters
+#   (?!PROCEDURE|SUBROUTINE|FUNCTION)  : but *don't* match if the next word
+#                                        matches PROCEDURE, SUBROUTINE or
+#                                        FUNCTION (negative lookahead
+#                                        assertion), case insensitive
+#   (\w+)                              : match one or more alphanumeric
+#                                        characters that make up the defined
+#                                        module name and save it in a group
 
-    def_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE)(\w+)"""
+    def_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
 
     scanner = F90Scanner("FortranScan",
                          "$FORTRANSUFFIXES",

--- a/src/engine/SCons/Scanner/Fortran.py
+++ b/src/engine/SCons/Scanner/Fortran.py
@@ -187,7 +187,7 @@ def FortranScan(path_variable="FORTRANPATH"):
 #   (\w+)              : match the module name that is being USE'd
 #
 #
-    use_regex = "(?i)(?:^|;)\s*USE(?:\s+|(?:(?:\s*,\s*(?:NON_)?INTRINSIC)?\s*::))\s*(\w+)"
+    use_regex = r"(?i)(?:^|;)\s*USE(?:\s+|(?:(?:\s*,\s*(?:NON_)?INTRINSIC)?\s*::))\s*(\w+)"
 
 
 #   The INCLUDE statement regex matches the following:
@@ -275,7 +275,7 @@ def FortranScan(path_variable="FORTRANPATH"):
 #                        set of semicolon-separated INCLUDE statements
 #                        (as allowed by the F2003 standard)
 
-    include_regex = """(?i)(?:^|['">]\s*;)\s*INCLUDE\s+(?:\w+_)?[<"'](.+?)(?=["'>])"""
+    include_regex = r"""(?i)(?:^|['">]\s*;)\s*INCLUDE\s+(?:\w+_)?[<"'](.+?)(?=["'>])"""
 
 #   The MODULE statement regex finds module definitions by matching
 #   the following:
@@ -304,7 +304,7 @@ def FortranScan(path_variable="FORTRANPATH"):
 #                                        characters that make up the defined
 #                                        module name and save it in a group
 
-    def_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
+    def_regex = r"""(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
 
     scanner = F90Scanner("FortranScan",
                          "$FORTRANSUFFIXES",

--- a/src/engine/SCons/Tool/FortranCommon.py
+++ b/src/engine/SCons/Tool/FortranCommon.py
@@ -64,7 +64,8 @@ def _fortranEmitter(target, source, env):
     if not node.exists() and not node.is_derived():
        print("Could not locate " + str(node.name))
        return ([], [])
-    mod_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE)(\w+)"""
+    # This has to match the def_regex in the Fortran scanner
+    mod_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
     cre = re.compile(mod_regex,re.M)
     # Retrieve all USE'd module names
     modules = cre.findall(node.get_text_contents())

--- a/src/engine/SCons/Tool/FortranCommon.py
+++ b/src/engine/SCons/Tool/FortranCommon.py
@@ -65,7 +65,7 @@ def _fortranEmitter(target, source, env):
        print("Could not locate " + str(node.name))
        return ([], [])
     # This has to match the def_regex in the Fortran scanner
-    mod_regex = """(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
+    mod_regex = r"""(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
     cre = re.compile(mod_regex,re.M)
     # Retrieve all USE'd module names
     modules = cre.findall(node.get_text_contents())


### PR DESCRIPTION
This fixes issue #3135 regarding the issue with using type bound
procedures in Fortran submodules. The fix consists of changing the
regex used in the scanner and the emitter to ignore lines starting
with:

module subroutine

and

module function

as these are used to define type bound procedures instead of modules
named 'subroutine' or 'function'.  The regex is case insensitive.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
