### PR TITLE
Fix Issue #3333 - Find vswhere under 32 bit windows installs

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -19,6 +19,7 @@ RELEASE 3.0.5.alpha.yyyymmdd - NEW DATE WILL BE INSERTED HERE
     - Add default paths for yacc tool on windows to include cygwin, mingw, and chocolatey
     - Fix issue #2799 - Fix mingw tool to respect SHCCCOMSTR, SHLINKCOMSTR and LDMODULECOMSTR
     - Fix Issue #3329 - Add support for MS SDK V10.0A (which is commonly installed with VS2017)
+    - Fix Issue #3333 - Add support for finding vswhere under 32 bit windows installs.
 
   From Daniel Moody:
     - Change the default for AppendENVPath to delete_existing=0, so path

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -286,13 +286,21 @@ def find_vc_pdir_vswhere(msvc_version):
     :param msvc_version:
     :return: MSVC install dir or None
     """
-    vswhere_path = os.path.join(
-        'C:\\',
-        'Program Files (x86)',
-        'Microsoft Visual Studio',
-        'Installer',
-        'vswhere.exe'
-    )
+
+    # For bug 3333 - support default location of vswhere for both 64 and 32 bit windows
+    # installs. 
+    for pf in ['Program Files (x86)', 'Program Files']:
+        vswhere_path = os.path.join(
+            'C:\\',
+            pf,
+            'Microsoft Visual Studio',
+            'Installer',
+            'vswhere.exe'
+        )
+        if os.path.exists(vswhere_path):
+            # If we found vswhere, then use it.
+            break
+
     vswhere_cmd = [vswhere_path, '-products', '*', '-version', msvc_version, '-property', 'installationPath']
 
     if os.path.exists(vswhere_path):


### PR DESCRIPTION
Fix Issue #3333 - Find vswhere under 32 bit windows installs
Under 32 bit windows vswhere is under c:\Program Files\ and for 64 bit it's under c:\Program Files (x86).

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
