### PR TITLE
[PY 3.8] fix more warnings

### DIFF
--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -826,6 +826,7 @@ else:  # PY3 version, from newer pydoc
     def importfile(path):
         """Import a Python source file or compiled file given its path."""
         import importlib
+        from pydoc import ErrorDuringImport
         magic = importlib.util.MAGIC_NUMBER
         with open(path, 'rb') as file:
             is_bytecode = magic == file.read(len(magic))

--- a/bin/scons-test.py
+++ b/bin/scons-test.py
@@ -18,7 +18,6 @@ from __future__ import print_function
 
 import atexit
 import getopt
-import imp
 import os
 import os.path
 import sys

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -10,6 +10,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - scons-time takes more care closing files and uses safer mkdtemp to avoid
       possible races on multi-job runs.
+    - Use importlib to dynamically load tool and platform modules instead of imp module
 
   From John Doe:
 
@@ -53,8 +54,6 @@ RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700
     - Properly retrieve exit code when catching SystemExit
     - scons-time now uses context managers around file opens
     - Fix regex patterns that were not specified as raw strings
-    - Use importlib to dynamically load tool and platform modules instead of imp module.
-    - Define regex patterns as raw strings to avoid Python 3.8 warnings about unknown escapes.
 
   From Bernhard M. Wiedemann:
     - Do not store build host+user name if reproducible builds are wanted

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -53,6 +53,8 @@ RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700
     - Properly retrieve exit code when catching SystemExit
     - scons-time now uses context managers around file opens
     - Fix regex patterns that were not specified as raw strings
+    - Use importlib to dynamically load tool and platform modules instead of imp module.
+    - Define regex patterns as raw strings to avoid Python 3.8 warnings about unknown escapes.
 
   From Bernhard M. Wiedemann:
     - Do not store build host+user name if reproducible builds are wanted

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -47,7 +47,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 
-import imp
+import importlib
 import os
 import sys
 import tempfile
@@ -101,13 +101,8 @@ def platform_module(name = platform_default()):
             eval(full_name)
         else:
             try:
-                file, path, desc = imp.find_module(name,
-                                        sys.modules['SCons.Platform'].__path__)
-                try:
-                    mod = imp.load_module(full_name, file, path, desc)
-                finally:
-                    if file:
-                        file.close()
+                # the specific platform module is a relative import
+                mod = importlib.import_module("." + name, __name__)
             except ImportError:
                 try:
                     import zipimport

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -41,7 +41,6 @@ import sys
 import re
 import os
 import shutil
-import importlib
 
 import SCons.Builder
 import SCons.Errors

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -37,12 +37,11 @@ tool definition.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import imp
-import importlib
 import sys
 import re
 import os
 import shutil
+import importlib
 
 import SCons.Builder
 import SCons.Errors
@@ -121,6 +120,8 @@ class Tool(object):
             self.options = module.options
 
     def _load_dotted_module_py2(self, short_name, full_name, searchpaths=None):
+        import imp
+
         splitname = short_name.split('.')
         index = 0
         srchpths = searchpaths

--- a/src/engine/SCons/Tool/cyglink.py
+++ b/src/engine/SCons/Tool/cyglink.py
@@ -133,7 +133,7 @@ def _versioned_lib_suffix(env, suffix, version):
     if Verbose:
         print("_versioned_lib_suffix: suffix= ", suffix)
         print("_versioned_lib_suffix: version= ", version)
-    cygversion = re.sub('\.', '-', version)
+    cygversion = re.sub(r'\.', '-', version)
     if not suffix.startswith('-' + cygversion):
         suffix = '-' + cygversion + suffix
     if Verbose:

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -1080,7 +1080,7 @@ V10DSPPropertyGroupCondition = """\
 
 V10DSPImportGroupCondition = """\
 \t<ImportGroup Condition="'$(Configuration)|$(Platform)'=='%(variant)s|%(platform)s'" Label="PropertySheets">
