### PR TITLE
[wip] Py38warns4 tests

### DIFF
--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -178,22 +178,21 @@ def isSConsXml(fpath):
         contains the default target namespace definition.
     """
     try:
-        f = open(fpath,'r')
-        content = f.read()
-        f.close()
+        with open(fpath,'r') as f:
+            content = f.read()
         if content.find('xmlns="%s"' % dbxsd) >= 0:
             return True
     except:
         pass
-    
-    return False 
+
+    return False
 
 def remove_entities(content):
     # Cut out entity inclusions
     content = re_entity_header.sub("", content, re.M)
     # Cut out entities themselves
     content = re_entity.sub(lambda match: match.group(1), content)
-    
+
     return content
 
 default_xsd = os.path.join('doc','xsd','scons.xsd')
@@ -201,11 +200,11 @@ default_xsd = os.path.join('doc','xsd','scons.xsd')
 ARG = "dbscons"
 
 class Libxml2ValidityHandler:
-    
+
     def __init__(self):
         self.errors = []
         self.warnings = []
-        
+
     def error(self, msg, data):
         if data != ARG:
             raise Exception("Error handler did not receive correct argument")
@@ -221,14 +220,14 @@ class DoctypeEntity:
     def __init__(self, name_, uri_):
         self.name = name_
         self.uri = uri_
-        
+
     def getEntityString(self):
         txt = """    <!ENTITY %(perc)s %(name)s SYSTEM "%(uri)s">
     %(perc)s%(name)s;
 """ % {'perc' : perc, 'name' : self.name, 'uri' : self.uri}
 
         return txt
-        
+
 class DoctypeDeclaration:
     def __init__(self, name_=None):
         self.name = name_
@@ -241,23 +240,23 @@ class DoctypeDeclaration:
             self.addEntity("functions-mod", "functions.mod")
             self.addEntity("tools-mod", "tools.mod")
             self.addEntity("variables-mod", "variables.mod")
-        
+
     def addEntity(self, name, uri):
         self.entries.append(DoctypeEntity(name, uri))
-        
+
     def createDoctype(self):
         content = '<!DOCTYPE %s [\n' % self.name
         for e in self.entries:
             content += e.getEntityString()
         content += ']>\n'
-        
+
         return content
 
 if not has_libxml2:
     class TreeFactory:
         def __init__(self):
             pass
-        
+
         def newNode(self, tag):
             return etree.Element(tag)
 
@@ -268,22 +267,22 @@ if not has_libxml2:
                 return etree.Element(tag, nsmap=NSMAP)
 
             return etree.Element(tag)
-        
+
         def copyNode(self, node):
             return copy.deepcopy(node)
-        
+
         def appendNode(self, parent, child):
             parent.append(child)
 
         def hasAttribute(self, node, att):
             return att in node.attrib
-        
+
         def getAttribute(self, node, att):
             return node.attrib[att]
-        
+
         def setAttribute(self, node, att, value):
             node.attrib[att] = value
-            
+
         def getText(self, root):
             return root.text
 
@@ -292,30 +291,27 @@ if not has_libxml2:
 
         def writeGenTree(self, root, fp):
             dt = DoctypeDeclaration()
-            fp.write(etree.tostring(root, xml_declaration=True, 
-                                    encoding="UTF-8", pretty_print=True, 
+            fp.write(etree.tostring(root, xml_declaration=True,
+                                    encoding="UTF-8", pretty_print=True,
                                     doctype=dt.createDoctype()))
 
         def writeTree(self, root, fpath):
-            fp = open(fpath, 'w')
-            fp.write(etree.tostring(root, xml_declaration=True, 
-                                    encoding="UTF-8", pretty_print=True))            
-            fp.close()
+            with open(fpath, 'w') as fp:
+                fp.write(etree.tostring(root, xml_declaration=True,
+                                        encoding="UTF-8", pretty_print=True))
 
         def prettyPrintFile(self, fpath):
-            fin = open(fpath,'r')
-            tree = etree.parse(fin)
-            pretty_content = etree.tostring(tree, pretty_print=True)
-            fin.close()
-    
-            fout = open(fpath,'w')
-            fout.write(pretty_content)
-            fout.close()
+            with open(fpath,'r') as fin:
+                tree = etree.parse(fin)
+                pretty_content = etree.tostring(tree, pretty_print=True)
+
+            with open(fpath,'w') as fout:
+                fout.write(pretty_content)
 
         def decorateWithHeader(self, root):
             root.attrib["{"+xsi+"}schemaLocation"] = "%s %s/scons.xsd" % (dbxsd, dbxsd)
             return root
-            
+
         def newXmlTree(self, root):
             """ Return a XML file tree with the correct namespaces set,
                 the element root as top entry and the given header comment.
@@ -324,7 +320,7 @@ if not has_libxml2:
                      'xsi' : xsi}
             t = etree.Element(root, nsmap=NSMAP)
             return self.decorateWithHeader(t)
-        
+
         def validateXml(self, fpath, xmlschema_context):
             # Use lxml
             xmlschema = etree.XMLSchema(xmlschema_context)
@@ -361,21 +357,21 @@ if not has_libxml2:
                 current XML toolkit.
             """
             return [root]
-        
-else:        
+
+else:
     class TreeFactory:
         def __init__(self):
             pass
-        
+
         def newNode(self, tag):
             return libxml2.newNode(tag)
 
         def newEtreeNode(self, tag, init_ns=False):
             return etree.Element(tag)
-        
+
         def copyNode(self, node):
             return node.copyNode(1)
-        
+
         def appendNode(self, parent, child):
             if hasattr(parent, 'addChild'):
                 parent.addChild(child)
@@ -386,7 +382,7 @@ else:
             if hasattr(node, 'hasProp'):
                 return node.hasProp(att)
             return att in node.attrib
-        
+
         def getAttribute(self, node, att):
             if hasattr(node, 'prop'):
                 return node.prop(att)
@@ -397,7 +393,7 @@ else:
                 node.setProp(att, value)
             else:
                 node.attrib[att] = value
-                
+
         def getText(self, root):
             if hasattr(root, 'getContent'):
                 return root.getContent()
@@ -425,20 +421,18 @@ else:
             doc.freeDoc()
 
         def writeTree(self, root, fpath):
-            fp = open(fpath, 'w')
-            doc = libxml2.newDoc('1.0')
-            doc.setRootElement(root)
-            fp.write(doc.serialize("UTF-8", 1))
-            doc.freeDoc()
-            fp.close()
+            with open(fpath, 'w') as fp:
+                doc = libxml2.newDoc('1.0')
+                doc.setRootElement(root)
+                fp.write(doc.serialize("UTF-8", 1))
+                doc.freeDoc()
 
         def prettyPrintFile(self, fpath):
             # Read file and resolve entities
             doc = libxml2.readFile(fpath, None, libxml2d.XML_PARSE_NOENT)
-            fp = open(fpath, 'w')
-            # Prettyprint
-            fp.write(doc.serialize("UTF-8", 1))
-            fp.close()
+            with open(fpath, 'w') as fp:
+                # Prettyprint
+                fp.write(doc.serialize("UTF-8", 1))
             # Cleanup
             doc.freeDoc()
 
@@ -447,9 +441,9 @@ else:
             ns = root.newNs(dbxsd, None)
             xi = root.newNs(xsi, 'xsi')
             root.setNs(ns)  #put this node in the target namespace
-    
+
             root.setNsProp(xi, 'schemaLocation', "%s %s/scons.xsd" % (dbxsd, dbxsd))
-        
+
             return root
 
         def newXmlTree(self, root):
@@ -461,7 +455,7 @@ else:
 
         def validateXml(self, fpath, xmlschema_context):
             retval = True
-        
+
             # Create validation context
             validation_context = xmlschema_context.schemaNewValidCtxt()
             # Set error/warning handlers
@@ -471,18 +465,18 @@ else:
             doc = libxml2.readFile(fpath, None, libxml2.XML_PARSE_NOENT)
             doc.xincludeProcessFlags(libxml2.XML_PARSE_NOENT)
             err = validation_context.schemaValidateDoc(doc)
-        
+
             if err or eh.errors:
                 for e in eh.errors:
                     print(e.rstrip("\n"))
                 # import pdb; pdb.set_trace()
                 print("%s fails to validate" % fpath)
                 retval = False
-                
+
             # Cleanup
             doc.freeDoc()
             del validation_context
-    
+
             return retval
 
         def findAll(self, root, tag, ns=None, xpath_context=None, nsmap=None):
@@ -506,7 +500,7 @@ else:
                 expression = "./%s/node()" % tag
                 if ns:
                     expression = "./%s:%s/node()" % (ns, tag)
-                
+
                 return xpath_context.xpathEval(expression)
             else:
                 expression = "./{%s}%s/node()" % (nsmap[ns], tag)
@@ -536,7 +530,7 @@ else:
             if child.tail:
                 tail = libxml2.newText(child.tail)
                 elements.append(tail)
-                
+
             return elements
 
         def convertElementTree(self, root):
@@ -562,7 +556,7 @@ else:
             if root.tail:
                 tail = libxml2.newText(root.tail)
                 elements.append(tail)
-                
+
             return elements
 
 tf = TreeFactory()
@@ -603,7 +597,7 @@ class SConsDocTree:
             # Register namespaces
             for key, val in self.nsmap.items():
                 self.xpath_context.xpathRegisterNs(key, val)
-            
+
     def __del__(self):
         if self.doc is not None:
             self.doc.freeDoc()
@@ -622,7 +616,7 @@ def validate_all_xml(dpaths, xsdfile=default_xsd):
         ctxt = libxml2.schemaNewParserCtxt(xsdfile)
         xmlschema_context = ctxt.schemaParse()
         del ctxt
-    
+
     fpaths = []
     for dp in dpaths:
         if dp.endswith('.xml') and isSConsXml(dp):
@@ -635,13 +629,13 @@ def validate_all_xml(dpaths, xsdfile=default_xsd):
                         fp = os.path.join(path, f)
                         if isSConsXml(fp):
                             fpaths.append(fp)
-                
+
     fails = []
     for idx, fp in enumerate(fpaths):
         fpath = os.path.join(path, fp)
         print("%.2f%s (%d/%d) %s" % (float(idx+1)*100.0/float(len(fpaths)),
                                      perc, idx+1, len(fpaths),fp))
-                                              
+
         if not tf.validateXml(fp, xmlschema_context):
             fails.append(fp)
             continue
@@ -652,7 +646,7 @@ def validate_all_xml(dpaths, xsdfile=default_xsd):
 
     if fails:
         return False
-    
+
     return True
 
 class Item(object):
@@ -733,10 +727,10 @@ class SConsDocHandler(object):
             uses.extend(self.parseItems(u, xpath_context, nsmap))
         for s in tf.findAll(domelem, "sets", dbxid, xpath_context, nsmap):
             sets.extend(self.parseItems(s, xpath_context, nsmap))
-        
+
         return sorted(uses), sorted(sets)
 
-    def parseInstance(self, domelem, map, Class, 
+    def parseInstance(self, domelem, map, Class,
                         xpath_context, nsmap, include_entities=True):
         name = 'unknown'
         if tf.hasAttribute(domelem, 'name'):
@@ -760,24 +754,24 @@ class SConsDocHandler(object):
                     instance.arguments = []
                 instance.arguments.append(tf.copyNode(a))
 
-    def parseDomtree(self, root, xpath_context=None, nsmap=None, include_entities=True):    
+    def parseDomtree(self, root, xpath_context=None, nsmap=None, include_entities=True):
         # Process Builders
         for b in tf.findAll(root, "builder", dbxid, xpath_context, nsmap):
-            self.parseInstance(b, self.builders, Builder, 
+            self.parseInstance(b, self.builders, Builder,
                                xpath_context, nsmap, include_entities)
         # Process Functions
         for f in tf.findAll(root, "scons_function", dbxid, xpath_context, nsmap):
-            self.parseInstance(f, self.functions, Function, 
+            self.parseInstance(f, self.functions, Function,
                                xpath_context, nsmap, include_entities)
         # Process Tools
         for t in tf.findAll(root, "tool", dbxid, xpath_context, nsmap):
-            self.parseInstance(t, self.tools, Tool, 
+            self.parseInstance(t, self.tools, Tool,
                                xpath_context, nsmap, include_entities)
         # Process CVars
         for c in tf.findAll(root, "cvar", dbxid, xpath_context, nsmap):
-            self.parseInstance(c, self.cvars, ConstructionVariable, 
+            self.parseInstance(c, self.cvars, ConstructionVariable,
                                xpath_context, nsmap, include_entities)
-        
+
     def parseContent(self, content, include_entities=True):
         """ Parses the given content as XML file. This method
             is used when we generate the basic lists of entities
@@ -798,28 +792,26 @@ class SConsDocHandler(object):
         t.parseXmlFile(fpath)
         # Parse it
         self.parseDomtree(t.root, t.xpath_context, t.nsmap)
-        
+
 # lifted from Ka-Ping Yee's way cool pydoc module.
 if sys.version_info[0] == 2:
     def importfile(path):
         """Import a Python source file or compiled file given its path."""
         import imp
         magic = imp.get_magic()
-        file = open(path, 'r')
-        if file.read(len(magic)) == magic:
-            kind = imp.PY_COMPILED
-        else:
-            kind = imp.PY_SOURCE
-        file.close()
+        with open(path, 'r') as ifp:
+            if ifp.read(len(magic)) == magic:
+                kind = imp.PY_COMPILED
+            else:
+                kind = imp.PY_SOURCE
         filename = os.path.basename(path)
         name, ext = os.path.splitext(filename)
-        file = open(path, 'r')
-        try:
-            module = imp.load_module(name, file, path, (ext, 'r', kind))
-        except ImportError as e:
-            sys.stderr.write("Could not import %s: %s\n" % (path, e))
-            return None
-        file.close()
+        with open(path, 'r') as ifp:
+            try:
+                module = imp.load_module(name, ifp, path, (ext, 'r', kind))
+            except ImportError as e:
+                sys.stderr.write("Could not import %s: %s\n" % (path, e))
+                return None
         return module
 
 else:  # PY3 version, from newer pydoc
@@ -828,8 +820,8 @@ else:  # PY3 version, from newer pydoc
         import importlib
         from pydoc import ErrorDuringImport
         magic = importlib.util.MAGIC_NUMBER
-        with open(path, 'rb') as file:
-            is_bytecode = magic == file.read(len(magic))
+        with open(path, 'rb') as ifp:
+            is_bytecode = magic == ifp.read(len(magic))
         filename = os.path.basename(path)
         name, ext = os.path.splitext(filename)
         if is_bytecode:

--- a/site_scons/soe_utils.py
+++ b/site_scons/soe_utils.py
@@ -17,16 +17,14 @@ def soelim(target, source, env):
     t = str(target[0])
     s = str(source[0])
     dir, f = os.path.split(s)
-    tfp = open(t, 'w')
-    sfp = open(s, 'r')
-    for line in sfp.readlines():
-        if line[:4] in ['.so ', "'so "]:
-            sofile = os.path.join(dir, line[4:-1])
-            tfp.write(open(sofile, 'r').read())
-        else:
-            tfp.write(line)
-    sfp.close()
-    tfp.close()
+    with open(t, 'w') as tfp, open(s, 'r') as sfp:
+        for line in sfp.readlines():
+            if line[:4] in ['.so ', "'so "]:
+                sofile = os.path.join(dir, line[4:-1])
+                with open(sofile, 'r') as f:
+                    tfp.write(f.read())
+            else:
+                tfp.write(line)
 
 def soscan(node, env, path):
     c = node.get_text_contents()

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -211,7 +211,7 @@ def _object_contents(obj):
 
 
 def _code_contents(code, docstring=None):
-    """Return the signature contents of a code object.
+    r"""Return the signature contents of a code object.
 
     By providing direct access to the code object of the
     function, Python makes this extremely easy.  Hooray!

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -784,10 +784,7 @@ def _subproc(scons_env, cmd, error = 'ignore', **kw):
             if DEVNULL:
                 kw[stream] = DEVNULL
             else:
-                if sys.platform == 'win32':
-                    kw[stream] = msvcrt.get_osfhandle(os.open(os.devnull, os.O_RDWR))
-                else:
-                    kw[stream] = open(os.devnull, "r+")
+                kw[stream] = open(os.devnull, "r+")
 
     # Figure out what shell environment to use
     ENV = kw.get('env', None)

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -785,7 +785,7 @@ def _subproc(scons_env, cmd, error = 'ignore', **kw):
                 kw[stream] = DEVNULL
             else:
                 if sys.platform == 'win32':
-                    kw[stream] = msvcrt.get_osfhandle(open(os.devnull, "r+"))
+                    kw[stream] = msvcrt.get_osfhandle(os.open(os.devnull, os.O_RDWR))
                 else:
                     kw[stream] = open(os.devnull, "r+")
 

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -108,8 +108,6 @@ import subprocess
 import itertools
 import inspect
 from collections import OrderedDict
-if sys.platform == 'win32':
-    import msvcrt
 
 import SCons.Debug
 from SCons.Debug import logInstanceCreation

--- a/src/engine/SCons/ActionTests.py
+++ b/src/engine/SCons/ActionTests.py
@@ -1529,6 +1529,7 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
             (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         meth_matches = [
@@ -1707,6 +1708,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
 
         }
 
@@ -1715,6 +1717,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 5): bytearray(b'1, 1, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 8): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         def factory(act, **kw):
@@ -1959,6 +1962,7 @@ class LazyActionTestCase(unittest.TestCase):
             (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         meth_matches = [
@@ -2017,6 +2021,7 @@ class ActionCallerTestCase(unittest.TestCase):
             (3, 5): b'd\x00\x00S',
             (3, 6): b'd\x00S\x00',
             (3, 7): b'd\x00S\x00',
+            (3, 8): b'd\x00S\x00',
 
         }
 
@@ -2217,6 +2222,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 5): bytearray(b'3, 3, 0, 0,(),(),(|\x00\x00S),(),()'),
             (3, 6): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
             (3, 7): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
+            (3, 8): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
         }
 
         c = SCons.Action._function_contents(func1)
@@ -2242,6 +2248,8 @@ class ObjectContentsTestCase(unittest.TestCase):
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
             (3, 7): bytearray(
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
+            (3, 8): bytearray(
+                b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
         }
 
         assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(
@@ -2259,6 +2267,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 5): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00\x00d\x00\x00\x83\x01\x00\x01d\x01\x00S)'),
             (3, 6): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
             (3, 7): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
