### PR TITLE
Issue #3349 - Refactor EnvironmentError to SConsEnvironmentError to avoid overriding python's native EnvironmentError

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,10 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From William Deegan:
+    - Fix Issue #3350 - SCons Exception EnvironmentError is conflicting with Python's EnvironmentError.
+      Renamed to SConsEnvironmentError
+
   From Mats Wichmann:
     - scons-time takes more care closing files and uses safer mkdtemp to avoid
       possible races on multi-job runs.

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -2433,16 +2433,16 @@ f5: \
         exc_caught = None
         try:
             env.Tool('does_not_exist')
-        except SCons.Errors.EnvironmentError:
+        except SCons.Errors.SConsEnvironmentError:
             exc_caught = 1
-        assert exc_caught, "did not catch expected EnvironmentError"
+        assert exc_caught, "did not catch expected SConsEnvironmentError"
 
         exc_caught = None
         try:
             env.Tool('$NONE')
-        except SCons.Errors.EnvironmentError:
+        except SCons.Errors.SConsEnvironmentError:
             exc_caught = 1
-        assert exc_caught, "did not catch expected EnvironmentError"
+        assert exc_caught, "did not catch expected SConsEnvironmentError"
 
         # Use a non-existent toolpath directory just to make sure we
         # can call Tool() with the keyword argument.

--- a/src/engine/SCons/Errors.py
+++ b/src/engine/SCons/Errors.py
@@ -124,7 +124,7 @@ class UserError(Exception):
 class StopError(Exception):
     pass
 
-class EnvironmentError(Exception):
+class SConsEnvironmentError(Exception):
     pass
 
 class MSVCError(IOError):
@@ -184,7 +184,7 @@ def convert_to_BuildError(status, exc_info=None):
             filename=filename,
             exc_info=exc_info)
 
-    elif isinstance(status, (EnvironmentError, OSError, IOError)):
+    elif isinstance(status, (SConsEnvironmentError, OSError, IOError)):
         # If an IOError/OSError happens, raise a BuildError.
         # Report the name of the file or directory that caused the
         # error, which might be different from the target being built

--- a/src/engine/SCons/ErrorsTests.py
+++ b/src/engine/SCons/ErrorsTests.py
@@ -101,10 +101,10 @@ class ErrorsTestCase(unittest.TestCase):
             assert e.node == "node"
 
     def test_convert_EnvironmentError_to_BuildError(self):