-\t\t<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+\t\t<Import Project="$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
 \t</ImportGroup>
 """
 
@@ -1159,7 +1159,7 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
         name = self.name
         confkeys = sorted(self.configs.keys())
 
-        self.file.write('\t<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />\n')
+        self.file.write('\t<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />\n')
 
         toolset = ''
         if 'MSVC_VERSION' in self.env:
@@ -1170,7 +1170,7 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
             platform = self.configs[kind].platform
             self.file.write(V10DSPPropertyGroupCondition % locals())
 
-        self.file.write('\t<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />\n')
+        self.file.write('\t<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />\n')
         self.file.write('\t<ImportGroup Label="ExtensionSettings">\n')
         self.file.write('\t</ImportGroup>\n')
 
@@ -1233,7 +1233,7 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
         self.filters_file.write('</Project>')
         self.filters_file.close()
 
-        self.file.write('\t<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />\n'
+        self.file.write('\t<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />\n'
                         '\t<ImportGroup Label="ExtensionTargets">\n'
                         '\t</ImportGroup>\n'
                         '</Project>\n')

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -35,7 +35,7 @@ from SCons.Util import is_List, make_path_relative
 from SCons.Warnings import warn, Warning
 
 import os
-import imp
+import importlib
 
 __all__ = [
     'src_targz', 'src_tarbz2', 'src_xz', 'src_zip',
@@ -122,12 +122,12 @@ def Package(env, target=None, source=None, **kw):
     # load the needed packagers.
     def load_packager(type):
         try:
-            file,path,desc=imp.find_module(type, __path__)
-            return imp.load_module(type, file, path, desc)
+            # the specific packager is a relative import
+            return importlib.import_module("." + type, __name__)
         except ImportError as e:
             raise EnvironmentError("packager %s not available: %s"%(type,str(e)))
 
-    packagers=list(map(load_packager, PACKAGETYPE))
+    packagers = list(map(load_packager, PACKAGETYPE))
 
     # set up targets and the PACKAGEROOT
     try:

--- a/src/engine/SCons/Tool/suncxx.py
+++ b/src/engine/SCons/Tool/suncxx.py
@@ -56,7 +56,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
         except EnvironmentError:
             pass
         else:
-            sadm_re = re.compile('^(\S*/bin/CC)(=\S*)? %s$' % package_name, re.M)
+            sadm_re = re.compile(r'^(\S*/bin/CC)(=\S*)? %s$' % package_name, re.M)
             sadm_match = sadm_re.search(sadm_contents)
             if sadm_match:
                 pathname = os.path.dirname(sadm_match.group(1))
@@ -69,7 +69,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
             pass
         else:
             pkginfo_contents = p.communicate()[0]
-            version_re = re.compile('^ *VERSION:\s*(.*)$', re.M)
+            version_re = re.compile(r'^ *VERSION:\s*(.*)$', re.M)
             version_match = version_re.search(pkginfo_contents)
             if version_match:
                 version = version_match.group(1)

--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -61,27 +61,18 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import sys
-import imp  # Use the "imp" module to protect imports from fixers.
+import importlib
 
 PYPY = hasattr(sys, 'pypy_translation_info')
 
 
-def import_as(module, name):
-    """
-    Imports the specified module (from our local directory) as the
-    specified name, returning the loaded module object.
-    """
-    dir = os.path.split(__file__)[0]
-    return imp.load_module(name, *imp.find_module(module, [dir]))
-
-
 def rename_module(new, old):
     """
-    Attempts to import the old module and load it under the new name.
+    Attempt to import the old module and load it under the new name.
     Used for purely cosmetic name changes in Python 3.x.
     """
     try:
-        sys.modules[new] = imp.load_module(old, *imp.find_module(old))
+        sys.modules[new] = importlib.import_module(old)
         return True
     except ImportError:
         return False

--- a/src/script/scons-time.py
+++ b/src/script/scons-time.py
@@ -41,6 +41,7 @@ import shutil
 import sys
 import tempfile
 import time
+import subprocess
 
 def HACK_for_exec(cmd, *args):
     """
@@ -443,8 +444,10 @@ class SConsTimer(object):
 
     def log_execute(self, command, log):
         command = self.subst(command, self.__dict__)
-        with os.popen(command) as p:
-            output = p.read()
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
+        output = process.stdout.read()
+        process.stdout.close()
+        process.wait()
         if self.verbose:
             sys.stdout.write(output)
         # TODO: Figure out