+            (3, 8): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
         }
 
         assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(expected[

--- a/src/engine/SCons/Conftest.py
+++ b/src/engine/SCons/Conftest.py
@@ -704,7 +704,7 @@ def CheckProg(context, prog_name):
 #
 
 def _YesNoResult(context, ret, key, text, comment = None):
-    """
+    r"""
     Handle the result of a test with a "yes" or "no" result.
 
     :Parameters:
@@ -723,7 +723,7 @@ def _YesNoResult(context, ret, key, text, comment = None):
 
 
 def _Have(context, key, have, comment = None):
-    """
+    r"""
     Store result of a test in context.havedict and context.headerfilename.
 
     :Parameters:

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -699,13 +699,13 @@ class Base(SCons.Node.Node):
 
     @SCons.Memoize.CountMethodCall
     def stat(self):
-        try: 
+        try:
             return self._memo['stat']
-        except KeyError: 
+        except KeyError:
             pass
-        try: 
+        try:
             result = self.fs.stat(self.get_abspath())
-        except os.error: 
+        except os.error:
             result = None
 
         self._memo['stat'] = result
@@ -719,16 +719,16 @@ class Base(SCons.Node.Node):
 
     def getmtime(self):
         st = self.stat()
-        if st: 
+        if st:
             return st[stat.ST_MTIME]
-        else: 
+        else:
             return None
 
     def getsize(self):
         st = self.stat()
-        if st: 
+        if st:
             return st[stat.ST_SIZE]
-        else: 
+        else:
             return None
 
     def isdir(self):
@@ -3350,7 +3350,7 @@ class File(Base):
         df = dmap.get(c_str, None)
         if df:
             return df
-        
+
         if os.altsep:
             c_str = c_str.replace(os.sep, os.altsep)
             df = dmap.get(c_str, None)
@@ -3387,7 +3387,7 @@ class File(Base):
               file and just copy the prev_ni provided.  If the prev_ni
               is wrong. It will propagate it.
               See: https://github.com/SCons/scons/issues/2980
-        
+
         Args:
             self - dependency
             target - target
@@ -3396,7 +3396,7 @@ class File(Base):
                    node to function. So if we detect that it's not passed.
                    we throw DeciderNeedsNode, and caller should handle this and pass node.
 
-        Returns: 
+        Returns:
             Boolean - Indicates if node(File) has changed.
         """
         if node is None:

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -480,7 +480,7 @@ class EntryProxy(SCons.Util.Proxy):
             return SCons.Subst.SpecialAttrWrapper(r, entry.name + "_posix")
 
     def __get_windows_path(self):
-        """Return the path with \ as the path separator,
+        r"""Return the path with \ as the path separator,
         regardless of platform."""
         if OS_SEP == '\\':
             return self
@@ -1418,7 +1418,7 @@ class FS(LocalFS):
             self.Top.addRepository(d)
 
     def PyPackageDir(self, modulename):
-        """Locate the directory of a given python module name
+        r"""Locate the directory of a given python module name
 
         For example scons might resolve to
         Windows: C:\Python27\Lib\site-packages\scons-2.5.1

--- a/src/engine/SCons/Platform/PlatformTests.py
+++ b/src/engine/SCons/Platform/PlatformTests.py
@@ -186,7 +186,8 @@ class TempFileMungeTestCase(unittest.TestCase):
         cmd = t(None, None, env, 0)
         # print("CMD is:%s"%cmd)
 
-        file_content = open(cmd[-1],'rb').read()
+        with open(cmd[-1],'rb') as f:
+            file_content = f.read()
         # print("Content is:[%s]"%file_content)
         # ...and restoring its setting.
         SCons.Action.print_actions = old_actions

--- a/src/engine/SCons/Platform/darwin.py
+++ b/src/engine/SCons/Platform/darwin.py
@@ -56,12 +56,11 @@ def generate(env):
 
     for file in filelist:
         if os.path.isfile(file):
-            f = open(file, 'r')
-            lines = f.readlines()
-            for line in lines:
-                if line:
-                    env.AppendENVPath('PATHOSX', line.strip('\n'))
-            f.close()
+            with open(file, 'r') as f:
+                lines = f.readlines()
+                for line in lines:
+                    if line:
+                        env.AppendENVPath('PATHOSX', line.strip('\n'))
 
     # Not sure why this wasn't the case all along?
     if env['ENV'].get('PATHOSX', False) and os.environ.get('SCONS_USE_MAC_PATHS', False):

--- a/src/engine/SCons/Platform/win32.py
+++ b/src/engine/SCons/Platform/win32.py
@@ -193,7 +193,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
 
         # actually do the spawn
         try:
-            args = [sh, '/C', escape(' '.join(args)) ]
+            args = [sh, '/C', escape(' '.join(args))]
             ret = spawnve(os.P_WAIT, sh, args, env)
         except OSError as e:
             # catch any error
@@ -207,15 +207,17 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         # and do clean up stuff
         if stdout is not None and stdoutRedirected == 0:
             try:
-                stdout.write(open( tmpFileStdout, "r" ).read())
-                os.remove( tmpFileStdout )
+                with open(tmpFileStdout, "r" ) as tmp:
+                    stdout.write(tmp.read())
+                os.remove(tmpFileStdout)
             except (IOError, OSError):
                 pass
 
         if stderr is not None and stderrRedirected == 0:
             try:
-                stderr.write(open( tmpFileStderr, "r" ).read())
-                os.remove( tmpFileStderr )
+                with open(tmpFileStderr, "r" ) as tmp:
+                    stderr.write(tmp.read())
+                os.remove(tmpFileStderr)
             except (IOError, OSError):
                 pass
         return ret

--- a/src/engine/SCons/SConsign.py
+++ b/src/engine/SCons/SConsign.py
@@ -338,6 +338,11 @@ class DirFile(Dir):
             SCons.Warnings.warn(SCons.Warnings.CorruptSConsignWarning,
                                 "Ignoring corrupt .sconsign file: %s"%self.sconsign)
 
+        try:
+            fp.close()
+        except AttributeError:
+            pass
+
         global sig_files
         sig_files.append(self)
 

--- a/src/engine/SCons/Scanner/RC.py
+++ b/src/engine/SCons/Scanner/RC.py
@@ -48,9 +48,9 @@ def RCScan():
     """Return a prototype Scanner instance for scanning RC source files"""
 
     res_re= r'^(?:\s*#\s*(?:include)|' \
-            '.*?\s+(?:ICON|BITMAP|CURSOR|HTML|FONT|MESSAGETABLE|TYPELIB|REGISTRY|D3DFX)' \
-            '\s*.*?)' \
-            '\s*(<|"| )([^>"\s]+)(?:[>"\s])*$'
+            r'.*?\s+(?:ICON|BITMAP|CURSOR|HTML|FONT|MESSAGETABLE|TYPELIB|REGISTRY|D3DFX)' \
+            r'\s*.*?)' \
+            r'\s*(<|"| )([^>"\s]+)(?:[>"\s])*$'
     resScanner = SCons.Scanner.ClassicCPP("ResourceScanner",
                                           "$RCSUFFIXES",
                                           "CPPPATH",

--- a/src/engine/SCons/Tool/PharLapCommon.py
+++ b/src/engine/SCons/Tool/PharLapCommon.py
@@ -79,7 +79,8 @@ def getPharLapVersion():
     include_path = os.path.join(getPharLapPath(), os.path.normpath("include/embkern.h"))
     if not os.path.exists(include_path):
         raise SCons.Errors.UserError("Cannot find embkern.h in ETS include directory.\nIs Phar Lap ETS installed properly?")
-    mo = REGEX_ETS_VER.search(open(include_path, 'r').read())
+    with open(include_path, 'r') as f:
+        mo = REGEX_ETS_VER.search(f.read())
     if mo:
         return int(mo.group(1))
     # Default return for Phar Lap 9.1

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -51,7 +51,12 @@ import SCons.Scanner.D
 import SCons.Scanner.LaTeX
 import SCons.Scanner.Prog
 import SCons.Scanner.SWIG
-import collections
+try:
+    # Python 3
+    from collections.abc import Callable
+except ImportError:
+    # Python 2.7
+    from collections import Callable
 
 DefaultToolpath = []
 
@@ -378,7 +383,7 @@ def _call_linker_cb(env, callback, args, result=None):
         if Verbose:
             print('_call_linker_cb: env["LINKCALLBACKS"][%r] found' % callback)
             print('_call_linker_cb: env["LINKCALLBACKS"][%r]=%r' % (callback, cbfun))
-        if isinstance(cbfun, collections.Callable):
+        if isinstance(cbfun, Callable):
             if Verbose:
                 print('_call_linker_cb: env["LINKCALLBACKS"][%r] is callable' % callback)
             result = cbfun(env, *args)

--- a/src/engine/SCons/Tool/clang.py
+++ b/src/engine/SCons/Tool/clang.py
@@ -77,7 +77,8 @@ def generate(env):
                                      stdout=subprocess.PIPE)
         if pipe.wait() != 0: return
         # clang -dumpversion is of no use
-        line = pipe.stdout.readline()
+        with pipe.stdout:
+            line = pipe.stdout.readline()
         if sys.version_info[0] > 2:
             line = line.decode()
         match = re.search(r'clang +version +([0-9]+(?:\.[0-9]+)+)', line)

--- a/src/engine/SCons/Tool/clangxx.py
+++ b/src/engine/SCons/Tool/clangxx.py
@@ -85,7 +85,8 @@ def generate(env):
             return
         
         # clang -dumpversion is of no use
-        line = pipe.stdout.readline()
+        with pipe.stdout:
+            line = pipe.stdout.readline()
         if sys.version_info[0] > 2:
             line = line.decode()
         match = re.search(r'clang +version +([0-9]+(?:\.[0-9]+)+)', line)

--- a/src/engine/SCons/Tool/docbook/__init__.py
+++ b/src/engine/SCons/Tool/docbook/__init__.py
@@ -84,7 +84,7 @@ def __extend_targets_sources(target, source):
         source = [source]
     if len(target) < len(source):
         target.extend(source[len(target):])
-        
+
     return target, source
 
 def __init_xsl_stylesheet(kw, env, user_xsl_var, default_path):
@@ -94,12 +94,12 @@ def __init_xsl_stylesheet(kw, env, user_xsl_var, default_path):
             path_args = [scriptpath, db_xsl_folder] + default_path
             xsl_style = os.path.join(*path_args)
         kw['DOCBOOK_XSL'] =  xsl_style
-    
+
 def __select_builder(lxml_builder, libxml2_builder, cmdline_builder):
     """ Selects a builder, based on which Python modules are present. """
     if prefer_xsltproc:
         return cmdline_builder
-    
+
     if not has_libxml2:
         # At the moment we prefer libxml2 over lxml, the latter can lead
         # to conflicts when installed together with libxml2.
@@ -115,7 +115,7 @@ def __ensure_suffix(t, suffix):
     tpath = str(t)
     if not tpath.endswith(suffix):
         return tpath+suffix
-    
+
     return t
 
 def __ensure_suffix_stem(t, suffix):
@@ -124,11 +124,11 @@ def __ensure_suffix_stem(t, suffix):
     if not tpath.endswith(suffix):
         stem = tpath
         tpath += suffix
-        
+
         return tpath, stem
     else:
         stem, ext = os.path.splitext(tpath)
-    
+
     return t, stem
 
 def __get_xml_text(root):
@@ -151,7 +151,7 @@ def __create_output_dir(base_dir):
     else:
         if base_dir.endswith('/'):
             dir = base_dir
-    
+
     if dir and not os.path.isdir(dir):
         os.makedirs(dir)
 
@@ -203,10 +203,10 @@ def _detect(env):
     the requested output formats.
     """
     global prefer_xsltproc
-    
+
     if env.get('DOCBOOK_PREFER_XSLTPROC',''):
         prefer_xsltproc = True
-        
+
     if ((not has_libxml2 and not has_lxml) or (prefer_xsltproc)):
         # Try to find the XSLT processors
         __detect_cl_tool(env, 'DOCBOOK_XSLTPROC', xsltproc_com, xsltproc_com_priority)
@@ -219,15 +219,15 @@ def _detect(env):
 #
 include_re = re.compile('fileref\\s*=\\s*["|\']([^\\n]*)["|\']')
 sentity_re = re.compile('<!ENTITY\\s+%*\\s*[^\\s]+\\s+SYSTEM\\s+["|\']([^\\n]*)["|\']>')
- 
+
 def __xml_scan(node, env, path, arg):
     """ Simple XML file scanner, detecting local images and XIncludes as implicit dependencies. """
     # Does the node exist yet?
     if not os.path.isfile(str(node)):
         return []
-    
+
     if env.get('DOCBOOK_SCANENT',''):
-        # Use simple pattern matching for system entities..., no support 
+        # Use simple pattern matching for system entities..., no support
         # for recursion yet.
         contents = node.get_text_contents()
         return sentity_re.findall(contents)
@@ -235,9 +235,9 @@ def __xml_scan(node, env, path, arg):
     xsl_file = os.path.join(scriptpath,'utils','xmldepend.xsl')
     if not has_libxml2 or prefer_xsltproc:
         if has_lxml and not prefer_xsltproc:
-            
+
             from lxml import etree
-            
+
             xsl_tree = etree.parse(xsl_file)
             doc = etree.parse(str(node))
             result = doc.xslt(xsl_tree)
@@ -266,7 +266,7 @@ def __xml_scan(node, env, path, arg):
     for x in str(result).splitlines():
         if x.strip() != "" and not x.startswith("<?xml "):
             depfiles.extend(x.strip().split())
-    
+
     style.freeStylesheet()
     doc.freeDoc()
     result.freeDoc()
@@ -282,7 +282,7 @@ docbook_xml_scanner = SCons.Script.Scanner(function = __xml_scan,
 # Action generators
 #
 def __generate_xsltproc_action(source, target, env, for_signature):
-    cmd = env['DOCBOOK_XSLTPROCCOM']    
+    cmd = env['DOCBOOK_XSLTPROCCOM']
     # Does the environment have a base_dir defined?
     base_dir = env.subst('$base_dir')
     if base_dir:
@@ -300,7 +300,7 @@ def __emit_xsl_basedir(target, source, env):
     if base_dir:
         # Yes, so prepend it to each target
         return [os.path.join(base_dir, str(t)) for t in target], source
-    
+
     # No, so simply pass target and source names through
     return target, source
 
@@ -334,11 +334,11 @@ def __build_lxml(target, source, env):
     General XSLT builder (HTML/FO), using the lxml module.
     """
     from lxml import etree
-    
-    xslt_ac = etree.XSLTAccessControl(read_file=True, 
-                                      write_file=True, 
-                                      create_dir=True, 
-                                      read_network=False, 
+
+    xslt_ac = etree.XSLTAccessControl(read_file=True,
+                                      write_file=True,
+                                      create_dir=True,
+                                      read_network=False,
                                       write_network=False)
     xsl_style = env.subst('$DOCBOOK_XSL')
     xsl_tree = etree.parse(xsl_style)
@@ -350,7 +350,7 @@ def __build_lxml(target, source, env):
         result = transform(doc, **parampass)
     else:
         result = transform(doc)
-        
+
     try:
         with open(str(target[0]), "wb") as of:
             of.write(of.write(etree.tostring(result, pretty_print=True)))
@@ -375,11 +375,11 @@ def __xinclude_lxml(target, source, env):
     Resolving XIncludes, using the lxml module.
     """
     from lxml import etree
-    
+
     doc = etree.parse(str(source[0]))
     doc.xinclude()
     try:
-        doc.write(str(target[0]), xml_declaration=True, 
+        doc.write(str(target[0]), xml_declaration=True,
                   encoding="UTF-8", pretty_print=True)
     except:
         pass
@@ -431,11 +431,11 @@ def DocbookEpub(env, target, source=None, *args, **kw):
     """
     import zipfile
     import shutil
-    
+
     def build_open_container(target, source, env):
         """Generate the *.epub file from intermediate outputs
 
-        Constructs the epub file according to the Open Container Format. This 
+        Constructs the epub file according to the Open Container Format. This
         function could be replaced by a call to the SCons Zip builder if support
         was added for different compression formats for separate source nodes.
         """
@@ -465,7 +465,7 @@ def DocbookEpub(env, target, source=None, *args, **kw):
         content_file = os.path.join(source[0].get_abspath(), 'content.opf')
         if not os.path.isfile(content_file):
             return
-        
+
         hrefs = []
         if has_libxml2:
             nsmap = {'opf' : 'http://www.idpf.org/2007/opf'}
@@ -492,51 +492,51 @@ def DocbookEpub(env, target, source=None, *args, **kw):
                     hrefs.append(item.attrib['href'])
 
             doc.freeDoc()
-            xpath_context.xpathFreeContext()            
+            xpath_context.xpathFreeContext()
         elif has_lxml:
             from lxml import etree
-            
+
             opf = etree.parse(content_file)
             # All the opf:item elements are resources
-            for item in opf.xpath('//opf:item', 
+            for item in opf.xpath('//opf:item',
                     namespaces= { 'opf': 'http://www.idpf.org/2007/opf' }):
                 hrefs.append(item.attrib['href'])
-        
+
         for href in hrefs:
-            # If the resource was not already created by DocBook XSL itself, 
+            # If the resource was not already created by DocBook XSL itself,
             # copy it into the OEBPS folder
             referenced_file = os.path.join(source[0].get_abspath(), href)
             if not os.path.exists(referenced_file):
                 shutil.copy(href, os.path.join(source[0].get_abspath(), href))
-        
+
     # Init list of targets/sources
     target, source = __extend_targets_sources(target, source)
-    
+
     # Init XSL stylesheet
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_EPUB', ['epub','docbook.xsl'])
 
     # Setup builder
     __builder = __select_builder(__lxml_builder, __libxml2_builder, __xsltproc_builder)
-    
+
     # Create targets
     result = []
-    if not env.GetOption('clean'):        
+    if not env.GetOption('clean'):
         # Ensure that the folders OEBPS and META-INF exist
         __create_output_dir('OEBPS/')
         __create_output_dir('META-INF/')
     dirs = env.Dir(['OEBPS', 'META-INF'])
-    
+
     # Set the fixed base_dir
     kw['base_dir'] = 'OEBPS/'
     tocncx = __builder.__call__(env, 'toc.ncx', source[0], **kw)
     cxml = env.File('META-INF/container.xml')
     env.SideEffect(cxml, tocncx)
-    
+
     env.Depends(tocncx, kw['DOCBOOK_XSL'])
     result.extend(tocncx+[cxml])
 
-    container = env.Command(__ensure_suffix(str(target[0]), '.epub'), 
-        tocncx+[cxml], [add_resources, build_open_container])    
+    container = env.Command(__ensure_suffix(str(target[0]), '.epub'),
+        tocncx+[cxml], [add_resources, build_open_container])
     mimetype = env.File('mimetype')
     env.SideEffect(mimetype, container)
 
@@ -552,13 +552,13 @@ def DocbookHtml(env, target, source=None, *args, **kw):
     """
     # Init list of targets/sources
     target, source = __extend_targets_sources(target, source)
-    
+
     # Init XSL stylesheet
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_HTML', ['html','docbook.xsl'])
 
     # Setup builder
     __builder = __select_builder(__lxml_builder, __libxml2_builder, __xsltproc_builder)
-    
+
     # Create targets
     result = []
     for t,s in zip(target,source):
@@ -580,18 +580,18 @@ def DocbookHtmlChunked(env, target, source=None, *args, **kw):
         target = ['index.html']
     elif not SCons.Util.is_List(source):
         source = [source]
-        
+
     # Init XSL stylesheet
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_HTMLCHUNKED', ['html','chunkfast.xsl'])
 
     # Setup builder
     __builder = __select_builder(__lxml_builder, __libxml2_builder, __xsltproc_builder)
-    
+
     # Detect base dir
     base_dir = kw.get('base_dir', '')
     if base_dir:
         __create_output_dir(base_dir)
-   
+
     # Create targets
     result = []
     r = __builder.__call__(env, __ensure_suffix(str(target[0]), '.html'), source[0], **kw)
@@ -614,8 +614,8 @@ def DocbookHtmlhelp(env, target, source=None, *args, **kw):
         source = target
         target = ['index.html']
     elif not SCons.Util.is_List(source):
-        source = [source]    
-    
+        source = [source]
+
     # Init XSL stylesheet
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_HTMLHELP', ['htmlhelp','htmlhelp.xsl'])
 
@@ -626,7 +626,7 @@ def DocbookHtmlhelp(env, target, source=None, *args, **kw):
     base_dir = kw.get('base_dir', '')
     if base_dir:
         __create_output_dir(base_dir)
-    
+
     # Create targets
     result = []
     r = __builder.__call__(env, __ensure_suffix(str(target[0]), '.html'), source[0], **kw)
@@ -684,29 +684,29 @@ def DocbookMan(env, target, source=None, *args, **kw):
         if os.path.isfile(srcfile):
             try:
                 import xml.dom.minidom
-                
+
                 dom = xml.dom.minidom.parse(__ensure_suffix(str(s),'.xml'))
                 # Extract volume number, default is 1
                 for node in dom.getElementsByTagName('refmeta'):
                     for vol in node.getElementsByTagName('manvolnum'):
                         volnum = __get_xml_text(vol)
-                        
+
                 # Extract output filenames
                 for node in dom.getElementsByTagName('refnamediv'):
                     for ref in node.getElementsByTagName('refname'):
                         outfiles.append(__get_xml_text(ref)+'.'+volnum)
-                        
+
             except:
-                # Use simple regex parsing 
+                # Use simple regex parsing
                 with open(__ensure_suffix(str(s),'.xml'), 'r') as f:
                     content = f.read()
-                
+
                 for m in re_manvolnum.finditer(content):
                     volnum = m.group(1)
-                    
+
                 for m in re_refname.finditer(content):
                     outfiles.append(m.group(1)+'.'+volnum)
-            
+
             if not outfiles:
                 # Use stem of the source file
                 spath = str(s)
@@ -718,14 +718,14 @@ def DocbookMan(env, target, source=None, *args, **kw):
         else:
             # We have to completely rely on the given target name
             outfiles.append(t)
-            
+
         __builder.__call__(env, outfiles[0], s, **kw)
         env.Depends(outfiles[0], kw['DOCBOOK_XSL'])
         result.append(outfiles[0])
         if len(outfiles) > 1:
             env.Clean(outfiles[0], outfiles[1:])
 
-        
+
     return result
 
 def DocbookSlidesPdf(env, target, source=None, *args, **kw):
@@ -746,7 +746,7 @@ def DocbookSlidesPdf(env, target, source=None, *args, **kw):
     for t,s in zip(target,source):
         t, stem = __ensure_suffix_stem(t, '.pdf')
         xsl = __builder.__call__(env, stem+'.fo', s, **kw)
-        env.Depends(xsl, kw['DOCBOOK_XSL'])        
+        env.Depends(xsl, kw['DOCBOOK_XSL'])
         result.extend(xsl)
         result.extend(__fop_builder.__call__(env, t, xsl, **kw))
 
@@ -763,7 +763,7 @@ def DocbookSlidesHtml(env, target, source=None, *args, **kw):
         source = target
         target = ['index.html']
     elif not SCons.Util.is_List(source):
-        source = [source]    
+        source = [source]
 
     # Init XSL stylesheet
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_SLIDESHTML', ['slides','html','plain.xsl'])
@@ -796,12 +796,12 @@ def DocbookXInclude(env, target, source, *args, **kw):
 
     # Setup builder
     __builder = __select_builder(__xinclude_lxml_builder,__xinclude_libxml2_builder,__xmllint_builder)
-            
+
     # Create targets
     result = []
     for t,s in zip(target,source):
         result.extend(__builder.__call__(env, t, s, **kw))
-        
+
     return result
 
 def DocbookXslt(env, target, source=None, *args, **kw):
@@ -810,13 +810,13 @@ def DocbookXslt(env, target, source=None, *args, **kw):
     """
     # Init list of targets/sources
     target, source = __extend_targets_sources(target, source)
-    
+
     # Init XSL stylesheet
     kw['DOCBOOK_XSL'] = kw.get('xsl', 'transform.xsl')
 
     # Setup builder
     __builder = __select_builder(__lxml_builder, __libxml2_builder, __xsltproc_builder)
-    
+
     # Create targets
     result = []
     for t,s in zip(target,source):
@@ -840,18 +840,18 @@ def generate(env):
         DOCBOOK_DEFAULT_XSL_MAN = '',
         DOCBOOK_DEFAULT_XSL_SLIDESPDF = '',
         DOCBOOK_DEFAULT_XSL_SLIDESHTML = '',
-        
+
         # Paths to the detected executables
         DOCBOOK_XSLTPROC = '',
         DOCBOOK_XMLLINT = '',
         DOCBOOK_FOP = '',
-        
+
         # Additional flags for the text processors
         DOCBOOK_XSLTPROCFLAGS = SCons.Util.CLVar(''),
         DOCBOOK_XMLLINTFLAGS = SCons.Util.CLVar(''),
         DOCBOOK_FOPFLAGS = SCons.Util.CLVar(''),
         DOCBOOK_XSLTPROCPARAMS = SCons.Util.CLVar(''),
-        
+
         # Default command lines for the detected executables
         DOCBOOK_XSLTPROCCOM = xsltproc_com['xsltproc'],
         DOCBOOK_XMLLINTCOM = xmllint_com['xmllint'],
@@ -861,7 +861,7 @@ def generate(env):
         DOCBOOK_XSLTPROCCOMSTR = None,
         DOCBOOK_XMLLINTCOMSTR = None,
         DOCBOOK_FOPCOMSTR = None,
-        
+
         )
     _detect(env)
 

--- a/src/engine/SCons/Tool/docbook/__init__.py
+++ b/src/engine/SCons/Tool/docbook/__init__.py
@@ -352,9 +352,8 @@ def __build_lxml(target, source, env):
         result = transform(doc)
         
     try:
-        of = open(str(target[0]), "wb")
-        of.write(of.write(etree.tostring(result, pretty_print=True)))
-        of.close()
+        with open(str(target[0]), "wb") as of:
+            of.write(of.write(etree.tostring(result, pretty_print=True)))
     except:
         pass
 
@@ -440,25 +439,23 @@ def DocbookEpub(env, target, source=None, *args, **kw):
         function could be replaced by a call to the SCons Zip builder if support
         was added for different compression formats for separate source nodes.
         """
-        zf = zipfile.ZipFile(str(target[0]), 'w')
-        mime_file = open('mimetype', 'w')
-        mime_file.write('application/epub+zip')
-        mime_file.close()
-        zf.write(mime_file.name, compress_type = zipfile.ZIP_STORED)
-        for s in source:
-            if os.path.isfile(str(s)):
-                head, tail = os.path.split(str(s))
-                if not head:
-                    continue
-                s = head
-            for dirpath, dirnames, filenames in os.walk(str(s)):
-                for fname in filenames:
-                    path = os.path.join(dirpath, fname)
-                    if os.path.isfile(path):
-                        zf.write(path, os.path.relpath(path, str(env.get('ZIPROOT', ''))),
-                            zipfile.ZIP_DEFLATED)
-        zf.close()
-        
+        with zipfile.ZipFile(str(target[0]), 'w') as zf:
+            with open('mimetype', 'w') as mime_file:
+                mime_file.write('application/epub+zip')
+            zf.write(mime_file.name, compress_type = zipfile.ZIP_STORED)
+            for s in source:
+                if os.path.isfile(str(s)):
+                    head, tail = os.path.split(str(s))
+                    if not head:
+                        continue
+                    s = head
+                for dirpath, dirnames, filenames in os.walk(str(s)):
+                    for fname in filenames:
+                        path = os.path.join(dirpath, fname)
+                        if os.path.isfile(path):
+                            zf.write(path, os.path.relpath(path, str(env.get('ZIPROOT', ''))),
+                                zipfile.ZIP_DEFLATED)
+
     def add_resources(target, source, env):
         """Add missing resources to the OEBPS directory
 
@@ -701,9 +698,8 @@ def DocbookMan(env, target, source=None, *args, **kw):
                         
             except:
                 # Use simple regex parsing 
-                f = open(__ensure_suffix(str(s),'.xml'), 'r')
-                content = f.read()
-                f.close()
+                with open(__ensure_suffix(str(s),'.xml'), 'r') as f:
+                    content = f.read()
                 
                 for m in re_manvolnum.finditer(content):
                     volnum = m.group(1)

--- a/src/engine/SCons/Tool/hpcxx.py
+++ b/src/engine/SCons/Tool/hpcxx.py
@@ -68,7 +68,8 @@ def generate(env):
         env['CXX']        = acc or 'aCC'
         env['SHCXXFLAGS'] = SCons.Util.CLVar('$CXXFLAGS +Z')
         # determine version of aCC
-        line = os.popen(acc + ' -V 2>&1').readline().rstrip()
+        with os.popen(acc + ' -V 2>&1') as p:
+            line = p.readline().rstrip()
         if line.find('aCC: HP ANSI C++') == 0:
             env['CXXVERSION'] = line.split()[-1]
 

--- a/src/engine/SCons/Tool/ipkg.py
+++ b/src/engine/SCons/Tool/ipkg.py
@@ -55,8 +55,10 @@ def generate(env):
     env['IPKGCOM'] = '$IPKG $IPKGFLAGS ${SOURCE}'
 
     if env.WhereIs('id'):
-        env['IPKGUSER'] = os.popen('id -un').read().strip()
-        env['IPKGGROUP'] = os.popen('id -gn').read().strip()
+        with os.popen('id -un') as p:
+            env['IPKGUSER'] = p.read().strip()
+        with os.popen('id -gn') as p:
+            env['IPKGGROUP'] = p.read().strip()
     env['IPKGFLAGS'] = SCons.Util.CLVar('-o $IPKGUSER -g $IPKGGROUP')
     env['IPKGSUFFIX'] = '.ipk'
 

--- a/src/engine/SCons/Tool/mingw.py
+++ b/src/engine/SCons/Tool/mingw.py
@@ -123,7 +123,7 @@ key_program = 'mingw32-make'
 
 
 def find_version_specific_mingw_paths():
-    """
+    r"""
     One example of default mingw install paths is:
     C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev2\mingw64\bin
 

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -1494,7 +1494,7 @@ class _GenerateV7DSW(_DSWGenerator):
         while line:
             line = dswfile.readline()
             datas = datas + line
-        dspfile.close()
+        dswfile.close()
 
         # OK, we've found our little pickled cache of data.
         try:

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -645,10 +645,10 @@ class _GenerateV6DSP(_DSPGenerator):
         if self.nokeep == 0:
             # now we pickle some data and add it to the file -- MSDEV will ignore it.
             pdata = pickle.dumps(self.configs,PICKLE_PROTOCOL)
-            pdata = base64.encodestring(pdata).decode()
+            pdata = base64.b64encode(pdata).decode()
             self.file.write(pdata + '\n')
             pdata = pickle.dumps(self.sources,PICKLE_PROTOCOL)
-            pdata = base64.encodestring(pdata).decode()
+            pdata = base64.b64encode(pdata).decode()
             self.file.write(pdata + '\n')
 
     def PrintSourceFiles(self):
@@ -917,10 +917,10 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
         if self.nokeep == 0:
             # now we pickle some data and add it to the file -- MSDEV will ignore it.
             pdata = pickle.dumps(self.configs,PICKLE_PROTOCOL)
-            pdata = base64.encodestring(pdata).decode()
+            pdata = base64.b64encode(pdata).decode()
             self.file.write('<!-- SCons Data:\n' + pdata + '\n')
             pdata = pickle.dumps(self.sources,PICKLE_PROTOCOL)
-            pdata = base64.encodestring(pdata).decode()
+            pdata = base64.b64encode(pdata).decode()
             self.file.write(pdata + '-->\n')
 
     def printSources(self, hierarchy, commonprefix):
@@ -1241,10 +1241,10 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
         if self.nokeep == 0:
             # now we pickle some data and add it to the file -- MSDEV will ignore it.
             pdata = pickle.dumps(self.configs,PICKLE_PROTOCOL)
-            pdata = base64.encodestring(pdata).decode()
+            pdata = base64.b64encode(pdata).decode()
             self.file.write('<!-- SCons Data:\n' + pdata + '\n')
             pdata = pickle.dumps(self.sources,PICKLE_PROTOCOL)
-            pdata = base64.encodestring(pdata).decode()
+            pdata = base64.b64encode(pdata).decode()
             self.file.write(pdata + '-->\n')
 
     def printFilters(self, hierarchy, name):
@@ -1617,7 +1617,7 @@ class _GenerateV7DSW(_DSWGenerator):
         self.file.write('EndGlobal\n')
         if self.nokeep == 0:
             pdata = pickle.dumps(self.configs,PICKLE_PROTOCOL)
-            pdata = base64.encodestring(pdata).decode()
+            pdata = base64.b64encode(pdata).decode()
             self.file.write(pdata)
             self.file.write('\n')
 

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -695,6 +695,7 @@ class _GenerateV6DSP(_DSPGenerator):
         while line and line != '\n':
             line = dspfile.readline()
             datas = datas + line
+        dspfile.close()
 
         # OK, we've found our little pickled cache of data.
         try:
@@ -713,6 +714,7 @@ class _GenerateV6DSP(_DSPGenerator):
         while line and line != '\n':
             line = dspfile.readline()
             datas = datas + line
+        dspfile.close()
 
         # OK, we've found our little pickled cache of data.
         # it has a "# " in front of it, so we strip that.
@@ -1008,6 +1010,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
         while line and line != '\n':
             line = dspfile.readline()
             datas = datas + line
+        dspfile.close()
 
         # OK, we've found our little pickled cache of data.
         try:
@@ -1491,6 +1494,7 @@ class _GenerateV7DSW(_DSWGenerator):
         while line:
             line = dswfile.readline()
             datas = datas + line
+        dspfile.close()
 
         # OK, we've found our little pickled cache of data.
         try:
@@ -1738,6 +1742,7 @@ def GenerateProject(target, source, env):
             raise
 
         bdsp.write("This is just a placeholder file.\nThe real project file is here:\n%s\n" % dspfile.get_abspath())
+        bdsp.close()
 
     GenerateDSP(dspfile, source, env)
 
@@ -1754,6 +1759,7 @@ def GenerateProject(target, source, env):
                 raise
 
             bdsw.write("This is just a placeholder file.\nThe real workspace file is here:\n%s\n" % dswfile.get_abspath())
+            bdsw.close()
 
         GenerateDSW(dswfile, source, env)
 

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -188,7 +188,7 @@ def build_wxsfile(target, source, env):
     """ Compiles a .wxs file from the keywords given in env['msi_spec'] and
         by analyzing the tree of source nodes and their tags.
     """
-    file = open(target[0].get_abspath(), 'w')
+    f = open(target[0].get_abspath(), 'w')
 
     try:
         # Create a document with the Wix root tag
@@ -209,7 +209,7 @@ def build_wxsfile(target, source, env):
         build_license_file(target[0].get_dir(), env)
 
         # write the xml to a file
-        file.write( doc.toprettyxml() )
+        f.write( doc.toprettyxml() )
 
         # call a user specified function
         if 'CHANGE_SPECFILE' in env:
@@ -217,6 +217,8 @@ def build_wxsfile(target, source, env):
 
     except KeyError as e:
         raise SCons.Errors.UserError( '"%s" package field for MSI is missing.' % e.args[0] )
+    finally:
+        f.close()
 
 #
 # setup function
@@ -440,14 +442,13 @@ def build_license_file(directory, spec):
         pass # ignore this as X_MSI_LICENSE_TEXT is optional
 
     if name!='' or text!='':
-        file = open( os.path.join(directory.get_path(), 'License.rtf'), 'w' )
-        file.write('{\\rtf')
-        if text!='':
-             file.write(text.replace('\n', '\\par '))
-        else:
-             file.write(name+'\\par\\par')
-        file.write('}')
-        file.close()
+        with open(os.path.join(directory.get_path(), 'License.rtf'), 'w') as f:
+            f.write('{\\rtf')
+            if text!='':
+                 f.write(text.replace('\n', '\\par '))
+            else:
+                 file.write(name+'\\par\\par')
+            f.write('}')
 
 #
 # mandatory and optional package tags

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -447,7 +447,7 @@ def build_license_file(directory, spec):
             if text!='':
                  f.write(text.replace('\n', '\\par '))
             else:
-                 file.write(name+'\\par\\par')
+                 f.write(name+'\\par\\par')
             f.write('}')
 
 #

--- a/src/engine/SCons/Tool/packaging/rpm.py
+++ b/src/engine/SCons/Tool/packaging/rpm.py
@@ -125,11 +125,11 @@ def build_specfile(target, source, env):
     """ Builds a RPM specfile from a dictionary with string metadata and
     by analyzing a tree of nodes.
     """
-    with open(target[0].get_abspath(), 'w') as file:
+    with open(target[0].get_abspath(), 'w') as ofp:
         try:
-            file.write(build_specfile_header(env))
-            file.write(build_specfile_sections(env))
-            file.write(build_specfile_filesection(env, source))
+            ofp.write(build_specfile_header(env))
+            ofp.write(build_specfile_sections(env))
+            ofp.write(build_specfile_filesection(env, source))
 
             # call a user specified function
             if 'CHANGE_SPECFILE' in env:

--- a/src/engine/SCons/Tool/qt.py
+++ b/src/engine/SCons/Tool/qt.py
@@ -66,11 +66,17 @@ if SCons.Util.case_sensitive_suffixes('.h', '.H'):
 cxx_suffixes = cplusplus.CXXSuffixes
 
 
-#
 def find_platform_specific_qt_paths():
     """
-    If the platform has non-standard paths which it installs QT in,return the likely default path
-    :return:
+    find non-standard QT paths
+
+    If the platform does not put QT tools in standard search paths,
+    the path is expected to be set using QTDIR. SCons violates
+    the normal rule of not pulling from the user's environment
+    in this case.  However, some test cases try to validate what
+    happens when QTDIR is unset, so we need to try to make a guess.
+
+    :return: a guess at a path
     """
 
     # qt_bin_dirs = []
@@ -83,6 +89,7 @@ def find_platform_specific_qt_paths():
             # Centos installs QT under /usr/{lib,lib64}/qt{4,5,-3.3}/bin
             # so we need to handle this differently
             # qt_bin_dirs = glob.glob('/usr/lib64/qt*/bin')
+            # TODO: all current Fedoras do the same, need to look deeper here.
             qt_bin_dir = '/usr/lib64/qt-3.3/bin'
 
     return qt_bin_dir

--- a/src/engine/SCons/Tool/rpmutils.py
+++ b/src/engine/SCons/Tool/rpmutils.py
@@ -482,9 +482,11 @@ def updateRpmDicts(rpmrc, pyfile):
     """
     try:
         # Read old rpmutils.py file
-        oldpy = open(pyfile,"r").readlines()
+        with open(pyfile,"r") as f:
+            oldpy = f.readlines()
         # Read current rpmrc.in file
-        rpm = open(rpmrc,"r").readlines()
+        with open(rpmrc,"r") as f:
+            rpm = f.readlines()
         # Parse for data
         data = {}
         # Allowed section names that get parsed
@@ -511,24 +513,23 @@ def updateRpmDicts(rpmrc, pyfile):
                     # Insert data
                     data[key][tokens[1]] = tokens[2:]
         # Write new rpmutils.py file
-        out = open(pyfile,"w")
-        pm = 0
-        for l in oldpy:
-            if pm:
-                if l.startswith('# End of rpmrc dictionaries'):
-                    pm = 0
+        with open(pyfile,"w") as out:
+            pm = 0
+            for l in oldpy:
+                if pm:
+                    if l.startswith('# End of rpmrc dictionaries'):
+                        pm = 0
+                        out.write(l)
+                else:
                     out.write(l)
-            else:
-                out.write(l)
-                if l.startswith('# Start of rpmrc dictionaries'):
-                    pm = 1
-                    # Write data sections to single dictionaries
-                    for key, entries in data.items():
-                        out.write("%s = {\n" % key)
-                        for arch in sorted(entries.keys()):
-                            out.write("  '%s' : ['%s'],\n" % (arch, "','".join(entries[arch])))
-                        out.write("}\n\n")
-        out.close()
+                    if l.startswith('# Start of rpmrc dictionaries'):
+                        pm = 1
+                        # Write data sections to single dictionaries
+                        for key, entries in data.items():
+                            out.write("%s = {\n" % key)
+                            for arch in sorted(entries.keys()):
+                                out.write("  '%s' : ['%s'],\n" % (arch, "','".join(entries[arch])))
+                            out.write("}\n\n")
     except:
         pass
 

--- a/src/engine/SCons/Tool/suncxx.py
+++ b/src/engine/SCons/Tool/suncxx.py
@@ -52,7 +52,13 @@ def get_package_info(package_name, pkginfo, pkgchk):
         version = None
         pathname = None
         try:
-            sadm_contents = open('/var/sadm/install/contents', 'r').read()
+            from subprocess import DEVNULL # py3k
+        except ImportError:
+            DEVNULL = open(os.devnull, 'wb')
+
+        try:
+            with open('/var/sadm/install/contents', 'r') as f:
+                sadm_contents = f.read()
         except EnvironmentError:
             pass
         else:
@@ -64,7 +70,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
         try:
             p = subprocess.Popen([pkginfo, '-l', package_name],
                                  stdout=subprocess.PIPE,
-                                 stderr=open('/dev/null', 'w'))
+                                 stderr=DEVNULL)
         except EnvironmentError:
             pass
         else:
@@ -78,7 +84,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
             try:
                 p = subprocess.Popen([pkgchk, '-l', package_name],
                                      stdout=subprocess.PIPE,
-                                     stderr=open('/dev/null', 'w'))
+                                     stderr=DEVNULL)
             except EnvironmentError:
                 pass
             else:

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -679,7 +679,7 @@ if can_read_reg:
     HKEY_USERS         = hkey_mod.HKEY_USERS
 
     def RegGetValue(root, key):
-        """This utility function returns a value in the registry
+        r"""This utility function returns a value in the registry
         without having to open the key first.  Only available on
         Windows platforms with a version of Python that can read the
         registry.  Returns the same thing as
@@ -1002,7 +1002,9 @@ if sys.platform == 'cygwin':
     def get_native_path(path):
         """Transforms an absolute path into a native path for the system.  In
         Cygwin, this converts from a Cygwin path to a Windows one."""
-        return os.popen('cygpath -w ' + path).read().replace('\n', '')
+        with os.popen('cygpath -w ' + path) as p:
+            npath = p.read().replace('\n', '')
+        return npath
 else:
     def get_native_path(path):
         """Transforms an absolute path into a native path for the system.
@@ -1478,13 +1480,12 @@ if hasattr(hashlib, 'md5'):
         :return: String of Hex digits representing the signature
         """
         m = hashlib.md5()
-        f = open(fname, "rb")
-        while True:
-            blck = f.read(chunksize)
-            if not blck:
-                break
-            m.update(to_bytes(blck))
-        f.close()
+        with open(fname, "rb") as f:
+            while True:
+                blck = f.read(chunksize)
+                if not blck:
+                    break
+                m.update(to_bytes(blck))
         return m.hexdigest()
 else:
     # if md5 algorithm not available, just return data unmodified
@@ -1511,7 +1512,6 @@ def MD5collect(signatures):
         return signatures[0]
     else:
         return MD5signature(', '.join(signatures))
-
 
 
 def silent_intern(x):

--- a/src/test_interrupts.py
+++ b/src/test_interrupts.py
@@ -87,7 +87,8 @@ exceptall_pat   = re.compile(r' *except(?: *| +Exception *, *[^: ]+):[^\n]*')
 
 uncaughtKeyboardInterrupt = 0
 for f in files:
-    contents = open(os.path.join(scons_lib_dir, f)).read()
+    with open(os.path.join(scons_lib_dir, f)) as ifp:
+        contents = ifp.read()
     try_except_lines = {}
     lastend = 0
     while True:

--- a/src/test_pychecker.py
+++ b/src/test_pychecker.py
@@ -63,7 +63,8 @@ else:
 src_engine_ = os.path.join(src_engine, '')
 
 MANIFEST = os.path.join(src_engine, 'MANIFEST.in')
-files = open(MANIFEST).read().split()
+with open(MANIFEST) as f:
+    files = f.read().split()
 
 files = [f for f in files if f[-3:] == '.py']
 

--- a/src/test_setup.py
+++ b/src/test_setup.py
@@ -176,21 +176,26 @@ tar_gz = os.path.join(cwd, 'build', 'dist', '%s.tar.gz' % scons_version)
 zip = os.path.join(cwd, 'build', 'dist', '%s.zip' % scons_version)
 
 if os.path.isfile(zip):
-    try: import zipfile
-    except ImportError: pass
+    try: 
+        import zipfile
+    except 
+        ImportError: pass
     else:
-        zf = zipfile.ZipFile(zip, 'r')
+        with zipfile.ZipFile(zip, 'r') as zf:
 
-        for name in zf.namelist():
-            dir = os.path.dirname(name)
-            try: os.makedirs(dir)
-            except: pass
-            # if the file exists, then delete it before writing
-            # to it so that we don't end up trying to write to a symlink:
-            if os.path.isfile(name) or os.path.islink(name):
-                os.unlink(name)
-            if not os.path.isdir(name):
-                open(name, 'w').write(zf.read(name))
+            for name in zf.namelist():
+                dname = os.path.dirname(name)
+                try: 
+                    os.makedirs(dname)
+                except FileExistsError: 
+                    pass
+                # if the file exists, then delete it before writing
+                # to it so that we don't end up trying to write to a symlink:
+                if os.path.isfile(name) or os.path.islink(name):
+                    os.unlink(name)
+                if not os.path.isdir(name):
+                    with open(name, 'w') as ofp:
+                        ofp.write(zf.read(name))
 
 if not os.path.isdir(scons_version) and os.path.isfile(tar_gz):
     # Unpack the .tar.gz file.  This should create the scons_version/

--- a/src/test_setup.py
+++ b/src/test_setup.py
@@ -178,8 +178,8 @@ zip = os.path.join(cwd, 'build', 'dist', '%s.zip' % scons_version)
 if os.path.isfile(zip):
     try: 
         import zipfile
-    except 
-        ImportError: pass
+    except ImportError:
+        pass
     else:
         with zipfile.ZipFile(zip, 'r') as zf:
 

--- a/src/test_strings.py
+++ b/src/test_strings.py
@@ -98,7 +98,8 @@ class Checker(object):
             for fname in filenames:
                 fpath = os.path.join(dirpath, fname)
                 if self.search_this(fpath) and not self.remove_this(fname, fpath):
-                    body = open(fpath, 'r').read()
+                    with open(fpath, 'r') as f:
+                        body = f.read()
                     for expr in self.expressions:
                         if not expr.search(body):
                             msg = '%s: missing %s' % (fpath, repr(expr.pattern))

--- a/test/AS/as-live.py
+++ b/test/AS/as-live.py
@@ -58,7 +58,8 @@ if sys.platform == "win32":
 test.write("wrapper.py", """\
 import os
 import sys
-open('%s', 'wb').write(("wrapper.py: %%s\\n" %% sys.argv[-1]).encode())
+with open('%s', 'wb') as f:
+    f.write(("wrapper.py: %%s\\n" %% sys.argv[-1]).encode())
 cmd = " ".join(sys.argv[1:])
 os.system(cmd)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))

--- a/test/AS/fixture/myas.py
+++ b/test/AS/fixture/myas.py
@@ -15,11 +15,10 @@ if sys.platform == 'win32':
                 inf = a
             continue
         if a[:3] == '/Fo': out = a[3:]
-    infile = open(inf, 'rb')
-    outfile = open(out, 'wb')
-    for l in infile.readlines():
-        if l[:3] != b'#as':
-            outfile.write(l)
+    with open(inf, 'rb') as ifp, open(out, 'wb') as ofp:
+        for l in ifp.readlines():
+            if l[:3] != b'#as':
+                ofp.write(l)
     sys.exit(0)
 
 else:
@@ -27,9 +26,8 @@ else:
     opts, args = getopt.getopt(sys.argv[1:], 'co:')
     for opt, arg in opts:
         if opt == '-o': out = arg
-    infile = open(args[0], 'rb')
-    outfile = open(out, 'wb')
-    for l in infile.readlines():
-        if l[:3] != b'#as':
-            outfile.write(l)
+    with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
+        for l in ifp.readlines():
+            if l[:3] != b'#as':
+                ofp.write(l)
     sys.exit(0)

--- a/test/AS/fixture/myas.py
+++ b/test/AS/fixture/myas.py
@@ -23,11 +23,16 @@ if sys.platform == 'win32':
 
 else:
     import getopt
-    opts, args = getopt.getopt(sys.argv[1:], 'co:')
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'co:')
+    except getopt.GetoptError:
+        # we may be called with --version, just quit if so
+        sys.exit(0)
     for opt, arg in opts:
         if opt == '-o': out = arg
-    with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
-        for l in ifp.readlines():
-            if l[:3] != b'#as':
-                ofp.write(l)
+    if args:
+        with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
+            for l in ifp.readlines():
+                if l[:3] != b'#as':
+                    ofp.write(l)
     sys.exit(0)

--- a/test/AS/fixture/myas_args.py
+++ b/test/AS/fixture/myas_args.py
@@ -21,12 +21,11 @@ if sys.platform == 'win32':
             out = a[3:]
             continue
         optstring = optstring + ' ' + a
-    infile = open(inf, 'rb')
-    outfile = open(out, 'wb')
-    outfile.write(bytearray(optstring + "\n",'utf-8'))
-    for l in infile.readlines():
-        if l[:3] != b'#as':
-            outfile.write(l)
+    with open(inf, 'rb') as ifp, open(out, 'wb') as ofp:
+        ofp.write(bytearray(optstring + "\n",'utf-8'))
+        for l in ifp.readlines():
+            if l[:3] != b'#as':
+                ofp.write(l)
     sys.exit(0)
 else:
     import getopt
@@ -37,12 +36,10 @@ else:
         if opt == '-o': out = arg
         else: optstring = optstring + ' ' + opt
 
-    infile = open(args[0], 'rb')
-    outfile = open(out, 'wb')
-    outfile.write(bytearray(optstring + "\n",'utf-8'))
-
-    for l in infile.readlines():
-        if l[:3] != b'#as':
-            outfile.write(l)
+    with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
+        ofp.write(bytearray(optstring + "\n",'utf-8'))
+        for l in ifp.readlines():
+            if l[:3] != b'#as':
+                ofp.write(l)
 
     sys.exit(0)

