### PR TITLE
Tweaks to packaging tests: avoid default tool list

### DIFF
--- a/test/packaging/multiple-subdirs.py
+++ b/test/packaging/multiple-subdirs.py
@@ -42,7 +42,7 @@ if not tar:
 test.subdir('one', 'two', 'three')
 
 test.write('SConstruct', """\
-env = Environment(tools=['default', 'packaging'])
+env = Environment(tools=['packaging', 'filesystem', 'tar'])
 Export('env')
 SConscript(dirs = ['one', 'two', 'three'])
 """)

--- a/test/packaging/option--package-type.py
+++ b/test/packaging/option--package-type.py
@@ -53,7 +53,7 @@ test.write( 'main', '' )
 
 test.write('SConstruct', """
 # -*- coding: iso-8859-15 -*-
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'tar', 'rpm'])
 env.Prepend(RPM = 'TAR_OPTIONS=--wildcards ')
 env.Append(RPMFLAGS = r' --buildroot %(rpm_build_root)s')
 prog=env.Install( '/bin', 'main' )

--- a/test/packaging/place-files-in-subdirectory.py
+++ b/test/packaging/place-files-in-subdirectory.py
@@ -48,7 +48,7 @@ test.subdir('src')
 test.write('src/main.c', '')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'packaging'])
+env = Environment(tools=['packaging', 'filesystem', 'zip'])
 env.Package( NAME        = 'libfoo',
              PACKAGEROOT = 'libfoo',
              PACKAGETYPE = 'src_zip',
@@ -70,7 +70,7 @@ test.subdir('src')
 test.write('src/main.c', '')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'packaging'])
+env = Environment(tools=['packaging', 'filesystem', 'zip'])
 env.Package( NAME        = 'libfoo',
              VERSION     = '1.2.3',
              PACKAGETYPE = 'src_zip',
@@ -93,7 +93,7 @@ test.subdir('temp')
 test.write('src/main.c', '')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'packaging'])
+env = Environment(tools=['packaging', 'filesystem', 'tar'])
 env.Package( NAME        = 'libfoo',
              VERSION     = '1.2.3',
              PACKAGETYPE = 'src_targz',

--- a/test/packaging/strip-install-dir.py
+++ b/test/packaging/strip-install-dir.py
@@ -43,7 +43,7 @@ if not tar:
 test.write( 'main.c', '' )
 test.write('SConstruct', """
 prog = Install( '/bin', 'main.c' )
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'tar'])
 env.Package( NAME    = 'foo',
              VERSION = '1.2.3',
              source  = [ prog ],

--- a/test/packaging/tar/bz2_packaging.py
+++ b/test/packaging/tar/bz2_packaging.py
@@ -54,7 +54,7 @@ int main( int argc, char* argv[] )
 
 test.write('SConstruct', """
 Program( 'src/main.c' )
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'tar'])
 env.Package( PACKAGETYPE  = 'src_tarbz2',
              target       = 'src.tar.bz2',
              PACKAGEROOT  = 'test',

--- a/test/packaging/tar/gz.py
+++ b/test/packaging/tar/gz.py
@@ -50,7 +50,7 @@ int main( int argc, char* argv[] )
 
 test.write('SConstruct', """
 Program( 'src/main.c' )
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'tar'])
 env.Package( PACKAGETYPE  = 'src_targz',
              target       = 'src.tar.gz',
              PACKAGEROOT  = 'test',

--- a/test/packaging/tar/xz_packaging.py
+++ b/test/packaging/tar/xz_packaging.py
@@ -54,7 +54,7 @@ int main( int argc, char* argv[] )
 
 test.write('SConstruct', """
 Program( 'src/main.c' )
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'tar'])
 env.Package( PACKAGETYPE  = 'src_tarxz',
              target       = 'src.tar.xz',
              PACKAGEROOT  = 'test',

--- a/test/packaging/use-builddir.py
+++ b/test/packaging/use-builddir.py
@@ -50,7 +50,7 @@ test.write('src/main.c', '')
 
 test.write('SConstruct', """
 VariantDir('build', 'src')
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'zip'])
 env.Package( NAME        = 'libfoo',
              PACKAGEROOT = 'build/libfoo',
              VERSION     = '1.2.3',
@@ -74,7 +74,7 @@ test.write('src/main.c', '')
 
 test.write('SConstruct', """
 VariantDir('build', 'src')
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'tar'])
 env.Package( NAME        = 'libfoo',
              VERSION     = '1.2.3',
              PAKCAGETYPE = 'src_targz',

--- a/test/packaging/zip.py
+++ b/test/packaging/zip.py
@@ -51,7 +51,7 @@ int main( int argc, char* argv[] )
 
 test.write('SConstruct', """
 Program( 'src/main.c' )
-env=Environment(tools=['default', 'packaging'])
+env=Environment(tools=['packaging', 'filesystem', 'zip'])
 env.Package( PACKAGETYPE  = 'src_zip',
              target       = 'src.zip',
              PACKAGEROOT  = 'test',


### PR DESCRIPTION
In test setup, don't include "defaults" in the tool list. Test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
