### PR TITLE
[PYPY] [PY 3.8] add context mgr use in scons-time

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -34,6 +34,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add the textfile tool to the default tool list
     - Fix syntax on is/is not clauses: should not use with a literal
     - Properly retrieve exit code when catching SystemExit
+    - scons-time now uses context managers around file opens
 
   From Bernhard M. Wiedemann:
     - Do not store build host+user name if reproducible builds are wanted

--- a/src/script/scons-time.py
+++ b/src/script/scons-time.py
@@ -814,7 +814,9 @@ class SConsTimer(object):
                 self.title = a
 
         if self.config_file:
-            exec(open(self.config_file, 'r').read(), self.__dict__)
+            with open(self.config_file, 'r') as f:
+                config = f.read()
+            exec(config, self.__dict__)
 
         if self.chdir:
             os.chdir(self.chdir)
@@ -933,7 +935,9 @@ class SConsTimer(object):
                 self.title = a
 
         if self.config_file:
-            HACK_for_exec(open(self.config_file, 'r').read(), self.__dict__)
+            with open(self.config_file, 'r') as f:
+                config = f.read()
+            HACK_for_exec(config, self.__dict__)
 
         if self.chdir:
             os.chdir(self.chdir)
@@ -1053,7 +1057,9 @@ class SConsTimer(object):
         object_name = args.pop(0)
 
         if self.config_file:
-            HACK_for_exec(open(self.config_file, 'r').read(), self.__dict__)
+            with open(self.config_file, 'r') as f:
+                config = f.read()
+            HACK_for_exec(config, self.__dict__)
 
         if self.chdir:
             os.chdir(self.chdir)
@@ -1191,7 +1197,9 @@ class SConsTimer(object):
             sys.exit(1)
 
         if self.config_file:
-            exec(open(self.config_file, 'r').read(), self.__dict__)
+            with open(self.config_file, 'r') as f:
+                config = f.read()
+            exec(config, self.__dict__)
 
         if args:
             self.archive_list = args

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -38,18 +38,18 @@ import os
 import sys
 
 def write_args(fp, args):
-    fp.write(args[0] + '\\n')
+    fp.write(args[0] + os.linesep)
     for arg in args[1:]:
-        fp.write('    ' + arg + '\\n')
+        fp.write('    ' + arg + os.linesep)
 
 write_args(sys.stdout, sys.argv)
 for arg in sys.argv[1:]:
     if arg[:10] == '--profile=':
         with open(arg[10:], 'w') as profile:
-            profile.write('--profile\\n')
+            profile.write('--profile' + os.linesep)
             write_args(profile, sys.argv)
         break
-sys.stdout.write('SCONS_LIB_DIR = ' + os.environ['SCONS_LIB_DIR'] + '\\n')
+sys.stdout.write('SCONS_LIB_DIR = ' + os.environ['SCONS_LIB_DIR'] + os.linesep)
 with open('SConstruct', 'r') as f:
     script = f.read()
 exec(script)
@@ -63,8 +63,8 @@ import sys
 script_dir = 'src/script'
 if not os.path.exists(script_dir):
     os.makedirs(script_dir)
-open(script_dir + '/scons.py', 'w').write(
-r'''%s''')
+with open(script_dir + '/scons.py', 'w') as f:
+    f.write(r'''%s''')
 """ % scons_py
 
 
@@ -76,8 +76,8 @@ import sys
 dir = sys.argv[-1]
 script_dir = dir + '/src/script'
 os.makedirs(script_dir)
-open(script_dir + '/scons.py', 'w').write(
-r'''%s''')
+with open(script_dir + '/scons.py', 'w') as f:
+    f.write(r'''%s''')
 """ % scons_py
 
 
@@ -89,8 +89,8 @@ import sys
 dir = sys.argv[-1]
 script_dir = dir + '/src/script'
 os.makedirs(script_dir)
-open(script_dir + '/scons.py', 'w').write(
-r'''%s''')
+with open(script_dir + '/scons.py', 'w') as f:
+    f.write(r'''%s''')
 """ % scons_py
 
 
@@ -297,13 +297,15 @@ class TestSCons_time(TestCommon):
             tar = tarfile.open(archive, mode[suffix])
             for name, content in files:
                 path = os.path.join(dir, name)
-                open(path, 'wb').write(bytearray(content,'utf-8'))
+                with open(path, 'wb') as f:
+                    f.write(bytearray(content,'utf-8'))
                 tarinfo = tar.gettarinfo(path, path)
                 tarinfo.uid = 111
                 tarinfo.gid = 111
                 tarinfo.uname = 'fake_user'
                 tarinfo.gname = 'fake_group'
-                tar.addfile(tarinfo, open(path, 'rb'))
+                with open(path, 'rb') as f:
+                    tar.addfile(tarinfo, f)
             tar.close()
             shutil.rmtree(dir)
             return self.workpath(archive)
@@ -322,7 +324,8 @@ class TestSCons_time(TestCommon):
             zip = zipfile.ZipFile(archive, 'w')
             for name, content in files:
                 path = os.path.join(dir, name)
-                open(path, 'w').write(content)
+                with open(path, 'w') as f:
+                    f.write(content)
                 zip.write(path)
             zip.close()
             shutil.rmtree(dir)

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -38,18 +38,18 @@ import os
 import sys
 
 def write_args(fp, args):
-    fp.write(args[0] + os.linesep)
+    fp.write(args[0] + '\\n')
     for arg in args[1:]:
-        fp.write('    ' + arg + os.linesep)
+        fp.write('    ' + arg + '\\n')
 
 write_args(sys.stdout, sys.argv)
 for arg in sys.argv[1:]:
     if arg[:10] == '--profile=':
         with open(arg[10:], 'w') as profile:
-            profile.write('--profile' + os.linesep)
+            profile.write('--profile\\n')
             write_args(profile, sys.argv)
         break
-sys.stdout.write('SCONS_LIB_DIR = ' + os.environ['SCONS_LIB_DIR'] + os.linesep)
+sys.stdout.write('SCONS_LIB_DIR = ' + os.environ['SCONS_LIB_DIR'] + '\\n')
 with open('SConstruct', 'r') as f:
     script = f.read()
 exec(script)


### PR DESCRIPTION
To fix some test problems for pypy, which seem more prone to problems of lost data if files are written and not explicitly closed, add context managers on file opens in scons-time. Also quiets warnings which are emitted by the much noisier Python 3.8. Changes are to the scons-time script and to the framework.

After visual inspection of outputs while debugging, switched the framework's created tools in the scons-time area to use os.linesep instead of explicit `'\\n'` strings; tools shouldoperate in a native way.

Existing tests were catching this if using pypy. No doc impact.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