--- a/test/Actions/actions.py
+++ b/test/Actions/actions.py
@@ -32,10 +32,9 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-file = open(sys.argv[1], 'wb')
-file.write((sys.argv[2] + "\n").encode())
-file.write(open(sys.argv[3], 'rb').read())
-file.close
+with open(sys.argv[1], 'wb') as f, open(sys.argv[3], 'rb') as infp:
+    f.write((sys.argv[2] + "\n").encode())
+    f.write(infp.read())
 sys.exit(0)
 """)
 

--- a/test/Actions/append.py
+++ b/test/Actions/append.py
@@ -44,19 +44,14 @@ test.write('SConstruct', """
 env=Environment()
 
 def before(env, target, source):
-    f=open(str(target[0]), "wb")
-    f.write(b"Foo\\n")
-    f.close()
-    f=open("before.txt", "wb")
-    f.write(b"Bar\\n")
-    f.close()
+    with open(str(target[0]), "wb") as f:
+        f.write(b"Foo\\n")
+    with open("before.txt", "wb") as f:
+        f.write(b"Bar\\n")
 
 def after(env, target, source):
-    fin = open(str(target[0]), "rb")
-    fout = open("after%s", "wb")
-    fout.write(fin.read())
-    fout.close()
-    fin.close()
+    with open(str(target[0]), "rb") as fin, open("after%s", "wb") as fout:
+        fout.write(fin.read())
 
 env.Prepend(LINKCOM=Action(before))
 env.Append(LINKCOM=Action(after))

--- a/test/Actions/exitstatfunc.py
+++ b/test/Actions/exitstatfunc.py
@@ -38,8 +38,8 @@ def always_succeed(s):
     return 0
 
 def copy_fail(target, source, env):
-    content = open(str(source[0]), 'rb').read()
-    open(str(target[0]), 'wb').write(content)
+    with open(str(source[0]), 'rb') as infp, open(str(target[0]), 'wb') as f:
+        f.write(infp.read())
     return 2
 
 a = Action(copy_fail, exitstatfunc=always_succeed)

