### PR TITLE
Runtest improvements for multi-job runs

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -4,7 +4,7 @@
 #
 # runtest.py - wrapper script for running SCons tests
 #
-# SCons test suite consists of:
+# The SCons test suite consists of:
 #
 #  - unit tests        - included in *Tests.py files from src/ dir
 #  - end-to-end tests  - these are *.py files in test/ directory that
@@ -16,71 +16,59 @@
 # With -p (--package) option, script tests specified package from
 # build directory and sets PYTHONPATH to reference modules unpacked
 # during build process for testing purposes (build/test-*).
-#
-#       -a              Run all tests found under the current directory.
-#                       It is also possible to specify a list of
-#                       subdirectories to search.
-#
-#       -d              Debug.  Runs the script under the Python
-#                       debugger (pdb.py) so you don't have to
-#                       muck with PYTHONPATH yourself.
-#
-#       -e              Starts the script in external mode, for
-#                       testing separate Tools and packages.
-#
-#       -f file         Only execute the tests listed in the specified
-#                       file.
-#
-#       -k              Suppress printing of count and percent progress for
-#                       the single tests.
-#
-#       -l              List available tests and exit.
-#
-#       -n              No execute, just print command lines.
-#
-#       -o file         Save screen output to the specified log file.
-#
-#       -P Python       Use the specified Python interpreter.
-#
-#       -p package      Test against the specified package.
-#
-#       --passed        In the final summary, also report which tests
-#                       passed.  The default is to only report tests
-#                       which failed or returned NO RESULT.
-#
-#       -q              Quiet.  By default, runtest.py prints the
-#                       command line it will execute before
-#                       executing it.  This suppresses that print.
-#
-#       --quit-on-failure Quit on any test failure
-#
-#       -s              Short progress.  Prints only the command line
-#                       and a percentage value, based on the total and
-#                       current number of tests.
-#                       All stdout and stderr messages get suppressed (this
-#                       does only work with subprocess though)!
-#
-#       -t              Print the execution time of each test.
-#
-#       -X              The scons "script" is an executable; don't
-#                       feed it to Python.
-#
-#       -x scons        The scons script to use for tests.
-#
-#       --xml file      Save test results to the specified file in an
-#                       SCons-specific XML format.
-#                       This is (will be) used for reporting results back
-#                       to a central SCons test monitoring infrastructure.
-#
-#       --exclude-list file 
-#                       list of tests to exclude in the current selection of test
-#                       mostly meant to easily exclude tests from -a option
-#
-# (Note:  There used to be a -v option that specified the SCons
-# version to be tested, when we were installing in a version-specific
-# library directory.  If we ever resurrect that as the default, then
-# you can find the appropriate code in the 0.04 version of this script,
-# rather than reinventing that wheel.)
+
+"""
+Options:
+  -a --all                 Run all tests.
+  -b --baseline BASE       Run test scripts against baseline BASE.
+     --builddir DIR        Directory in which packages were built.
+  -d --debug               Run test scripts under the Python debugger.
+  -e --external            Run the script in external mode (for external Tools)
+  -f --file FILE           Only run tests listed in FILE.
+  -j --jobs JOBS           Run tests in JOBS parallel jobs.
+  -k --no-progress         Suppress count and percent progress messages.
+  -l --list                List available tests and exit.
+  -n --no-exec             No execute, just print command lines.
+     --nopipefiles         Do not use the "file pipe" workaround for Popen()
+                           for starting tests. WARNING: use only when too much
+                           file traffic is giving you trouble AND you can be 
+                           sure that none of your tests create output >65K 
+                           chars! You might run into some deadlocks else.
+  -o --output FILE         Save the output from a test run to the log file.
+  -P PYTHON                Use the specified Python interpreter.
+  -p --package PACKAGE     Test against the specified PACKAGE:
+                             deb           Debian
+                             local-tar-gz  .tar.gz standalone package
+                             local-zip     .zip standalone package
+                             rpm           Red Hat
+                             src-tar-gz    .tar.gz source package
+                             src-zip       .zip source package
+                             tar-gz        .tar.gz distribution
+                             zip           .zip distribution
+     --passed              Summarize which tests passed.
+  -q --quiet               Don't print the test being executed.
+     --quit-on-failure     Quit on any test failure.
+     --runner CLASS        Alternative test runner class for unit tests.
+  -s --short-progress      Short progress, prints only the command line.
+                           and a percentage value, based on the total and
+                           current number of tests.
+  -t --time                Print test execution time.
+  -v VERSION               Specify the SCons version.
+     --verbose=LEVEL       Set verbose level:
+                             1 = print executed commands,
+                             2 = print commands and non-zero output,
+                             3 = print commands and all output.
+  -X                       Test script is executable, don't feed to Python.
+  -x --exec SCRIPT         Test SCRIPT.
+     --xml file            Save results to file in SCons XML format.
+     --exclude-list FILE   List of tests to exclude in the current selection.
+                           Use to exclude tests when using the -a option.
+
+Environment Variables:
+  PRESERVE, PRESERVE_{PASS,FAIL,NO_RESULT}: preserve test subdirs
+  TESTCMD_VERBOSE: turn on verbosity in TestCommand\
+"""
+
 from __future__ import print_function
 
 
