### PR TITLE
Avoid cachedir races

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -58,6 +58,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       drop one (unused) use; replace one.  Fix another instance of
       renaming to SConsEnvironmentError. Trailing whitespace.
       Consistently use not is/in (if not x is y -> if x is not y).
+    - Add a PY3-only function for setting up the cachedir that should be less
+      prone to races. Add a hack to the PY2 version (from Issue #3351) to
+      be less prone to a race in the check for old-style cache.
 
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -139,16 +139,78 @@ warned = dict()
 class CacheDir(object):
 
     def __init__(self, path):
+        """
+        Initialize a CacheDir object.
+
+        The cache configuration is stored in the object. It
+        is read from the config file in the supplied path if
+        one exists,  if not the config file is created and
+        the default config is written, as well as saved in the object.
+        """
         self.path = path
         self.current_cache_debug = None
         self.debugFP = None
         self.config = dict()
         if path is None:
             return
-        # See if there's a config file in the cache directory. If there is,
-        # use it. If there isn't, and the directory exists and isn't empty,
-        # produce a warning. If the directory doesn't exist or is empty,
-        # write a config file.
+
+        from SCons.Util import PY3
+        if PY3:
+            self._readconfig3(path)
+        else:
+            self._readconfig2(path)
+
+
+    def _readconfig3(self, path):
+        """
+        Python3 version of reading the cache config.
+
+        If directory or config file do not exist, create.  Take advantage
+        of Py3 capability in os.makedirs() and in file open(): just try
+        the operation and handle failure appropriately.
+
+        Omit the check for old cache format, assume that's old enough
+        there will be none of those left to worry about.
+
+        :param path: path to the cache directory
+        """
+        config_file = os.path.join(path, 'config')
+        try:
+            os.makedirs(path, exist_ok=True)
+        except FileExistsError:
+            pass
+        except OSError:
+            msg = "Failed to create cache directory " + path
+            raise SCons.Errors.EnvironmentError(msg)
+
+        try:
+            with open(config_file, 'x') as config:
+                self.config['prefix_len'] = 2
+                try:
+                    json.dump(self.config, config)
+                except:
+                    msg = "Failed to write cache configuration for " + path
+                    raise SCons.Errors.EnvironmentError(msg)
+        except FileExistsError:
+            try:
+                with open(config_file) as config:
+                    self.config = json.load(config)
+            except ValueError:
+                msg = "Failed to read cache configuration for " + path
+                raise SCons.Errors.EnvironmentError(msg)
+
+
+    def _readconfig2(self, path):
+        """
+        Python2 version of reading cache config.
+
+        See if there's a config file in the cache directory. If there is,
+        use it. If there isn't, and the directory exists and isn't empty,
+        produce a warning. If the directory doesn't exist or is empty,
+        write a config file.
+
+        :param path: path to the cache directory
+        """
         config_file = os.path.join(path, 'config')
         if not os.path.exists(config_file):
             # A note: There is a race hazard here, if two processes start and
@@ -159,14 +221,15 @@ class CacheDir(object):
             # as an attempt to alleviate this, on the basis that it's a pretty
             # unlikely occurence (it'd require two builds with a brand new cache
             # directory)
-            if os.path.isdir(path) and len(os.listdir(path)) != 0:
+            #if os.path.isdir(path) and len(os.listdir(path)) != 0:
+            if os.path.isdir(path) and len([f for f in os.listdir(path) if os.path.basename(f) != "config"]) != 0:
                 self.config['prefix_len'] = 1
                 # When building the project I was testing this on, the warning
                 # was output over 20 times. That seems excessive
                 global warned
                 if self.path not in warned:
                     msg = "Please upgrade your cache by running " +\
-                          " scons-configure-cache.py " +  self.path
+                          "scons-configure-cache.py " +  self.path
                     SCons.Warnings.warn(SCons.Warnings.CacheVersionWarning, msg)
                     warned[self.path] = True
             else:

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -35,6 +35,7 @@ import sys
 
 import SCons.Action
 import SCons.Warnings
+from SCons.Util import PY3
 
 cache_enabled = True
 cache_debug = False
@@ -154,7 +155,6 @@ class CacheDir(object):
         if path is None:
             return
 
-        from SCons.Util import PY3
         if PY3:
             self._readconfig3(path)
         else:
@@ -204,9 +204,9 @@ class CacheDir(object):
         """
         Python2 version of reading cache config.
 
-        See if there's a config file in the cache directory. If there is,
+        See if there is a config file in the cache directory. If there is,
         use it. If there isn't, and the directory exists and isn't empty,
-        produce a warning. If the directory doesn't exist or is empty,
+        produce a warning. If the directory does not exist or is empty,
         write a config file.
 
         :param path: path to the cache directory
@@ -215,14 +215,13 @@ class CacheDir(object):
         if not os.path.exists(config_file):
             # A note: There is a race hazard here, if two processes start and
             # attempt to create the cache directory at the same time. However,
-            # python doesn't really give you the option to do exclusive file
-            # creation (it doesn't even give you the option to error on opening
-            # an existing file for writing...). The ordering of events here
-            # as an attempt to alleviate this, on the basis that it's a pretty
-            # unlikely occurence (it'd require two builds with a brand new cache
+            # Python 2.x does not give you the option to do exclusive file
+            # creation (not even the option to error on opening ad existing
+            # file for writing...). The ordering of events here as an attempt
+            # to alleviate this, on the basis that it's a pretty unlikely
+            # occurence (would require two builds with a brand new cache
             # directory)
-            #if os.path.isdir(path) and len(os.listdir(path)) != 0:
-            if os.path.isdir(path) and len([f for f in os.listdir(path) if os.path.basename(f) != "config"]) != 0:
+            if os.path.isdir(path) and any(f != "config" for f in os.listdir(path)):
                 self.config['prefix_len'] = 1
                 # When building the project I was testing this on, the warning
                 # was output over 20 times. That seems excessive

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -213,13 +213,13 @@ class CacheDir(object):
         """
         config_file = os.path.join(path, 'config')
         if not os.path.exists(config_file):
-            # A note: There is a race hazard here, if two processes start and
+            # A note: There is a race hazard here if two processes start and
             # attempt to create the cache directory at the same time. However,
             # Python 2.x does not give you the option to do exclusive file
-            # creation (not even the option to error on opening ad existing
-            # file for writing...). The ordering of events here as an attempt
+            # creation (not even the option to error on opening an existing
+            # file for writing...). The ordering of events here is an attempt
             # to alleviate this, on the basis that it's a pretty unlikely
-            # occurence (would require two builds with a brand new cache
+            # occurrence (would require two builds with a brand new cache
             # directory)
             if os.path.isdir(path) and any(f != "config" for f in os.listdir(path)):
                 self.config['prefix_len'] = 1

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -188,7 +188,7 @@ class CacheDir(object):
                 self.config['prefix_len'] = 2
                 try:
                     json.dump(self.config, config)
-                except:
+                except Exception:
                     msg = "Failed to write cache configuration for " + path
                     raise SCons.Errors.EnvironmentError(msg)
         except FileExistsError:
@@ -247,7 +247,7 @@ class CacheDir(object):
                     try:
                         with open(config_file, 'w') as config:
                             json.dump(self.config, config)
-                    except:
+                    except Exception:
                         msg = "Failed to write cache configuration for " + path
                         raise SCons.Errors.SConsEnvironmentError(msg)
         else:


### PR DESCRIPTION
1. Add a Py3-only version of the cachedir config read, using exclusive open to avoid races.
2. In the Py2-only version, add the hack from issue #3351 to dodge one source of races.

This is an initial try to experiment with.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