--- a/test/Actions/function.py
+++ b/test/Actions/function.py
@@ -90,7 +90,7 @@ def toto(header='%(header)s', trailer='%(trailer)s'):
     return writeDeps
 '''
 
-exec( withClosure % optEnv )
+exec(withClosure % optEnv)
 
 genHeaderBld = SCons.Builder.Builder(
     action = SCons.Action.Action(

--- a/test/Actions/pre-post-fixture/work2/SConstruct
+++ b/test/Actions/pre-post-fixture/work2/SConstruct
@@ -1,5 +1,6 @@
 def b(target, source, env):
-    open(str(target[0]), 'wb').write((env['X'] + '\n').encode())
+    with open(str(target[0]), 'wb') as f:
+        f.write((env['X'] + '\n').encode())
 env1 = Environment(X='111')
 env2 = Environment(X='222')
 B = Builder(action = b, env = env1, multi=1)

--- a/test/Actions/pre-post-fixture/work3/SConstruct
+++ b/test/Actions/pre-post-fixture/work3/SConstruct
@@ -3,7 +3,8 @@ def pre(target, source, env):
 def post(target, source, env):
     pass
 def build(target, source, env):
-    open(str(target[0]), 'wb').write(b'build()\n')
+    with open(str(target[0]), 'wb') as f:
+        f.write(b'build()\n')
 env = Environment()
 AddPreAction('dir', pre)
 AddPostAction('dir', post)

--- a/test/Actions/pre-post-fixture/work4/build.py
+++ b/test/Actions/pre-post-fixture/work4/build.py
@@ -1,5 +1,5 @@
 import sys
-outfp = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    outfp.write(open(f, 'rb').read())
-outfp.close()
+with open(sys.argv[1], 'wb') as outfp:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as infp:
+            outfp.write(infp.read())

--- a/test/Actions/timestamp.py
+++ b/test/Actions/timestamp.py
@@ -45,7 +45,8 @@ test.not_up_to_date(arguments = 'file.out')
 
 test.write('SConstruct', """\
 def my_copy(target, source, env):
-    open(str(target[0]), 'w').write(open(str(source[0]), 'r').read())
+    with open(str(target[0]), 'w') as f, open(str(source[0]), 'r') as infp:
+        f.write(infp.read())
 env = Environment()
 env.Decider('timestamp-match')
 env.Command('file.out', 'file.in', my_copy)

--- a/test/Actions/unicode-signature-fixture/SConstruct
+++ b/test/Actions/unicode-signature-fixture/SConstruct
@@ -1,7 +1,8 @@
 fnode = File(u'foo.txt')
 
 def funcact(target, source, env):
-    open(str(target[0]), 'wb').write(b"funcact\n")
+    with open(str(target[0]), 'wb') as f:
+        f.write(b"funcact\n")
     for i in range(300):
         pass
     return 0

--- a/test/Alias/Alias.py
+++ b/test/Alias/Alias.py
@@ -37,7 +37,8 @@ test.subdir('sub1', 'sub2')
 
 test.write('build.py', r"""
 import sys
-open(sys.argv[1], 'wb').write(open(sys.argv[2], 'rb').read())
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as ifp:
+    f.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/Alias/Depends.py
+++ b/test/Alias/Depends.py
@@ -37,7 +37,8 @@ test.subdir('sub1', 'sub2')
 
 test.write('build.py', r"""
 import sys
-open(sys.argv[1], 'wb').write(open(sys.argv[2], 'rb').read())
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as ifp:
+    f.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/Alias/action.py
+++ b/test/Alias/action.py
@@ -35,20 +35,22 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 def cat(target, source, env):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 
 def foo(target, source, env):
     target = list(map(str, target))
     source = list(map(str, source))
-    open('foo', 'wb').write(bytearray("foo(%s, %s)\\n" % (target, source),'utf-8'))
+    with open('foo', 'wb') as f:
+        f.write(bytearray("foo(%s, %s)\\n" % (target, source),'utf-8'))
 
 def bar(target, source, env):
     target = list(map(str, target))
     source = list(map(str, source))
-    open('bar', 'wb').write(bytearray("bar(%s, %s)\\n" % (target, source),'utf-8'))
+    with open('bar', 'wb') as f:
+        f.write(bytearray("bar(%s, %s)\\n" % (target, source),'utf-8'))
 
 env = Environment(BUILDERS = {'Cat':Builder(action=cat)})
 env.Alias(target = ['build-f1'], source = 'f1.out', action = foo)

--- a/test/Alias/scanner.py
+++ b/test/Alias/scanner.py
@@ -35,10 +35,10 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 
 XBuilder = Builder(action = cat, src_suffix = '.x', suffix = '.c')
 env = Environment()

--- a/test/Alias/srcdir.py
+++ b/test/Alias/srcdir.py
@@ -63,21 +63,23 @@ test.subdir('python')
 test.write('SConstruct', """\
 import os.path
 
-env = Environment ()
+env = Environment()
 
-def at_copy_ext (target, source, env):
-    n = str (source[0])
-    s = open (n, 'rb').read ()
-    e = os.path.splitext (n)[1]
-    t = str (target[0]) + e
-    open (t, 'wb').write (s)
+def at_copy_ext(target, source, env):
+    n = str(source[0])
+    with open(n, 'rb') as f:
+        s = f.read()
+    e = os.path.splitext(n)[1]
+    t = str(target[0]) + e
+    with open(t, 'wb') as f:
+        f.write(s)
 
-AT_COPY_EXT = Builder (action = at_copy_ext, src_suffix=['.py', '.sh',])
-env.Append (BUILDERS = {'AT_COPY_EXT': AT_COPY_EXT})
+AT_COPY_EXT = Builder(action=at_copy_ext, src_suffix=['.py', '.sh',])
+env.Append(BUILDERS={'AT_COPY_EXT': AT_COPY_EXT})
 
-env.Alias ('minimal', ['python'])
+env.Alias('minimal', ['python'])
 
-Export ('env')
+Export('env')
 
 b = 'python/out-scons'
 
@@ -87,7 +89,7 @@ SConscript(b + '/SConscript')
 """)
 
 test.write(['python', 'SConscript'], """\
-Import ('env')
+Import('env')
 env.AT_COPY_EXT('foo.py')
 """)
 

--- a/test/AlwaysBuild.py
+++ b/test/AlwaysBuild.py
@@ -55,7 +55,8 @@ c2 = env.Alias('clean2', [], [Delete('clean2-t1'), Delete('clean2-t2')])
 env.AlwaysBuild(c2)
 
 def dir_build(target, source, env):
-    open('dir_build.txt', 'ab').write(b'dir_build()\\n')
+    with open('dir_build.txt', 'ab') as f:
+        f.write(b'dir_build()\\n')
 env.Command(Dir('dir'), None, dir_build)
 env.AlwaysBuild('dir')
 """ % locals())

--- a/test/Batch/Boolean.py
+++ b/test/Batch/Boolean.py
@@ -36,7 +36,8 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 def batch_build(target, source, env):
     for t, s in zip(target, source):
-        open(str(t), 'wb').write(open(str(s), 'rb').read())
+        with open(str(t), 'wb') as f, open(str(s), 'rb') as infp:
+            f.write(infp.read())
 env = Environment()
 bb = Action(batch_build, batch_key=True)
 env['BUILDERS']['Batch'] = Builder(action=bb)

--- a/test/Batch/CHANGED_SOURCES.py
+++ b/test/Batch/CHANGED_SOURCES.py
@@ -43,7 +43,8 @@ dir = sys.argv[1]
 for infile in sys.argv[2:]:
     inbase = os.path.splitext(os.path.split(infile)[1])[0]
     outfile = os.path.join(dir, inbase+'.out')
-    open(outfile, 'wb').write(open(infile, 'rb').read())
+    with open(outfile, 'wb') as f, open(infile, 'rb') as infp:
+            f.write(infp.read())
 sys.exit(0)
 """)
 

--- a/test/Batch/SOURCES.py
+++ b/test/Batch/SOURCES.py
@@ -43,7 +43,8 @@ dir = sys.argv[1]
 for infile in sys.argv[2:]:
     inbase = os.path.splitext(os.path.split(infile)[1])[0]
     outfile = os.path.join(dir, inbase+'.out')
-    open(outfile, 'wb').write(open(infile, 'rb').read())
+    with open(outfile, 'wb') as f, open(infile, 'rb') as infp:
+        f.write(infp.read())
 sys.exit(0)
 """)
 

--- a/test/Batch/action-changed.py
+++ b/test/Batch/action-changed.py
@@ -46,10 +46,9 @@ sources = sys.argv[sep+1:]
 for i in range(len(targets)):
     t = targets[i]
     s = sources[i]
-    fp = open(t, 'wb')
-    fp.write(bytearray('%s\\n','utf-8'))
-    fp.write(open(s, 'rb').read())
-    fp.close()
+    with open(t, 'wb') as fp, open(s, 'rb') as infp:
+        fp.write(bytearray('%s\\n','utf-8'))
+        fp.write(infp.read())
 sys.exit(0)
 """
 

--- a/test/Batch/callable.py
+++ b/test/Batch/callable.py
@@ -40,7 +40,8 @@ test.subdir('sub1', 'sub2')
 test.write('SConstruct', """
 def batch_build(target, source, env):
     for t, s in zip(target, source):
-        open(str(t), 'wb').write(open(str(s), 'rb').read())
+        with open(str(t), 'wb') as f, open(str(s), 'rb') as infp:
+            f.write(infp.read())
 if ARGUMENTS.get('BATCH_CALLABLE'):
     def batch_key(action, env, target, source):
         return (id(action), id(env), target[0].dir)

--- a/test/Batch/removed.py
+++ b/test/Batch/removed.py
@@ -42,7 +42,8 @@ dir = sys.argv[1]
 for infile in sys.argv[2:]:
     inbase = os.path.splitext(os.path.split(infile)[1])[0]
     outfile = os.path.join(dir, inbase+'.out')
-    open(outfile, 'wb').write(open(infile, 'rb').read())
+    with open(outfile, 'wb') as f, open(infile, 'rb') as infp:
+        f.write(infp.read())
 sys.exit(0)
 """)
 

--- a/test/Batch/up_to_date.py
+++ b/test/Batch/up_to_date.py
@@ -42,7 +42,8 @@ dir = sys.argv[1]
 for infile in sys.argv[2:]:
     inbase = os.path.splitext(os.path.split(infile)[1])[0]
     outfile = os.path.join(dir, inbase+'.out')
-    open(outfile, 'wb').write(open(infile, 'rb').read())
+    with open(outfile, 'wb') as f, open(infile, 'rb') as infp:
+        f.write(infp.read())
 sys.exit(0)
 """)
 

--- a/test/Builder-factories.py
+++ b/test/Builder-factories.py
@@ -43,15 +43,16 @@ import os.path
 def mkdir(env, source, target):
     t = str(target[0])
     os.makedirs(t)
-    open(os.path.join(t, 'marker'), 'wb').write(b"MakeDirectory\\n")
+    with open(os.path.join(t, 'marker'), 'wb') as f:
+        f.write(b"MakeDirectory\\n")
 MakeDirectory = Builder(action=mkdir, target_factory=Dir)
 def collect(env, source, target):
-    out = open(str(target[0]), 'wb')
-    dir = str(source[0])
-    for f in sorted(os.listdir(dir)):
-        f = os.path.join(dir, f)
-        out.write(open(f, 'rb').read())
-    out.close()
+    with open(str(target[0]), 'wb') as out:
+        dir = str(source[0])
+        for f in sorted(os.listdir(dir)):
+            f = os.path.join(dir, f)
+            with open(f, 'rb') as infp:
+                out.write(infp.read())
 Collect = Builder(action=collect, source_factory=Dir)
 env = Environment(BUILDERS = {'MakeDirectory':MakeDirectory,
                               'Collect':Collect})

--- a/test/Builder/errors.py
+++ b/test/Builder/errors.py
@@ -38,13 +38,10 @@ SConstruct_path = test.workpath('SConstruct')
 
 sconstruct = """
 def buildop(env, source, target):
-    outf = open(str(target[0]), 'wb')
-    inpf = open(str(source[0]), 'r')
-    for line in inpf.readlines():
-        if line.find(str(target[0])) == -1:
-            outf.write(line)
-    inpf.close()
-    outf.close()
+    with open(str(target[0]), 'wb') as outf, open(str(source[0]), 'r') as infp:
+        for line in inpf.readlines():
+            if line.find(str(target[0])) == -1:
+                outf.write(line)
 b1 = Builder(action=buildop, src_suffix='.a', suffix='.b')
 %s
 env=Environment(tools=[], BUILDERS={'b1':b1, 'b2':b2})
@@ -58,7 +55,7 @@ foo.b
 built
 """)
 
-python_file_line = test.python_file_line(SConstruct_path, 14)
+python_file_line = test.python_file_line(SConstruct_path, 11)
 
 ### Gross mistake in Builder spec
 

--- a/test/Builder/multi/different-actions.py
+++ b/test/Builder/multi/different-actions.py
@@ -36,9 +36,10 @@ test = TestSCons.TestSCons(match=TestSCons.match_re)
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 B = Builder(action=Action(build, varlist=['XXX']), multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B }, XXX = 'foo')

--- a/test/Builder/multi/different-environments.py
+++ b/test/Builder/multi/different-environments.py
@@ -39,10 +39,11 @@ _python_ = TestSCons._python_
 test.write('build.py', r"""\
 import sys
 def build(num, target, source):
-    file = open(str(target), 'wb')
-    file.write('%s\n' % num)
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target), 'wb') as f:
+        f.write('%s\n' % num)
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 build(sys.argv[1],sys.argv[2],sys.argv[3:])
 """)
 

--- a/test/Builder/multi/different-multi.py
+++ b/test/Builder/multi/different-multi.py
@@ -37,9 +37,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 def build2(env, target, source):
     build(env, target, source)

--- a/test/Builder/multi/different-order.py
+++ b/test/Builder/multi/different-order.py
@@ -39,9 +39,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
     for t in target:
-        file = open(str(target[0]), 'wb')
-        for s in source:
-            file.write(open(str(s), 'rb').read())
+        with open(str(target[0]), 'wb') as f:
+            for s in source:
+                with open(str(s), 'rb') as infp:
+                    f.write(infp.read())
 
 B = Builder(action=build, multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/multi/different-overrides.py
+++ b/test/Builder/multi/different-overrides.py
@@ -36,9 +36,10 @@ test = TestSCons.TestSCons(match=TestSCons.match_re)
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 B = Builder(action=build, multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/multi/different-target-lists.py
+++ b/test/Builder/multi/different-target-lists.py
@@ -43,9 +43,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
     for t in target:
-        file = open(str(target[0]), 'wb')
-        for s in source:
-            file.write(open(str(s), 'rb').read())
+        with open(str(target[0]), 'wb') as f:
+            for s in source:
+                with open(str(s), 'rb') as infp:
+                    f.write(infp.read())
 
 B = Builder(action=build, multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/multi/error.py
+++ b/test/Builder/multi/error.py
@@ -37,9 +37,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 B = Builder(action=build, multi=0)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/multi/lone-target-list.py
+++ b/test/Builder/multi/lone-target-list.py
@@ -37,9 +37,10 @@ DefaultEnvironment(tools=[])
 
 def build(env, target, source):
     for t in target:
-        file = open(str(target[0]), 'wb')
-        for s in source:
-            file.write(open(str(s), 'rb').read())
+        with open(str(target[0]), 'wb') as f:
+            for s in source:
+                with open(str(s), 'rb') as infp:
+                    f.write(infp.read())
 
 B = Builder(action=build, multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/multi/multi.py
+++ b/test/Builder/multi/multi.py
@@ -37,9 +37,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 B = Builder(action=build, multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/multi/same-actions.py
+++ b/test/Builder/multi/same-actions.py
@@ -37,9 +37,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 B = Builder(action=build, multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/multi/same-overrides.py
+++ b/test/Builder/multi/same-overrides.py
@@ -37,11 +37,12 @@ _python_ = TestSCons._python_
 test.write('build.py', r"""\
 import sys
 def build(num, target, source):
-    file = open(str(target), 'wb')
-    file.write(bytearray('%s\n'% num,'utf-8'))
-    for s in source:
-        file.write(open(str(s), 'rb').read())
-build(sys.argv[1],sys.argv[2],sys.argv[3:])
+    with open(str(target), 'wb') as f:
+        f.write(bytearray('%s\n'% num,'utf-8'))
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
+build(sys.argv[1], sys.argv[2], sys.argv[3:])
 """)
 
 test.write('SConstruct', """\

--- a/test/Builder/multi/same-targets.py
+++ b/test/Builder/multi/same-targets.py
@@ -38,9 +38,10 @@ DefaultEnvironment(tools=[])
 
 def build(env, target, source):
     for t in target:
-        file = open(str(t), 'wb')
-        for s in source:
-            file.write(open(str(s), 'rb').read())
+        with open(str(t), 'wb') as f:
+            for s in source:
+                with open(str(s), 'rb') as infp:
+                    f.write(infp.read())
 
 B = Builder(action=build, multi=1)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/non-multi.py
+++ b/test/Builder/non-multi.py
@@ -37,9 +37,10 @@ test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 B = Builder(action=build, multi=0)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/same-actions-diff-envs.py
+++ b/test/Builder/same-actions-diff-envs.py
@@ -37,8 +37,8 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    file = open(str(target[0]), 'w')
-    file.write('1')
+    with open(str(target[0]), 'w') as f:
+        f.write('1')
 
 B = Builder(action=build)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/same-actions-diff-overrides.py
+++ b/test/Builder/same-actions-diff-overrides.py
@@ -37,8 +37,8 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    file = open(str(target[0]), 'w')
-    file.write('1')
+    with open(str(target[0]), 'w') as f:
+        f.write('1')
 
 B = Builder(action=build)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Builder/srcdir.py
+++ b/test/Builder/srcdir.py
@@ -41,10 +41,10 @@ file3 = test.workpath('file3')
 
 test.write(['src', 'cat.py'], """\
 import sys
-o = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    o.write(open(f, 'rb').read())
-o.close()
+with open(sys.argv[1], 'wb') as o:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as i:
+            o.write(i.read())
 """)
 
 test.write(['src', 'SConstruct'], """\

--- a/test/Builder/wrapper.py
+++ b/test/Builder/wrapper.py
@@ -39,9 +39,10 @@ DefaultEnvironment(tools=[])
 import os.path
 import string
 def cat(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in map(str, source):
-        fp.write(open(s, 'rb').read())
+    with open(str(target[0]), 'wb') as fp:
+        for s in map(str, source):
+            with open(s, 'rb') as infp:
+                fp.write(infp.read())
 Cat = Builder(action=cat)
 def Wrapper(env, target, source):
     if not target:

--- a/test/CFILESUFFIX.py
+++ b/test/CFILESUFFIX.py
@@ -45,7 +45,8 @@ else:
     longopts = []
 cmd_opts, args = getopt.getopt(sys.argv[1:], 't', longopts)
 for a in args:
-    contents = open(a, 'rb').read()
+    with open(a, 'rb') as f:
+        contents = f.read()
     sys.stdout.write((contents.replace(b'LEX', b'mylex.py')).decode())
 sys.exit(0)
 """)

--- a/test/CPPFLAGS.py
+++ b/test/CPPFLAGS.py
@@ -51,11 +51,10 @@ while args:
         break
     args.pop(0)
     if a[:5] == '/OUT:': out = a[5:]
-infile = open(args[0], 'r')
-outfile = open(out, 'w')
-for l in infile.readlines():
-    if l[:5] != '#link':
-        outfile.write(l)
+with open(out, 'w') as ofp, open(args[0], 'r') as ifp:
+    for l in ifp.readlines():
+        if l[:5] != '#link':
+            ofp.write(l)
 sys.exit(0)
 """)
 
@@ -67,12 +66,12 @@ import sys
 opts, args = getopt.getopt(sys.argv[1:], 'o:s:')
 for opt, arg in opts:
     if opt == '-o': out = arg
-outfile = open(out, 'w')
-for f in args:
-    infile = open(f, 'r')
-    for l in infile.readlines():
-        if l[:5] != '#link':
-            outfile.write(l)
+with open(out, 'w') as ofp:
+    for f in args:
+        with open(f, 'r') as ifp:
+            for l in ifp.readlines():
+                if l[:5] != '#link':
+                    ofp.write(l)
 sys.exit(0)
 """)
 
@@ -85,12 +84,13 @@ clen = len(compiler) + 1
 opts, args = getopt.getopt(sys.argv[2:], 'co:xf:K:')
 for opt, arg in opts:
     if opt == '-o': out = arg
-    elif opt == '-x': open('mygcc.out', 'a').write(compiler + "\n")
-infile = open(args[0], 'r')
-outfile = open(out, 'w')
-for l in infile.readlines():
-    if l[:clen] != '#' + compiler:
-        outfile.write(l)
+    elif opt == '-x':
+        with open('mygcc.out', 'a') as f:
+            f.write(compiler + "\n")
+with open(out, 'w') as ofp, open(args[0], 'r') as ifp:
+    for l in ifp.readlines():
+        if l[:clen] != '#' + compiler:
+            ofp.write(l)
 sys.exit(0)
 """)
 

--- a/test/CPPSUFFIXES.py
+++ b/test/CPPSUFFIXES.py
@@ -37,14 +37,15 @@ test = TestSCons.TestSCons()
 test.write('mycc.py', r"""
 import sys
 def do_file(outf, inf):
-    for line in open(inf, 'r').readlines():
-        if line[:10] == '#include <':
-            do_file(outf, line[10:-2])
-        else:
-            outf.write(line)
-outf = open(sys.argv[1], 'w')
-for f in sys.argv[2:]:
-    do_file(outf, f)
+    with open(inf, 'r') as ifp:
+        for line in ifp.readlines():
+            if line[:10] == '#include <':
+                do_file(outf, line[10:-2])
+            else:
+                outf.write(line)
+with open(sys.argv[1], 'w') as outf:
+    for f in sys.argv[2:]:
+        do_file(outf, f)
 sys.exit(0)
 """)
 

--- a/test/CXX/CXXFILESUFFIX.py
+++ b/test/CXX/CXXFILESUFFIX.py
@@ -41,7 +41,8 @@ else:
     longopts = []
 cmd_opts, args = getopt.getopt(sys.argv[1:], 't', longopts)
 for a in args:
-    contents = open(a, 'r').read()
+    with open(a, 'r') as f:
+        contents = f.read()
     sys.stdout.write(contents.replace('LEX', 'mylex.py'))
 sys.exit(0)
 """)

--- a/test/Chmod.py
+++ b/test/Chmod.py
@@ -45,10 +45,10 @@ Execute(Chmod('d2', 0o777))
 Execute(Chmod(Dir('d2-Dir'), 0o777))
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as infp:
+                f.write(infp.read())
 Cat = Action(cat)
 env = Environment()
 env.Command('bar.out', 'bar.in', [Cat,

--- a/test/Clean/Option.py
+++ b/test/Clean/Option.py
@@ -39,10 +39,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/Clean/basic.py
+++ b/test/Clean/basic.py
@@ -38,10 +38,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/Clean/function.py
+++ b/test/Clean/function.py
@@ -38,10 +38,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 """)
 
 test.subdir('subd')

--- a/test/Climb/U-Default-no-target.py
+++ b/test/Climb/U-Default-no-target.py
@@ -37,8 +37,8 @@ test.write('SConstruct', """
 Default('not_a_target.in')
 """)
 
-test.run(arguments = '-U', status=2, match=TestSCons.match_re, stderr="""\
-scons: \*\*\* Do not know how to make File target `not_a_target.in' \(.*not_a_target.in\).  Stop.
+test.run(arguments = '-U', status=2, match=TestSCons.match_re, stderr=\
+r"""scons: \*\*\* Do not know how to make File target `not_a_target.in' \(.*not_a_target.in\).  Stop.
 """)
 
 test.pass_test()

--- a/test/Climb/explicit-parent--D.py
+++ b/test/Climb/explicit-parent--D.py
@@ -39,10 +39,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, 'wb') as ofp:
+        for src in source:
+            with open(str(src), 'rb') as ifp:
+                ofp.write(ifp.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('f1.out', 'f1.in')
 f2 = env.Cat('f2.out', 'f2.in')

--- a/test/Climb/explicit-parent--U.py
+++ b/test/Climb/explicit-parent--U.py
@@ -38,10 +38,10 @@ test.subdir('subdir')
 test.write('SConstruct', """\
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, 'wb') as ofp:
+        for src in source:
+            with open(str(src), 'rb') as ifp:
+                ofp.write(ifp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('foo.out', 'foo.in')
 SConscript('subdir/SConscript', "env")

--- a/test/Climb/explicit-parent-u.py
+++ b/test/Climb/explicit-parent-u.py
@@ -39,10 +39,10 @@ test.subdir('subdir')
 test.write('SConstruct', """\
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, 'wb') as ofp:
+        for src in source:
+            with open(str(src), 'rb') as ifp:
+                ofp.write(ifp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('f1.out', 'f1.in')
 env.Cat('f2.out', 'f2.in')

--- a/test/Climb/option--D.py
+++ b/test/Climb/option--D.py
@@ -34,10 +34,8 @@ test.subdir('sub1', 'sub2')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/Climb/option--U.py
+++ b/test/Climb/option--U.py
@@ -36,10 +36,8 @@ test.subdir('sub1', 'sub2', 'sub3')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', r"""

--- a/test/Climb/option-u.py
+++ b/test/Climb/option-u.py
@@ -44,10 +44,10 @@ test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, 'wb') as ofp:
+        for src in source:
+            with open(str(src), 'rb') as ifp:
+                ofp.write(ifp.read())
 env = Environment(tools=[])
 env.Append(BUILDERS = {'Cat' : Builder(action=cat)})
 env.Cat(target = 'sub1/f1a.out', source = 'sub1/f1a.in')

--- a/test/CommandGenerator.py
+++ b/test/CommandGenerator.py
@@ -34,10 +34,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'r').read()
-file = open(sys.argv[1], 'w')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'w') as f, open(sys.argv[2], 'r') as ifp:
+    f.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/Configure/Builder-call.py
+++ b/test/Configure/Builder-call.py
@@ -39,7 +39,8 @@ test.write('mycommand.py', r"""
 import sys
 sys.stderr.write( 'Hello World on stderr\n' )
 sys.stdout.write( 'Hello World on stdout\n' )
-open(sys.argv[1], 'w').write( 'Hello World\n' )
+with open(sys.argv[1], 'w') as f:
+    f.write( 'Hello World\n' )
 """)
 
 test.write('SConstruct', """\

--- a/test/Configure/VariantDir.py
+++ b/test/Configure/VariantDir.py
@@ -45,26 +45,27 @@ test.write('SConstruct', """\
 env = Environment(LOGFILE='build/config.log')
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])
-VariantDir( 'build', '.' )
+VariantDir('build', '.')
 conf = env.Configure(conf_dir='build/config.tests', log_file='$LOGFILE')
-r1 = conf.CheckCHeader( 'math.h' )
-r2 = conf.CheckCHeader( 'no_std_c_header.h' ) # leads to compile error
+r1 = conf.CheckCHeader('math.h')
+r2 = conf.CheckCHeader('no_std_c_header.h') # leads to compile error
 env = conf.Finish()
-Export( 'env' )
-# print open( 'build/config.log' ).readlines()
-SConscript( 'build/SConscript' )
+Export('env')
+# with open('build/config.log') as f:
+#     print f.readlines()
+SConscript('build/SConscript')
 """)
 
 test.write('SConscript', """\
-Import( 'env' )
-env.Program( 'TestProgram', 'TestProgram.c' )
+Import('env')
+env.Program('TestProgram', 'TestProgram.c')
 """)
 
 test.write('TestProgram.c', """\
 #include <stdio.h>
 
 int main(void) {
-  printf( "Hello\\n" );
+  printf("Hello\\n");
 }
 """)
 

--- a/test/Configure/custom-tests.py
+++ b/test/Configure/custom-tests.py
@@ -170,7 +170,7 @@ env = conf.Finish()
 test.run()
 
 test.must_match('config.log',
-""".*
+r""".*
 .*
 scons: Configure: Display of list ...
 scons: Configure: \(cached\) yes

--- a/test/Copy-Action.py
+++ b/test/Copy-Action.py
@@ -43,10 +43,10 @@ Execute(Copy(File('d2.out'), 'd2.in'))
 Execute(Copy('d3.out', File('f3.in')))
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open(target, "w") as f:
+        for src in source:
+            with open(str(src), "r") as ifp:
+                f.write(ifp.read())
 Cat = Action(cat)
 env = Environment()
 env.Command('bar.out', 'bar.in', [Cat,

--- a/test/D/AllAtOnce/Common/common.py
+++ b/test/D/AllAtOnce/Common/common.py
@@ -44,7 +44,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('Image')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format(tool))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format(tool)
+    test.write('SConstruct', config)
 
     test.run()
 

--- a/test/D/CoreScanner/Common/common.py
+++ b/test/D/CoreScanner/Common/common.py
@@ -47,7 +47,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('Image')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format(tool))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format(tool)
+    test.write('SConstruct', config)
 
     arguments = 'test1%(_obj)s test2%(_obj)s' % locals()
 

--- a/test/D/HSTeoh/Common/arLibIssue.py
+++ b/test/D/HSTeoh/Common/arLibIssue.py
@@ -46,7 +46,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('ArLibIssue')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format('tools=["{0}", "ar"]'.format(tool)))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format('tools=["{0}", "ar"]'.format(tool))
+    test.write('SConstruct', config)
 
     test.run()
 

--- a/test/D/HSTeoh/Common/libCompileOptions.py
+++ b/test/D/HSTeoh/Common/libCompileOptions.py
@@ -46,7 +46,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('LibCompileOptions')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format('tools=["{0}", "link", "ar"]'.format(tool)))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format('tools=["{0}", "link", "ar"]'.format(tool))
+    test.write('SConstruct', config)
 
     test.run()
 

--- a/test/D/HSTeoh/Common/linkingProblem.py
+++ b/test/D/HSTeoh/Common/linkingProblem.py
@@ -47,7 +47,9 @@ def testForTool(tool):
         test.skip_test("ncurses not apparently installed, skip this test.")
 
     test.dir_fixture('LinkingProblem')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format(tool))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format(tool)
+    test.write('SConstruct', config)
 
     test.run()
 

--- a/test/D/HSTeoh/Common/singleStringCannotBeMultipleOptions.py
+++ b/test/D/HSTeoh/Common/singleStringCannotBeMultipleOptions.py
@@ -45,7 +45,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('SingleStringCannotBeMultipleOptions')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format(tool))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format(tool)
+    test.write('SConstruct', config)
 
     test.run(status=2, stdout=None, stderr=None)
 

--- a/test/D/HelloWorld/CompileAndLinkOneStep/Common/common.py
+++ b/test/D/HelloWorld/CompileAndLinkOneStep/Common/common.py
@@ -44,7 +44,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('Image')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format(tool))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format(tool)
+    test.write('SConstruct', config)
 
     if tool == 'dmd':
         # The gdmd executable in Debian Unstable as at 2012-05-12, version 4.6.3 puts out messages on stderr

--- a/test/D/HelloWorld/CompileThenLinkTwoSteps/Common/common.py
+++ b/test/D/HelloWorld/CompileThenLinkTwoSteps/Common/common.py
@@ -44,7 +44,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('Image')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format(tool))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format(tool)
+    test.write('SConstruct', config)
 
     if tool == 'dmd':
         # The gdmd executable in Debian Unstable as at 2012-05-12, version 4.6.3 puts out messages on stderr

--- a/test/D/Issues/2939_Ariovistus/Common/correctLinkOptions.py
+++ b/test/D/Issues/2939_Ariovistus/Common/correctLinkOptions.py
@@ -46,7 +46,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('Project')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format('tools=["{0}", "link"]'.format(tool)))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format('tools=["{0}", "link"]'.format(tool))
+    test.write('SConstruct', config)
 
     test.run()
 

--- a/test/D/Issues/2940_Ariovistus/Common/correctLinkOptions.py
+++ b/test/D/Issues/2940_Ariovistus/Common/correctLinkOptions.py
@@ -61,7 +61,9 @@ def testForTool(tool):
         test.fail_test('No information about platform: ' + platform)
 
     test.dir_fixture('Project')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format('tools=["{0}", "link"]'.format(tool)))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format('tools=["{0}", "link"]'.format(tool))
+    test.write('SConstruct', config)
 
     test.run()
 

--- a/test/D/Issues/2994/Common/D_changed_DFLAGS_not_rebuilding.py
+++ b/test/D/Issues/2994/Common/D_changed_DFLAGS_not_rebuilding.py
@@ -46,7 +46,9 @@ def testForTool(tool):
         test.skip_test("Required executable for tool '{0}' not found, skipping test.\n".format(tool))
 
     test.dir_fixture('Project')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format('tools=["{0}", "link"]'.format(tool)))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format('tools=["{0}", "link"]'.format(tool))
+    test.write('SConstruct', config)
 
     test.run()
     test.fail_test('main.o' not in test.stdout())

--- a/test/D/SharedObjects/Common/common.py
+++ b/test/D/SharedObjects/Common/common.py
@@ -76,7 +76,9 @@ def testForTool(tool):
         test.fail_test()
 
     test.dir_fixture('Image')
-    test.write('SConstruct', open('SConstruct_template', 'r').read().format(tool))
+    with open('SConstruct_template', 'r') as f:
+        config = f.read().format(tool)
+    test.write('SConstruct', config)
 
     if Base()['DC'] == 'gdmd':
         # The gdmd executable in Debian Unstable as at 2012-05-12, version 4.6.3 puts out messages on stderr

--- a/test/DSUFFIXES.py
+++ b/test/DSUFFIXES.py
@@ -37,14 +37,15 @@ test = TestSCons.TestSCons()
 test.write('mydc.py', r"""
 import sys
 def do_file(outf, inf):
-    for line in open(inf, 'rb').readlines():
-        if line[:7] == b'import ':
-            do_file(outf, line[7:-2] + b'.d')
-        else:
-            outf.write(line)
-outf = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    do_file(outf, f)
+    with open(inf, 'rb') as ifp:
+        for line in ifp.readlines():
+            if line[:7] == b'import ':
+                do_file(outf, line[7:-2] + b'.d')
+            else:
+                outf.write(line)
+with open(sys.argv[1], 'wb') as outf:
+    for f in sys.argv[2:]:
+        do_file(outf, f)
 sys.exit(0)
 """)
 

--- a/test/Decider/switch-rebuild.py
+++ b/test/Decider/switch-rebuild.py
@@ -38,7 +38,8 @@ DefaultEnvironment(tools=[])
 Decider('%s')
 
 def build(env, target, source):
-    open(str(target[0]), 'wt').write(open(str(source[0]), 'rt').read())
+    with open(str(target[0]), 'wt') as f, open(str(source[0]), 'rt') as ifp:
+        f.write(ifp.read())
 B = Builder(action=build)
 env = Environment(tools=[], BUILDERS = { 'B' : B })
 env.B(target='switch.out', source='switch.in')

--- a/test/Default.py
+++ b/test/Default.py
@@ -43,10 +43,8 @@ for dirname in ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight']:
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'r').read()
-file = open(sys.argv[1], 'w')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'w') as f, open(sys.argv[2], 'r') as ifp:
+    f.write(ifp.read())
 """)
 
 #

--- a/test/Delete.py
+++ b/test/Delete.py
@@ -44,10 +44,10 @@ Execute(Delete('symlinks/dirlink'))
 
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 Cat = Action(cat)
 env = Environment()
 env.Command('f3.out', 'f3.in', [Cat, Delete("f4"), Delete("d5")])
@@ -194,10 +194,10 @@ if sys.platform != 'win32':
 test.write("SConstruct", """\
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ifp:
+        for src in source:
+            with open(str(src), "rb") as ofp:
+                ofp.write(ifp.read())
 Cat = Action(cat)
 env = Environment()
 env.Command('f14-nonexistent.out', 'f14.in', [Delete("$TARGET", must_exist=1),

--- a/test/Depends/Depends.py
+++ b/test/Depends/Depends.py
@@ -40,10 +40,10 @@ test.subdir('subdir', 'sub2')
 
 test.write('build.py', r"""
 import sys
-fp = open(sys.argv[1], 'wb')
-for fname in sys.argv[2:]:
-    fp.write(open(fname, 'rb').read())
-fp.close()
+with open(sys.argv[1], 'wb') as ofp:
+    for fname in sys.argv[2:]:
+        with open(fname, 'rb') as ifp:
+            ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/Depends/spurious-rebuilds.py
+++ b/test/Depends/spurious-rebuilds.py
@@ -47,7 +47,8 @@ import os.path
 if not os.path.exists('mkl'):
   os.mkdir('mkl')
 if not os.path.exists('test.c'):
-  open('test.c', 'w').write('int i;')
+  with open('test.c', 'w') as f:
+      f.write('int i;')
 
 env=Environment()
 env.SharedObject('all-defuns.obj', 'all-defuns.c')

--- a/test/Deprecated/BuildDir.py
+++ b/test/Deprecated/BuildDir.py
@@ -97,11 +97,8 @@ import os.path
 def buildIt(target, source, env):
     if not os.path.exists('build'):
         os.mkdir('build')
-    f1=open(str(source[0]), 'r')
-    f2=open(str(target[0]), 'w')
-    f2.write(f1.read())
-    f2.close()
-    f1.close()
+    with open(str(source[0]), 'r') as ifp, open(str(target[0]), 'w') as ofp:
+        ofp.write(ifp.read())
     return 0
 Import("env")
 env.Command(target='f2.c', source='f2.in', action=buildIt)

--- a/test/Deprecated/SConscript-build_dir.py
+++ b/test/Deprecated/SConscript-build_dir.py
@@ -73,10 +73,10 @@ var9 = Dir('../build/var9')
 
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)},
                   BUILD='build')

--- a/test/Deprecated/SourceCode/SourceCode.py
+++ b/test/Deprecated/SourceCode/SourceCode.py
@@ -49,10 +49,10 @@ import os
 
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 
 def sc_cat(env, source, target):
     source = []

--- a/test/Deprecated/SourceSignatures/basic.py
+++ b/test/Deprecated/SourceSignatures/basic.py
@@ -35,7 +35,8 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 base_sconstruct_contents = """\
 SetOption('warn', 'deprecated-source-signatures')
 def build(env, target, source):
-    open(str(target[0]), 'wt').write(open(str(source[0]), 'rt').read())
+    with open(str(target[0]), 'wt') as ofp, open(str(source[0]), 'rt') as ifp:
+        ofp.write(ifp.read())
 B = Builder(action = build)
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'f1.out', source = 'f1.in')

--- a/test/Deprecated/SourceSignatures/env.py
+++ b/test/Deprecated/SourceSignatures/env.py
@@ -39,7 +39,8 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 base_sconstruct_contents = """\
 SetOption('warn', 'deprecated-source-signatures')
 def build(env, target, source):
-    open(str(target[0]), 'wt').write(open(str(source[0]), 'rt').read())
+    with open(str(target[0]), 'wt') as ofp, open(str(source[0]), 'rt') as ifp:
+        ofp.write(ifp.read())
 B = Builder(action = build)
 env = Environment(BUILDERS = { 'B' : B })
 env2 = env.Clone()

--- a/test/Deprecated/SourceSignatures/implicit-cache.py
+++ b/test/Deprecated/SourceSignatures/implicit-cache.py
@@ -41,7 +41,8 @@ SetOption('implicit_cache', 1)
 SourceSignatures('timestamp')
 
 def build(env, target, source):
-    open(str(target[0]), 'wt').write(open(str(source[0]), 'rt').read())
+    with open(str(target[0]), 'wt') as ofp, open(str(source[0]), 'rt') as ifp:
+        ofp.write(ifp.read())
 B = Builder(action = build)
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'both.out', source = 'both.in')

--- a/test/Deprecated/SourceSignatures/no-csigs.py
+++ b/test/Deprecated/SourceSignatures/no-csigs.py
@@ -36,7 +36,8 @@ test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
 test.write('SConstruct', """\
 SetOption('warn', 'deprecated-source-signatures')
 def build(env, target, source):
-    open(str(target[0]), 'wt').write(open(str(source[0]), 'rt').read())
+    with open(str(target[0]), 'wt') as ofp, open(str(source[0]), 'rt') as ifp:
+        ofp.write(ifp.read())
 B = Builder(action = build)
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'f1.out', source = 'f1.in')

--- a/test/Deprecated/SourceSignatures/switch-rebuild.py
+++ b/test/Deprecated/SourceSignatures/switch-rebuild.py
@@ -45,7 +45,8 @@ SetOption('warn', 'deprecated-source-signatures')
 SourceSignatures('%s')
 
 def build(env, target, source):
-    open(str(target[0]), 'wt').write(open(str(source[0]), 'rt').read())
+    with open(str(target[0]), 'wt') as ofp, open(str(source[0]), 'rt') as ifp:
+        ofp.write(ifp.read())
 B = Builder(action = build)
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'switch.out', source = 'switch.in')

--- a/test/Deprecated/TargetSignatures/content.py
+++ b/test/Deprecated/TargetSignatures/content.py
@@ -48,10 +48,10 @@ SetOption('warn', 'deprecated-target-signatures')
 env = Environment()
 
 def copy(env, source, target):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-       fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+           with open(str(s), 'rb') as ifp:
+               ofp.write(ifp.read())
 
 copyAction = Action(copy, "Copying $TARGET")
 

--- a/test/Deprecated/debug-nomemoizer.py
+++ b/test/Deprecated/debug-nomemoizer.py
@@ -34,7 +34,8 @@ test = TestSCons.TestSCons(match = TestSCons.match_re)
 
 test.write('SConstruct', """
 def cat(target, source, env):
-    open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
+    with open(str(target[0]), 'wb') as ofp, open(str(source[0]), 'rb') as ifp:
+        ofp.write(ifp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)

--- a/test/ENV.py
+++ b/test/ENV.py
@@ -49,8 +49,10 @@ test.write('build.py',
 r"""\
 import os
 import sys
-contents = open(sys.argv[2], 'r').read()
-open(sys.argv[1], 'w').write("build.py %s\n%s" % (os.environ['X'], contents))
+with open(sys.argv[2], 'r') as f:
+    contents = f.read()
+with open(sys.argv[1], 'w') as f:
+    f.write("build.py %s\n%s" % (os.environ['X'], contents))
 """)
 
 test.write('input', "input file\n")

--- a/test/ESCAPE.py
+++ b/test/ESCAPE.py
@@ -36,10 +36,10 @@ test = TestSCons.TestSCons()
 
 test.write('cat.py', """\
 import sys
-ofp = open(sys.argv[1], 'wb')
-for s in sys.argv[2:]:
-    ofp.write(open(s, 'rb').read())
-ofp.close()
+with open(sys.argv[1], 'wb') as ofp:
+    for s in sys.argv[2:]:
+        with open(s, 'rb') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', """\

--- a/test/Errors/AttributeError.py
+++ b/test/Errors/AttributeError.py
@@ -39,9 +39,9 @@ a.append(2)
 """)
 
 test.run(status = 2, stderr = """\
-(AttributeError|<type 'exceptions\.AttributeError'>): 'int' object has no attribute 'append':
+(AttributeError|<type 'exceptions\\.AttributeError'>): 'int' object has no attribute 'append':
   File ".+SConstruct", line 2:
-    a.append\(2\)
+    a.append\\(2\\)
 """)
 
 test.pass_test()

--- a/test/Errors/Exception.py
+++ b/test/Errors/Exception.py
@@ -31,7 +31,8 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 test.write('SConstruct', """\
 def foo(env, target, source):
     print(str(target[0]))
-    open(str(target[0]), 'wt').write('foo')
+    with open(str(target[0]), 'wt') as f:
+        f.write('foo')
 
 def exit(env, target, source):
     raise Exception('exit')
@@ -51,7 +52,7 @@ test.write('exit.in', 'exit\n')
 # no longer exists or that line in the source file no longer exists,
 # so make sure the proper variations are supported in the following
 # regexp.
-expect = """scons: \*\*\* \[exit.out\] Exception : exit
+expect = r"""scons: \*\*\* \[exit.out\] Exception : exit
 Traceback \((most recent call|innermost) last\):
 (  File ".+", line \d+, in \S+
     [^\n]+

--- a/test/Errors/SyntaxError.py
+++ b/test/Errors/SyntaxError.py
@@ -42,7 +42,7 @@ test.run(stdout = "scons: Reading SConscript files ...\n",
 
     a ! x
 
-      \^
+      \\^
 
 SyntaxError: (invalid syntax|Unknown character)
 

--- a/test/Errors/TypeError.py
+++ b/test/Errors/TypeError.py
@@ -41,7 +41,7 @@ a[2] = 3
 test.run(status = 2, stderr = """\
 TypeError:( 'int')? object does not support item assignment:
   File ".+SConstruct", line 2:
-    a\[2\] = 3
+    a\\[2\\] = 3
 """)
 
 test.pass_test()

--- a/test/Errors/UserError.py
+++ b/test/Errors/UserError.py
@@ -39,7 +39,7 @@ import SCons.Errors
 raise SCons.Errors.UserError('Depends() requires both sources and targets.')
 """)
 
-expect = """
+expect = r"""
 scons: \*\*\* Depends\(\) requires both sources and targets.
 """ + TestSCons.file_expr
 

--- a/test/Execute.py
+++ b/test/Execute.py
@@ -36,7 +36,8 @@ test = TestSCons.TestSCons()
 
 test.write('my_copy.py', """\
 import sys
-open(sys.argv[2], 'wb').write(open(sys.argv[1], 'rb').read())
+with open(sys.argv[2], 'wb') as ofp, open(sys.argv[1], 'rb') as ifp:
+    ofp.write(ifp.read())
 try:
     exitval = int(sys.argv[3])
 except IndexError:

--- a/test/Exit.py
+++ b/test/Exit.py
@@ -104,10 +104,10 @@ SConscript('subdir/SConscript')
 test.write(['subdir', 'SConscript'], """\
 def exit_builder(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
     Exit(27)
 env = Environment(BUILDERS = {'my_exit' : Builder(action=exit_builder)})
 env.my_exit('foo.out', 'foo.in')
@@ -133,10 +133,10 @@ exitscan = Scanner(function = exit_scanner, skeys = ['.k'])
 
 def cat(env, source, target):
     target = str(target[0])
-    outf = open(target, 'wb')
-    for src in source:
-        outf.write(open(str(src), "rb").read())
-    outf.close()
+    with open(target, 'wb') as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                outf.write(ifp.read())
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Append(SCANNERS = [exitscan])

--- a/test/FindFile.py
+++ b/test/FindFile.py
@@ -40,13 +40,17 @@ test.write(['bar', 'baz', 'testfile2'], 'test 4\n')
 test.write('SConstruct', """
 env = Environment(FILE = 'file', BAR = 'bar')
 file1 = FindFile('testfile1', [ 'foo', '.', 'bar', 'bar/baz' ])
-print(open(str(file1), 'r').read())
+with open(str(file1), 'r') as f:
+    print(f.read())
 file2 = env.FindFile('test${FILE}1', [ 'bar', 'foo', '.', 'bar/baz' ])
-print(open(str(file2), 'r').read())
+with open(str(file2), 'r') as f:
+    print(f.read())
 file3 = FindFile('testfile2', [ 'foo', '.', 'bar', 'bar/baz' ])
-print(open(str(file3), 'r').read())
+with open(str(file3), 'r') as f:
+    print(f.read())
 file4 = env.FindFile('testfile2', [ '$BAR/baz', 'foo', '.', 'bar' ])
-print(open(str(file4), 'r').read())
+with open(str(file4), 'r') as f:
+    print(f.read())
 """)
 
 expect = test.wrap_stdout(read_str = """test 1

--- a/test/Flatten.py
+++ b/test/Flatten.py
@@ -37,10 +37,10 @@ test.subdir('work')
 test.write(['work', 'SConstruct'], """
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 f1 = env.Cat('../file1.out', 'file1.in')
 f2 = env.Cat('../file2.out', ['file2a.in', 'file2b.in'])

--- a/test/Fortran/FORTRANMODDIR.py
+++ b/test/Fortran/FORTRANMODDIR.py
@@ -47,14 +47,16 @@ import re
 import sys
 # case insensitive matching, because Fortran is case insensitive
 mod_regex = "(?im)^\\s*MODULE\\s+(?!PROCEDURE)(\\w+)"
-contents = open(sys.argv[2]).read()
+with open(sys.argv[2]) as f:
+    contents = f.read()
 modules = re.findall(mod_regex, contents)
 (prefix, moddir) = sys.argv[1].split('=')
 if prefix != 'moduledir':
     sys.exit(1)
 modules = [os.path.join(moddir, m.lower()+'.mod') for m in modules]
 for t in sys.argv[3:] + modules:
-    open(t, 'wb').write(('myfortran.py wrote %s\n' % os.path.split(t)[1]).encode())
+    with open(t, 'wb') as f:
+        f.write(('myfortran.py wrote %s\n' % os.path.split(t)[1]).encode())
 """)
 
 test.write('SConstruct', """

--- a/test/Fortran/FORTRANSUFFIXES.py
+++ b/test/Fortran/FORTRANSUFFIXES.py
@@ -37,14 +37,15 @@ test = TestSCons.TestSCons()
 test.write('myfc.py', r"""
 import sys
 def do_file(outf, inf):
-    for line in open(inf, 'rb').readlines():
-        if line[:15] == b"      INCLUDE '":
-            do_file(outf, line[15:-2])
-        else:
-            outf.write(line)
-outf = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    do_file(outf, f)
+    with open(inf, 'rb') as inf:
+        for line in inf.readlines():
+            if line[:15] == b"      INCLUDE '":
+                do_file(outf, line[15:-2])
+            else:
+                outf.write(line)
+with open(sys.argv[1], 'wb') as outf:
+    for f in sys.argv[2:]:
+        do_file(outf, f)
 sys.exit(0)
 """)
 

--- a/test/Fortran/USE-MODULE.py
+++ b/test/Fortran/USE-MODULE.py
@@ -38,11 +38,13 @@ import os.path
 import re
 import sys
 mod_regex = "(?im)^\\s*MODULE\\s+(?!PROCEDURE)(\\w+)"
-contents = open(sys.argv[1]).read()
+with open(sys.argv[1]) as f:
+    contents = f.read()
 modules = re.findall(mod_regex, contents)
 modules = [m.lower()+'.mod' for m in modules]
 for t in sys.argv[2:] + modules:
-    open(t, 'wb').write(('myfortran.py wrote %s\n' % os.path.split(t)[1]).encode())
+    with open(t, 'wb') as f:
+        f.write(('myfortran.py wrote %s\n' % os.path.split(t)[1]).encode())
 sys.exit(0)
 """)
 

--- a/test/Fortran/link-with-cxx.py
+++ b/test/Fortran/link-with-cxx.py
@@ -39,23 +39,23 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons(match = TestSCons.match_re)
 
 
-test.write('test_linker.py', r"""
+test.write('test_linker.py', """\
 import sys
 if sys.argv[1] == '-o':
-    ofp = open(sys.argv[2], 'wb')
-    infiles = sys.argv[3:]
+    with open(sys.argv[2], 'wb') as ofp:
+        for infile in sys.argv[3:]:
+            with open(infile, 'rb') as ifp:
+                ofp.write(ifp.read())
 elif sys.argv[1][:5] == '/OUT:':
-    ofp = open(sys.argv[1][5:], 'wb')
-    infiles = sys.argv[2:]
-for infile in infiles:
-    with open(infile, 'rb') as ifp:
-        ofp.write(ifp.read())
-ofp.close()
+    with open(sys.argv[1][5:], 'wb') as ofp:
+        for infile in sys.argv[2:]:
+            with open(infile, 'rb') as ifp:
+                ofp.write(ifp.read())
 sys.exit(0)
 """)
 
 
-test.write('test_fortran.py', r"""
+test.write('test_fortran.py', """\
 import sys
 with open(sys.argv[2], 'wb') as ofp:
     for infile in sys.argv[4:]:

--- a/test/Fortran/link-with-cxx.py
+++ b/test/Fortran/link-with-cxx.py
@@ -42,25 +42,25 @@ test = TestSCons.TestSCons(match = TestSCons.match_re)
 test.write('test_linker.py', r"""
 import sys
 if sys.argv[1] == '-o':
-    outfile = open(sys.argv[2], 'wb')
+    ofp = open(sys.argv[2], 'wb')
     infiles = sys.argv[3:]
 elif sys.argv[1][:5] == '/OUT:':
-    outfile = open(sys.argv[1][5:], 'wb')
+    ofp = open(sys.argv[1][5:], 'wb')
     infiles = sys.argv[2:]
 for infile in infiles:
-    with open(infile, 'rb') as f:
-        outfile.write(f.read())
-outfile.close()
+    with open(infile, 'rb') as ifp:
+        ofp.write(ifp.read())
+ofp.close()
 sys.exit(0)
 """)
 
 
 test.write('test_fortran.py', r"""
 import sys
-outfile = open(sys.argv[2], 'wb')
-for infile in sys.argv[4:]:
-    outfile.write(open(infile, 'rb').read())
-outfile.close()
+with open(sys.argv[2], 'wb') as ofp:
+    for infile in sys.argv[4:]:
+        with open(infile, 'rb') as ifp:
+            ofp.write(ifp.read())
 sys.exit(0)
 """)
 
@@ -70,8 +70,9 @@ import SCons.Tool.link
 def copier(target, source, env):
     s = str(source[0])
     t = str(target[0])
-    with open(t, 'wb') as fo, open(s, 'rb') as fi:
-        fo.write(fi.read())
+    with open(t, 'wb') as ofp, open(s, 'rb') as ifp:
+        ofp.write(ifp.read())
+
 env = Environment(CXX = r'%(_python_)s test_linker.py',
                   CXXCOM = Action(copier),
                   SMARTLINK = SCons.Tool.link.smart_link,

--- a/test/Fortran/module-subdir.py
+++ b/test/Fortran/module-subdir.py
@@ -52,23 +52,23 @@ for opt, arg in opts:
     if opt == '-o': out = arg
     elif opt == '-M': modsubdir = arg
 import os
-infile = open(args[0], 'rb')
-outfile = open(out, 'wb')
-for l in infile.readlines():
-    if l[:7] == b'module ':
-        module = modsubdir + os.sep + l[7:-1].decode() + '.mod'
-        open(module, 'wb').write(('myfortran.py wrote %s\n' % module).encode())
-    if l[:length] != comment:
-        outfile.write(l)
+with open(out, 'wb') as ofp, open(args[0], 'rb') as ifp:
+    for l in ifp.readlines():
+        if l[:7] == b'module ':
+            module = modsubdir + os.sep + l[7:-1].decode() + '.mod'
+            with open(module, 'wb') as f:
+                f.write(('myfortran.py wrote %s\n' % module).encode())
+        if l[:length] != comment:
+            ofp.write(l)
 sys.exit(0)
 """)
 
 test.write('myar.py', """\
 import sys
-t = open(sys.argv[1], 'wb')
-for s in sys.argv[2:]:
-    t.write(open(s, 'rb').read())
-t.close
+with open(sys.argv[1], 'wb') as ofp:
+    for s in sys.argv[2:]:
+        with open(s, 'rb') as ifp:
+            ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/GetBuildFailures/option-k.py
+++ b/test/GetBuildFailures/option-k.py
@@ -46,7 +46,8 @@ test = TestSCons.TestSCons()
 contents = r"""\
 import sys
 if sys.argv[0] == 'mypass.py':
-    open(sys.argv[3], 'wb').write(open(sys.argv[4], 'rb').read())
+    with open(sys.argv[3], 'wb') as ofp, open(sys.argv[4], 'rb') as ifp:
+        ofp.write(ifp.read())
     exit_value = 0
 elif sys.argv[0] == 'myfail.py':
     exit_value = 1

--- a/test/GetBuildFailures/parallel.py
+++ b/test/GetBuildFailures/parallel.py
@@ -60,7 +60,8 @@ if wait_marker != '-.marker':
     while not os.path.exists(wait_marker):
         time.sleep(1)
 if sys.argv[0] == 'mypass.py':
-    open(sys.argv[3], 'wb').write(open(sys.argv[4], 'rb').read())
+    with open(sys.argv[3], 'wb') as ofp, open(sys.argv[4], 'rb') as ifp:
+        ofp.write(ifp.read())
     exit_value = 0
 elif sys.argv[0] == 'myfail.py':
     exit_value = 1

--- a/test/GetBuildFailures/serial.py
+++ b/test/GetBuildFailures/serial.py
@@ -49,7 +49,8 @@ test = TestSCons.TestSCons()
 contents = r"""\
 import sys
 if sys.argv[0] == 'mypass.py':
-    open(sys.argv[3], 'wb').write(open(sys.argv[4], 'rb').read())
+    with open(sys.argv[3], 'wb') as ofp, open(sys.argv[4], 'rb') as ifp:
+        ofp.write(ifp.read())
     exit_value = 0
 elif sys.argv[0] == 'myfail.py':
     exit_value = 1
@@ -195,8 +196,7 @@ scons: *** [f12] f12: My SConsEnvironmentError
 scons: *** [f13] f13: My SConsEnvironmentError
 scons: *** [f14] InternalError : My InternalError
 """) + \
-"""\
-Traceback \((most recent call|innermost) last\):
+r"""Traceback \((most recent call|innermost) last\):
 (  File ".+", line \d+, in \S+
     [^\n]+
 )*(  File ".+", line \d+, in \S+

--- a/test/Glob/Repository.py
+++ b/test/Glob/Repository.py
@@ -50,10 +50,10 @@ test.write(['repository', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 
 # Verify that we can glob a repository-only Node that exists
 # only in memory, not on disk.

--- a/test/Glob/VariantDir.py
+++ b/test/Glob/VariantDir.py
@@ -52,10 +52,10 @@ test.write(['src', 'SConscript'], """\
 env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
 
@@ -67,10 +67,10 @@ test.write(['src', 'sub1', 'SConscript'], """\
 env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
 

--- a/test/Glob/basic.py
+++ b/test/Glob/basic.py
@@ -37,10 +37,10 @@ DefaultEnvironment(tools=[])
 env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
 

--- a/test/Glob/exclude.py
+++ b/test/Glob/exclude.py
@@ -40,10 +40,10 @@ DefaultEnvironment(tools=[])
 env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
 

--- a/test/Glob/source.py
+++ b/test/Glob/source.py
@@ -41,10 +41,10 @@ DefaultEnvironment(tools=[])
 env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
 

--- a/test/Glob/strings.py
+++ b/test/Glob/strings.py
@@ -49,10 +49,10 @@ test.write(['src', 'SConscript'], """\
 env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
 

--- a/test/Glob/subdir.py
+++ b/test/Glob/subdir.py
@@ -40,10 +40,10 @@ DefaultEnvironment(tools=[])
 env = Environment(tools=[]) 
 
 def concatenate(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
 

--- a/test/Glob/subst.py
+++ b/test/Glob/subst.py
@@ -38,10 +38,10 @@ DefaultEnvironment(tools=[])
 env = Environment(tools=[], PATTERN = 'f*.in')
 
 def copy(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env['BUILDERS']['Copy'] = Builder(action=copy)
 

--- a/test/HeaderGen.py
+++ b/test/HeaderGen.py
@@ -35,9 +35,8 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 def writeFile(target, contents):
-    file = open(str(target[0]), 'w')
-    file.write(contents)
-    file.close()
+    with open(str(target[0]), 'w') as f:
+        f.write(contents)
     return 0
 
 env = Environment()
@@ -60,10 +59,9 @@ test.write('SConstruct', """\
 env = Environment()
 
 def gen_a_h(target, source, env):
-    t = open(str(target[0]), 'w')
-    s = open(str(source[0]), 'r')
-    s.readline()
-    t.write(s.readline()[:-1] + ';\\n')
+    with open(str(target[0]), 'w') as t, open(str(source[0]), 'r') as s:
+        s.readline()
+        t.write(s.readline()[:-1] + ';\\n')
 
 MakeHeader = Builder(action = gen_a_h)
 env_no_scan = env.Clone(SCANNERS=[], BUILDERS={'MakeHeader' : MakeHeader})

--- a/test/IDL/MIDLCOM.py
+++ b/test/IDL/MIDLCOM.py
@@ -39,16 +39,14 @@ test = TestSCons.TestSCons()
 test.write('mymidl.py', """
 import os.path
 import sys
-out_tlb = open(sys.argv[1], 'w')
 base = os.path.splitext(sys.argv[1])[0]
-out_h = open(base + '.h', 'w')
-out_c = open(base + '_i.c', 'w')
-for f in sys.argv[2:]:
-    infile = open(f, 'r')
-    for l in [l for l in infile.readlines() if l != '/*midl*/\\n']:
-        out_tlb.write(l)
-        out_h.write(l)
-        out_c.write(l)
+with open(sys.argv[1], 'w') as out_tlb, open(base + '.h', 'w') as out_h, open(base + '_i.c', 'w') as out_c:
+    for f in sys.argv[2:]:
+        with open(f, 'r') as ifp:
+            for l in [l for l in ifp.readlines() if l != '/*midl*/\\n']:
+                out_tlb.write(l)
+                out_h.write(l)
+                out_c.write(l)
 sys.exit(0)
 """)
 

--- a/test/Ignore.py
+++ b/test/Ignore.py
@@ -36,11 +36,12 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read() + open(sys.argv[3], 'rb').read()
-file = open(sys.argv[1], 'wb')
-for arg in sys.argv[2:]:
-    file.write(open(arg, 'rb').read())
-file.close()
+with open(sys.argv[2], 'rb') as afp2, open(sys.argv[3], 'rb') as afp3:
+    contents = afp2.read() + afp3.read()
+with open(sys.argv[1], 'wb') as f:
+    for arg in sys.argv[2:]:
+        with open(arg, 'rb') as ifp:
+            f.write(ifp.read())
 """)
 
 SUBDIR_f3_out = os.path.join('$SUBDIR', 'f3.out')

--- a/test/Install/wrap-by-attribute.py
+++ b/test/Install/wrap-by-attribute.py
@@ -47,10 +47,10 @@ import os.path
 
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, 'wb') as ofp:
+        for src in source:
+            with open(str(src), 'rb') as ifp:
+                ofp.write(ifp.read())
 
 env = Environment(tools=[], DESTDIR='dest')
 env.Append(BUILDERS={'Cat':Builder(action=cat)})

--- a/test/Interactive/configure.py
+++ b/test/Interactive/configure.py
@@ -51,15 +51,14 @@ env = Environment(CXXCOM = r'%(_python_)s mycc.py $TARGET $SOURCE',
 # Ensure that our 'compiler' works...
 def CheckMyCC(context):
     context.Message('Checking for MyCC compiler...')
-    result = context.TryBuild(context.env.Object, 
-                              'int main(void) {return 0;}', 
+    result = context.TryBuild(context.env.Object,
+                              'int main(void) {return 0;}',
                               '.cpp')
     context.Result(result)
     return result
-    
-conf = Configure(env, 
-                 custom_tests = {'CheckMyCC' : CheckMyCC})
-                 
+
+conf = Configure(env, custom_tests = {'CheckMyCC' : CheckMyCC})
+
 if conf.CheckMyCC():
     pass # build succeeded
 else:

--- a/test/LEX/LEX.py
+++ b/test/LEX/LEX.py
@@ -44,7 +44,8 @@ else:
     longopts = []
 cmd_opts, args = getopt.getopt(sys.argv[1:], 't', longopts)
 for a in args:
-    contents = open(a, 'rb').read()
+    with open(a, 'rb') as f:
+        contents = f.read()
     sys.stdout.write(contents.replace(b'LEX', b'mylex.py').decode())
 sys.exit(0)
 """)

--- a/test/LEX/LEXFLAGS.py
+++ b/test/LEX/LEXFLAGS.py
@@ -51,7 +51,8 @@ for opt, arg in cmd_opts:
     if opt == '-I': i_arguments = i_arguments + ' ' + arg
     else: opt_string = opt_string + ' ' + opt
 for a in args:
-    contents = open(a, 'r').read()
+    with open(a, 'r') as f:
+        contents = f.read()
     contents = contents.replace('LEXFLAGS', opt_string)
     contents = contents.replace('I_ARGS', i_arguments)
     sys.stdout.write(contents)

--- a/test/LINK/LINKFLAGS.py
+++ b/test/LINK/LINKFLAGS.py
@@ -36,7 +36,8 @@ test = TestSCons.TestSCons()
 test.write("wrapper.py",
 """import os
 import sys
-open('%s', 'wb').write(("wrapper.py\\n").encode())
+with open('%s', 'wb') as f:
+    f.write(("wrapper.py\\n").encode())
 args = [s for s in sys.argv[1:] if s != 'fake_link_flag']
 os.system(" ".join(args))
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))

--- a/test/LINK/SHLINKFLAGS.py
+++ b/test/LINK/SHLINKFLAGS.py
@@ -37,7 +37,8 @@ test = TestSCons.TestSCons()
 test.write("wrapper.py",
 """import os
 import sys
-open('%s', 'wb').write(("wrapper.py\\n").encode())
+with open('%s', 'wb') as f:
+    f.write(("wrapper.py\\n").encode())
 args = [s for s in sys.argv[1:] if s != 'fake_shlink_flag']
 os.system(" ".join(args))
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))

--- a/test/M4/M4COM.py
+++ b/test/M4/M4COM.py
@@ -38,11 +38,11 @@ test = TestSCons.TestSCons()
 
 test.write('mym4.py', """
 import sys
-outfile = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    infile = open(f, 'rb')
-    for l in [l for l in infile.readlines() if l != b'/*m4*/\\n']:
-        outfile.write(l)
+with open(sys.argv[1], 'wb') as ofp:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as ifp:
+            for l in [l for l in ifp.readlines() if l != b'/*m4*/\\n']:
+                ofp.write(l)
 sys.exit(0)
 """)
 

--- a/test/M4/M4COMSTR.py
+++ b/test/M4/M4COMSTR.py
@@ -39,11 +39,11 @@ test = TestSCons.TestSCons()
 
 test.write('mym4.py', """
 import sys
-outfile = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    infile = open(f, 'rb')
-    for l in [l for l in infile.readlines() if l != b'/*m4*/\\n']:
-        outfile.write(l)
+with open(sys.argv[1], 'wb') as ofp:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as ifp:
+            for l in [l for l in ifp.readlines() if l != b'/*m4*/\\n']:
+                ofp.write(l)
 sys.exit(0)
 """)
 

--- a/test/MSVC/batch.py
+++ b/test/MSVC/batch.py
@@ -56,20 +56,24 @@ else:
 # Delay writing the .log output until here so any trailing slash or
 # backslash has been stripped, and the output comparisons later in this
 # script don't have to account for the difference.
-open('fake_cl.log', 'a').write(" ".join(sys.argv[1:]) + '\\n')
+with open('fake_cl.log', 'a') as ofp:
+    ofp.write(" ".join(sys.argv[1:]) + '\\n')
 for infile in input_files:
     if dir:
         outfile = os.path.join(dir, infile.replace('.c', '.obj'))
     else:
         outfile = output
-    open(outfile, 'w').write(open(infile, 'r').read())
+    with open(outfile, 'w') as ofp:
+        with open(infile, 'r') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.write('fake_link.py', """\
 import sys
-ofp = open(sys.argv[1], 'w')
-for infile in sys.argv[2:]:
-    ofp.write(open(infile, 'r').read())
+with open(sys.argv[1], 'w') as ofp:
+    for infile in sys.argv[2:]:
+        with open(infile, 'r') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/MSVS/vs-10.0-scc-files.py
+++ b/test/MSVS/vs-10.0-scc-files.py
@@ -51,7 +51,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='10.0',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-10.0-scc-legacy-files.py
+++ b/test/MSVS/vs-10.0-scc-legacy-files.py
@@ -46,11 +46,11 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='10.0',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-11.0-scc-files.py
+++ b/test/MSVS/vs-11.0-scc-files.py
@@ -51,7 +51,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='11.0',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-11.0-scc-legacy-files.py
+++ b/test/MSVS/vs-11.0-scc-legacy-files.py
@@ -46,11 +46,11 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='11.0',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-14.0-scc-files.py
+++ b/test/MSVS/vs-14.0-scc-files.py
@@ -51,7 +51,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.0',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-14.0-scc-legacy-files.py
+++ b/test/MSVS/vs-14.0-scc-legacy-files.py
@@ -46,11 +46,11 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.0',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-14.1-scc-files.py
+++ b/test/MSVS/vs-14.1-scc-files.py
@@ -49,7 +49,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.1',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-14.1-scc-legacy-files.py
+++ b/test/MSVS/vs-14.1-scc-legacy-files.py
@@ -44,11 +44,11 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.1',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']

--- a/test/MSVS/vs-7.0-scc-files.py
+++ b/test/MSVS/vs-7.0-scc-files.py
@@ -42,8 +42,8 @@ test._msvs_versions = ['7.0']
 
 expected_slnfile = TestSConsMSVS.expected_slnfile_7_0
 expected_vcprojfile = TestSConsMSVS.expected_vcprojfile_7_0
-SConscript_contents = """\
-env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='7.0',
+SConscript_contents = \
+r"""env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='7.0',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
                 MSVS_SCC_CONNECTION_ROOT='.',

--- a/test/MSVS/vs-7.0-scc-legacy-files.py
+++ b/test/MSVS/vs-7.0-scc-legacy-files.py
@@ -46,7 +46,7 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='7.0',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']

--- a/test/MSVS/vs-7.1-scc-legacy-files.py
+++ b/test/MSVS/vs-7.1-scc-legacy-files.py
@@ -46,7 +46,7 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='7.1',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']

--- a/test/MSVS/vs-8.0-scc-legacy-files.py
+++ b/test/MSVS/vs-8.0-scc-legacy-files.py
@@ -46,7 +46,7 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='8.0',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']

--- a/test/MSVS/vs-9.0-scc-legacy-files.py
+++ b/test/MSVS/vs-9.0-scc-legacy-files.py
@@ -46,7 +46,7 @@ SConscript_contents = """\
 env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='9.0',
                 CPPDEFINES=['DEF1', 'DEF2',('DEF3','1234')],
                 CPPPATH=['inc1', 'inc2'],
-                MSVS_SCC_LOCAL_PATH='C:\\MyMsVsProjects',
+                MSVS_SCC_LOCAL_PATH=r'C:\\MyMsVsProjects',
                 MSVS_SCC_PROJECT_NAME='Perforce Project')
 
 testsrc = ['test1.cpp', 'test2.cpp']

--- a/test/Mkdir.py
+++ b/test/Mkdir.py
@@ -41,10 +41,10 @@ Execute(Mkdir('d1'))
 Execute(Mkdir(Dir('#d1-Dir')))
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 Cat = Action(cat)
 env = Environment()
 env.Command('f2.out', 'f2.in', [Cat, Mkdir("d3")])
@@ -126,14 +126,14 @@ test.write(['work2', 'SConstruct'], """\
 import os
 def catdir(env, source, target):
     target = str(target[0])
-    outfp = open(target, "wb")
-    for src in source:
-        s = str(src)
-        for f in sorted(os.listdir(s)):
-            f = os.path.join(s, f)
-            if os.path.isfile(f):
-                outfp.write(open(f, "rb").read())
-    outfp.close()
+    with open(target, "wb") as outfp:
+        for src in source:
+            s = str(src)
+            for f in sorted(os.listdir(s)):
+                f = os.path.join(s, f)
+                if os.path.isfile(f):
+                    with open(f, "rb") as infp:
+                        outfp.write(infp.read())
 CatDir = Builder(action = catdir)
 env = Environment(BUILDERS = {'CatDir' : CatDir})
 env.Command(Dir('hello'), None, [Mkdir('$TARGET')])

--- a/test/Move.py
+++ b/test/Move.py
@@ -37,10 +37,10 @@ Execute(Move('f1.out', 'f1.in'))
 Execute(Move('File-f1.out', File('f1.in-File')))
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 Cat = Action(cat)
 env = Environment()
 env.Command('f2.out', 'f2.in', [Cat, Move("f3.out", "f3.in")])

--- a/test/NoClean.py
+++ b/test/NoClean.py
@@ -34,15 +34,20 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 def action(target, source, env):
-	for t in target: open(t.get_internal_path(), 'w')
+    for t in target:
+        with open(t.get_internal_path(), 'w'):
+            pass
 Command('1.out', 'SConstruct', action)
 NoClean('1.out')
 """)
 
 test.write('SConstruct.force', """
 def action(target, source, env):
-	for t in target: open(t.get_internal_path(), 'w')
-	open('4.out', 'w')
+    for t in target:
+        with open(t.get_internal_path(), 'w'):
+            pass
+    with open('4.out', 'w'):
+        pass
 res = Command('3.out', 'SConstruct.force', action)
 Clean('4.out', res)
 NoClean('4.out')
@@ -50,7 +55,9 @@ NoClean('4.out')
 
 test.write('SConstruct.multi', """
 def action(target, source, env):
-	for t in target: open(t.get_internal_path(), 'w')
+    for t in target:
+        with open(t.get_internal_path(), 'w'):
+            pass
 Command(['5.out', '6.out'], 'SConstruct.multi', action)
 NoClean('6.out')
 """)

--- a/test/Parallel/failed-build.py
+++ b/test/Parallel/failed-build.py
@@ -77,7 +77,14 @@ test.write('mycopy.py', r"""\
 import os
 import sys
 import time
-os.mkdir('mycopy.started')
+try:
+    os.makedirs('mycopy.started', exist_ok=True)
+except TypeError:  # Python 2 has no exist_ok
+    try:
+        os.mkdir('mycopy.started')
+    except FileExistsError:
+        pass
+
 with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
     ofp.write(ifp.read())
 for i in [1, 2, 3, 4, 5]:

--- a/test/ParseDepends.py
+++ b/test/ParseDepends.py
@@ -36,10 +36,8 @@ test.subdir('subdir', 'sub2')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read() + open(sys.argv[3], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as afp2, open(sys.argv[3], 'rb') as afp3:
+    f.write(afp2.read() + afp3.read())
 """)
 
 test.write('SConstruct', """

--- a/test/QT/qt_warnings.py
+++ b/test/QT/qt_warnings.py
@@ -84,8 +84,8 @@ if moc:
     qtdir = os.path.dirname(os.path.dirname(moc))
     qtdir = qtdir.replace('\\', '\\\\' )
 
-    expect = """
-scons: warning: Could not detect qt, using moc executable as a hint \(QTDIR=%s\)
+    expect = \
+r"""scons: warning: Could not detect qt, using moc executable as a hint \(QTDIR=%s\)
 File "%s", line \d+, in (\?|<module>)
 """ % (qtdir, re.escape(SConstruct_path))
 else:

--- a/test/QT/qt_warnings.py
+++ b/test/QT/qt_warnings.py
@@ -84,8 +84,8 @@ if moc:
     qtdir = os.path.dirname(os.path.dirname(moc))
     qtdir = qtdir.replace('\\', '\\\\' )
 
-    expect = \
-r"""scons: warning: Could not detect qt, using moc executable as a hint \(QTDIR=%s\)
+    expect = r"""
+scons: warning: Could not detect qt, using moc executable as a hint \(QTDIR=%s\)
 File "%s", line \d+, in (\?|<module>)
 """ % (qtdir, re.escape(SConstruct_path))
 else:

--- a/test/Repository/Default.py
+++ b/test/Repository/Default.py
@@ -47,7 +47,8 @@ def copy(env, source, target):
     source = str(source[0])
     target = str(target[0])
     print('copy() < %s > %s' % (source, target))
-    open(target, "w").write(open(source, "r").read())
+    with open(target, "w") as ofp, open(source, "r") as ifp:
+        ofp.write(ifp.read())
 
 Build = Builder(action=copy)
 env = Environment(BUILDERS={'Build':Build})

--- a/test/Repository/LIBPATH.py
+++ b/test/Repository/LIBPATH.py
@@ -46,14 +46,13 @@ bbb_exe = env_yyy.Program('bbb', 'bbb.c')
 def write_LIBDIRFLAGS(env, target, source):
     pre = env.subst('$LIBDIRPREFIX')
     suf = env.subst('$LIBDIRSUFFIX')
-    f = open(str(target[0]), 'w')
-    for arg in env.subst('$_LIBDIRFLAGS', target=target).split():
-        if arg[:len(pre)] == pre:
-            arg = arg[len(pre):]
-        if arg[-len(suf):] == suf:
-            arg = arg[:-len(pre)]
-        f.write(arg + '\n')
-    f.close()
+    with open(str(target[0]), 'w') as f:
+        for arg in env.subst('$_LIBDIRFLAGS', target=target).split():
+            if arg[:len(pre)] == pre:
+                arg = arg[len(pre):]
+            if arg[-len(suf):] == suf:
+                arg = arg[:-len(pre)]
+            f.write(arg + '\n')
     return 0
 env_zzz.Command('zzz.out', aaa_exe, write_LIBDIRFLAGS)
 env_yyy.Command('yyy.out', bbb_exe, write_LIBDIRFLAGS)

--- a/test/Repository/Local.py
+++ b/test/Repository/Local.py
@@ -49,8 +49,8 @@ def copy(env, source, target):
     source = str(source[0])
     target = str(target[0])
     print('copy() < %s > %s' % (source, target))
-    with open(target, 'w') as fo, open(source, 'r') as fi:
-        fo.write(fi.read())
+    with open(target, 'w') as ofp, open(source, 'r') as ifp:
+        ofp.write(ifp.read())
 
 Build = Builder(action=copy)
 env = Environment(BUILDERS={'Build':Build}, BBB='bbb')

--- a/test/Repository/SConscript.py
+++ b/test/Repository/SConscript.py
@@ -61,10 +61,11 @@ SConscript('src/SConscript')
 test.write(['rep1', 'src', 'SConscript'], """\
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "w")
-    for src in source:
-        f.write(open(str(src), "r").read())
-    f.close()
+    with open(target, "w") as ofp:
+        for src in source:
+            with open(str(src), "r") as ifp:
+                ofp.write(ifp.read())
+
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Cat(target = 'foo', source = ['aaa.in', 'bbb.in', 'ccc.in'])
 """)
@@ -97,10 +98,11 @@ SConscript('src/SConscript')
 test.write(['rep2', 'src', 'SConscript'], """\
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "w") as ofp:
+        for src in source:
+            with open(str(src), "r") as ifp:
+                ofp.write(ifp.read())
+
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Cat(target = 'foo', source = ['aaa.in', 'bbb.in', 'ccc.in'])
 SConscript('sub/SConscript')

--- a/test/Repository/VariantDir.py
+++ b/test/Repository/VariantDir.py
@@ -49,10 +49,10 @@ def cat(env, source, target):
     target = str(target[0])
     source = list(map(str, source))
     print('cat(%s) > %s' % (source, target))
-    f = open(target, "w")
-    for src in source:
-        f.write(open(src, "r").read())
-    f.close()
+    with open(target, "w") as ofp:
+        for src in source:
+            with open(src, "r") as ifp:
+                ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})
 env.Build('aaa.mid', 'aaa.in')

--- a/test/Repository/option-c.py
+++ b/test/Repository/option-c.py
@@ -66,8 +66,8 @@ def copy(env, source, target):
     source = str(source[0])
     target = str(target[0])
     print('copy() < %s > %s' % (source, target))
-    with open(target, 'w') as fo, open(source, 'r') as fi:
-        fo.write(fi.read())
+    with open(target, 'w') as ofp, open(source, 'r') as ifp:
+        ofp.write(ifp.read())
 
 Build = Builder(action=copy)
 env = Environment(BUILDERS={'Build':Build})

--- a/test/Repository/option-f.py
+++ b/test/Repository/option-f.py
@@ -43,10 +43,10 @@ test.write(['repository', 'SConstruct'], """\
 Repository(r'%s')
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})
 env.Build('aaa.out', 'aaa.in')

--- a/test/Repository/option-n.py
+++ b/test/Repository/option-n.py
@@ -49,7 +49,8 @@ def copy(env, source, target):
     source = str(source[0])
     target = str(target[0])
     print('copy() < %s > %s' % (source, target))
-    open(target, "w").write(open(source, "r").read())
+    with open(target, "w") as ofp, open(source, "r") as ifp:
+        ofp.write(ifp.read())
 
 Build = Builder(action=copy)
 env = Environment(BUILDERS={'Build':Build})

--- a/test/Repository/targets.py
+++ b/test/Repository/targets.py
@@ -44,10 +44,10 @@ def cat(env, source, target):
     target = str(target[0])
     source = list(map(str, source))
     print('cat(%s) > %s' % (source, target))
-    f = open(target, "w")
-    for src in source:
-        f.write(open(src, "r").read())
-    f.close()
+    with open(target, "w") as ofp:
+        for src in source:
+            with open(src, "r") as ifp:
+                ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})
 env.Build('aaa.out', 'aaa.in')

--- a/test/Requires/basic.py
+++ b/test/Requires/basic.py
@@ -35,11 +35,12 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 def append_prereq_func(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.write(open('prereq.out', 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as ofp:
+        for s in source:
+            with open(str(s), 'rb') as ifp:
+                ofp.write(ifp.read())
+        with open('prereq.out', 'rb') as ifp:
+            ofp.write(ifp.read())
     return None
 append_prereq = Action(append_prereq_func)
 env = Environment()

--- a/test/Requires/eval-order.py
+++ b/test/Requires/eval-order.py
@@ -34,11 +34,10 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 def copy_and_create_func(target, source, env):
-    with open(str(target[0]), 'w') as fp:
+    with open(str(target[0]), 'w') as ofp:
         for s in source:
-            with open(str(s), 'r') as f:
-                fp.write(f.read())
-    open('file.in', 'w').write("file.in 1\\n")
+            with open(str(s), 'r') as ifp:
+                ofp.write(ifp.read())
     with open('file.in', 'w') as f:
         f.write("file.in 1\\n")
     return None

--- a/test/Rpcgen/RPCGEN.py
+++ b/test/Rpcgen/RPCGEN.py
@@ -38,12 +38,13 @@ import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'chlmo:', [])
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
-output.write(" ".join(sys.argv) + "\\n")
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents.replace('RPCGEN', 'myrpcgen.py'))
-output.close()
+    if opt == '-o': out = arg
+with open(out, 'w') as ofp:
+    ofp.write(" ".join(sys.argv) + "\\n")
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        ofp.write(contents.replace('RPCGEN', 'myrpcgen.py'))
 sys.exit(0)
 """)
 

--- a/test/Rpcgen/RPCGENCLIENTFLAGS.py
+++ b/test/Rpcgen/RPCGENCLIENTFLAGS.py
@@ -38,12 +38,13 @@ import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'chlmo:x', [])
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
-output.write(" ".join(sys.argv) + "\\n")
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents.replace('RPCGEN', 'myrpcgen.py'))
-output.close()
+    if opt == '-o': out = arg
+with open(out, 'w') as ofp:
+    ofp.write(" ".join(sys.argv) + "\\n")
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        ofp.write(contents.replace('RPCGEN', 'myrpcgen.py'))
 sys.exit(0)
 """)
 

--- a/test/Rpcgen/RPCGENFLAGS.py
+++ b/test/Rpcgen/RPCGENFLAGS.py
@@ -38,12 +38,13 @@ import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'chlmo:x', [])
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
-output.write(" ".join(sys.argv) + "\\n")
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents.replace('RPCGEN', 'myrpcgen.py'))
-output.close()
+    if opt == '-o': out = arg
+with open(out, 'w') as ofp:
+    ofp.write(" ".join(sys.argv) + "\\n")
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        ofp.write(contents.replace('RPCGEN', 'myrpcgen.py'))
 sys.exit(0)
 """)
 

--- a/test/Rpcgen/RPCGENHEADERFLAGS.py
+++ b/test/Rpcgen/RPCGENHEADERFLAGS.py
@@ -38,12 +38,13 @@ import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'chlmo:x', [])
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
-output.write(" ".join(sys.argv) + "\\n")
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents.replace('RPCGEN', 'myrpcgen.py'))
-output.close()
+    if opt == '-o': out = arg
+with open(out, 'w') as ofp:
+    ofp.write(" ".join(sys.argv) + "\\n")
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        ofp.write(contents.replace('RPCGEN', 'myrpcgen.py'))
 sys.exit(0)
 """)
 

--- a/test/Rpcgen/RPCGENSERVICEFLAGS.py
+++ b/test/Rpcgen/RPCGENSERVICEFLAGS.py
@@ -38,12 +38,13 @@ import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'chlmo:x', [])
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
-output.write(" ".join(sys.argv) + "\\n")
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents.replace('RPCGEN', 'myrpcgen.py'))
-output.close()
+    if opt == '-o': out = arg
+with open(out, 'w') as ofp:
+    ofp.write(" ".join(sys.argv) + "\\n")
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        ofp.write(contents.replace('RPCGEN', 'myrpcgen.py'))
 sys.exit(0)
 """)
 

--- a/test/Rpcgen/RPCGENXDRFLAGS.py
+++ b/test/Rpcgen/RPCGENXDRFLAGS.py
@@ -38,12 +38,13 @@ import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'chlmo:x', [])
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
-output.write(" ".join(sys.argv) + "\\n")
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents.replace('RPCGEN', 'myrpcgen.py'))
-output.close()
+    if opt == '-o': out = arg
+with open(out, 'w') as ofp:
+    ofp.write(" ".join(sys.argv) + "\\n")
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        ofp.write(contents.replace('RPCGEN', 'myrpcgen.py'))
 sys.exit(0)
 """)
 

--- a/test/SConscript/SConscript.py
+++ b/test/SConscript/SConscript.py
@@ -74,7 +74,7 @@ SConscript('SConscript5')
 try:
     from collections import UserList
 except ImportError:
-    exec('from UserList import UserList')
+    from UserList import UserList
 x7 = "SConstruct x7"
 x8 = "SConstruct x8"
 x9 = SConscript('SConscript6', UserList(["x7", "x8"]))

--- a/test/SConscript/SConscriptChdir.py
+++ b/test/SConscript/SConscriptChdir.py
@@ -44,33 +44,43 @@ SConscript('dir5/SConscript')
 """)
 
 test.write(['dir1', 'SConscript'], """
-exec(open("create_test.py", 'r').read())
+with open("create_test.py", 'r') as f:
+    contents = f.read()
+exec(contents)
 """)
 
 test.write(['dir2', 'SConscript'], """
-exec(open("create_test.py", 'r').read())
+with open("create_test.py", 'r') as f:
+    contents = f.read()
+exec(contents)
 """)
 
 test.write(['dir3', 'SConscript'], """
 import os.path
 name = os.path.join('dir3', 'create_test.py')
-exec(open(name, 'r').read())
+with open(name, 'r') as f:
+    contents = f.read()
+exec(contents)
 """)
 
 test.write(['dir4', 'SConscript'], """
-exec(open("create_test.py", 'r').read())
+with open("create_test.py", 'r') as f:
+    contents = f.read()
+exec(contents)
 """)
 
 test.write(['dir5', 'SConscript'], """
 import os.path
 name = os.path.join('dir5', 'create_test.py')
-exec(open(name, 'r').read())
+with open(name, 'r') as f:
+    contents = f.read()
+exec(contents)
 """)
 
 for dir in ['dir1', 'dir2', 'dir3','dir4', 'dir5']:
     test.write([dir, 'create_test.py'], r"""
-f = open("test.txt", "a")
-f.write("This is the %s test.\n")
+with open("test.txt", "a") as f:
+    f.write("This is the %s test.\n")
 f.close()
 """ % dir)
 

--- a/test/SConsignFile/default.py
+++ b/test/SConsignFile/default.py
@@ -39,10 +39,8 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/SConsignFile/explicit-file.py
+++ b/test/SConsignFile/explicit-file.py
@@ -39,10 +39,8 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 """)
 
 #

--- a/test/SConsignFile/use-dbhash.py
+++ b/test/SConsignFile/use-dbhash.py
@@ -43,10 +43,8 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/SConsignFile/use-dbm.py
+++ b/test/SConsignFile/use-dbm.py
@@ -49,10 +49,8 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/SConsignFile/use-dumbdbm.py
+++ b/test/SConsignFile/use-dumbdbm.py
@@ -48,10 +48,8 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/SConsignFile/use-gdbm.py
+++ b/test/SConsignFile/use-gdbm.py
@@ -43,10 +43,8 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/SHELL.py
+++ b/test/SHELL.py
@@ -57,10 +57,10 @@ def stripquote(s):
     return s
 args = stripquote(sys.argv[2]).split()
 args = list(map(stripquote, args))
-ofp = open(args[2], 'wb')
-for f in args[3:] + ['extra.txt']:
-    ofp.write(open(f, 'rb').read())
-ofp.close()
+with open(args[2], 'wb') as ofp:
+    for f in args[3:] + ['extra.txt']:
+        with open(f, 'rb') as ifp:
+            ofp.write(ifp.read())
 sys.exit(0)
 """ % locals())
 

--- a/test/SPAWN.py
+++ b/test/SPAWN.py
@@ -36,10 +36,10 @@ test = TestSCons.TestSCons()
 
 test.write('cat.py', """\
 import sys
-ofp = open(sys.argv[1], 'wb')
-for s in sys.argv[2:]:
-    ofp.write(open(s, 'rb').read())
-ofp.close()
+with open(sys.argv[1], 'wb') as ofp:
+    for s in sys.argv[2:]:
+        with open(s, 'rb') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/Scanner/FindPathDirs.py
+++ b/test/Scanner/FindPathDirs.py
@@ -41,8 +41,6 @@ test.write('build.py', r"""
 import os.path
 import sys
 path = sys.argv[1].split()
-input = open(sys.argv[2], 'r')
-output = open(sys.argv[3], 'w')
 
 def find_file(f):
     for dir in path:
@@ -55,11 +53,13 @@ def process(infp, outfp):
     for line in infp.readlines():
         if line[:8] == 'include ':
             file = line[8:-1]
-            process(find_file(file), outfp)
+            with find_file(file) as f:
+                process(f, outfp)
         else:
             outfp.write(line)
 
-process(input, output)
+with open(sys.argv[2], 'r') as ifp, open(sys.argv[3], 'w') as ofp:
+    process(ifp, ofp)
 
 sys.exit(0)
 """)

--- a/test/Scanner/Scanner.py
+++ b/test/Scanner/Scanner.py
@@ -33,14 +33,13 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-input = open(sys.argv[1], 'r')
-output = open(sys.argv[2], 'w')
 
 def process(infp, outfp):
     for line in infp.readlines():
         if line[:8] == 'include ':
             file = line[8:-1]
-            process(open(file, 'r'), outfp)
+            with open(file, 'r') as f:
+                process(f, outfp)
         elif line[:8] == 'getfile ':
             outfp.write('include ')
             outfp.write(line[8:])
@@ -48,7 +47,8 @@ def process(infp, outfp):
         else:
             outfp.write(line)
 
-process(input, output)
+with open(sys.argv[1], 'r') as ifp, open(sys.argv[2], 'w') as ofp:
+    process(ifp, ofp)
 
 sys.exit(0)
 """, mode='w')
@@ -118,7 +118,8 @@ def third(env, target, source):
     contents = source[0].get_contents()
     # print("TYPE:"+str(type(contents)))
     contents = contents.replace(b'getfile', b'MISSEDME')
-    open(str(target[0]), 'wb').write(contents)
+    with open(str(target[0]), 'wb') as f:
+        f.write(contents)
 
 kbld = Builder(action=r'%(_python_)s build.py $SOURCES $TARGET',
                src_suffix='.first',

--- a/test/Scanner/dictionary.py
+++ b/test/Scanner/dictionary.py
@@ -36,8 +36,6 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-input = open(sys.argv[1], 'r')
-output = open(sys.argv[2], 'w')
 
 include_prefix = 'include%s ' % sys.argv[1][-1]
 
@@ -45,11 +43,13 @@ def process(infp, outfp):
     for line in infp.readlines():
         if line[:len(include_prefix)] == include_prefix:
             file = line[len(include_prefix):-1]
-            process(open(file, 'r'), outfp)
+            with open(file, 'r') as f:
+                process(f, outfp)
         else:
             outfp.write(line)
 
-process(input, output)
+with open(sys.argv[2], 'w') as ofp, open(sys.argv[1], 'r') as ifp:
+    process(ifp, ofp)
 
 sys.exit(0)
 """)

--- a/test/Scanner/empty-implicit.py
+++ b/test/Scanner/empty-implicit.py
@@ -53,7 +53,8 @@ def echo(env, target, source):
     t = os.path.split(str(target[0]))[1]
     s = os.path.split(str(source[0]))[1]
     print('create %s from %s' % (t, s))
-    open(t, 'wb').write(open(s, 'rb').read())
+    with open(t, 'wb') as ofb, open(s, 'rb') as ifb:
+        ofb.write(ifb.read())
 
 Echo = Builder(action = Action(echo, None),
                src_suffix = '.x',

--- a/test/Scanner/exception.py
+++ b/test/Scanner/exception.py
@@ -61,16 +61,17 @@ def process(outf, inf):
     for line in inf.readlines():
         if line[:8] == 'include ':
             file = line[8:-1]
-            process(outf, open(file, 'rb'))
+            with open(file, 'rb') as ifp:
+                process(outf, ifp)
         else:
             outf.write(line)
 
 def cat(env, source, target):
     target = str(target[0])
-    outf = open(target, 'wb')
-    for src in source:
-        process(outf, open(str(src), 'rb'))
-    outf.close()
+    with open(target, 'wb') as outf:
+        for src in source:
+            with open(str(src), 'rb') as inf:
+                process(outf, inf)
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Append(SCANNERS = [kscan])

--- a/test/Scanner/generated.py
+++ b/test/Scanner/generated.py
@@ -245,7 +245,7 @@ lib_name = "g"
 lib_fullname = env.subst("${LIBPREFIX}g${LIBSUFFIX}")
 lib_srcs = "libg_1.c libg_2.c libg_3.c".split()
 import re
-lib_objs = [re.sub("\.c$", ".o", x) for x in lib_srcs]
+lib_objs = [re.sub(r"\.c$", ".o", x) for x in lib_srcs]
 
 Mylib.ExportHeader(env, exported_hdrs)
 Mylib.ExportLib(env, lib_fullname)
@@ -259,7 +259,7 @@ Mylib.ExportLib(env, lib_fullname)
 #cmd_generated = "cd %s ; sh MAKE-HEADER.sh" % Dir(".")
 #cmd_justlib = "cd %s ; make" % Dir(".")
 
-_ws = re.compile('\s')
+_ws = re.compile(r'\s')
 
 def escape(s):
     if _ws.search(s):
@@ -294,7 +294,8 @@ import sys
 os.chdir(os.path.split(sys.argv[0])[0])
 
 for h in ['libg_gx.h', 'libg_gy.h', 'libg_gz.h']:
-    open(h, 'w').write('')
+    with open(h, 'w') as f:
+        f.write('')
 """ % locals())
 
 test.write(['src', 'lib_geng', 'SConstruct'], """\
@@ -302,12 +303,11 @@ import os
 
 Scanned = {}
 
-def write_out(file, dict):
-    f = open(file, 'w')
-    for k in sorted(dict.keys()):
-        file = os.path.split(k)[1]
-        f.write(file + ": " + str(dict[k]) + "\\n")
-    f.close()
+def write_out(fname, dict):
+    with open(fname, 'w') as f:
+        for k in sorted(dict.keys()):
+            name = os.path.split(k)[1]
+            f.write(name + ": " + str(dict[k]) + "\\n")
 
 # A hand-coded new-style class proxy to wrap the underlying C Scanner
 # with a method that counts the calls.

--- a/test/Scanner/multi-env.py
+++ b/test/Scanner/multi-env.py
@@ -72,12 +72,13 @@ def process(infp, outfp):
     l = len(prefix)
     for line in infp.readlines():
         if line[:l] == prefix:
-            process(open(line[l:-1], 'r'), outfp)
+            with open(line[l:-1], 'r') as f:
+                process(f, outfp)
         else:
             outfp.write(line)
 
-process(open(sys.argv[2], 'r'),
-        open(sys.argv[1], 'w'))
+with open(sys.argv[2], 'r') as ifp, open(sys.argv[1], 'w') as ofp:
+    process(ifp, ofp)
 sys.exit(0)
 """
 

--- a/test/Scanner/no-Dir-node.py
+++ b/test/Scanner/no-Dir-node.py
@@ -54,8 +54,6 @@ test.write('build.py', r"""
 import os.path
 import sys
 path = sys.argv[1].split()
-input = open(sys.argv[2], 'r')
-output = open(sys.argv[3], 'w')
 
 def find_file(f):
     if os.path.isabs(f):
@@ -69,12 +67,14 @@ def find_file(f):
 def process(infp, outfp):
     for line in infp.readlines():
         if line[:8] == 'include ':
-            file = line[8:-1]
-            process(find_file(file), outfp)
+            fname = line[8:-1]
+            with find_file(fname) as f:
+                process(f, outfp)
         else:
             outfp.write(line)
 
-process(input, output)
+with open(sys.argv[2], 'r') as ifp, open(sys.argv[3], 'w') as ofp:
+    process(ifp, ofp)
 
 sys.exit(0)
 """)

--- a/test/Scanner/source_scanner-dict.py
+++ b/test/Scanner/source_scanner-dict.py
@@ -39,21 +39,21 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-output = open(sys.argv[1], 'w')
-for infile in sys.argv[2:]:
-    input = open(infile, 'r')
+with open(sys.argv[1], 'w') as ofp:
+    for infile in sys.argv[2:]:
+        with open(infile, 'r') as ifp:
+            include_prefix = 'include%s ' % infile[-1]
 
-    include_prefix = 'include%s ' % infile[-1]
+            def process(infp, outfp, include_prefix=include_prefix):
+                for line in infp.readlines():
+                    if line[:len(include_prefix)] == include_prefix:
+                        file = line[len(include_prefix):-1]
+                        with open(file, 'r') as f:
+                            process(f, outfp)
+                    else:
+                        outfp.write(line)
 
-    def process(infp, outfp, include_prefix=include_prefix):
-        for line in infp.readlines():
-            if line[:len(include_prefix)] == include_prefix:
-                file = line[len(include_prefix):-1]
-                process(open(file, 'r'), outfp)
-            else:
-                outfp.write(line)
-
-    process(input, output)
+            process(ifp, ofp)
 
 sys.exit(0)
 """)

--- a/test/Scanner/unicode.py
+++ b/test/Scanner/unicode.py
@@ -49,7 +49,8 @@ import codecs
 import sys
 
 def process(outfp, infile):
-    contents = open(infile, 'rb').read()
+    with open(infile, 'rb') as f:
+        contents = f.read()
     if contents[:len(codecs.BOM_UTF8)] == codecs.BOM_UTF8:
         contents = contents[len(codecs.BOM_UTF8):].decode('utf-8')
     elif contents[:len(codecs.BOM_UTF16_LE)] == codecs.BOM_UTF16_LE:
@@ -70,8 +71,8 @@ def process(outfp, infile):
         else:
             outfp.write(line + '\n')
 
-output = open(sys.argv[2], 'w')
-process(output, sys.argv[1])
+with open(sys.argv[2], 'w') as ofp:
+    process(ofp, sys.argv[1])
 
 sys.exit(0)
 """)

--- a/test/SideEffect/directory.py
+++ b/test/SideEffect/directory.py
@@ -37,7 +37,8 @@ import os.path
 import os
 
 def copy(source, target):
-    open(target, "wb").write(open(source, "rb").read())
+    with open(target, "wb") as ofp, open(source, "rb") as ifp:
+        ofp.write(ifp.read())
 
 def build(env, source, target):
     copy(str(source[0]), str(target[0]))

--- a/test/SideEffect/parallel.py
+++ b/test/SideEffect/parallel.py
@@ -52,7 +52,8 @@ except OSError as e:
 
 src, target = sys.argv[1:]
 
-open(logfile, 'ab').write(('%s -> %s\\n' % (src, target)).encode())
+with open(logfile, 'ab') as f:
+    f.write(('%s -> %s\\n' % (src, target)).encode())
 
 # Give the other threads a chance to start.
 time.sleep(1)

--- a/test/Subst/null-sources-attr.py
+++ b/test/Subst/null-sources-attr.py
@@ -37,10 +37,10 @@ test = TestSCons.TestSCons()
 
 test.write('cat.py', """\
 import sys
-fp = open(sys.argv[1], 'wb')
-for infile in sys.argv[2:]:
-  fp.write(open(infile, 'rb').read())
-fp.close()
+with open(sys.argv[1], 'wb') as ofp:
+    for infile in sys.argv[2:]:
+      with open(infile, 'rb') as ifp:
+          ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/TAR/TAR.py
+++ b/test/TAR/TAR.py
@@ -42,16 +42,18 @@ import sys
 opts, args = getopt.getopt(sys.argv[1:], 'cf:')
 for opt, arg in opts:
     if opt == '-f': out = arg
+
 def process(outfile, name):
     if os.path.isdir(name):
         for entry in sorted(os.listdir(name)):
             process(outfile, os.path.join(name, entry))
     else:
-        outfile.write(open(name, 'r').read())
-outfile = open(out, 'w')
-for infile in args:
-    process(outfile, infile)
-outfile.close()
+        with open(name, 'r') as ifp:
+            outfile.write(ifp.read())
+
+with open(out, 'w') as ofp:
+    for infile in args:
+        process(ofp, infile)
 sys.exit(0)
 """)
 

--- a/test/TAR/TARFLAGS.py
+++ b/test/TAR/TARFLAGS.py
@@ -44,17 +44,19 @@ opt_string = ''
 for opt, arg in cmd_opts:
     if opt == '-f': out = arg
     else: opt_string = opt_string + ' ' + opt
+
 def process(outfile, name):
     if os.path.isdir(name):
         for entry in sorted(os.listdir(name)):
             process(outfile, os.path.join(name, entry))
     else:
-        outfile.write(open(name, 'r').read())
-outfile = open(out, 'w')
-outfile.write('options: %s\\n' % opt_string)
-for infile in args:
-    process(outfile, infile)
-outfile.close()
+        with open(name, 'r') as ifp:
+            outfile.write(ifp.read())
+
+with open(out, 'w') as ofp:
+    ofp.write('options: %s\\n' % opt_string)
+    for infile in args:
+        process(ofp, infile)
 sys.exit(0)
 """)
 

--- a/test/TARGET-dir.py
+++ b/test/TARGET-dir.py
@@ -43,9 +43,10 @@ test.subdir('src', 'build1', 'build2')
 test.write('SConstruct', """
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
     f.close()
 env = Environment(CPPPATH='${TARGET.dir}')
 env.Append(BUILDERS = {'Cat' : Builder(action=cat)})

--- a/test/TEX/LATEX.py
+++ b/test/TEX/LATEX.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can set the LATEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.
@@ -44,15 +44,16 @@ import os
 import getopt
 cmd_opts, arg = getopt.getopt(sys.argv[1:], 'i:r:', [])
 base_name = os.path.splitext(arg[0])[0]
-infile = open(arg[0], 'r')
-dvi_file = open(base_name+'.dvi', 'w')
-aux_file = open(base_name+'.aux', 'w')
-log_file = open(base_name+'.log', 'w')
-for l in infile.readlines():
-    if l[0] != '\\':
-        dvi_file.write(l)
-        aux_file.write(l)
-        log_file.write(l)
+with open(arg[0], 'r') as ifp:
+    with open(base_name+'.dvi', 'w') as dvi_file, \
+         open(base_name+'.aux', 'w') as aux_file, \
+         open(base_name+'.log', 'w') as log_file:
+
+        for l in ifp.readlines():
+            if l[0] != '\\':
+                dvi_file.write(l)
+                aux_file.write(l)
+                log_file.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/LATEX2.py
+++ b/test/TEX/LATEX2.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can produce several .pdf at once from several sources.
 """
 

--- a/test/TEX/LATEXCOM.py
+++ b/test/TEX/LATEXCOM.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test the ability to configure the $LATEXCOM construction variable.
 """
 

--- a/test/TEX/LATEXCOMSTR.py
+++ b/test/TEX/LATEXCOMSTR.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test that the $LATEXCOMSTR construction variable allows you to configure
 the C compilation output.
 """

--- a/test/TEX/LATEXFLAGS.py
+++ b/test/TEX/LATEXFLAGS.py
@@ -43,12 +43,11 @@ opt_string = ''
 for opt, arg in cmd_opts:
     opt_string = opt_string + ' ' + opt
 base_name = os.path.splitext(args[0])[0]
-infile = open(args[0], 'r')
-out_file = open(base_name+'.dvi', 'w')
-out_file.write(opt_string + "\n")
-for l in infile.readlines():
-    if l[0] != '\\':
-        out_file.write(l)
+with open(base_name+'.dvi', 'w') as ofp, open(args[0], 'r') as ifp:
+    ofp.write(opt_string + "\n")
+    for l in ifp.readlines():
+        if l[0] != '\\':
+            ofp.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/PDFLATEX.py
+++ b/test/TEX/PDFLATEX.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can set the PDFLATEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.
@@ -44,15 +44,16 @@ import os
 import getopt
 cmd_opts, arg = getopt.getopt(sys.argv[1:], 'i:r:', [])
 base_name = os.path.splitext(arg[0])[0]
-infile = open(arg[0], 'rb')
-pdf_file = open(base_name+'.pdf', 'wb')
-aux_file = open(base_name+'.aux', 'wb')
-log_file = open(base_name+'.log', 'wb')
-for l in infile.readlines():
-    if l[0] != '\\':
-        pdf_file.write(l)
-        aux_file.write(l)
-        log_file.write(l)
+with open(arg[0], 'r') as ifp:
+    with open(base_name+'.pdf', 'w') as pdf_file, \
+         open(base_name+'.aux', 'w') as aux_file, \
+         open(base_name+'.log', 'w') as log_file:
+
+        for l in ifp.readlines():
+            if l[0] != '\\':
+                pdf_file.write(l)
+                aux_file.write(l)
+                log_file.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/PDFLATEXCOM.py
+++ b/test/TEX/PDFLATEXCOM.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test the ability to configure the $PDFLATEXCOM construction variable.
 """
 

--- a/test/TEX/PDFLATEXCOMSTR.py
+++ b/test/TEX/PDFLATEXCOMSTR.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 #
 # __COPYRIGHT__
@@ -25,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test that the $PDFLATEXCOMSTR construction variable allows you to configure
 the C compilation output.
 """

--- a/test/TEX/PDFLATEXFLAGS.py
+++ b/test/TEX/PDFLATEXFLAGS.py
@@ -43,12 +43,11 @@ opt_string = ''
 for opt, arg in cmd_opts:
     opt_string = opt_string + ' ' + opt
 base_name = os.path.splitext(args[0])[0]
-infile = open(args[0], 'r')
-out_file = open(base_name+'.pdf', 'w')
-out_file.write(opt_string + "\n")
-for l in infile.readlines():
-    if l[0] != '\\':
-        out_file.write(l)
+with open(base_name+'.pdf', 'w') as ofp, open(args[0], 'r') as ifp:
+    ofp.write(opt_string + "\n")
+    for l in ifp.readlines():
+        if l[0] != '\\':
+            ofp.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/PDFTEX.py
+++ b/test/TEX/PDFTEX.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can set the PDFTEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.
@@ -44,15 +44,16 @@ import os
 import getopt
 cmd_opts, arg = getopt.getopt(sys.argv[2:], 'i:r:', [])
 base_name = os.path.splitext(arg[0])[0]
-infile = open(arg[0], 'rb')
-pdf_file = open(base_name+'.pdf', 'wb')
-aux_file = open(base_name+'.aux', 'wb')
-log_file = open(base_name+'.log', 'wb')
-for l in infile.readlines():
-    if l[0] != '\\':
-        pdf_file.write(l)
-        aux_file.write(l)
-        log_file.write(l)
+with open(arg[0], 'r') as ifp:
+    with open(base_name+'.pdf', 'w') as pdf_file, \
+         open(base_name+'.aux', 'w') as aux_file, \
+         open(base_name+'.log', 'w') as log_file:
+
+        for l in ifp.readlines():
+            if l[0] != '\\':
+                pdf_file.write(l)
+                aux_file.write(l)
+                log_file.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/PDFTEXCOM.py
+++ b/test/TEX/PDFTEXCOM.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test the ability to configure the $PDFTEXCOM construction variable.
 """
 

--- a/test/TEX/PDFTEXCOMSTR.py
+++ b/test/TEX/PDFTEXCOMSTR.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 #
 # __COPYRIGHT__
@@ -25,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test that the $PDFTEXCOMSTR construction variable allows you to configure
 the C compilation output.
 """

--- a/test/TEX/PDFTEXFLAGS.py
+++ b/test/TEX/PDFTEXFLAGS.py
@@ -43,12 +43,11 @@ opt_string = ''
 for opt, arg in cmd_opts:
     opt_string = opt_string + ' ' + opt
 base_name = os.path.splitext(args[0])[0]
-infile = open(args[0], 'r')
-out_file = open(base_name+'.pdf', 'w')
-out_file.write(opt_string + "\n")
-for l in infile.readlines():
-    if l[0] != '\\':
-        out_file.write(l)
+with open(base_name+'.pdf', 'w') as ofp, open(args[0], 'r') as ifp:
+    ofp.write(opt_string + "\n")
+    for l in ifp.readlines():
+        if l[0] != '\\':
+            ofp.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/PDF_single_source.py
+++ b/test/TEX/PDF_single_source.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a mulitple pdf's from a list of PostScript files.
 
 Test courtesy Rob Managan.
@@ -108,7 +108,7 @@ $F2psBegin
  0.06299 0.06299 sc
 %
 % Fig objects follow
-% 
+%
 7.500 slw
 % Ellipse
 n 1170 945 766 766 0 360 DrawEllipse gs col0 s gr

--- a/test/TEX/TEX.py
+++ b/test/TEX/TEX.py
@@ -24,7 +24,7 @@ from __future__ import print_function
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can set the TEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.
@@ -47,15 +47,16 @@ import os
 import getopt
 cmd_opts, arg = getopt.getopt(sys.argv[1:], 'i:r:', [])
 base_name = os.path.splitext(arg[0])[0]
-infile = open(arg[0], 'r')
-dvi_file = open(base_name+'.dvi', 'w')
-aux_file = open(base_name+'.aux', 'w')
-log_file = open(base_name+'.log', 'w')
-for l in infile.readlines():
-    if l[0] != '\\':
-        dvi_file.write(l)
-        aux_file.write(l)
-        log_file.write(l)
+with open(arg[0], 'r') as ifp:
+    with open(base_name+'.dvi', 'w') as dvi_file, \
+         open(base_name+'.aux', 'w') as aux_file, \
+         open(base_name+'.log', 'w') as log_file:
+
+        for l in ifp.readlines():
+            if l[0] != '\\':
+                dvi_file.write(l)
+                aux_file.write(l)
+                log_file.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/TEXCOM.py
+++ b/test/TEX/TEXCOM.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test the ability to configure the $TEXCOM construction variable.
 """
 

--- a/test/TEX/TEXCOMSTR.py
+++ b/test/TEX/TEXCOMSTR.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test that the $TEXCOMSTR construction variable allows you to configure
 the C compilation output.
 """

--- a/test/TEX/TEXFLAGS.py
+++ b/test/TEX/TEXFLAGS.py
@@ -43,12 +43,11 @@ opt_string = ''
 for opt, arg in cmd_opts:
     opt_string = opt_string + ' ' + opt
 base_name = os.path.splitext(args[0])[0]
-infile = open(args[0], 'r')
-out_file = open(base_name+'.dvi', 'w')
-out_file.write(opt_string + "\n")
-for l in infile.readlines():
-    if l[0] != '\\':
-        out_file.write(l)
+with open(base_name+'.dvi', 'w') as ofp, open(args[0], 'r') as ifp:
+    ofp.write(opt_string + "\n")
+    for l in ifp.readlines():
+        if l[0] != '\\':
+            ofp.write(l)
 sys.exit(0)
 """)
 

--- a/test/TEX/auxiliaries.py
+++ b/test/TEX/auxiliaries.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify that sections of LaTeX output that use auxiliary files (a
 bibliography in our configuration below) are consistent when re-run
 after modifying the input file.

--- a/test/TEX/biber_biblatex.py
+++ b/test/TEX/biber_biblatex.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a Tex document that uses the multibib oackage
 
 Test courtesy Rob Managan.

--- a/test/TEX/biber_biblatex2.py
+++ b/test/TEX/biber_biblatex2.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a Tex document that uses the biblatex package
 It uses the default backend, could be bibtex or biber. 
 Require both be installed

--- a/test/TEX/biblatex.py
+++ b/test/TEX/biblatex.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a Tex document that uses the biblatex package
 
 Test courtesy Rob Managan.

--- a/test/TEX/biblatex_plain.py
+++ b/test/TEX/biblatex_plain.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a Tex document that uses the biblatex package
 
 Test courtesy Rob Managan.

--- a/test/TEX/bibliography.py
+++ b/test/TEX/bibliography.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that use of \bibliography in TeX source files causes SCons to
 be aware of the necessary created bibliography files.
 
@@ -48,7 +48,7 @@ have_latex = test.where_is('latex')
 if not have_latex:
     test.skip_test('Could not find latex; skipping test(s).\n')
 
-    
+
 test.write('SConstruct', """\
 import os
 env = Environment(tools = ['tex', 'latex', 'dvips'])

--- a/test/TEX/bibtex-latex-rerun.py
+++ b/test/TEX/bibtex-latex-rerun.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify that we re-run LaTeX after running BibTeX in response to
 changes in a .bib file.
 

--- a/test/TEX/clean.py
+++ b/test/TEX/clean.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Check that all auxilary files created by LaTeX are properly cleaned by scons -c.
 """
 

--- a/test/TEX/configure.py
+++ b/test/TEX/configure.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify execution of custom test case.
 The old code base would not be able to fail the test
 """

--- a/test/TEX/dryrun.py
+++ b/test/TEX/dryrun.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can set the LATEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.

--- a/test/TEX/eps_graphics.py
+++ b/test/TEX/eps_graphics.py
@@ -24,8 +24,8 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
-Test creation of a Tex document with nested includes in a 
+r"""
+Test creation of a Tex document with nested includes in a
 subdir that needs to create a fig.pdf.
 
 Test courtesy Rob Managan.
@@ -115,7 +115,7 @@ $F2psBegin
  0.06299 0.06299 sc
 %
 % Fig objects follow
-% 
+%
 7.500 slw
 % Ellipse
 n 1170 945 766 766 0 360 DrawEllipse gs col0 s gr
@@ -133,13 +133,13 @@ r"""\documentclass{report}
 \usepackage{epsfig,color} % for .tex version of figures if we go that way
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -150,7 +150,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are shown as well.  
+The Acknowledgements are shown as well.
 
 To get a hard copy of this report call me.
 

--- a/test/TEX/eps_graphics2.py
+++ b/test/TEX/eps_graphics2.py
@@ -24,8 +24,8 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
-Test creation of a Tex document with nested includes in a 
+r"""
+Test creation of a Tex document with nested includes in a
 subdir that needs to create a fig.pdf.
 Test creation with pdflatex
 
@@ -117,7 +117,7 @@ $F2psBegin
  0.06299 0.06299 sc
 %
 % Fig objects follow
-% 
+%
 7.500 slw
 % Ellipse
 n 1170 945 766 766 0 360 DrawEllipse gs col0 s gr
@@ -135,13 +135,13 @@ r"""\documentclass{report}
 \usepackage{epsfig,color} % for .tex version of figures if we go that way
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -152,14 +152,14 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are shown as well.  
+The Acknowledgements are shown as well.
 
 To get a hard copy of this report call me.
 
 \begin{figure}[htbp]
 \begin{center}
-\includegraphics 
- [width=.5\textwidth] 
+\includegraphics
+ [width=.5\textwidth]
  {Fig1}
 \caption{Zone and Node indexing}
 \label{fig1}

--- a/test/TEX/generated_files.py
+++ b/test/TEX/generated_files.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a Tex document with generated tex files
 This checks whether the .bbl file is kept as a side effect
 Test creation with pdflatex

--- a/test/TEX/glossaries.py
+++ b/test/TEX/glossaries.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that use of \glossaries in TeX source files causes SCons to
 be aware of the necessary created glossary files.
 

--- a/test/TEX/glossary.py
+++ b/test/TEX/glossary.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that use of \glossary in TeX source files causes SCons to
 be aware of the necessary created glossary files.
 

--- a/test/TEX/input_docClass.py
+++ b/test/TEX/input_docClass.py
@@ -24,9 +24,9 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a LaTeX document that uses \input{filename}
-to set the documentclass. When the file has .tex we have to search 
+to set the documentclass. When the file has .tex we have to search
 to find the documentclass command.
 
 Test courtesy Rob Managan.
@@ -53,13 +53,13 @@ r"""
 \input{theClass}
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -73,7 +73,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are shown as well.  
+The Acknowledgements are shown as well.
 
 \end{document}
 """)

--- a/test/TEX/lstinputlisting.py
+++ b/test/TEX/lstinputlisting.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify that we re-run LaTeX when a source file in \lstinputlisting
 changes.
 

--- a/test/TEX/makeindex.py
+++ b/test/TEX/makeindex.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that use of \makeindex in TeX source files causes SCons to be
 aware of the necessary created index files.
 

--- a/test/TEX/multi-line_include_options.py
+++ b/test/TEX/multi-line_include_options.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 When an inclusion's optional argument (enclosed in square brackets:
 []) spans multiple lines (via comment wrapping), ensure that the LaTeX
 Scanner doesn't throw an IndexError.

--- a/test/TEX/multi-run.py
+++ b/test/TEX/multi-run.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that both .tex and .ltx files can handle a LaTeX-style
 bibliography (by calling $BIBTEX to generate a .bbl file) and
 correctly re-run to resolve undefined references.

--- a/test/TEX/multibib.py
+++ b/test/TEX/multibib.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a Tex document that uses the multibib oackage
 
 Test courtesy Rob Managan.

--- a/test/TEX/multiple_include.py
+++ b/test/TEX/multiple_include.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a fully-featured TeX document (with bibliography
 and index) in a variant_dir.
 
@@ -116,7 +116,7 @@ $F2psBegin
  0.06299 0.06299 sc
 %
 % Fig objects follow
-% 
+%
 7.500 slw
 % Ellipse
 n 1170 945 766 766 0 360 DrawEllipse gs col0 s gr
@@ -155,13 +155,13 @@ r"""\documentclass{report}
 \makeindex
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -177,7 +177,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are shown as well.  
+The Acknowledgements are shown as well.
 
 \index{Getting the Report}
 

--- a/test/TEX/multiple_include_subdir.py
+++ b/test/TEX/multiple_include_subdir.py
@@ -24,8 +24,8 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
-Test creation of a Tex document with nested includes in a 
+r"""
+Test creation of a Tex document with nested includes in a
 subdir that needs to create a fig.pdf.
 
 Test courtesy Rob Managan.
@@ -116,7 +116,7 @@ $F2psBegin
  0.06299 0.06299 sc
 %
 % Fig objects follow
-% 
+%
 7.500 slw
 % Ellipse
 n 1170 945 766 766 0 360 DrawEllipse gs col0 s gr
@@ -155,13 +155,13 @@ r"""\documentclass{report}
 \makeindex
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -177,7 +177,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are shown as well.  
+The Acknowledgements are shown as well.
 
 \index{Getting the Report}
 

--- a/test/TEX/newglossary.py
+++ b/test/TEX/newglossary.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that use of \newglossary in TeX source files causes SCons to
 be aware of the necessary created glossary files.
 
@@ -72,7 +72,7 @@ test.write('newglossary.tex', r"""
 
 \newacronym{gnu}{GNU}{GNU's Not UNIX}
 \makeglossaries
-\glstoctrue 
+\glstoctrue
 %\loadglsentries[\acronymtype]{chapters/acronyms}
 \loadglsentries[symbol]{symbols}
 %\loadglsentries[definition]{defns}
@@ -97,7 +97,7 @@ a definition \gls{defPower}
 
 
 test.write('symbols.tex', r"""
-\newglossaryentry{mel}{name={Microelectronic Fundamentals},description={\nopostdesc},sort=d}  
+\newglossaryentry{mel}{name={Microelectronic Fundamentals},description={\nopostdesc},sort=d}
 \newsym{dynPower}{P_{dyn}}{P}{Dynamic power consumption}{mel}
 
 %\newcommand{\newsym}[5]{\newglossaryentry{#1}{name=\ensuremath{#2},description={\symtab{#2}{#4}},parent={#5},sort={#3}}}

--- a/test/TEX/nomencl.py
+++ b/test/TEX/nomencl.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that use of \nomencl in TeX source files causes SCons to
 be aware of the necessary created glossary files.
 
@@ -65,7 +65,7 @@ test.write('nomencl.tex', r"""
 
 \begin{document}
 
-A nomenclature entry \nomenclature{gnu}{an animal or software group} 
+A nomenclature entry \nomenclature{gnu}{an animal or software group}
 and another\nomenclature{nix}{not sure}.
 
 %handle old version of nomencl.sty

--- a/test/TEX/recursive_scanner_dependencies_import.py
+++ b/test/TEX/recursive_scanner_dependencies_import.py
@@ -24,14 +24,14 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""Verify that we re-run LaTeX after changing a nested \import. This
+r"""
+Verify that we re-run LaTeX after changing a nested \import. This
 checks that recursive implicit dependencies are found correctly.
 
 This is a separate test from the
 recursive_scanner_dependencies_input.py test because \input and
 \include are handled specially by the PDF builder, whereas \import
 dependencies are found only by the scanner.
-
 """
 
 import os

--- a/test/TEX/recursive_scanner_dependencies_input.py
+++ b/test/TEX/recursive_scanner_dependencies_input.py
@@ -24,7 +24,8 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""Verify that we re-run LaTeX after changing a nested \input. This
+r"""
+Verify that we re-run LaTeX after changing a nested \input. This
 checks that recursive implicit dependencies are found correctly.
 """
 

--- a/test/TEX/rename_result.py
+++ b/test/TEX/rename_result.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can rename the output from latex to the
 target name provided by the user.
 """

--- a/test/TEX/subdir-as-include.py
+++ b/test/TEX/subdir-as-include.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 This is an obscure test case. When
   1) a file without a suffix is included in a TeX build and
   2) there is a directory with the same name as that file,

--- a/test/TEX/subdir-input.py
+++ b/test/TEX/subdir-input.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify that we execute TeX in a subdirectory (if that's where the document
 resides) by checking that all the auxiliary files get created there and
 not in the top-level directory.

--- a/test/TEX/subdir_variantdir_include.py
+++ b/test/TEX/subdir_variantdir_include.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify that we execute TeX in a subdirectory (if that's where the document
 resides) by checking that all the auxiliary files get created there and
 not in the top-level directory. Test this when variantDir is used

--- a/test/TEX/subdir_variantdir_include2.py
+++ b/test/TEX/subdir_variantdir_include2.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify that we execute TeX in a subdirectory (if that's where the document
 resides) by checking that all the auxiliary files get created there and
 not in the top-level directory. Test this when variantDir is used
@@ -73,8 +73,8 @@ Hi there.
 \end{document}
 """)
 
-test.write(['docs','content','chapter.tex'], """\
-Sub-document 1
+test.write(['docs','content','chapter.tex'],
+r"""Sub-document 1
 \input{content/subchap}
 
 """)
@@ -87,8 +87,8 @@ Sub-chapter 2
 #test.run(arguments = '.')
 #test.run(arguments = '.', stderr=None, stdout=None)
 
-# next line tests that side effect nodes get disambiguated 
-# and their directories created in a variantDir before 
+# next line tests that side effect nodes get disambiguated
+# and their directories created in a variantDir before
 # the builder tries to populate them and fails
 test.run(arguments = 'build/main.pdf', stderr=None, stdout=None)
 

--- a/test/TEX/subdir_variantdir_input.py
+++ b/test/TEX/subdir_variantdir_input.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Verify that we execute TeX in a subdirectory (if that's where the document
 resides) by checking that all the auxiliary files get created there and
 not in the top-level directory. Test this when variantDir is used

--- a/test/TEX/synctex.py
+++ b/test/TEX/synctex.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that use of -synctex command option causes SCons to
 be aware of the created synctex.gz file.
 

--- a/test/TEX/usepackage.py
+++ b/test/TEX/usepackage.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate that we can set the LATEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.

--- a/test/TEX/variant_dir.py
+++ b/test/TEX/variant_dir.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a fully-featured TeX document (with bibliography
 and index) in a variant_dir.
 
@@ -122,7 +122,7 @@ $F2psBegin
  0.06299 0.06299 sc
 %
 % Fig objects follow
-% 
+%
 7.500 slw
 % Ellipse
 n 1170 945 766 766 0 360 DrawEllipse gs col0 s gr
@@ -156,10 +156,10 @@ test.write(['docs', 'test.bib'], """\
 %% http://bibdesk.sourceforge.net/
 
 
-%% Created for Rob Managan at 2006-11-15 12:53:16 -0800 
+%% Created for Rob Managan at 2006-11-15 12:53:16 -0800
 
 
-%% Saved with string encoding Western (ASCII) 
+%% Saved with string encoding Western (ASCII)
 
 
 
@@ -184,13 +184,13 @@ r"""\documentclass{report}
 \makeindex
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -206,7 +206,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are show as well \cite{Managan:2006fk}.  
+The Acknowledgements are show as well \cite{Managan:2006fk}.
 
 \index{Getting the Report}
 

--- a/test/TEX/variant_dir_bibunit.py
+++ b/test/TEX/variant_dir_bibunit.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a fully-featured TeX document (with bibunit
 driven bibliographies) in a variant_dir.
 

--- a/test/TEX/variant_dir_dup0.py
+++ b/test/TEX/variant_dir_dup0.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a fully-featured TeX document (with bibliography
 and index) in a variant_dir.
 
@@ -129,7 +129,7 @@ $F2psBegin
  0.06299 0.06299 sc
 %
 % Fig objects follow
-% 
+%
 7.500 slw
 % Ellipse
 n 1170 945 766 766 0 360 DrawEllipse gs col0 s gr
@@ -162,7 +162,7 @@ test.write(['docs', 'test.bib'], """\
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Saved with string encoding Western (ASCII) 
+%% Saved with string encoding Western (ASCII)
 
 @techreport{AnAuthor:2006fk,
 	Author = {A. N. Author},
@@ -185,13 +185,13 @@ r"""\documentclass{report}
 \makeindex
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -207,7 +207,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are show as well \cite{AnAuthor:2006fk}.  
+The Acknowledgements are show as well \cite{AnAuthor:2006fk}.
 
 \index{Getting the Report}
 
@@ -242,13 +242,13 @@ r"""\documentclass{report}
 \makeindex
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -264,7 +264,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are show as well \cite{AnAuthor:2006fk}.  
+The Acknowledgements are show as well \cite{AnAuthor:2006fk}.
 
 \index{Getting the Report}
 

--- a/test/TEX/variant_dir_newglossary.py
+++ b/test/TEX/variant_dir_newglossary.py
@@ -24,9 +24,9 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Validate the use of \newglossary in TeX source files in conjunction
-with variant_dir. 
+with variant_dir.
 
 Test configuration contributed by Kendrick Boyd.
 """
@@ -104,6 +104,6 @@ files = [
 for f in files:
     test.must_exist(['build',f])
     test.must_not_exist(['src',f])
-    
+
 
 test.pass_test()

--- a/test/TEX/variant_dir_style_dup0.py
+++ b/test/TEX/variant_dir_style_dup0.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test creation of a fully-featured TeX document (with bibliography
 and index) in a variant_dir.
 
@@ -117,13 +117,13 @@ r"""
 \makeindex
 
 \begin{document}
- 
+
 \title{Report Title}
 
 \author{A. N. Author}
- 
-\maketitle 
- 
+
+\maketitle
+
 \begin{abstract}
 there is no abstract
 \end{abstract}
@@ -139,7 +139,7 @@ The introduction is short.
 
 \section{Acknowledgements}
 
-The Acknowledgements are show as well \cite{AnAuthor:2006fk}.  
+The Acknowledgements are show as well \cite{AnAuthor:2006fk}.
 
 \index{Getting the Report}
 

--- a/test/ToolSurrogate.py
+++ b/test/ToolSurrogate.py
@@ -68,10 +68,10 @@ class ToolSurrogate(object):
 
 def Cat(target, source, env):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in map(str, source):
-        f.write(open(src, "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in map(str, source):
+            with open(src, "rb") as ifp:
+                ofp.write(ifp.read())
 
 ToolList = {
     'posix' :   [('cc', 'CCCOM', Cat),

--- a/test/Touch.py
+++ b/test/Touch.py
@@ -39,10 +39,10 @@ Execute(Touch('f1'))
 Execute(Touch(File('f1-File')))
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 Cat = Action(cat)
 env = Environment()
 env.Command('f2.out', 'f2.in', [Cat, Touch("f3")])

--- a/test/Value.py
+++ b/test/Value.py
@@ -63,7 +63,6 @@ def create_value (target, source, env):
     target[0].write(source[0].get_contents())
 
 def create_value_file (target, source, env):
-    #open(str(target[0]), 'wb').write(source[0].read())
     with open(str(target[0]), 'wb') as f:
         f.write(source[0].read())
 

--- a/test/Variables/Variables.py
+++ b/test/Variables/Variables.py
@@ -231,7 +231,9 @@ opts.Save('variables.saved', env)
 def checkSave(file, expected):
     gdict = {}
     ldict = {}
-    exec(open(file, 'r').read(), gdict, ldict)
+    with open(file, 'r') as f:
+       contents = f.read()
+    exec(contents, gdict, ldict)
     assert expected == ldict, "%s\n...not equal to...\n%s" % (expected, ldict)
 
 # First test with no command line variables

--- a/test/Variables/chdir.py
+++ b/test/Variables/chdir.py
@@ -52,7 +52,9 @@ print("VARIABLE = "+repr(env['VARIABLE']))
 test.write(['bin', 'opts.cfg'], """\
 import os
 os.chdir(os.path.split(__name__)[0])
-exec(open('opts2.cfg', 'r').read())
+with open('opts2.cfg', 'r') as f:
+    contents = f.read()
+exec(contents)
 """)
 
 test.write(['bin', 'opts2.cfg'], """\

--- a/test/VariantDir/Clean.py
+++ b/test/VariantDir/Clean.py
@@ -43,8 +43,10 @@ VariantDir('build1', '.', duplicate=1)
 def build_sample(target, source, env):
     targetdir = str(target[0].dir)
     target = str(target[0])
-    open(target, 'w').write(open(str(source[0]), 'r').read())
-    open(targetdir+'/sample.junk', 'w').write('Side effect!\\n')
+    with open(target, 'w') as ofd, open(str(source[0]), 'r') as ifd:
+        ofd.write(ifd.read())
+    with open(targetdir+'/sample.junk', 'w') as f:
+        f.write('Side effect!\\n')
 
 t0 = Command("build0/sample.out", "sample.in", build_sample)
 t1 = Command("build1/sample.out", "sample.in", build_sample)

--- a/test/VariantDir/SConscript-variant_dir.py
+++ b/test/VariantDir/SConscript-variant_dir.py
@@ -59,10 +59,10 @@ var9 = Dir('../build/var9')
 
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)},
                   BUILD='build')
@@ -94,7 +94,7 @@ env.SConscript('src/SConscript', variant_dir='../$BUILD/var8', duplicate=0)
 # VariantDir('build/var9', '.')
 # SConscript('build/var9/src/SConscript')
 SConscript('src/SConscript', variant_dir='build/var9', src_dir='.')
-""") 
+""")
 
 test.subdir(['test', 'src'], ['test', 'alt'])
 
@@ -154,12 +154,12 @@ for file in ['aaa.in', 'bbb.in', 'ccc.in']:
     test.must_exist(test.workpath('test', 'build', 'var2', file))
     test.fail_test(not equal_stats(test.workpath('test', 'build', 'var2', file),
                                    test.workpath('test', 'src', file)))
- 
+
 # Make sure we didn't duplicate the source files in build/var3.
 test.must_not_exist(test.workpath('test', 'build', 'var3', 'aaa.in'))
 test.must_not_exist(test.workpath('test', 'build', 'var3', 'bbb.in'))
 test.must_not_exist(test.workpath('test', 'build', 'var3', 'ccc.in'))
- 
+
 #XXX We can't support var4 and var5 yet, because our VariantDir linkage
 #XXX is to an entire source directory.  We haven't yet generalized our
 #XXX infrastructure to be able to take the SConscript file from one source
@@ -186,12 +186,12 @@ for file in ['aaa.in', 'bbb.in', 'ccc.in']:
     test.must_exist(test.workpath('build', 'var6', file))
     test.fail_test(not equal_stats(test.workpath('build', 'var6', file),
                                    test.workpath('test', 'src', file)))
- 
+
 # Make sure we didn't duplicate the source files in build/var7.
 test.must_not_exist(test.workpath('build', 'var7', 'aaa.in'))
 test.must_not_exist(test.workpath('build', 'var7', 'bbb.in'))
 test.must_not_exist(test.workpath('build', 'var7', 'ccc.in'))
- 
+
 # Make sure we didn't duplicate the source files in build/var8.
 test.must_not_exist(test.workpath('build', 'var8', 'aaa.in'))
 test.must_not_exist(test.workpath('build', 'var8', 'bbb.in'))

--- a/test/WhereIs.py
+++ b/test/WhereIs.py
@@ -31,7 +31,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-subdir_SConscript = os.path.join('subdir', 'SConscript')
+subdir_SConscript = os.path.join('subdir/SConscript')
 sub1_xxx_exe = test.workpath('sub1', 'xxx.exe')
 sub2_xxx_exe = test.workpath('sub2', 'xxx.exe')
 sub3_xxx_exe = test.workpath('sub3', 'xxx.exe')

--- a/test/Win32/bad-drive.py
+++ b/test/Win32/bad-drive.py
@@ -60,10 +60,10 @@ def cat(env, source, target):
     target = str(target[0])
     source = list(map(str, source))
     print('cat(%%s) > %%s' %% (source, target))
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(src, "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(src, "rb") as ifp:
+                ofp.write(ifp.read())
 
 bad_drive = '%s'
 env = Environment(BUILDERS={'Build':Builder(action=cat)})

--- a/test/Win32/default-drive.py
+++ b/test/Win32/default-drive.py
@@ -47,10 +47,10 @@ test.subdir('src')
 test.write(['src', 'SConstruct'], """
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as ofp:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})
 env.Build('../build/file.out', 'file.in')

--- a/test/YACC/YACC-fixture/myyacc.py
+++ b/test/YACC/YACC-fixture/myyacc.py
@@ -1,13 +1,13 @@
 import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'o:', [])
-output = None
 opt_string = ''
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
+    if opt == '-o': out = arg
     else: opt_string = opt_string + ' ' + opt
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents.replace('YACC', 'myyacc.py'))
-output.close()
+with open(out, 'w') as ofp:
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        ofp.write(contents.replace('YACC', 'myyacc.py'))
 sys.exit(0)

--- a/test/YACC/YACCFLAGS-fixture/myyacc.py
+++ b/test/YACC/YACCFLAGS-fixture/myyacc.py
@@ -1,17 +1,17 @@
 import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'o:I:x', [])
-output = None
 opt_string = ''
 i_arguments = ''
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'wb')
+    if opt == '-o': out = arg
     elif opt == '-I': i_arguments = i_arguments + ' ' + arg
     else: opt_string = opt_string + ' ' + opt
-for a in args:
-    contents = open(a, 'rb').read()
-    contents = contents.replace(b'YACCFLAGS', opt_string.encode())
-    contents = contents.replace(b'I_ARGS', i_arguments.encode())
-    output.write(contents)
-output.close()
+with open(out, 'wb') as ofp:
+    for a in args:
+        with open(a, 'rb') as ifp:
+            contents = ifp.read()
+        contents = contents.replace(b'YACCFLAGS', opt_string.encode())
+        contents = contents.replace(b'I_ARGS', i_arguments.encode())
+        ofp.write(contents)
 sys.exit(0)

--- a/test/YACC/YACCHFILESUFFIX.py
+++ b/test/YACC/YACCHFILESUFFIX.py
@@ -46,12 +46,13 @@ for o, a in opts:
     if o == '-o':
         outfile = open(a, 'wb')
 for f in args:
-    infile = open(f, 'rb')
-    for l in [l for l in infile.readlines() if l != b'/*yacc*/\\n']:
-        outfile.write(l)
+    with open(f, 'rb') as infile:
+        for l in [l for l in infile.readlines() if l != b'/*yacc*/\\n']:
+            outfile.write(l)
 outfile.close()
 base, ext = os.path.splitext(args[0])
-open(base+'.hsuffix', 'wb').write((" ".join(sys.argv)+'\\n').encode())
+with open(base+'.hsuffix', 'wb') as outfile:
+    outfile.write((" ".join(sys.argv) + '\\n').encode())
 sys.exit(0)
 """)
 

--- a/test/YACC/YACCHXXFILESUFFIX.py
+++ b/test/YACC/YACCHXXFILESUFFIX.py
@@ -46,12 +46,13 @@ for o, a in opts:
     if o == '-o':
         outfile = open(a, 'wb')
 for f in args:
-    infile = open(f, 'rb')
-    for l in [l for l in infile.readlines() if l != b'/*yacc*/\\n']:
-        outfile.write(l)
+    with open(f, 'rb') as infile:
+        for l in [l for l in infile.readlines() if l != b'/*yacc*/\\n']:
+            outfile.write(l)
 outfile.close()
 base, ext = os.path.splitext(args[0])
-open(base+'.hxxsuffix', 'wb').write((" ".join(sys.argv)+'\\n').encode())
+with open(base+'.hxxsuffix', 'wb') as outfile:
+    outfile.write((" ".join(sys.argv)+'\\n').encode())
 sys.exit(0)
 """)
 

--- a/test/YACC/YACCVCGFILESUFFIX.py
+++ b/test/YACC/YACCVCGFILESUFFIX.py
@@ -48,13 +48,14 @@ for o, a in opts:
     elif o == '-o':
         outfile = open(a, 'wb')
 for f in args:
-    infile = open(f, 'rb')
-    for l in [l for l in infile.readlines() if l != b'/*yacc*/\\n']:
-        outfile.write(l)
+    with open(f, 'rb') as infile:
+        for l in [l for l in infile.readlines() if l != b'/*yacc*/\\n']:
+            outfile.write(l)
 outfile.close()
 if vcg:
     base, ext = os.path.splitext(args[0])
-    open(base+'.vcgsuffix', 'wb').write((" ".join(sys.argv)+'\\n').encode())
+    with open(base+'.vcgsuffix', 'wb') as outfile:
+        outfile.write((" ".join(sys.argv)+'\\n').encode())
 sys.exit(0)
 """)
 

--- a/test/builderrors.py
+++ b/test/builderrors.py
@@ -38,10 +38,8 @@ test.write('build.py', r"""
 import sys
 exitval = int(sys.argv[1])
 if exitval == 0:
-    contents = open(sys.argv[3], 'r').read()
-    file = open(sys.argv[2], 'w')
-    file.write(contents)
-    file.close()
+    with open(sys.argv[2], 'w') as f, open(sys.argv[3], 'r') as infp:
+        f.write(infp.read())
 sys.exit(exitval)
 """)
 
@@ -198,8 +196,8 @@ env = Environment()
 env.Default("all")
 env.Alias("all", env.Install("dir", "file.txt"))
 """)
-test.run(status=2, match=TestSCons.match_re, stderr="""\
-scons: \*\*\* Do not know how to make File target `all' \(.*all\).  Stop.
+test.run(status=2, match=TestSCons.match_re, stderr=\
+r"""scons: \*\*\* Do not know how to make File target `all' \(.*all\).  Stop.
 """)
 
 # No tests failed; OK.

--- a/test/chdir.py
+++ b/test/chdir.py
@@ -91,11 +91,10 @@ other9_f19_in = test.workpath('other9', 'f19.in')
 
 test.write(cat_py, """\
 import sys
-ofp = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    ifp = open(f, 'rb')
-    ofp.write(ifp.read())
-ofp.close
+with open(sys.argv[1], 'wb') as ofp:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.write(['work1', 'SConstruct'], """

--- a/test/duplicate-sources.py
+++ b/test/duplicate-sources.py
@@ -35,10 +35,10 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 def cat(target, source, env):
-    t = open(str(target[0]), 'wb')
-    for s in source:
-        t.write(open(str(s), 'rb').read())
-    t.close()
+    with open(str(target[0]), 'wb') as t:
+        for s in source:
+            with open(str(s), 'rb') as s:
+                t.write(s.read())
 env = Environment(BUILDERS = {'Cat' : Builder(action = cat)})
 env.Cat('out.txt', ['f1.in', 'f2.in', 'f1.in'])
 """)

--- a/test/emitter.py
+++ b/test/emitter.py
@@ -42,7 +42,8 @@ SConscript('var2/SConscript')
 test.write('src/SConscript',"""
 def build(target, source, env):
     for t in target:
-        open(str(t), "wt").write(str(t))
+        with open(str(t), "wt") as f:
+            f.write(str(t))
 
 def emitter(target, source, env):
     target.append(str(target[0])+".foo")

--- a/test/explain/basic.py
+++ b/test/explain/basic.py
@@ -67,13 +67,15 @@ def process(outfp, infp):
                 print("os.getcwd() =", os.getcwd())
                 raise
             process(outfp, fp)
+            fp.close()
         else:
             outfp.write(line)
 
-outfp = open(sys.argv[1], 'w')
-for f in sys.argv[2:]:
-    if f != '-':
-        process(outfp, open(f, 'r'))
+with open(sys.argv[1], 'w') as ofp:
+    for f in sys.argv[2:]:
+        if f != '-':
+            with open(f, 'r') as ifp:
+                process(ofp, ifp)
 
 sys.exit(0)
 """)

--- a/test/explain/save-info.py
+++ b/test/explain/save-info.py
@@ -57,13 +57,15 @@ def process(outfp, infp):
                 print("os.getcwd() =", os.getcwd())
                 raise
             process(outfp, fp)
+            fp.close()
         else:
             outfp.write(line)
 
-outfp = open(sys.argv[1], 'w')
-for f in sys.argv[2:]:
-    if f != '-':
-        process(outfp, open(f, 'r'))
+with open(sys.argv[1], 'w') as ofp:
+    for f in sys.argv[2:]:
+        if f != '-':
+            with open(f, 'r') as ifp:
+                process(ofp, ifp)
 
 sys.exit(0)
 """)

--- a/test/fixture/mycompile.py
+++ b/test/fixture/mycompile.py
@@ -9,10 +9,10 @@ has made a modification.
 import sys
 
 if __name__ == '__main__':
-    line = '/*' + sys.argv[1] + '*/\n'
-    with open(sys.argv[2], 'w') as ofp:
+    line = ('/*' + sys.argv[1] + '*/\n').encode()
+    with open(sys.argv[2], 'wb') as ofp:
         for f in sys.argv[3:]:
-            with open(f, 'r') as ifp:
+            with open(f, 'rb') as ifp:
                 lines = [l for l in ifp.readlines() if l != line]
                 for l in lines:
                     ofp.write(l)

--- a/test/fixture/mycompile.py
+++ b/test/fixture/mycompile.py
@@ -1,8 +1,19 @@
+r"""
+Phony "compiler" for testing SCons.
+
+Copies its source files to the target file, dropping lines
+that match a pattern, so we can recognize the tool
+has made a modification.
+"""
+
 import sys
-line = ('/*' + sys.argv[1] + '*/\n').encode()
-outfile = open(sys.argv[2], 'wb')
-for f in sys.argv[3:]:
-    infile = open(f, 'rb')
-    for l in [l for l in infile.readlines() if l != line]:
-        outfile.write(l)
-sys.exit(0)
+
+if __name__ == '__main__':
+    line = '/*' + sys.argv[1] + '*/\n'
+    with open(sys.argv[2], 'w') as ofp:
+        for f in sys.argv[3:]:
+            with open(f, 'r') as ifp:
+                lines = [l for l in ifp.readlines() if l != line]
+                for l in lines:
+                    ofp.write(l)
+    sys.exit(0)

--- a/test/fixture/mycompile.py
+++ b/test/fixture/mycompile.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     with open(sys.argv[2], 'wb') as ofp:
         for f in sys.argv[3:]:
             with open(f, 'rb') as ifp:
-                lines = [l for l in ifp.readlines() if l != line]
-                for l in lines:
-                    ofp.write(l)
+                lines = [ln for ln in ifp.readlines() if ln != line]
+                for ln in lines:
+                    ofp.write(ln)
     sys.exit(0)

--- a/test/fixture/mylink.py
+++ b/test/fixture/mylink.py
@@ -1,31 +1,39 @@
+r"""
+Phony "linker" for testing SCons.
+
+Recognizes the option to specify an output file, ignoring
+all others; copies input lines to the output file except
+ones that contain a pattern, so we can recognize the tool
+has made a modification.
+"""
+
 import sys
 
-if sys.platform == 'win32':
-    args = sys.argv[1:]
-    while args:
-        a = args[0]
-        if a == '-o':
-            out = args[1]
-            args = args[2:]
-            continue
-        if not a[0] in '/-':
-            break
-        args = args[1:]
-        if a[:5].lower() == '/out:': out = a[5:]
-    infile = open(args[0], 'rb')
-    outfile = open(out, 'wb')
-    for l in infile.readlines():
-        if l[:5] != b'#link':
-            outfile.write(l)
-    sys.exit(0)
-else:
-    import getopt
-    opts, args = getopt.getopt(sys.argv[1:], 'o:')
-    for opt, arg in opts:
-        if opt == '-o': out = arg
-    infile = open(args[0], 'rb')
-    outfile = open(out, 'wb')
-    for l in infile.readlines():
-        if l[:5] != b'#link':
-            outfile.write(l)
-    sys.exit(0)
+if __name__ == '__main__':
+    if sys.platform == 'win32':
+        args = sys.argv[1:]
+        while args:
+            a = args[0]
+            if a == '-o':
+                out = args[1]
+                args = args[2:]
+                continue
+            if not a[0] in '/-':
+                break
+            args = args[1:]
+            if a[:5].lower() == '/out:': out = a[5:]
+        with open(args[0], 'r') as ifp, open(out, 'w') as ofp:
+            for l in ifp.readlines():
+                if not l.startswith('#link'):
+                    ofp.write(l)
+        sys.exit(0)
+    else:
+        import getopt
+        opts, args = getopt.getopt(sys.argv[1:], 'o:')
+        for opt, arg in opts:
+            if opt == '-o': out = arg
+        with open(args[0], 'r') as ifp, open(out, 'w') as ofp:
+            for l in ifp.readlines():
+                if not l.startswith('#link'):
+                    ofp.write(l)
+        sys.exit(0)

--- a/test/fixture/mylink.py
+++ b/test/fixture/mylink.py
@@ -22,9 +22,9 @@ if __name__ == '__main__':
                 break
             args = args[1:]
             if a[:5].lower() == '/out:': out = a[5:]
-        with open(args[0], 'r') as ifp, open(out, 'w') as ofp:
+        with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
             for l in ifp.readlines():
-                if not l.startswith('#link'):
+                if not l.startswith(b'#link'):
                     ofp.write(l)
         sys.exit(0)
     else:
@@ -32,8 +32,8 @@ if __name__ == '__main__':
         opts, args = getopt.getopt(sys.argv[1:], 'o:')
         for opt, arg in opts:
             if opt == '-o': out = arg
-        with open(args[0], 'r') as ifp, open(out, 'w') as ofp:
+        with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
             for l in ifp.readlines():
-                if not l.startswith('#link'):
+                if not l.startswith(b'#link'):
                     ofp.write(l)
         sys.exit(0)

--- a/test/fixture/myrewrite.py
+++ b/test/fixture/myrewrite.py
@@ -1,7 +1,16 @@
+r"""
+Phony tool to modify a file in place for testing SCons.
+
+Drops lines that match a pattern.  Currently used to test
+ranlib-related behavior without invoking ranlib.
+"""
+
 import sys
-line = ('/*' + sys.argv[1] + '*/\n').encode()
-lines = open(sys.argv[2], 'rb').readlines()
-outfile = open(sys.argv[2], 'wb')
-for l in [l for l in lines if l != line]:
-    outfile.write(l)
-sys.exit(0)
+
+if __name__ == '__main__':
+    line = ('/*' + sys.argv[1] + '*/\n')
+    with open(sys.argv[2], 'w') as ofp, open(sys.argv[2], 'r') as ifp:
+        lines = [l for l in ifp.readlines() if l != line]
+        for l in lines:
+            ofp.write(l)
+    sys.exit(0)

--- a/test/fixture/myrewrite.py
+++ b/test/fixture/myrewrite.py
@@ -10,8 +10,8 @@ import sys
 if __name__ == '__main__':
     line = ('/*' + sys.argv[1] + '*/\n').encode()
     with open(sys.argv[2], 'rb') as ifp:
-        lines = [l for l in ifp.readlines() if l != line]
+        lines = [ln for ln in ifp.readlines() if ln != line]
     with open(sys.argv[2], 'wb') as ofp:
-        for l in lines:
-            ofp.write(l)
+        for ln in lines:
+            ofp.write(ln)
     sys.exit(0)

--- a/test/fixture/myrewrite.py
+++ b/test/fixture/myrewrite.py
@@ -8,9 +8,10 @@ ranlib-related behavior without invoking ranlib.
 import sys
 
 if __name__ == '__main__':
-    line = ('/*' + sys.argv[1] + '*/\n')
-    with open(sys.argv[2], 'w') as ofp, open(sys.argv[2], 'r') as ifp:
+    line = ('/*' + sys.argv[1] + '*/\n').encode()
+    with open(sys.argv[2], 'rb') as ifp:
         lines = [l for l in ifp.readlines() if l != line]
+    with open(sys.argv[2], 'wb') as ofp:
         for l in lines:
             ofp.write(l)
     sys.exit(0)

--- a/test/fixture/wrapper.py
+++ b/test/fixture/wrapper.py
@@ -1,6 +1,10 @@
 import os
 import sys
-if '--version' not in sys.argv and '-dumpversion' not in sys.argv:
+import subprocess
+
+if __name__ == '__main__':
     path = os.path.join(os.path.dirname(os.path.relpath(__file__)), 'wrapper.out')
-    open(path, 'wb').write(b"wrapper.py\n")
-os.system(" ".join(sys.argv[1:]))
+    if '--version' not in sys.argv and '-dumpversion' not in sys.argv:
+        with open(path, 'w') as f:
+            f.write("wrapper.py\n")
+    subprocess.call(sys.argv[1:])

--- a/test/fixture/wrapper.py
+++ b/test/fixture/wrapper.py
@@ -5,6 +5,6 @@ import subprocess
 if __name__ == '__main__':
     path = os.path.join(os.path.dirname(os.path.relpath(__file__)), 'wrapper.out')
     if '--version' not in sys.argv and '-dumpversion' not in sys.argv:
-        with open(path, 'w') as f:
-            f.write("wrapper.py\n")
+        with open(path, 'wb') as f:
+            f.write(b"wrapper.py\n")
     subprocess.call(sys.argv[1:])

--- a/test/fixture/wrapper_with_args.py
+++ b/test/fixture/wrapper_with_args.py
@@ -1,7 +1,9 @@
 import os
 import sys
+import subprocess
 
-path = os.path.join(os.path.dirname(os.path.relpath(__file__)), 'wrapper.out')
-
-open(path, 'a').write("wrapper_with_args.py %s\n" % " ".join(sys.argv[1:]))
-os.system(" ".join(sys.argv[1:]))
+if __name__ == '__main__':
+    path = os.path.join(os.path.dirname(os.path.relpath(__file__)), 'wrapper.out')
+    with open(path, 'a') as f:
+        f.write("wrapper_with_args.py %s\n" % " ".join(sys.argv[1:]))
+    subprocess.call(sys.argv[1:])

--- a/test/gnutools.py
+++ b/test/gnutools.py
@@ -45,7 +45,11 @@ test.subdir('gnutools')
 test.write(['gnutools','mygcc.py'], """
 import getopt
 import sys
-cmd_opts, args = getopt.getopt(sys.argv[1:], 'f:s:co:', [])
+try:
+    cmd_opts, args = getopt.getopt(sys.argv[1:], 'f:s:co:', [])
+except getopt.GetoptError:
+    # we may be called with --version, just quit if so
+    sys.exit(0)
 out = None
 opt_string = ''
 for opt, arg in cmd_opts:
@@ -62,7 +66,11 @@ sys.exit(0)
 test.write(['gnutools','myg++.py'], """
 import getopt
 import sys
-cmd_opts, args = getopt.getopt(sys.argv[1:], 'f:s:co:', [])
+try:
+    cmd_opts, args = getopt.getopt(sys.argv[1:], 'f:s:co:', [])
+except getopt.GetoptError:
+    # we may be called with --version, just quit if so
+    sys.exit(0)
 out = None
 opt_string = ''
 for opt, arg in cmd_opts:

--- a/test/gnutools.py
+++ b/test/gnutools.py
@@ -46,16 +46,16 @@ test.write(['gnutools','mygcc.py'], """
 import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'f:s:co:', [])
-output = None
+out = None
 opt_string = ''
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
+    if opt == '-o': out = arg
     else: opt_string = opt_string + ' ' + opt + arg
-output.write('gcc ' + opt_string + '\\n')
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents)
-output.close()
+with open(out, 'w') as ofp:
+    ofp.write('gcc ' + opt_string + '\\n')
+    for a in args:
+        with open(a, 'r') as ifp:
+            ofp.write(ifp.read())
 sys.exit(0)
 """)
 
@@ -63,16 +63,16 @@ test.write(['gnutools','myg++.py'], """
 import getopt
 import sys
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'f:s:co:', [])
-output = None
+out = None
 opt_string = ''
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
+    if opt == '-o': out = arg
     else: opt_string = opt_string + ' ' + opt + arg
-output.write('g++ ' + opt_string + '\\n')
-for a in args:
-    contents = open(a, 'r').read()
-    output.write(contents)
-output.close()
+with open(out, 'w') as ofp:
+    ofp.write('g++ ' + opt_string + '\\n')
+    for a in args:
+        with open(a, 'r') as ifp:
+            ofp.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/ignore-command.py
+++ b/test/ignore-command.py
@@ -40,10 +40,10 @@ test.subdir('build', 'src')
 
 test.write('build.py', r"""
 import sys
-fp = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    fp.write(open(f, 'rb').read())
-fp.close()
+with open(sys.argv[1], 'wb') as fp:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as ifp:
+            fp.write(ifp.read())
 sys.exit(1)
 """)
 

--- a/test/implicit/IMPLICIT_COMMAND_DEPENDENCIES.py
+++ b/test/implicit/IMPLICIT_COMMAND_DEPENDENCIES.py
@@ -45,16 +45,17 @@ generate_build_py_py_contents = """\
 import os
 import sys
 
-open(sys.argv[1], 'w').write('''\
+with open(sys.argv[1], 'w') as f:
+    f.write('''\
 #!/usr/bin/env %(python)s
 import os
 import sys
-fp = open(sys.argv[1], 'w')
-args = [os.path.split(sys.argv[0])[1]] + sys.argv[1:]
-fp.write(" ".join(args) + '\\\\n' + '%(extra)s')
-for infile in sys.argv[2:]:
-    fp.write(open(infile, 'r').read())
-fp.close()
+with open(sys.argv[1], 'w') as fp:
+    args = [os.path.split(sys.argv[0])[1]] + sys.argv[1:]
+    fp.write(" ".join(args) + '\\\\n' + '%(extra)s')
+    for infile in sys.argv[2:]:
+        with open(infile, 'r') as ifp:
+            fp.write(ifp.read())
 ''')
 os.chmod(sys.argv[1], 0o755)
 