@@ -119,67 +107,19 @@ print_times = None
 python = None
 sp = []
 print_progress = 1
-suppress_stdout = False
-suppress_stderr = False
+catch_output = False
+suppress_output = False
 allow_pipe_files = True
 quit_on_failure = False
 excludelistfile = None
 
+script = sys.argv[0].split("/")[-1]
 usagestr = """\
-Usage: runtest.py [OPTIONS] [TEST ...]
-       runtest.py -h|--help
-"""
-helpstr = usagestr + """\
-Options:
-  -a --all                    Run all tests.
-  -b --baseline BASE          Run test scripts against baseline BASE.
-     --builddir DIR           Directory in which packages were built.
-  -d --debug                  Run test scripts under the Python debugger.
-  -e --external               Run the script in external mode (for testing separate Tools)
-  -f --file FILE              Run tests in specified FILE.
-  -k --no-progress            Suppress count and percent progress messages.
-  -l --list                   List available tests and exit.
-  -n --no-exec                No execute, just print command lines.
-     --nopipefiles            Doesn't use the "file pipe" workaround for subprocess.Popen()
-                              for starting tests. WARNING: Only use this when too much file
-                              traffic is giving you trouble AND you can be sure that none of
-                              your tests create output that exceed 65K chars! You might
-                              run into some deadlocks else.
-  -o --output FILE            Save the output from a test run to the log file.
-  -P PYTHON                   Use the specified Python interpreter.
-  -p --package PACKAGE        Test against the specified PACKAGE:
-                                deb           Debian
-                                local-tar-gz  .tar.gz standalone package
-                                local-zip     .zip standalone package
-                                rpm           Red Hat
-                                src-tar-gz    .tar.gz source package
-                                src-zip       .zip source package
-                                tar-gz        .tar.gz distribution
-                                zip           .zip distribution
-     --passed                 Summarize which tests passed.
-  -q --quiet                  Don't print the test being executed.
-     --quit-on-failure        Quit on any test failure
-     --runner CLASS           Alternative test runner class for unit tests
-  -s --short-progress         Short progress, prints only the command line
-                              and a percentage value, based on the total and
-                              current number of tests.
-  -t --time                   Print test execution time.
-  -v VERSION                  Specify the SCons version.
-     --verbose=LEVEL          Set verbose level: 1 = print executed commands,
-                                2 = print commands and non-zero output,
-                                3 = print commands and all output.
-  -X                          Test script is executable, don't feed to Python.
-  -x --exec SCRIPT            Test SCRIPT.
-     --xml file               Save results to file in SCons XML format.
-     --exclude-list FILE      List of tests to exclude in the current selection of test,
-                              mostly meant to easily exclude tests from the -a option
+Usage: %(script)s [OPTIONS] [TEST ...]
+       %(script)s -h|--help
+""" % locals()
 
