### PR TITLE
Fix gh 3329 add mssdk V10.0A support

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -18,6 +18,7 @@ RELEASE 3.0.5.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
       Decider and not clearing it when the configure context is completed.
     - Add default paths for yacc tool on windows to include cygwin, mingw, and chocolatey
     - Fix issue #2799 - Fix mingw tool to respect SHCCCOMSTR, SHLINKCOMSTR and LDMODULECOMSTR
+    - Fix Issue #3329 - Add support for MS SDK V10.0A (which is commonly installed with VS2017)
 
   From Daniel Moody:
     - Change the default for AppendENVPath to delete_existing=0, so path

--- a/src/engine/SCons/Tool/MSCommon/sdk.py
+++ b/src/engine/SCons/Tool/MSCommon/sdk.py
@@ -178,6 +178,16 @@ SDK100VCSetupScripts =    {'x86'      : r'bin\vcvars32.bat',
 #
 # If you update this list, update the documentation in Tool/mssdk.xml.
 SupportedSDKList = [
+    WindowsSDK('10.0A',
+               sanity_check_file=r'bin\SetEnv.Cmd',
+               include_subdir='include',
+               lib_subdir={
+                   'x86'       : ['lib'],
+                   'x86_64'    : [r'lib\x64'],
+                   'ia64'      : [r'lib\ia64'],
+               },
+               vc_setup_scripts = SDK70VCSetupScripts,
+              ),
     WindowsSDK('10.0',
                sanity_check_file=r'bin\SetEnv.Cmd',
                include_subdir='include',

--- a/test/MSVC/mssdk.py
+++ b/test/MSVC/mssdk.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+from __future__ import print_function
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Simple test to make sure mssdk works.
+"""
+
+import time
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+test.verbose_set(1)
+
+test.skip_if_not_msvc()
+
+#####
+# Test the basics
+
+test.write('SConstruct',"""
+import os
+DefaultEnvironment(tools=[])
+# TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
+# and ideally we shouldn't need to specify the tools= list anyway.
+env = Environment(tools=['mssdk', 'msvc', 'mslink'])
+env.Tool('mssdk')
+
+""")
+
+
+#  Visual Studio 8 has deprecated the /Yd option and prints warnings
+#  about it, so ignore stderr when running SCons.
+test.run(stderr=None, stdout=None)
+
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
A recent update to VS2017 bumped the SDK version included from V10.0 to V10.0A. Adding support for that.

This fixes issue #3329 


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