--- a/test/implicit/asynchronous-modification.py
+++ b/test/implicit/asynchronous-modification.py
@@ -55,8 +55,10 @@ test.write(['hdr.h'], """\
 """)
 
 test.write(['mod.py'], """\
-open('mod', 'w').write(open('mod.py', 'r').read())
-open('hdr.h', 'w').write("/* modified */\\n")
+with open('mod', 'w') as f, open('mod.py', 'r') as ifp:
+    f.write(ifp.read())
+with open('hdr.h', 'w') as f:
+    f.write("/* modified */\\n")
 """)
 
 test.write(['one.c'], """\

--- a/test/implicit/changed-node.py
+++ b/test/implicit/changed-node.py
@@ -46,14 +46,13 @@ SetOption('max_drift', 1)
 
 def lister(target, source, env):
     import os
-    fp = open(str(target[0]), 'w')
-    s = str(source[0])
-    if os.path.isdir(s):
-        for l in os.listdir(str(source[0])):
-            fp.write(l + '\\n')
-    else:
-        fp.write(s + '\\n')
-    fp.close()
+    with open(str(target[0]), 'w') as ofp:
+        s = str(source[0])
+        if os.path.isdir(s):
+            for l in os.listdir(str(source[0])):
+                ofp.write(l + '\\n')
+        else:
+            ofp.write(s + '\\n')
 
 builder = Builder(action=lister,
                   source_factory=Dir,
@@ -83,14 +82,13 @@ SetOption('max_drift', 1)
 
 def lister(target, source, env):
     import os.path
-    fp = open(str(target[0]), 'w')
-    s = str(source[0])
-    if os.path.isdir(s):
-        for l in os.listdir(str(source[0])):
-            fp.write(l + '\\n')
-    else:
-        fp.write(s + '\\n')
-    fp.close()
+    with open(str(target[0]), 'w') as ofp:
+        s = str(source[0])
+        if os.path.isdir(s):
+            for l in os.listdir(str(source[0])):
+                ofp.write(l + '\\n')
+        else:
+            ofp.write(s + '\\n')
 
 builder = Builder(action=lister,
                   source_factory=File)
@@ -111,12 +109,12 @@ test.pass_test()
 #
 #
 #def setfile(f, content):
-#    f = open(f, 'w')
-#    try: f.write(content)
-#    finally: f.close()
+#    with open(f, 'w') as ofp:
+#        ofp.write(content)
 #
 #def checkfile(f, content):
-#    assert open(f).read().strip() == content
+#    with open(f) as fp:
+#        assert fp.read().strip() == content
 #
 #def rm(f):
 #    if exists(f):

--- a/test/leaky-handles.py
+++ b/test/leaky-handles.py
@@ -41,11 +41,10 @@ if os.name != 'posix' or sys.platform == 'darwin':
 
 test.write('SConstruct', """
 
-#Leak a file handle
-open('/dev/null')
-
-#Check it gets closed
-test2 = Command('test2', [], '@ls /proc/$$$$/fd|wc -l')
+# Leave a file handle open when invoking a command
+with open('/dev/null'):
+    # Check it gets closed when an external command is forked off:
+    test2 = Command('test2', [], '@ls /proc/$$$$/fd|wc -l')
 """)
 
 # In theory that should have 3 lines (handles 0/1/2). This is v. unix specific

--- a/test/long-lines/signature.py
+++ b/test/long-lines/signature.py
@@ -42,14 +42,14 @@ test.write(build_py, """\
 #!%(_python_)s
 import sys
 if sys.argv[1][0] == '@':
-    args = open(sys.argv[1][1:], 'r').read()
-    args = args.split()
+    with open(sys.argv[1][1:], 'r') as f:
+        args = f.read().split()
 else:
     args = sys.argv[1:]
-fp = open(args[0], 'w')
-fp.write(open(args[1], 'r').read())
-fp.write('FILEFLAG=%%s\\n' %% args[2])
-fp.write('TIMESTAMP=%%s\\n' %% args[3])
+with open(args[0], 'w') as fp, open(args[1], 'r') as ifp:
+    fp.write(ifp.read())
+    fp.write('FILEFLAG=%%s\\n' %% args[2])
+    fp.write('TIMESTAMP=%%s\\n' %% args[3])
 """ % locals())
 
 os.chmod(build_py, 0o755)

--- a/test/multiline.py
+++ b/test/multiline.py
@@ -35,10 +35,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as ifp:
+    f.write(ifp.read())
 sys.exit(0)
 """)
 