-Environment Variables:
-
-  PRESERVE, PRESERVE_{PASS,FAIL,NO_RESULT}: preserve test subdirs
-  TESTCMD_VERBOSE: turn on verbosity in TestCommand\
-"""
-
+helpstr = usagestr + __doc__
 
 # "Pass-through" option parsing -- an OptionParser that ignores
 # unknown options and lets them pile up in the leftover argument
@@ -250,6 +190,9 @@ for o, a in opts:
         sys.exit(0)
     elif o in ['-j', '--jobs']:
         jobs = int(a)
+        # don't let tests write stdout/stderr directly if multi-job,
+        # or outputs will interleave and be hard to read
+        catch_output = True
     elif o in ['-k', '--no-progress']:
         print_progress = 0
     elif o in ['-l', '--list']:
@@ -266,14 +209,12 @@ for o, a in opts:
         python = a
     elif o in ['-q', '--quiet']:
         printcommand = 0
-        suppress_stdout = True
-        suppress_stderr = True
+        suppress_output = catch_output = True
     elif o in ['--quit-on-failure']:
         quit_on_failure = True
     elif o in ['-s', '--short-progress']:
         print_progress = 1
-        suppress_stdout = True
-        suppress_stderr = True
+        suppress_output = catch_output = True
     elif o in ['-t', '--time']:
         print_times = 1
     elif o in ['--verbose']:
@@ -355,7 +296,7 @@ def escape(s):
     return s
 
 
-if not suppress_stdout and not suppress_stderr:
+if not catch_output:
     # Without any output suppressed, we let the subprocess
     # write its stuff freely to stdout/stderr.
     def spawn_it(command_args):
@@ -428,8 +369,9 @@ else:
 
 
 class Base(object):
-    def __init__(self, path, spe=None):
+    def __init__(self, path, num, spe=None):
         self.path = path
+        self.num = num
         self.abspath = os.path.abspath(path)
         if spe:
             for dir in spe:
@@ -755,7 +697,7 @@ if excludelistfile:
 
 # ---[ test processing ]-----------------------------------
 tests = [t for t in tests if t not in excludetests]
-tests = [Test(t) for t in tests]
+tests = [Test(t, n+1) for n, t in enumerate(tests)]
 
 if list_only:
     for t in tests:
@@ -794,9 +736,33 @@ tests_passing = 0
 tests_failing = 0
 
 
-def run_test(t, io_lock, run_async=True):
+def log_result(t, io_lock):
     global tests_completed, tests_passing, tests_failing
-    header = ""
+    tests_completed += 1
+    if t.status == 0:
+        tests_passing += 1
+    else:
+        tests_failing += 1
+    if io_lock:
+        io_lock.acquire()
+    if suppress_output or catch_output:
+        sys.stdout.write(t.headline)
+    if not suppress_output:
+        if t.stdout:
+            print(t.stdout)
+        if t.stderr:
+            print(t.stderr)
+    print_time_func("Test execution time: %.1f seconds\n", t.test_time)
+    if io_lock:
+        io_lock.release()
+    if quit_on_failure and t.status == 1:
+        print("Exiting due to error")
+        print(t.status)
+        sys.exit(1)
+
+
+def run_test(t, io_lock, run_async=True):
+    t.headline = ""
     command_args = []
     if sys.version_info[0] < 3:
         command_args.append('-tt')
@@ -810,16 +776,15 @@ def run_test(t, io_lock, run_async=True):
     t.command_str = " ".join([escape(python)] + command_args)
     if printcommand:
         if print_progress:
-            tests_completed += 1
-            n = tests_completed # approx indicator of where we are
-            header += ("%d/%d (%.2f%s) %s\n" % (n, total_num_tests,
-                                                float(n)*100.0/float(total_num_tests),
+            t.headline += ("%d/%d (%.2f%s) %s\n" % (t.num, total_num_tests,
+                                                float(t.num)*100.0/float(total_num_tests),
                                                 '%',
                                                 t.command_str))
         else:
-            header += t.command_str + "\n"
-    if not suppress_stdout and not suppress_stderr:
-        sys.stdout.write(header)
+            t.headline += t.command_str + "\n"
+    if not suppress_output and not catch_output:
+        # defer printing the headline until test is done
+        sys.stdout.write(t.headline)
     head, tail = os.path.split(t.abspath)
     fixture_dirs = []
     if head:
@@ -830,28 +795,9 @@ def run_test(t, io_lock, run_async=True):
     test_start_time = time_func()
     if execute_tests:
         t.execute()
-
-    if t.status == 0:
-        tests_passing += 1
-    else:
-        tests_failing += 1
-
     t.test_time = time_func() - test_start_time
-    if io_lock:
-        io_lock.acquire()
-    if suppress_stdout or suppress_stderr:
-        sys.stdout.write(header)
-    if not suppress_stdout and t.stdout:
-        print(t.stdout)
-    if not suppress_stderr and t.stderr:
-        print(t.stderr)
-    print_time_func("Test execution time: %.1f seconds\n", t.test_time)
-    if io_lock:
-        io_lock.release()
-    if quit_on_failure and t.status == 1:
-        print("Exiting due to error")
-        print(t.status)
-        sys.exit(1)
+    log_result(t, io_lock)
+
 
 class RunTest(threading.Thread):
     def __init__(self, queue, io_lock):
@@ -862,7 +808,7 @@ class RunTest(threading.Thread):
     def run(self):
         while True:
             t = self.queue.get()
-            run_test(t, io_lock, True)
+            run_test(t, self.io_lock, True)
             self.queue.task_done()
 
 if jobs > 1:
@@ -870,13 +816,14 @@ if jobs > 1:
     # Start worker threads
     queue = Queue()
     io_lock = threading.Lock()
-    for i in range(1, jobs):
+    for _ in range(jobs):
         t = RunTest(queue, io_lock)
         t.daemon = True
         t.start()
     # Give tasks to workers
     for t in tests:
         queue.put(t)
+    # wait until all done
     queue.join()
 else:
     for t in tests:

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,10 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Mats Wichmann:
+    - scons-time takes more care closing files and uses safer mkdtemp to avoid
+      possible races on multi-job runs.
+
   From John Doe:
 
     - Whatever John Doe did.

--- a/src/script/scons-time.py
+++ b/src/script/scons-time.py
@@ -233,14 +233,16 @@ def unzip(fname):
             os.makedirs(dir)
         except:
             pass
-        open(name, 'wb').write(zf.read(name))
+        with open(name, 'wb') as f:
+            f.write(zf.read(name))
 
 def read_tree(dir):
     for dirpath, dirnames, filenames in os.walk(dir):
         for fn in filenames:
             fn = os.path.join(dirpath, fn)
             if os.path.isfile(fn):
-                open(fn, 'rb').read()
+                with open(fn, 'rb') as f:
+                    f.read()
 
 def redirect_to_file(command, log):
     return '%s > %s 2>&1' % (command, log)
@@ -441,14 +443,14 @@ class SConsTimer(object):
 
     def log_execute(self, command, log):
         command = self.subst(command, self.__dict__)
-        output = os.popen(command).read()
+        with os.popen(command) as p:
+            output = p.read()
         if self.verbose:
             sys.stdout.write(output)
         # TODO: Figure out
         # Not sure we need to write binary here
-        open(log, 'w').write(output)
-
-    #
+        with open(log, 'w') as f:
+            f.write(str(output))
 
     def archive_splitext(self, path):
         """