--- a/src/script/scons-time.py
+++ b/src/script/scons-time.py
@@ -444,10 +444,14 @@ class SConsTimer(object):
 
     def log_execute(self, command, log):
         command = self.subst(command, self.__dict__)
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
-        output = process.stdout.read()
-        process.stdout.close()
-        process.wait()
+        p = os.popen(command)
+        output = p.read()
+        p.close()
+        #TODO: convert to subrocess, os.popen is obsolete. This didn't work:
+        #process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
+        #output = process.stdout.read()
+        #process.stdout.close()
+        #process.wait()
         if self.verbose:
             sys.stdout.write(output)
         # TODO: Figure out

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -191,7 +191,6 @@ except ImportError as e:
 
 import time
 import pickle
-import imp
 
 import SCons.SConsign
 
@@ -217,6 +216,8 @@ whichdb = my_whichdb
 #dbm.whichdb = my_whichdb
 
 def my_import(mname):
+    import imp
+
     if '.' in mname:
         i = mname.rfind('.')
         parent = my_import(mname[:i])

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -370,7 +370,7 @@ testprefix = 'testcmd.'
 if os.name in ('posix', 'nt'):
     testprefix += "%s." % str(os.getpid())
 
-re_space = re.compile('\s')
+re_space = re.compile(r'\s')
 
 
 def _caller(tblist, skip):

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -1578,15 +1578,15 @@ class read_TestCase(TestCmdTestCase):
         wdir_file4 = os.path.join(test.workdir, 'file4')
         wdir_file5 = os.path.join(test.workdir, 'file5')
 
-        with open(wdir_file1, 'wb'):
+        with open(wdir_file1, 'wb') as f:
             f.write("")
-        with open(wdir_file2, 'wb'):
+        with open(wdir_file2, 'wb') as f:
             f.write("Test\nfile\n#2.\n")
-        with open(wdir_foo_file3, 'wb'):
+        with open(wdir_foo_file3, 'wb') as f:
             f.write("Test\nfile\n#3.\n")
-        with open(wdir_file4, 'wb'):
+        with open(wdir_file4, 'wb') as f:
             f.write("Test\nfile\n#4.\n")
-        with open(wdir_file5, 'wb'):
+        with open(wdir_file5, 'wb') as f:
             f.write("Test\r\nfile\r\n#5.\r\n")
 
         try:
@@ -2816,17 +2816,17 @@ class symlink_TestCase(TestCmdTestCase):
         test.symlink('target1', 'file1')
         assert os.path.islink(wdir_file1)
         assert not os.path.exists(wdir_file1)
-        with open(wdir_target1, 'w'):
+        with open(wdir_target1, 'w') as f:
             f.write("")
         assert os.path.exists(wdir_file1)
 
         test.symlink('target2', ['foo', 'file2'])
         assert os.path.islink(wdir_foo_file2)
         assert not os.path.exists(wdir_foo_file2)
-        with open(wdir_target2, 'w'):
+        with open(wdir_target2, 'w') as f:
             f.write("")
         assert not os.path.exists(wdir_foo_file2)
-        with open(wdir_foo_target2, 'w'):
+        with open(wdir_foo_target2, 'w') as f:
             f.write("")
         assert os.path.exists(wdir_foo_file2)
 
@@ -2959,17 +2959,17 @@ class unlink_TestCase(TestCmdTestCase):
         wdir_foo_file4 = os.path.join(test.workdir, 'foo', 'file4')
         wdir_file5 = os.path.join(test.workdir, 'file5')
 
-        with open(wdir_file1, 'w'):
+        with open(wdir_file1, 'w') as f:
             f.write("")
-        with open(wdir_file2, 'w'):
+        with open(wdir_file2, 'w') as f:
             f.write("")
-        with open(wdir_foo_file3a, 'w'):
+        with open(wdir_foo_file3a, 'w') as f:
             f.write("")
-        with open(wdir_foo_file3b, 'w'):
+        with open(wdir_foo_file3b, 'w') as f:
             f.write("")
-        with open(wdir_foo_file4, 'w'):
+        with open(wdir_foo_file4, 'w') as f:
             f.write("")
-        with open(wdir_file5, 'w'):
+        with open(wdir_file5, 'w') as f:
             f.write("")
 
         try:
@@ -2999,7 +2999,7 @@ class unlink_TestCase(TestCmdTestCase):
         # For Windows, open the file.
         os.chmod(test.workdir, 0o500)
         os.chmod(wdir_file5, 0o400)
-        with open(wdir_file5, 'r') as f:
+        with open(wdir_file5, 'r'):
             try:
                 try:
                     test.unlink('file5')