-        """Test the convert_to_BuildError function on EnvironmentError
+        """Test the convert_to_BuildError function on SConsEnvironmentError
         exceptions.
         """
-        ee = SCons.Errors.EnvironmentError("test env error")
+        ee = SCons.Errors.SConsEnvironmentError("test env error")
         be = SCons.Errors.convert_to_BuildError(ee)
         assert be.errstr == "test env error"
         assert be.status == 2

--- a/src/engine/SCons/Tool/ToolTests.py
+++ b/src/engine/SCons/Tool/ToolTests.py
@@ -72,7 +72,7 @@ class ToolTestCase(unittest.TestCase):
 
         try:
             p = SCons.Tool.Tool('_does_not_exist_')
-        except SCons.Errors.EnvironmentError:
+        except SCons.Errors.SConsEnvironmentError:
             pass
         else:
             raise

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -149,7 +149,7 @@ class Tool(object):
                 except ImportError as e:
                     splitname = self.name.split('.')
                     if str(e) != "No module named %s" % splitname[0]:
-                        raise SCons.Errors.EnvironmentError(e)
+                        raise SCons.Errors.SConsEnvironmentError(e)
                     try:
                         import zipimport
                     except ImportError:
@@ -211,13 +211,13 @@ class Tool(object):
 
             if spec is None:
                 error_string = "No module named %s" % self.name
-                raise SCons.Errors.EnvironmentError(error_string)
+                raise SCons.Errors.SConsEnvironmentError(error_string)
 
             module = importlib.util.module_from_spec(spec)
             if module is None:
                 if debug: print("MODULE IS NONE:%s" % self.name)
                 error_string = "No module named %s" % self.name
-                raise SCons.Errors.EnvironmentError(error_string)
+                raise SCons.Errors.SConsEnvironmentError(error_string)
 
             # Don't reload a tool we already loaded.
             sys_modules_value = sys.modules.get(found_name, False)
@@ -258,7 +258,7 @@ class Tool(object):
                     return module
                 except ImportError as e:
                     if str(e) != "No module named %s" % self.name:
-                        raise SCons.Errors.EnvironmentError(e)
+                        raise SCons.Errors.SConsEnvironmentError(e)
                     try:
                         import zipimport
                         importer = zipimport.zipimporter(sys.modules['SCons.Tool'].__path__[0])
@@ -267,10 +267,10 @@ class Tool(object):
                         return module
                     except ImportError as e:
                         m = "No tool named '%s': %s" % (self.name, e)
-                        raise SCons.Errors.EnvironmentError(m)
+                        raise SCons.Errors.SConsEnvironmentError(m)
             except ImportError as e:
                 m = "No tool named '%s': %s" % (self.name, e)
-                raise SCons.Errors.EnvironmentError(m)
+                raise SCons.Errors.SConsEnvironmentError(m)
 
     def __call__(self, env, *args, **kw):
         if self.init_kw is not None:

--- a/src/engine/SCons/Tool/intelc.py
+++ b/src/engine/SCons/Tool/intelc.py
@@ -221,7 +221,7 @@ def get_all_compiler_versions():
         versions = []
         try:
             while i < 100:
-                subkey = SCons.Util.RegEnumKey(k, i) # raises EnvironmentError
+                subkey = SCons.Util.RegEnumKey(k, i) # raises SConsEnvironmentError
                 # Check that this refers to an existing dir.
                 # This is not 100% perfect but should catch common
                 # installation issues like when the compiler was installed

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -125,7 +125,7 @@ def Package(env, target=None, source=None, **kw):
             # the specific packager is a relative import
             return importlib.import_module("." + type, __name__)
         except ImportError as e:
-            raise EnvironmentError("packager %s not available: %s"%(type,str(e)))
+            raise SConsEnvironmentError("packager %s not available: %s" % (type, str(e)))
 
     packagers = list(map(load_packager, PACKAGETYPE))
 

--- a/test/GetBuildFailures/serial.py
+++ b/test/GetBuildFailures/serial.py
@@ -83,8 +83,8 @@ Command('f08', 'f08.in', raiseExcAction(SCons.Errors.UserError("My User Error"))
 Command('f09', 'f09.in', returnExcAction(SCons.Errors.UserError("My User Error")))
 Command('f10', 'f10.in', raiseExcAction(MyBuildError(errstr="My Build Error", status=7)))
 Command('f11', 'f11.in', returnExcAction(MyBuildError(errstr="My Build Error", status=7)))
-Command('f12', 'f12.in', raiseExcAction(OSError(123, "My EnvironmentError", "f12")))
-Command('f13', 'f13.in', returnExcAction(OSError(123, "My EnvironmentError", "f13")))
+Command('f12', 'f12.in', raiseExcAction(OSError(123, "My SConsEnvironmentError", "f12")))
+Command('f13', 'f13.in', returnExcAction(OSError(123, "My SConsEnvironmentError", "f13")))
 Command('f14', 'f14.in', raiseExcAction(SCons.Errors.InternalError("My InternalError")))
 Command('f15', 'f15.in', returnExcAction(SCons.Errors.InternalError("My InternalError")))
 
@@ -173,9 +173,9 @@ BF: f10 failed (7):  My Build Error
 BF:    action(["f10"], ["f10.in"])
 BF: f11 failed (7):  My Build Error
 BF:    action(["f11"], ["f11.in"])
-BF: f12 failed (123):  My EnvironmentError
+BF: f12 failed (123):  My SConsEnvironmentError
 BF:    action(["f12"], ["f12.in"])
-BF: f13 failed (123):  My EnvironmentError
+BF: f13 failed (123):  My SConsEnvironmentError
 BF:    action(["f13"], ["f13.in"])
 BF: f14 failed (2):  InternalError : My InternalError
 BF:    action(["f14"], ["f14.in"])
@@ -191,8 +191,8 @@ scons: *** [f08] My User Error
 scons: *** [f09] My User Error
 scons: *** [f10] My Build Error
 scons: *** [f11] My Build Error
-scons: *** [f12] f12: My EnvironmentError
-scons: *** [f13] f13: My EnvironmentError
+scons: *** [f12] f12: My SConsEnvironmentError
+scons: *** [f13] f13: My SConsEnvironmentError
 scons: *** [f14] InternalError : My InternalError
 """) + \
 """\

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -1634,7 +1634,7 @@ class rmdir_TestCase(TestCmdTestCase):
         except EnvironmentError:
             pass
         else:
-            raise Exception("did not catch expected EnvironmentError")
+            raise Exception("did not catch expected SConsEnvironmentError")
 
         test.subdir(['sub'],
                     ['sub', 'dir'],
@@ -1649,7 +1649,7 @@ class rmdir_TestCase(TestCmdTestCase):
         except EnvironmentError:
             pass
         else:
-            raise Exception("did not catch expected EnvironmentError")
+            raise Exception("did not catch expected SConsEnvironmentError")
 
         assert os.path.isdir(s_d_o), "%s is gone?" % s_d_o
 
@@ -1658,7 +1658,7 @@ class rmdir_TestCase(TestCmdTestCase):
         except EnvironmentError:
             pass
         else:
-            raise Exception("did not catch expected EnvironmentError")
+            raise Exception("did not catch expected SConsEnvironmentError")
 
         assert os.path.isdir(s_d_o), "%s is gone?" % s_d_o
 


### PR DESCRIPTION

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