@@ -613,7 +615,8 @@ class SConsTimer(object):
             search_string = self.time_string_all
         else:
             search_string = time_string
-        contents = open(file).read()
+        with open(file) as f:
+            contents = f.read()
         if not contents:
             sys.stderr.write('file %s has no contents!\n' % repr(file))
             return None
@@ -658,7 +661,8 @@ class SConsTimer(object):
             search_string = self.memory_string_all
         else:
             search_string = memory_string
-        lines = open(file).readlines()
+        with open(file) as f:
+            lines = f.readlines()
         lines = [ l for l in lines if l.startswith(search_string) ][-4:]
         result = [ int(l.split()[-1]) for l in lines[-4:] ]
         if len(result) == 1:
@@ -670,14 +674,14 @@ class SConsTimer(object):
         Returns the counts of the specified object_name.
         """
         object_string = ' ' + object_name + '\n'
-        lines = open(file).readlines()
+        with open(file) as f:
+            lines = f.readlines()
         line = [ l for l in lines if l.endswith(object_string) ][0]
         result = [ int(field) for field in line.split()[:4] ]
         if index is not None:
             result = result[index]
         return result
 
-    #
 
     command_alias = {}
 
@@ -1419,7 +1423,9 @@ class SConsTimer(object):
                 which = a
 
         if self.config_file:
-            HACK_for_exec(open(self.config_file, 'r').read(), self.__dict__)
+            with open(self.config_file, 'r') as f:
+                config = f.read()
+            HACK_for_exec(config, self.__dict__)
 
         if self.chdir:
             os.chdir(self.chdir)

--- a/test/scons-time/run/config/initial_commands.py
+++ b/test/scons-time/run/config/initial_commands.py
@@ -38,7 +38,8 @@ test.write_sample_project('foo.tar.gz')
 
 test.write('config', """\
 def touch(arg):