@@ -3020,9 +3020,9 @@ class touch_TestCase(TestCmdTestCase):
         wdir_file1 = os.path.join(test.workdir, 'file1')
         wdir_sub_file2 = os.path.join(test.workdir, 'sub', 'file2')
 
-        with open(wdir_file1, 'w'):
+        with open(wdir_file1, 'w') as f:
             f.write("")
-        with open(wdir_sub_file2, 'w'):
+        with open(wdir_sub_file2, 'w') as f:
             f.write("")
 
         file1_old_time = os.path.getmtime(wdir_file1)

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -3332,7 +3332,7 @@ class write_TestCase(TestCmdTestCase):
         with open(test.workpath('file8'), 'r') as f:
             assert f.read() == "Test file #8.\n"
         with open(test.workpath('file9'), 'rb') as f:
-        assert f.read() == "Test file #9.\r\n"
+            assert f.read() == "Test file #9.\r\n"
 
 
 class variables_TestCase(TestCmdTestCase):

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -280,8 +280,10 @@ class chmod_TestCase(TestCmdTestCase):
         wdir_file1 = os.path.join(test.workdir, 'file1')
         wdir_sub_file2 = os.path.join(test.workdir, 'sub', 'file2')
 
-        open(wdir_file1, 'w').write("")
-        open(wdir_sub_file2, 'w').write("")
+        with open(wdir_file1, 'w') as f:
+            f.write("")
+        with open(wdir_sub_file2, 'w') as f:
+            f.write("")
 
         if sys.platform == 'win32':
 
@@ -1576,11 +1578,16 @@ class read_TestCase(TestCmdTestCase):
         wdir_file4 = os.path.join(test.workdir, 'file4')
         wdir_file5 = os.path.join(test.workdir, 'file5')
 
-        open(wdir_file1, 'wb').write("")
-        open(wdir_file2, 'wb').write("Test\nfile\n#2.\n")
-        open(wdir_foo_file3, 'wb').write("Test\nfile\n#3.\n")
-        open(wdir_file4, 'wb').write("Test\nfile\n#4.\n")
-        open(wdir_file5, 'wb').write("Test\r\nfile\r\n#5.\r\n")
+        with open(wdir_file1, 'wb'):
+            f.write("")
+        with open(wdir_file2, 'wb'):
+            f.write("Test\nfile\n#2.\n")
+        with open(wdir_foo_file3, 'wb'):
+            f.write("Test\nfile\n#3.\n")
+        with open(wdir_file4, 'wb'):
+            f.write("Test\nfile\n#4.\n")
+        with open(wdir_file5, 'wb'):
+            f.write("Test\r\nfile\r\n#5.\r\n")
 
         try:
             contents = test.read('no_file')
@@ -2343,16 +2350,15 @@ sys.stderr = Unbuffered(sys.stderr)
 
 sys.stdout.write('script_recv:  STDOUT\\n')
 sys.stderr.write('script_recv:  STDERR\\n')
-logfp = open(r'%s', 'wb')
-while 1:
-    line = sys.stdin.readline()
-    if not line:
-        break
-    logfp.write('script_recv:  ' + line)
-    sys.stdout.write('script_recv:  STDOUT:  ' + line)
-    sys.stderr.write('script_recv:  STDERR:  ' + line)
-logfp.close()
-        """ % t.recv_out_path
+with open(r'%s', 'wb') as logfp:
+    while 1:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        logfp.write('script_recv:  ' + line)
+        sys.stdout.write('script_recv:  STDOUT:  ' + line)
+        sys.stderr.write('script_recv:  STDERR:  ' + line)
+""" % t.recv_out_path
         t.run_env.write(t.recv_script_path, text)
         os.chmod(t.recv_script_path, 0o644)  # XXX UNIX-specific
         return t
@@ -2621,7 +2627,8 @@ script_recv:  STDERR:  input
             p.stdin.write(input)
             p.stdin.close()
             p.wait()
-            result = open(t.recv_out_path, 'rb').read()
+            with open(t.recv_out_path, 'rb') as f:
+                result = f.read()
             expect = 'script_recv:  ' + input
             assert result == expect, repr(result)
 
@@ -2630,7 +2637,8 @@ script_recv:  STDERR:  input
             p.send(input)
             p.stdin.close()
             p.wait()