--- a/test/no-arguments.py
+++ b/test/no-arguments.py
@@ -41,10 +41,10 @@ def cat(env, source, target):
     target = str(target[0])
     source = list(map(str, source))
     print('cat(%s) > %s' % (source, target))
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(src, "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(src, "rb") as ifp:
+                f.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})
 env.Build('aaa.out', 'aaa.in')

--- a/test/no-target.py
+++ b/test/no-target.py
@@ -42,10 +42,10 @@ SConscript(r'%s')
 test.write(subdir_SConscript, r"""
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 
 b = Builder(action=cat, suffix='.out', src_suffix='.in')
 env = Environment(BUILDERS={'Build':b})

--- a/test/option--max-drift.py
+++ b/test/option--max-drift.py
@@ -34,10 +34,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as ifp:
+    f.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/option--random.py
+++ b/test/option--random.py
@@ -38,10 +38,10 @@ test = TestSCons.TestSCons()
 test.write('SConscript', """\
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')
 env.Cat('bbb.out', 'bbb.in')

--- a/test/option-n.py
+++ b/test/option-n.py
@@ -52,9 +52,8 @@ test.subdir('build', 'src')
 
 test.write('build.py', r"""
 import sys
-file = open(sys.argv[1], 'w')
-file.write("build.py: %s\n" % sys.argv[1])
-file.close()
+with open(sys.argv[1], 'w') as ofp:
+    ofp.write("build.py: %s\n" % sys.argv[1])
 """)
 
 test.write('SConstruct', """

--- a/test/option/debug-count.py
+++ b/test/option/debug-count.py
@@ -46,7 +46,8 @@ except ImportError:
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
+    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+        f.write(infp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)
@@ -57,7 +58,7 @@ test.write('file.in', "file.in\n")
 # show up in the output.
 
 def find_object_count(s, stdout):
-    re_string = '\d+ +\d+   %s' % re.escape(s)
+    re_string = r'\d+ +\d+   %s' % re.escape(s)
     return re.search(re_string, stdout)
 
 objects = [

--- a/test/option/debug-findlibs.py
+++ b/test/option/debug-findlibs.py
@@ -34,11 +34,10 @@ test.subdir('sub1', 'sub2')
 
 test.write('cat.py', """\
 import sys
-ofp = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    ifp = open(f, 'rb')
-    ofp.write(ifp.read())
-ofp.close()
+with open(sys.argv[1], 'wb') as ofp:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.write('SConstruct', """\

--- a/test/option/debug-memoizer.py
+++ b/test/option/debug-memoizer.py
@@ -38,7 +38,8 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
+    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+        f.write(infp.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)

--- a/test/option/debug-memory.py
+++ b/test/option/debug-memory.py
@@ -49,7 +49,8 @@ except ImportError:
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
+    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as ifp:
+        f.write(ifp.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)

--- a/test/option/debug-multiple.py
+++ b/test/option/debug-multiple.py
@@ -38,7 +38,8 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
+    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+        f.write(infp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)
@@ -49,7 +50,7 @@ test.write('file.in', "file.in\n")
 # show up in the output.
 
 def find_object_count(s, stdout):
-    re_string = '\d+ +\d+   %s' % re.escape(s)
+    re_string = r'\d+ +\d+   %s' % re.escape(s)
     return re.search(re_string, stdout)
 
 objects = [

--- a/test/option/debug-objects.py
+++ b/test/option/debug-objects.py
@@ -43,7 +43,8 @@ except ImportError:
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
+    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+        f.write(infp.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')
 """)

--- a/test/option/debug-presub.py
+++ b/test/option/debug-presub.py
@@ -32,7 +32,8 @@ test = TestSCons.TestSCons()
 
 test.write('cat.py', """\
 import sys
-open(sys.argv[2], "wb").write(open(sys.argv[1], "rb").read())
+with open(sys.argv[2], "wb") as f, open(sys.argv[1], "rb") as infp:
+    f.write(infp.read())
 sys.exit(0)
 """)
 
@@ -40,10 +41,10 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as infp:
+                f.write(infp.read())
 FILE = Builder(action="$FILECOM")
 TEMP = Builder(action="$TEMPCOM")
 LIST = Builder(action="$LISTCOM")

--- a/test/option/debug-time.py
+++ b/test/option/debug-time.py
@@ -36,10 +36,10 @@ test.write('sleep_cat.py', """\
 import sys
 import time
 time.sleep(int(sys.argv[1]))
-fp = open(sys.argv[2], 'wb')
-for arg in sys.argv[3:]:
-    fp.write(open(arg, 'rb').read())
-fp.close()
+with open(sys.argv[2], 'wb') as fp:
+    for arg in sys.argv[3:]:
+        with open(arg, 'rb') as infp:
+            fp.write(infp.read())
 sys.exit(0)
 """)
 

--- a/test/option/md5-chunksize.py
+++ b/test/option/md5-chunksize.py
@@ -32,10 +32,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as infp:
+    f.write(infp.read())
 """)
 
 test.write('SConstruct', """
@@ -107,9 +105,8 @@ DefaultEnvironment(tools=[])
 import os
 def get_stat(target, source, env):
     stat = os.stat(source[0].get_abspath())
-    dest = open(target[0].get_abspath(),'w')
-    dest.write(str(stat))
-    dest.close()
+    with open(target[0].get_abspath(),'w') as dest:
+        dest.write(str(stat))
 env = Environment(tools=[])
 env.Command('test.big', 'SConstruct', 'dd if=/dev/zero of=test.big seek=100 bs=1M count=0 2>/dev/null')
 env.AlwaysBuild('test.big')

--- a/test/option/stack-size.py
+++ b/test/option/stack-size.py
@@ -41,10 +41,8 @@ test.subdir('work1', 'work2')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as infp:
+    f.write(infp.read())
 """)
 
 

--- a/test/option/warn-duplicate-environment.py
+++ b/test/option/warn-duplicate-environment.py
@@ -36,9 +36,10 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 WARN = ARGUMENTS.get('WARN')
 if WARN:

--- a/test/option/warn-misleading-keywords.py
+++ b/test/option/warn-misleading-keywords.py
@@ -36,9 +36,10 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    file = open(str(target[0]), 'wb')
-    for s in source:
-        file.write(open(str(s), 'rb').read())
+    with open(str(target[0]), 'wb') as f:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                f.write(infp.read())
 
 WARN = ARGUMENTS.get('WARN')
 if WARN:

--- a/test/overrides.py
+++ b/test/overrides.py
@@ -77,11 +77,13 @@ env.Program('hello', 'hello.c',
 test.write('hello.c',"this ain't no c file!\n")
 
 test.write('mycc.py',"""
-open('hello.not_obj', 'w').write('this is no object file!')
+with open('hello.not_obj', 'w') as f:
+    f.write('this is no object file!')
 """)
 
 test.write('mylink.py',"""
-open('hello.not_exe', 'w').write('this is not a program!')
+with open('hello.not_exe', 'w') as f:
+    f.write('this is not a program!')
 """)
 
 test.run(arguments='hello.not_exe')
@@ -107,11 +109,13 @@ env.Program('goodbye', 'goodbye.c',
 test.write('goodbye.c',"this ain't no c file!\n")
 
 test.write('mycc.py',"""
-open('goodbye.not_obj', 'wt').write('this is no object file!')
+with open('goodbye.not_obj', 'wt') as f:
+    f.write('this is no object file!')
 """)
 
 test.write('mylink.py',"""
-open('goodbye.not_exe', 'wt').write('this is not a program!')
+with open('goodbye.not_exe', 'wt') as f:
+    f.write('this is not a program!')
 """)
 
 test.run(arguments='goodbye.not_exe', stderr=None)

--- a/test/packaging/convenience-functions/convenience-functions.py
+++ b/test/packaging/convenience-functions/convenience-functions.py
@@ -33,7 +33,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.dir_fixture( "image" )
+test.dir_fixture("image")
 
 bin_f1 = os.path.join('bin', 'f1')
 bin_f2 = os.path.join('bin', 'f2')

--- a/test/packaging/ipkg.py
+++ b/test/packaging/ipkg.py
@@ -73,6 +73,11 @@ Maintainer, Depends, and Description fields.''',
              X_IPK_DEPENDS    = 'libc6, grep', )
 """)
 
+with os.popen('id -un') as p:
+    IPKGUSER = p.read().strip()
+with os.popen('id -gn') as p:
+    IPKGGROUP = p.read().strip()
+
 expected="""scons: Reading SConscript files ...
 scons: done reading SConscript files.
 scons: Building targets ...
@@ -84,7 +89,7 @@ build_specfiles(["foo-0.0/CONTROL/control", "foo-0.0/CONTROL/conffiles", "foo-0.
 ipkg-build -o %s -g %s foo-0.0
 Packaged contents of foo-0.0 into %s/foo_0.0_arm.ipk
 scons: done building targets.
-"""%(os.popen('id -un').read().strip(), os.popen('id -gn').read().strip(), test.workpath())
+"""%(IPKGUSER, IPKGGROUP, test.workpath())
 
 test.run(arguments="--debug=stacktrace foo_0.0_arm.ipk", stdout=expected)
 test.must_exist( 'foo-0.0/CONTROL/control' )

--- a/test/packaging/place-files-in-subdirectory.py
+++ b/test/packaging/place-files-in-subdirectory.py
@@ -102,8 +102,9 @@ env.Package( NAME        = 'libfoo',
 
 test.run(stderr = None)
 
-str = os.popen( 'tar -tzf %s'%test.workpath('libfoo-1.2.3.tar.gz') ).read()
-test.fail_test( str != "libfoo-1.2.3/src/main.c\nlibfoo-1.2.3/SConstruct\n" )
+with os.popen('tar -tzf %s'%test.workpath('libfoo-1.2.3.tar.gz')) as p:
+    str = p.read()
+test.fail_test(str != "libfoo-1.2.3/src/main.c\nlibfoo-1.2.3/SConstruct\n")
 
 test.pass_test()
 

--- a/test/packaging/rpm/explicit-target.py
+++ b/test/packaging/rpm/explicit-target.py
@@ -48,7 +48,7 @@ test.subdir('src')
 mainpath = os.path.join('src', 'main.c')
 test.file_fixture(mainpath, mainpath)
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 import os
 
 env=Environment(tools=['default', 'packaging'])
@@ -77,7 +77,7 @@ env.Package( NAME           = 'foo',
 
 expect = """
 scons: *** Setting target is not supported for rpm.
-""" + test.python_file_line(test.workpath('SConstruct'), 24)
+""" + test.python_file_line(test.workpath('SConstruct'), 12)
 
 test.run(arguments='', status=2, stderr=expect)
 

--- a/test/packaging/rpm/internationalization.py
+++ b/test/packaging/rpm/internationalization.py
@@ -94,25 +94,29 @@ machine_rpm = 'foo-1.2.3-0.%s.rpm' % SCons.Tool.rpmutils.defaultMachine()
 test.must_exist( src_rpm )
 test.must_exist( machine_rpm )
 
-test.must_not_exist( 'bin/main' )
+test.must_not_exist('bin/main')
 
 cmd = 'rpm -qp --queryformat \'%%{GROUP}-%%{SUMMARY}-%%{DESCRIPTION}\' %s'
 
 os.environ['LANGUAGE'] = 'de'
-out = os.popen( cmd % test.workpath(machine_rpm) ).read()
-test.fail_test( out != 'Applikation/büro-hallo-das sollte wirklich lang sein' )
+with os.popen(cmd % test.workpath(machine_rpm)) as p:
+    out = p.read()
+test.fail_test(out != 'Applikation/büro-hallo-das sollte wirklich lang sein')
 
 os.environ['LANGUAGE'] = 'fr'
-out = os.popen( cmd % test.workpath(machine_rpm) ).read()
-test.fail_test( out != 'Application/bureau-bonjour-ceci devrait être vraiment long' )
+with os.popen(cmd % test.workpath(machine_rpm)) as p:
+    out = p.read()
+test.fail_test(out != 'Application/bureau-bonjour-ceci devrait être vraiment long')
 
 os.environ['LANGUAGE'] = 'en'
-out = os.popen( cmd % test.workpath(machine_rpm) ).read()
-test.fail_test( out != 'Application/office-hello-this should be really long' )
+with os.popen(cmd % test.workpath(machine_rpm)) as p:
+    out = p.read()
+test.fail_test(out != 'Application/office-hello-this should be really long')
 
 os.environ['LC_ALL'] = 'ae'
-out = os.popen( cmd % test.workpath(machine_rpm) ).read()
-test.fail_test( out != 'Application/office-hello-this should be really long' )
+with os.popen(cmd % test.workpath(machine_rpm)) as p:
+    out = p.read()
+test.fail_test(out != 'Application/office-hello-this should be really long')
 
 #
 # test INTERNATIONAL PACKAGE TAGS

--- a/test/packaging/rpm/multipackage.py
+++ b/test/packaging/rpm/multipackage.py
@@ -104,9 +104,11 @@ test.must_exist( machine_rpm2 )
 test.must_exist( src_rpm2 )
 
 test.must_not_exist( 'bin/main' )
-out = os.popen( 'rpm -qpl %s' % machine_rpm).read()
+with os.popen('rpm -qpl %s' % machine_rpm) as p:
+    out = p.read()
 test.must_contain_all_lines( out, '/bin/main')
-out = os.popen( 'rpm -qpl %s' % src_rpm).read()
+with os.popen('rpm -qpl %s' % src_rpm) as p:
+    out = p.read()
 test.fail_test( not out == 'foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
 
 test.pass_test()

--- a/test/packaging/rpm/package.py
+++ b/test/packaging/rpm/package.py
@@ -86,7 +86,7 @@ test.must_not_exist( 'bin/main' )
 with os.popen('rpm -qpl %s' % machine_rpm) as p:
     out = p.read()
 test.must_contain_all_lines(out, '/bin/main')
-with os.popen('rpm -qpl %s' % machine_rpm) as p:
+with os.popen('rpm -qpl %s' % src_rpm) as p:
     out = p.read()
 test.fail_test( not out == 'foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
 

--- a/test/packaging/rpm/package.py
+++ b/test/packaging/rpm/package.py
@@ -83,9 +83,11 @@ machine_rpm = 'foo-1.2.3-0.%s.rpm' % SCons.Tool.rpmutils.defaultMachine()
 test.must_exist( machine_rpm )
 test.must_exist( src_rpm )
 test.must_not_exist( 'bin/main' )
-out = os.popen( 'rpm -qpl %s' % machine_rpm).read()
-test.must_contain_all_lines( out, '/bin/main')
-out = os.popen( 'rpm -qpl %s' % src_rpm).read()
+with os.popen('rpm -qpl %s' % machine_rpm) as p:
+    out = p.read()
+test.must_contain_all_lines(out, '/bin/main')
+with os.popen('rpm -qpl %s' % machine_rpm) as p:
+    out = p.read()
 test.fail_test( not out == 'foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
 
 test.pass_test()

--- a/test/packaging/rpm/tagging.py
+++ b/test/packaging/rpm/tagging.py
@@ -85,11 +85,13 @@ src_rpm = 'foo-1.2.3-0.src.rpm'
 machine_rpm = 'foo-1.2.3-0.%s.rpm' % SCons.Tool.rpmutils.defaultMachine()
 
 test.must_exist( machine_rpm )
-out = os.popen('rpm -qpl %s' % machine_rpm).read()
+with os.popen('rpm -qpl %s' % machine_rpm) as p:
+    out = p.read()
 test.must_contain_all_lines( out, '/bin/main')
 
 test.must_exist( src_rpm )
-out = os.popen('rpm -qpl %s' % src_rpm).read()
+with os.popen('rpm -qpl %s' % src_rpm) as p:
+    out = p.read()
 test.fail_test( not out == 'foo-1.2.3.spec\nfoo-1.2.3.tar.gz\n')
 
 expect = '(0755, root, users) /bin/main'

--- a/test/preserve-source.py
+++ b/test/preserve-source.py
@@ -36,10 +36,10 @@ def cat(env, source, target):
     target = str(target[0])
     source = list(map(str, source))
     print('cat(%s) > %s' % (source, target))
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(src, "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(src, "rb") as ifp:
+                f.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})
 env.Build('aaa.out', 'aaa.in')

--- a/test/python-version.py
+++ b/test/python-version.py
@@ -45,7 +45,7 @@ test.write('SetOption-python', "SetOption('warn', ['no-python-version'])\n")
 
 if TestSCons.unsupported_python_version():
 
-    error = "scons: \*\*\* SCons version \S+ does not run under Python version %s."
+    error = r"scons: \*\*\* SCons version \S+ does not run under Python version %s."
     error = error % re.escape(TestSCons.python_version_string()) + "\n"
     test.run(arguments = '-Q', status = 1, stderr = error)
 

--- a/test/question/basic.py
+++ b/test/question/basic.py
@@ -36,10 +36,8 @@ _python_ = TestSCons._python_
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as ifp:
+    f.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/redirection.py
+++ b/test/redirection.py
@@ -42,18 +42,19 @@ if sys.platform == "win32":
 
 
 try:
-    input = open(sys.argv[1], 'rb').read()
+    with open(sys.argv[1], 'rb') as f:
+        indata = f.read()
 except IndexError:
     if PY3K:
         source = sys.stdin.buffer
     else:
         source = sys.stdin
-    input = source.read()
+    indata = source.read()
     
 if PY3K:
-    sys.stdout.buffer.write(input)
+    sys.stdout.buffer.write(indata)
 else:
-    sys.stdout.write(input)
+    sys.stdout.write(indata)
 
 sys.exit(0)
 """)

--- a/test/runtest/python.py
+++ b/test/runtest/python.py
@@ -55,7 +55,7 @@ mypython = os.path.normpath(os.path.join(head, dir, os.path.pardir, dir, python)
 def escape(s):
     return s.replace('\\', '\\\\')
 
-if re.search('\s', mypython):
+if re.search(r'\s', mypython):
     mypythonstring = '"%s"' % escape(mypython)
 else:
     mypythonstring = escape(mypython)

--- a/test/sconsign/corrupt.py
+++ b/test/sconsign/corrupt.py
@@ -41,7 +41,8 @@ work2_sub__sconsign = test.workpath('work2', 'sub', '.sconsign')
 
 SConstruct_contents = """\
 def build1(target, source, env):
-    open(str(target[0]), 'wb').write(open(str(source[0]), 'rb').read())
+    with open(str(target[0]), 'wb') as ofp, open(str(source[0]), 'rb') as ifp:
+        ofp.write(ifp.read())
     return None
 
 B1 = Builder(action = build1)
@@ -55,12 +56,12 @@ test.write(['work1', 'SConstruct'], SConstruct_contents)
 
 test.write(['work1', 'foo.in'], "work1/foo.in\n")
 
-stderr = '''
+stderr = r'''
 scons: warning: Ignoring corrupt .sconsign file: \.sconsign\.dblite
 .*
 '''
 
-stdout = test.wrap_stdout('build1\(\["sub.foo\.out"\], \["foo\.in"\]\)\n')
+stdout = test.wrap_stdout(r'build1\(\["sub.foo\.out"\], \["foo\.in"\]\)' + '\n')
 
 test.write(work1__sconsign_dblite, 'not:a:sconsign:file')
 test.run(chdir='work1', arguments='.', stderr=stderr, stdout=stdout)
@@ -80,12 +81,12 @@ test.write(['work2', 'SConstruct'], SConstruct_contents)
 
 test.write(['work2', 'foo.in'], "work2/foo.in\n")
 
-stderr = '''
+stderr = r'''
 scons: warning: Ignoring corrupt .sconsign file: sub.\.sconsign
 .*
 '''
 
-stdout = test.wrap_stdout('build1\(\["sub.foo\.out"\], \["foo\.in"\]\)\n')
+stdout = test.wrap_stdout(r'build1\(\["sub.foo\.out"\], \["foo\.in"\]\)' + '\n')
 
 test.write(work2_sub__sconsign, 'not:a:sconsign:file')
 test.run(chdir='work2', arguments='.', stderr=stderr, stdout=stdout)

--- a/test/sconsign/ghost-entries.py
+++ b/test/sconsign/ghost-entries.py
@@ -51,10 +51,10 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 def cat(target, source, env):
-    fp = open(str(target[0]), 'wb')
-    for s in source:
-        fp.write(open(str(s), 'rb').read())
-    fp.close()
+    with open(str(target[0]), 'wb') as fp:
+        for s in source:
+            with open(str(s), 'rb') as infp:
+                fp.write(infp.read())
 env=Environment()
 Export('env')
 env['BUILDERS']['Cat']=Builder(action=cat, multi=1)

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -48,10 +48,6 @@ import re
 import sys
 
 path = sys.argv[1].split()
-output = open(sys.argv[2], 'w')
-input = open(sys.argv[3], 'r')
-
-output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
 def find_file(f):
     for dir in path:
@@ -62,14 +58,19 @@ def find_file(f):
 
 def process(infp, outfp):
     for line in infp.readlines():
-        m = re.match('#include <(.*)>', line)
+        m = re.match(r'#include <(.*)>', line)
         if m:
             file = m.group(1)
-            process(find_file(file), outfp)
+            found = find_file(file)
+            process(found, outfp)
+            if found:
+                found.close()
         else:
             outfp.write(line)
 
-process(input, output)
+with open(sys.argv[2], 'w') as outf, open(sys.argv[3], 'r') as ifp:
+    outf.write('fake_cc.py:  %%s\n' %% sys.argv)
+    process(ifp, outf)
 
 sys.exit(0)
 """ % locals())
@@ -77,12 +78,9 @@ sys.exit(0)
 test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
-output = open(sys.argv[1], 'w')
-input = open(sys.argv[2], 'r')
-
-output.write('fake_link.py:  %%s\n' %% sys.argv)
-
-output.write(input.read())
+with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
+    outf.write('fake_link.py:  %%s\n' %% sys.argv)
+    outf.write(ifp.read())
 
 sys.exit(0)
 """ % locals())

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -68,10 +68,6 @@ import re
 import sys
 
 path = sys.argv[1].split()
-output = open(sys.argv[2], 'w')
-input = open(sys.argv[3], 'r')
-
-output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
 def find_file(f):
     for dir in path:
@@ -85,11 +81,16 @@ def process(infp, outfp):
         m = re.match('#include <(.*)>', line)
         if m:
             file = m.group(1)
-            process(find_file(file), outfp)
+            found = find_file(file)
+            process(found, outfp)
+            if found:
+                found.close()
         else:
             outfp.write(line)
 
-process(input, output)
+with open(sys.argv[2], 'w') as outf, open(sys.argv[3], 'r') as ifp:
+    outf.write('fake_cc.py:  %%s\n' %% sys.argv)
+    process(ifp, outf)
 
 sys.exit(0)
 """ % locals())
@@ -97,12 +98,9 @@ sys.exit(0)
 test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
-output = open(sys.argv[1], 'w')
-input = open(sys.argv[2], 'r')
-
-output.write('fake_link.py:  %%s\n' %% sys.argv)
-
-output.write(input.read())
+with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
+    outf.write('fake_link.py:  %%s\n' %% sys.argv)
+    outf.write(ifp.read())
 
 sys.exit(0)
 """ % locals())

--- a/test/sconsign/script/bad.py
+++ b/test/sconsign/script/bad.py
@@ -38,13 +38,13 @@ test.write('bad2.dblite', "bad2.dblite\n")
 test.write('bad3', "bad3\n")
 
 test.run_sconsign(arguments = "-f dblite no_sconsign",
-         stderr = "sconsign: \[Errno 2\] No such file or directory: 'no_sconsign'\n")
+         stderr = "sconsign: \\[Errno 2\\] No such file or directory: 'no_sconsign'\n")
 
 test.run_sconsign(arguments = "-f dblite bad1",
-         stderr = "sconsign: \[Errno 2\] No such file or directory: 'bad1.dblite'\n")
+         stderr = "sconsign: \\[Errno 2\\] No such file or directory: 'bad1.dblite'\n")
 
 test.run_sconsign(arguments = "-f dblite bad1.dblite",
-         stderr = "sconsign: \[Errno 2\] No such file or directory: 'bad1.dblite'\n")
+         stderr = "sconsign: \\[Errno 2\\] No such file or directory: 'bad1.dblite'\n")
 
 test.run_sconsign(arguments = "-f dblite bad2",
          stderr = "sconsign: ignoring invalid `dblite' file `bad2'.*\n")