-    open(arg, 'w')
+    with open(arg, 'w'):
+        pass
 initial_commands = [(touch, 'touch %%%%s', r'%s')]
 """ % test.workpath('INITIAL'))
 

--- a/test/scons-time/run/option/verbose.py
+++ b/test/scons-time/run/option/verbose.py
@@ -72,7 +72,6 @@ scons_flags = '--debug=count --debug=memory --debug=time --debug=memoizer'
 
 
 expect = """\
-scons-time%(time_re)s: mkdir %(tmp_scons_time)s
 scons-time%(time_re)s: cd %(tmp_scons_time)s
 scons-time%(time_re)s: tar xzf %(foo_tar_gz)s
 scons-time%(time_re)s: cd foo

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -366,11 +366,9 @@ else:
     def is_String(e):
         return isinstance(e, (str, unicode, UserString))
 
-tempfile.template = 'testcmd.'
+testprefix = 'testcmd.'
 if os.name in ('posix', 'nt'):
-    tempfile.template = 'testcmd.' + str(os.getpid()) + '.'
-else:
-    tempfile.template = 'testcmd.'
+    testprefix += "%s." % str(os.getpid())
 
 re_space = re.compile('\s')
 
@@ -1662,10 +1660,11 @@ class TestCmd(object):
         """
         if path is None:
             try:
-                path = tempfile.mktemp(prefix=tempfile.template)
+                path = tempfile.mkdtemp(prefix=testprefix)
             except TypeError:
-                path = tempfile.mktemp()
-        os.mkdir(path)
+                path = tempfile.mkdtemp()
+        else:
+            os.mkdir(path)
 
         # Symlinks in the path will report things
         # differently from os.getcwd(), so chdir there


### PR DESCRIPTION
Main fix: if duing a multi-job run (-j flag is present), collect the test output in runtest and keep the test heading together with the test output, so the information about a given test will not separated in
the output.  The test number is recorded in the test instance instead of kept as a global.  Tests may appear out of order now, but since they may be run "out of order" depending on how fast the various threads complete the jobs they pull off the queue, that shouldn't be a problem.

The help message is now the script's docstring, and help prints the docstring along with some other info. This avoids having the options described twice (and going out of sync) - once in the inital comment, once in the help message.  A mention of the -j multi-job option is added, was previously missing.

Also: one less worker than requested was created due to use of range(1, n) (may have been intentional?). changed to number requested.

Also: the lock is taken from the RunTest instance, not from the global lock variable.  This must have been intended as the lock is stored in the instance on initialization. The lock was not really declared as
a global, it was just assigned in global scope.

Also: the test result reporting is now split off into its own function, makes a bit cleaner separation (and facilitates possible changes to the multi-job model in future).

Does not really need a CI build, but going to let it run to make sure nothing here affected any of the instances.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

No changes under src/ so CHANGES.txt unchanged; no new functionality so docs not changed either (except the inline help, which was updated)

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