-            result = open(t.recv_out_path, 'rb').read()
+            with open(t.recv_out_path, 'rb') as f:
+                result = f.read()
             expect = 'script_recv:  ' + input
             assert result == expect, repr(result)
 
@@ -2689,7 +2697,8 @@ script_recv:  STDERR:  input to the receive script
 """
             assert stdout == expect_stdout, stdout
             assert stderr == expect_stderr, stderr
-            result = open(t.recv_out_path, 'rb').read()
+            with open(t.recv_out_path, 'rb') as f:
+                result = f.read()
             expect = ('script_recv:  ' + input) * 2
             assert result == expect, (result, stdout, stderr)
 
@@ -2807,15 +2816,18 @@ class symlink_TestCase(TestCmdTestCase):
         test.symlink('target1', 'file1')
         assert os.path.islink(wdir_file1)
         assert not os.path.exists(wdir_file1)
-        open(wdir_target1, 'w').write("")
+        with open(wdir_target1, 'w'):
+            f.write("")
         assert os.path.exists(wdir_file1)
 
         test.symlink('target2', ['foo', 'file2'])
         assert os.path.islink(wdir_foo_file2)
         assert not os.path.exists(wdir_foo_file2)
-        open(wdir_target2, 'w').write("")
+        with open(wdir_target2, 'w'):
+            f.write("")
         assert not os.path.exists(wdir_foo_file2)
-        open(wdir_foo_target2, 'w').write("")
+        with open(wdir_foo_target2, 'w'):
+            f.write("")
         assert os.path.exists(wdir_foo_file2)
 
 
@@ -2947,12 +2959,18 @@ class unlink_TestCase(TestCmdTestCase):
         wdir_foo_file4 = os.path.join(test.workdir, 'foo', 'file4')
         wdir_file5 = os.path.join(test.workdir, 'file5')
 
-        open(wdir_file1, 'w').write("")
-        open(wdir_file2, 'w').write("")
-        open(wdir_foo_file3a, 'w').write("")
-        open(wdir_foo_file3b, 'w').write("")
-        open(wdir_foo_file4, 'w').write("")
-        open(wdir_file5, 'w').write("")
+        with open(wdir_file1, 'w'):
+            f.write("")
+        with open(wdir_file2, 'w'):
+            f.write("")
+        with open(wdir_foo_file3a, 'w'):
+            f.write("")
+        with open(wdir_foo_file3b, 'w'):
+            f.write("")
+        with open(wdir_foo_file4, 'w'):
+            f.write("")
+        with open(wdir_file5, 'w'):
+            f.write("")
 
         try:
             contents = test.unlink('no_file')
@@ -2981,20 +2999,17 @@ class unlink_TestCase(TestCmdTestCase):
         # For Windows, open the file.
         os.chmod(test.workdir, 0o500)
         os.chmod(wdir_file5, 0o400)
-        f = open(wdir_file5, 'r')
-
-        try:
+        with open(wdir_file5, 'r') as f:
             try:
-                test.unlink('file5')
-            except OSError: # expect "Permission denied"
-                pass
-            except:
-                raise
-        finally:
-            os.chmod(test.workdir, 0o700)
-            os.chmod(wdir_file5, 0o600)
-            f.close()
-
+                try:
+                    test.unlink('file5')
+                except OSError: # expect "Permission denied"
+                    pass
+                except:
+                    raise
+            finally:
+                os.chmod(test.workdir, 0o700)
+                os.chmod(wdir_file5, 0o600)
 
 
 class touch_TestCase(TestCmdTestCase):
@@ -3005,8 +3020,10 @@ class touch_TestCase(TestCmdTestCase):
         wdir_file1 = os.path.join(test.workdir, 'file1')
         wdir_sub_file2 = os.path.join(test.workdir, 'sub', 'file2')
 
-        open(wdir_file1, 'w').write("")
-        open(wdir_sub_file2, 'w').write("")
+        with open(wdir_file1, 'w'):
+            f.write("")
+        with open(wdir_sub_file2, 'w'):
+            f.write("")
 
         file1_old_time = os.path.getmtime(wdir_file1)
         file2_old_time = os.path.getmtime(wdir_sub_file2)
@@ -3312,9 +3329,10 @@ class write_TestCase(TestCmdTestCase):
         if os.name != "nt":
             assert not os.path.exists(test.workpath('file10'))
 
-        assert open(test.workpath('file8'), 'r').read() == "Test file #8.\n"
-        assert open(test.workpath('file9'), 'rb').read() == "Test file #9.\r\n"
-
+        with open(test.workpath('file8'), 'r') as f:
+            assert f.read() == "Test file #8.\n"
+        with open(test.workpath('file9'), 'rb') as f:
+        assert f.read() == "Test file #9.\r\n"
 
 
 class variables_TestCase(TestCmdTestCase):

--- a/testing/framework/TestRuntest.py
+++ b/testing/framework/TestRuntest.py
@@ -30,7 +30,7 @@ __all__.extend([ 'TestRuntest',
                  'pythonflags',
                ])
 
-if re.search('\s', python):
+if re.search(r'\s', python):
     pythonstring = _python_
 else:
     pythonstring = python

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -773,7 +773,7 @@ expected_vcprojfile_10_0 = """\
 \t\t<NMakeForcedUsingAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(NMakeForcedUsingAssemblies)</NMakeForcedUsingAssemblies>
 \t</PropertyGroup>
 \t<ItemGroup>
