### PR TITLE
[#3336] do not add not-found tool paths

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -13,6 +13,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Use importlib to dynamically load tool and platform modules instead of imp module
     - sconsign: default to .sconsign.dblite if no filename is specified.
       Be more informative in case of unsupported pickle protocol (py2 only).
+    - Fix issue #3336 - on Windows, paths were being added to PATH even if
+      tools were not found in those paths.
 
   From John Doe:
 

--- a/src/engine/SCons/Tool/ToolTests.py
+++ b/src/engine/SCons/Tool/ToolTests.py
@@ -31,7 +31,6 @@ import TestUnit
 
 import SCons.Errors
 import SCons.Tool
-from SCons.Environment import Environment
 
 
 class DummyEnvironment(object):
@@ -113,7 +112,7 @@ class ToolTestCase(unittest.TestCase):
         env['ENV'] = {}
         env['ENV']['PATH'] = '/usr/local/bin:/opt/bin:/bin:/usr/bin'
         pre_path = env['ENV']['PATH']
-        tool = SCons.Tool.find_program_path(env, 'no_tool', default_paths=PHONY_PATHS)
+        _ = SCons.Tool.find_program_path(env, 'no_tool', default_paths=PHONY_PATHS)
         assert env['ENV']['PATH'] == pre_path, env['ENV']['PATH']
 
 

--- a/src/engine/SCons/Tool/ToolTests.py
+++ b/src/engine/SCons/Tool/ToolTests.py
@@ -30,11 +30,14 @@ import TestUnit
 
 import SCons.Errors
 import SCons.Tool
+from SCons.Environment import Environment
+
 
 class ToolTestCase(unittest.TestCase):
     def test_Tool(self):
         """Test the Tool() function"""
-        class Environment(object):
+
+        class DummyEnvironment(object):
             def __init__(self):
                 self.dict = {}
             def Detect(self, progs):
@@ -53,7 +56,8 @@ class ToolTestCase(unittest.TestCase):
                 return key in self.dict
             def subst(self, string, *args, **kwargs):
                 return string
-        env = Environment()
+
+        env = DummyEnvironment()
         env['BUILDERS'] = {}
         env['ENV'] = {}
         env['PLATFORM'] = 'test'
@@ -76,6 +80,23 @@ class ToolTestCase(unittest.TestCase):
             pass
         else:   # TODO pylint E0704: bare raise not inside except
             raise
+
+
+    def test_pathfind(self):
+        """Test that find_program_path() does not alter PATH"""
+
+        PHONY_PATHS = [
+            r'C:\cygwin64\bin',
+            r'C:\cygwin\bin',
+            '/usr/local/dummy/bin',
+        ]
+
+        # Note this test cannot use the dummy environment,
+        # as function being tested calls env.WhereIs()
+        env = Environment()
+        pre_path = env['ENV']['PATH']
+        tool = SCons.Tool.find_program_path(env, 'no_tool', default_paths=PHONY_PATHS)
+        assert env['ENV']['PATH'] == pre_path, env['ENV']['PATH']
 
 
 if __name__ == "__main__":

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -1318,28 +1318,31 @@ def tool_list(platform, env):
 
 def find_program_path(env, key_program, default_paths=[]):
     """
-    Find the location of key_program and then return the path it was located at.
-    Checking the default install locations.
-    Mainly for windows where tools aren't all installed in /usr/bin,etc
-    :param env: Current Environment()
-    :param key_program: Program we're using to locate the directory to add to PATH.
+    Find the location of a tool using various means.
+
+    Mainly for windows where tools aren't all installed in /usr/bin, etc.
+
+    :param env: Current Construction Environment.
+    :param key_program: Tool to locate.
+    :param default_paths: List of additional paths this tool might be found in.
     """
     # First search in the SCons path
     path = env.WhereIs(key_program)
-    if (path):
-        return path
-    # then the OS path:
-    path = SCons.Util.WhereIs(key_program)
-    if (path):
+    if path:
         return path
 
-    # If that doesn't work try default location for mingw
+    # Then in the OS path
+    path = SCons.Util.WhereIs(key_program)
+    if path:
+        return path
+
+    # Finally, add the defaults and check again. Do not change
+    # ['ENV']['PATH'] permananetly, the caller can do that if needed.
     save_path = env['ENV']['PATH']
     for p in default_paths:
         env.AppendENVPath('PATH', p)
     path = env.WhereIs(key_program)
-    if not path:
-        env['ENV']['PATH'] = save_path
+    env['ENV']['PATH'] = save_path
     return path
 
 # Local Variables:

--- a/src/engine/SCons/Tool/lex.py
+++ b/src/engine/SCons/Tool/lex.py
@@ -45,6 +45,11 @@ from SCons.Platform.win32 import CHOCO_DEFAULT_PATH
 
 LexAction = SCons.Action.Action("$LEXCOM", "$LEXCOMSTR")
 
+if sys.platform == 'win32':
+    BINS = ['flex', 'lex', 'win_flex']
+else:
+    BINS = ["flex", "lex"]
+
 def lexEmitter(target, source, env):
     sourceBase, sourceExt = os.path.splitext(SCons.Util.to_String(source[0]))
 
@@ -79,12 +84,10 @@ def get_lex_path(env, append_paths=False):
     :param append_paths: if set, add the path to the tool to PATH
     :return: path to lex tool, if found
     """
-    bins = ['flex', 'lex', 'win_flex']
-
-    for prog in bins:
+    for prog in BINS:
         bin_path = SCons.Tool.find_program_path(
-            env, 
-            prog, 
+            env,
+            prog,
             default_paths=CHOCO_DEFAULT_PATH + MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
         if bin_path:
             if append_paths:
@@ -117,19 +120,19 @@ def generate(env):
     if sys.platform == 'win32':
         # ignore the return - we do not need the full path here
         _ = get_lex_path(env, append_paths=True)
-        env["LEX"] = env.Detect(['flex', 'lex', 'win_flex'])
+        env["LEX"] = env.Detect(BINS)
         if not env.get("LEXUNISTD"):
             env["LEXUNISTD"] = SCons.Util.CLVar("")
         env["LEXCOM"] = "$LEX $LEXUNISTD $LEXFLAGS -t $SOURCES > $TARGET"
     else:
-        env["LEX"] = env.Detect(["flex", "lex"])
+        env["LEX"] = env.Detect(BINS)
         env["LEXCOM"] = "$LEX $LEXFLAGS -t $SOURCES > $TARGET"
 
 def exists(env):
     if sys.platform == 'win32':
         return get_lex_path(env)
     else:
-        return env.Detect(["flex", "lex"])
+        return env.Detect(BINS)
 
 # Local Variables:
 # tab-width:4

--- a/src/engine/SCons/Tool/lex.py
+++ b/src/engine/SCons/Tool/lex.py
@@ -70,11 +70,15 @@ def lexEmitter(target, source, env):
 
 def get_lex_path(env, append_paths=False):
     """
-    Find the a path containing the lex or flex binaries. If a construction 
-    environment is passed in then append the path to the ENV PATH.
+    Find the path to the lex tool, searching several possible names
+
+    Only called in the Windows case, so the default_path
+    can be Windows-specific
+
+    :param env: current construction environment
+    :param append_paths: if set, add the path to the tool to PATH
+    :return: path to lex tool, if found
     """
-    # save existing path to reset if we don't want to append any paths
-    envPath = env['ENV']['PATH']
     bins = ['flex', 'lex', 'win_flex']
 
     for prog in bins:
@@ -83,9 +87,7 @@ def get_lex_path(env, append_paths=False):
             prog, 
             default_paths=CHOCO_DEFAULT_PATH + MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
         if bin_path:
-            if not append_paths:
-                env['ENV']['PATH'] = envPath
-            else:
+            if append_paths:
                 env.AppendENVPath('PATH', os.path.dirname(bin_path))
             return bin_path
     SCons.Warnings.Warning('lex tool requested, but lex or flex binary not found in ENV PATH')
@@ -113,7 +115,8 @@ def generate(env):
     env["LEXFLAGS"] = SCons.Util.CLVar("")
 
     if sys.platform == 'win32':
-        get_lex_path(env, append_paths=True)
+        # ignore the return - we do not need the full path here
+        _ = get_lex_path(env, append_paths=True)
         env["LEX"] = env.Detect(['flex', 'lex', 'win_flex'])
         if not env.get("LEXUNISTD"):
             env["LEXUNISTD"] = SCons.Util.CLVar("")

--- a/src/engine/SCons/Tool/swig.py
+++ b/src/engine/SCons/Tool/swig.py
@@ -184,9 +184,10 @@ def generate(env):
 
     from SCons.Platform.mingw import MINGW_DEFAULT_PATHS
     from SCons.Platform.cygwin import CYGWIN_DEFAULT_PATHS
+    from SCons.Platform.win32 import CHOCO_DEFAULT_PATH
 
     if sys.platform == 'win32':
-        swig = SCons.Tool.find_program_path(env, 'swig', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS + [r'C:\ProgramData\chocolatey\bin'] )
+        swig = SCons.Tool.find_program_path(env, 'swig', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS + CHOCO_DEFAULT_PATH)
         if swig:
             swig_bin_dir = os.path.dirname(swig)
             env.AppendENVPath('PATH', swig_bin_dir)

--- a/test/LEX/live_mingw.py
+++ b/test/LEX/live_mingw.py
@@ -41,7 +41,7 @@ if sys.platform != 'win32':
     test.skip_test('Not windows environment; skipping test.\n')
 
 if not test.where_is('gcc'):
-        test.skip_test('No mingw or cygwin on windows; skipping test.\n')
+        test.skip_test('No mingw or cygwin build environment found; skipping test.\n')
 
 lex = test.where_is('lex') or test.where_is('flex')
 


### PR DESCRIPTION
Resolve Issue #3336 

When tool modules initialize, they check paths to decide if the underlying tool is actually present.  The current checker adds any "default paths" the caller may have supplied (locations like mingw, cygwin, chocolatey install locations, etc.); if there is match from this list, any previous default paths are also kept. To avoid keeping these non-matching paths, restore the original PATH; the caller is responsible for adding to PATH if necessary. Docstring now says so.

Note lex and yacc tool modules expected the path-modifying behavior that's being gotten rid of - so they preseve the path first and restore it after.  That has been rolled back out.

The `swig.py` change is not functional, it just aligns the usage with what is introduced elsewhere.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