@@ -53,7 +53,7 @@ test.run_sconsign(arguments = "-f dblite bad2.dblite",
          stderr = "sconsign: ignoring invalid `dblite' file `bad2.dblite'.*\n")
 
 test.run_sconsign(arguments = "-f sconsign no_sconsign",
-         stderr = "sconsign: \[Errno 2\] No such file or directory: 'no_sconsign'\n")
+         stderr = "sconsign: \\[Errno 2\\] No such file or directory: 'no_sconsign'\n")
 
 test.run_sconsign(arguments = "-f sconsign bad3",
          stderr = "sconsign: ignoring invalid .sconsign file `bad3'.*\n")

--- a/test/sconsign/script/dblite.py
+++ b/test/sconsign/script/dblite.py
@@ -43,7 +43,7 @@ LINK = test.detect('LINK', norm=1)
 if LINK is None: LINK = CC
 
 def escape_drive_case(s):
-    """Turn c\: into [cC]\:"""
+    r"""Turn c\: into [cC]\:"""
     if re.match(r'^(.)[\\]?:', s):
         drive=s[0]
         return '['+drive.lower()+drive.upper()+']'+s[1:]
@@ -133,7 +133,7 @@ hello%(_obj)s: %(sig_re)s \d+ \d+
         %(sig_re)s \[.*\]
 """ % locals()
 
-expect_r = """=== sub1:
+expect_r = r"""=== sub1:
 hello%(_exe)s: %(sig_re)s '%(date_re)s' \d+
         %(sub1_hello_obj)s: %(sig_re)s '%(date_re)s' \d+
         %(LINK)s: None '%(date_re)s' \d+

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -57,10 +57,6 @@ import re
 import sys
 
 path = sys.argv[1].split()
-output = open(sys.argv[2], 'w')
-input = open(sys.argv[3], 'r')
-
-output.write('fake_cc.py:  %%s\n' %% sys.argv)
 
 def find_file(f):
     for dir in path:
@@ -71,14 +67,19 @@ def find_file(f):
 
 def process(infp, outfp):
     for line in infp.readlines():
-        m = re.match('#include <(.*)>', line)
+        m = re.match(r'#include <(.*)>', line)
         if m:
             file = m.group(1)
-            process(find_file(file), outfp)
+            found = find_file(file)
+            process(found, outfp)
+            if found:
+                found.close()
         else:
             outfp.write(line)
 
-process(input, output)
+with open(sys.argv[2], 'w') as outf, open(sys.argv[3], 'r') as ifp:
+    outf.write('fake_cc.py:  %%s\n' %% sys.argv)
+    process(ifp, outf)
 
 sys.exit(0)
 """ % locals())
