### PR TITLE
Add /nologo flag to RCFLAGS

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -37,7 +37,9 @@ RELEASE 3.0.5.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
 
   From Bernhard M. Wiedemann:
     - Do not store build host+user name if reproducible builds are wanted
-
+    
+  From Maciej Kumorek:
+    - Update the MSVC tool to include the nologo flag by default in RCFLAGS
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000
 

--- a/src/engine/SCons/Tool/msvc.py
+++ b/src/engine/SCons/Tool/msvc.py
@@ -262,7 +262,7 @@ def generate(env):
     env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 1
 
     env['RC'] = 'rc'
-    env['RCFLAGS'] = SCons.Util.CLVar('')
+    env['RCFLAGS'] = SCons.Util.CLVar('/nologo')
     env['RCSUFFIXES']=['.rc','.rc2']
     env['RCCOM'] = '$RC $_CPPDEFFLAGS $_CPPINCFLAGS $RCFLAGS /fo$TARGET $SOURCES'
     env['BUILDERS']['RES'] = res_builder


### PR DESCRIPTION
Add /nologo parameter to RCFLAGS to avoid the banner during resource compilation.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