-\t\t<ClInclude Include="sdk_dir\sdk.h" />
+\t\t<ClInclude Include="sdk_dir\\sdk.h" />
 \t</ItemGroup>
 \t<ItemGroup>
 \t\t<ClInclude Include="test.h" />
@@ -838,7 +838,7 @@ expected_vcprojfile_11_0 = """\
 \t\t<NMakeForcedUsingAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(NMakeForcedUsingAssemblies)</NMakeForcedUsingAssemblies>
 \t</PropertyGroup>
 \t<ItemGroup>
-\t\t<ClInclude Include="sdk_dir\sdk.h" />
+\t\t<ClInclude Include="sdk_dir\\sdk.h" />
 \t</ItemGroup>
 \t<ItemGroup>
 \t\t<ClInclude Include="test.h" />
@@ -903,7 +903,7 @@ expected_vcprojfile_14_0 = """\
 \t\t<NMakeForcedUsingAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(NMakeForcedUsingAssemblies)</NMakeForcedUsingAssemblies>
 \t</PropertyGroup>
 \t<ItemGroup>
-\t\t<ClInclude Include="sdk_dir\sdk.h" />
+\t\t<ClInclude Include="sdk_dir\\sdk.h" />
 \t</ItemGroup>
 \t<ItemGroup>
 \t\t<ClInclude Include="test.h" />
@@ -968,7 +968,7 @@ expected_vcprojfile_14_1 = """\
 \t\t<NMakeForcedUsingAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(NMakeForcedUsingAssemblies)</NMakeForcedUsingAssemblies>
 \t</PropertyGroup>
 \t<ItemGroup>
-\t\t<ClInclude Include="sdk_dir\sdk.h" />
+\t\t<ClInclude Include="sdk_dir\\sdk.h" />
 \t</ItemGroup>
 \t<ItemGroup>
 \t\t<ClInclude Include="test.h" />
@@ -1045,7 +1045,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='10.0',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = ['sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']
@@ -1068,7 +1068,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='11.0',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = ['sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']
@@ -1091,7 +1091,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.0',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = ['sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']
@@ -1114,7 +1114,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.1',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = ['sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -272,7 +272,8 @@ class TestSCons_time(TestCommon):
             d, f = os.path.split(path)
             if not os.path.isdir(d):
                 os.makedirs(d)
-            open(path, 'w').write(content)
+            with open(path, 'w') as f:
+                f.write(content)
         return dir
 
     def write_sample_tarfile(self, archive, dir, files):


### PR DESCRIPTION
Several locations with simple usage of deprecated `imp` module changed to use `importlib`. These match with work in #3159, but this is not a complete implementation of #3159.

More regex patterns are changed to be raw strings.

Some strings which did not seem appropriate to change to raw strings (e.g. contain embedded tabs, which Python should honor) had backslashes escaped to avoid accidental Python interpretation.
Example:
  ` '\t<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />\n'`
Python 3.8 was Warning `\M` was an unknown escape.

More open().write(), open().read() style usage changed to use context managers so the file is closed.

With this PR, 720 tests now pass with 3.8, and Warning messages reduced to 2800 (current master has 200 pass, 9000 warns)

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