@@ -86,12 +87,9 @@ sys.exit(0)
 test.write(fake_link_py, r"""#!%(_python_)s
 import sys
 
-output = open(sys.argv[1], 'w')
-input = open(sys.argv[2], 'r')
-
-output.write('fake_link.py:  %%s\n' %% sys.argv)
-
-output.write(input.read())
+with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
+    outf.write('fake_link.py:  %%s\n' %% sys.argv)
+    outf.write(ifp.read())
 
 sys.exit(0)
 """ % locals())

--- a/test/silent-command.py
+++ b/test/silent-command.py
@@ -40,10 +40,10 @@ test.subdir('build', 'src')
 
 test.write('build.py', r"""
 import sys
-fp = open(sys.argv[1], 'wb')
-for f in sys.argv[2:]:
-    fp.write(open(f, 'rb').read())
-fp.close()
+with open(sys.argv[1], 'wb') as fp:
+    for f in sys.argv[2:]:
+        with open(f, 'rb') as ifp:
+            fp.write(ifp.read())
 """)
 
 test.write('SConstruct', """\

--- a/test/site_scons/site_init.py
+++ b/test/site_scons/site_init.py
@@ -124,7 +124,7 @@ e.Foo(target='foo.out', source='SConstruct')
 
 test.run(arguments = '-Q .',
          stdout = "",
-         stderr = """.*Error loading site_init file.*Huh\?.*""",
+         stderr = r".*Error loading site_init file.*Huh\?.*",
          status=2,
          match=TestSCons.match_re_dotall)
 

--- a/test/special-filenames.py
+++ b/test/special-filenames.py
@@ -49,7 +49,8 @@ attempt_file_names = [
 
 test.write("cat.py", """\
 import sys
-open(sys.argv[1], 'wb').write(open(sys.argv[2], 'rb').read())
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as ifp:
+    f.write(ifp.read())
 """)
 
 file_names = []

--- a/test/srcchange.py
+++ b/test/srcchange.py
@@ -44,7 +44,8 @@ test = TestSCons.TestSCons()
 
 test.write('getrevision', """
 from __future__ import print_function
-print(open('revnum.in','r').read().strip(), end='')
+with open('revnum.in','r') as f:
+    print(f.read().strip(), end='')
 """)
 
 test.write('SConstruct', """
@@ -52,12 +53,11 @@ import re
 
 def subrevision(target, source ,env):
     orig = target[0].get_text_contents()
-    new = re.sub('\$REV.*?\$',
+    new = re.sub(r'\$REV.*?\$',
                  '$REV: %%s$'%%source[0].get_text_contents().strip(),
                  target[0].get_text_contents())
-    outf = open(str(target[0]),'w')
-    outf.write(new)
-    outf.close()
+    with open(str(target[0]),'w') as outf:
+        outf.write(new)
 
 SubRevision = Action(subrevision)
 

--- a/test/strfunction.py
+++ b/test/strfunction.py
@@ -36,7 +36,8 @@ test = TestSCons.TestSCons()
 
 test.write('cat.py', """\
 import sys
-open(sys.argv[2], "wb").write(open(sys.argv[1], "rb").read())
+with open(sys.argv[2], "wb") as f, open(sys.argv[1], "rb") as ifp:
+    f.write(ifp.read())
 sys.exit(0)
 """)
 
@@ -49,7 +50,8 @@ def strfunction(target, source, env):
 def func(target, source, env):
     t = str(target[0])
     s = str(source[0])
-    open(t, 'w').write(open(s, 'r').read())
+    with open(t, 'w') as f, open(s, 'r') as ifp:
+        f.write(ifp.read())
 func1action = Action(func, strfunction)
 func2action = Action(func, strfunction=strfunction)
 

--- a/test/subclassing.py
+++ b/test/subclassing.py
@@ -54,7 +54,7 @@ env.Command('f0.out', 'f0.in', copy_action)
 try:
     from collections import UserString
 except ImportError:
-    exec('from UserString import UserString')
+    from UserString import UserString
 try:
     class mystr(str):
         pass

--- a/test/subdir.py
+++ b/test/subdir.py
@@ -35,10 +35,8 @@ test.subdir('subdir')
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'r').read()
-file = open(sys.argv[1], 'w')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'w') as f, open(sys.argv[2], 'r') as ifp:
+    f.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/test/subdivide.py
+++ b/test/subdivide.py
@@ -59,18 +59,20 @@ fake_link_py = test.workpath('fake_link.py')
 
 test.write(fake_cc_py, """\
 import sys
-ofp = open(sys.argv[1], 'w')
-ofp.write('fake_cc.py:  %s\\n' % sys.argv)
-for s in sys.argv[2:]:
-    ofp.write(open(s, 'r').read())
+with open(sys.argv[1], 'w') as ofp:
+    ofp.write('fake_cc.py:  %s\\n' % sys.argv)
+    for s in sys.argv[2:]:
+        with open(s, 'r') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.write(fake_link_py, """\
 import sys
-ofp = open(sys.argv[1], 'w')
-ofp.write('fake_link.py:  %s\\n' % sys.argv)
-for s in sys.argv[2:]:
-    ofp.write(open(s, 'r').read())
+with open(sys.argv[1], 'w') as ofp:
+    ofp.write('fake_link.py:  %s\\n' % sys.argv)
+    for s in sys.argv[2:]:
+        with open(s, 'r') as ifp:
+            ofp.write(ifp.read())
 """)
 
 test.chmod(fake_cc_py, 0o755)

--- a/test/suffixes.py
+++ b/test/suffixes.py
@@ -35,10 +35,10 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 def cat(env, source, target):
     target = str(target[0])
-    f = open(target, "wb")
-    for src in source:
-        f.write(open(str(src), "rb").read())
-    f.close()
+    with open(target, "wb") as f:
+        for src in source:
+            with open(str(src), "rb") as ifp:
+                f.write(ifp.read())
 Cat = Builder(action=cat, suffix='.out')
 env = Environment(BUILDERS = {'Cat':Cat})
 env.Cat('file1', 'file1.in')

--- a/test/timestamp-fallback.py
+++ b/test/timestamp-fallback.py
@@ -63,8 +63,11 @@ os.environ['PYTHONPATH'] = test.workpath('.')
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
+
 def build(env, target, source):
-    open(str(target[0]), 'wt').write(open(str(source[0]), 'rt').read())
+    with open(str(target[0]), 'wt') as ofp, open(str(source[0]), 'rt') as ifp:
+        opf.write(ifp.read())
+
 B = Builder(action = build)
 env = Environment(tools = [], BUILDERS = { 'B' : B })
 env.B(target = 'f1.out', source = 'f1.in')
@@ -90,10 +93,10 @@ build(["f4.out"], ["f4.in"])
 """),
          stderr = None)
 
-os.utime(test.workpath('f1.in'), 
+os.utime(test.workpath('f1.in'),
          (os.path.getatime(test.workpath('f1.in')),
           os.path.getmtime(test.workpath('f1.in'))+10))
-os.utime(test.workpath('f3.in'), 
+os.utime(test.workpath('f3.in'),
          (os.path.getatime(test.workpath('f3.in')),
           os.path.getmtime(test.workpath('f3.in'))+10))
 

--- a/test/toolpath/VariantDir.py
+++ b/test/toolpath/VariantDir.py
@@ -50,8 +50,8 @@ test.write(['subdir', 'src', 'tools', 'MyBuilder.py'], """\
 from SCons.Script import Builder
 def generate(env):
     def my_copy(target, source, env):
-        content = open(str(source[0]), 'rb').read()
-        open(str(target[0]), 'wb').write(content)
+        with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as ifp:
+            f.write(ifp.read())
     env['BUILDERS']['MyCopy'] = Builder(action = my_copy)
 
 def exists(env):

--- a/test/up-to-date.py
+++ b/test/up-to-date.py
@@ -36,10 +36,8 @@ test = TestSCons.TestSCons()
 
 test.write('build.py', r"""
 import sys
-contents = open(sys.argv[2], 'rb').read()
-file = open(sys.argv[1], 'wb')
-file.write(contents)
-file.close()
+with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as ifp:
+    f.write(ifp.read())
 """)
 
 test.write('SConstruct', """

--- a/testing/framework/SConscript
+++ b/testing/framework/SConscript
@@ -41,12 +41,13 @@ files = [
 def copy(target, source, env):
     t = str(target[0])
     s = str(source[0])
-    c = open(s, 'r').read()
-    # Note:  We construct the __ VERSION __ substitution string at
-    # run-time so it doesn't get replaced when this file gets copied
-    # into the tree for packaging.
-    c = c.replace('__' + 'VERSION' + '__', env['VERSION'])
-    open(t, 'w').write(c)
+    with open(s, 'r') as i, open(t, 'w') as o:
+        c = i.read()
+        # Note:  We construct the __ VERSION __ substitution string at
+        # run-time so it doesn't get replaced when this file gets copied
+        # into the tree for packaging.
+        c = c.replace('__' + 'VERSION' + '__', env['VERSION'])
+        o.write(c)
 
 for file in files:
     # Guarantee that real copies of these files always exist in

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -949,7 +949,7 @@ class TestSCons(TestCommon):
     def Qt_dummy_installation(self, dir='qt'):
         # create a dummy qt installation
 
-        self.subdir( dir, [dir, 'bin'], [dir, 'include'], [dir, 'lib'] )
+        self.subdir(dir, [dir, 'bin'], [dir, 'include'], [dir, 'lib'])
 
         self.write([dir, 'bin', 'mymoc.py'], """\
 import getopt
@@ -960,11 +960,11 @@ cmd_opts, args = getopt.getopt(sys.argv[1:], 'io:wz', [])
 impl = 0
 opt_string = ''
 for opt, arg in cmd_opts:
-    if opt == '-o': out = arg
+    if opt == '-o': outfile = arg
     elif opt == '-i': impl = 1
     else: opt_string = opt_string + ' ' + opt
 
-with open(out, 'w') as ofp:
+with open(outfile, 'w') as ofp:
     ofp.write("/* mymoc.py%s */\\n" % opt_string)
     for a in args:
         with open(a, 'r') as ifp:
@@ -972,7 +972,7 @@ with open(out, 'w') as ofp:
         a = a.replace('\\\\', '\\\\\\\\')
         subst = r'{ my_qt_symbol( "' + a + '\\\\n" ); }'
         if impl:
-            contents = re.sub( r'#include.*', '', contents )
+            contents = re.sub(r'#include.*', '', contents)
         ofp.write(contents.replace('Q_OBJECT', subst))
 sys.exit(0)
 """)
@@ -988,7 +988,7 @@ source = None
 opt_string = ''
 for arg in sys.argv[1:]:
     if output_arg:
-        out = arg
+        outfile = arg
         output_arg = 0
     elif impl_arg:
         impl = arg
@@ -1004,17 +1004,17 @@ for arg in sys.argv[1:]:
             sys.exit(1)
         source = sourceFile = arg
 
-with open(out, 'w') as ofp, open(source, 'r') as ifp:
+with open(outfile, 'w') as ofp, open(source, 'r') as ifp:
     ofp.write("/* myuic.py%s */\\n" % opt_string)
     if impl:
-        ofp.write( '#include "' + impl + '"\\n' )
+        ofp.write('#include "' + impl + '"\\n')
         includes = re.findall('<include.*?>(.*?)</include>', ifp.read())
         for incFile in includes:
             # this is valid for ui.h files, at least
             if os.path.exists(incFile):
                 ofp.write('#include "' + incFile + '"\\n')
     else:
-        ofp.write( '#include "my_qobject.h"\\n' + ifp.read() + " Q_OBJECT \\n" )
+        ofp.write('#include "my_qobject.h"\\n' + ifp.read() + " Q_OBJECT \\n")
 sys.exit(0)
 """ )
 
@@ -1027,7 +1027,7 @@ void my_qt_symbol(const char *arg);
 #include "../include/my_qobject.h"
 #include <stdio.h>
 void my_qt_symbol(const char *arg) {
-  fputs( arg, stdout );
+  fputs(arg, stdout);
 }
 """)
 
@@ -1035,9 +1035,9 @@ void my_qt_symbol(const char *arg) {
 env = Environment()
 import sys
 if sys.platform == 'win32':
-    env.StaticLibrary( 'myqt', 'my_qobject.cpp' )
+    env.StaticLibrary('myqt', 'my_qobject.cpp')
 else:
-    env.SharedLibrary( 'myqt', 'my_qobject.cpp' )
+    env.SharedLibrary('myqt', 'my_qobject.cpp')
 """)
 
         self.run(chdir = self.workpath(dir, 'lib'),
@@ -1080,7 +1080,7 @@ if ARGUMENTS.get('variant_dir', 0):
 else:
     sconscript = File('SConscript')
 Export("env dup")
-SConscript( sconscript )
+SConscript(sconscript)
 """ % (self.QT, self.QT_LIB, self.QT_MOC, self.QT_UIC))
 
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -957,23 +957,23 @@ import sys
 import re
 # -w and -z are fake options used in test/QT/QTFLAGS.py
 cmd_opts, args = getopt.getopt(sys.argv[1:], 'io:wz', [])
-output = None
 impl = 0
 opt_string = ''
 for opt, arg in cmd_opts:
-    if opt == '-o': output = open(arg, 'w')
+    if opt == '-o': out = arg
     elif opt == '-i': impl = 1
     else: opt_string = opt_string + ' ' + opt
-output.write("/* mymoc.py%s */\\n" % opt_string)
-for a in args:
-    with open(a, 'r') as f:
-        contents = f.read()
-    a = a.replace('\\\\', '\\\\\\\\')
-    subst = r'{ my_qt_symbol( "' + a + '\\\\n" ); }'
-    if impl:
-        contents = re.sub( r'#include.*', '', contents )
-    output.write(contents.replace('Q_OBJECT', subst))
-output.close()
+
+with open(out, 'w') as ofp:
+    ofp.write("/* mymoc.py%s */\\n" % opt_string)
+    for a in args:
+        with open(a, 'r') as ifp:
+            contents = ifp.read()
+        a = a.replace('\\\\', '\\\\\\\\')
+        subst = r'{ my_qt_symbol( "' + a + '\\\\n" ); }'
+        if impl:
+            contents = re.sub( r'#include.*', '', contents )
+        ofp.write(contents.replace('Q_OBJECT', subst))
 sys.exit(0)
 """)
 
@@ -988,7 +988,7 @@ source = None
 opt_string = ''
 for arg in sys.argv[1:]:
     if output_arg:
-        output = open(arg, 'w')
+        out = arg
         output_arg = 0
     elif impl_arg:
         impl = arg
@@ -1002,19 +1002,19 @@ for arg in sys.argv[1:]:
     else:
         if source:
             sys.exit(1)
-        source = open(arg, 'r')
-        sourceFile = arg
-output.write("/* myuic.py%s */\\n" % opt_string)
-if impl:
-    output.write( '#include "' + impl + '"\\n' )
-    includes = re.findall('<include.*?>(.*?)</include>', source.read())
-    for incFile in includes:
-        # this is valid for ui.h files, at least
-        if os.path.exists(incFile):
-            output.write('#include "' + incFile + '"\\n')
-else:
-    output.write( '#include "my_qobject.h"\\n' + source.read() + " Q_OBJECT \\n" )
-output.close()
+        source = sourceFile = arg
+
+with open(out, 'w') as ofp, open(source, 'r') as ifp:
+    ofp.write("/* myuic.py%s */\\n" % opt_string)
+    if impl:
+        ofp.write( '#include "' + impl + '"\\n' )
+        includes = re.findall('<include.*?>(.*?)</include>', ifp.read())
+        for incFile in includes:
+            # this is valid for ui.h files, at least
+            if os.path.exists(incFile):
+                ofp.write('#include "' + incFile + '"\\n')
+    else:
+        ofp.write( '#include "my_qobject.h"\\n' + ifp.read() + " Q_OBJECT \\n" )
 sys.exit(0)
 """ )
 

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -1045,7 +1045,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='10.0',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']
@@ -1068,7 +1068,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='11.0',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']
@@ -1091,7 +1091,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.0',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']
@@ -1114,7 +1114,7 @@ env=Environment(platform='win32', tools=['msvs'], MSVS_VERSION='14.1',
                 HOST_ARCH='%(HOST_ARCH)s')
 
 testsrc = ['test1.cpp', 'test2.cpp']
-testincs = ['sdk_dir\\sdk.h']
+testincs = [r'sdk_dir\\sdk.h']
 testlocalincs = ['test.h']
 testresources = ['test.rc']
 testmisc = ['readme.txt']


### PR DESCRIPTION
Giant bundle of fixes for things that kill tests under Python 3.8, or alternatively, spew warnings that don't happen to kill tests.  

Pushing now (flagged as work-in-progress) to get a ci build series done.  There are a couple of areas that aren't clearly understood - one in gcc's version check, one relating to older visual studio versions (not to them themseleves, as these tests are OS-independent, and the file-handling bits fail even on Linux), something in Action.py one of the remaining uses if imp module, and some syntax that include ORIGIN - 15 tests are faiing on the development Linux box.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
