### PR TITLE
Fixup some code triggering pylint errors.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -17,6 +17,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Use importlib to dynamically load tool and platform modules instead of imp module
     - sconsign: default to .sconsign.dblite if no filename is specified.
       Be more informative in case of unsupported pickle protocol (py2 only).
+    - assorted fixups for pylint: exception types, redefined functions, 
+      globals, etc.  Some old code removed to resolve issues (hashlib is
+      always present on modern Pythons; no longer need the code for
+      2.5-and-earlier optparse). cmp is not a builtin function in Py3,
+      drop one (unused) use; replace one.  Fix another instance of
+      renaming to SConsEnvironmentError.
 
   From John Doe:
 

--- a/src/engine/SCons/ActionTests.py
+++ b/src/engine/SCons/ActionTests.py
@@ -1554,19 +1554,19 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
         assert c == func_matches[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + repr(
             func_matches[sys.version_info[:2]])
 
-        def f_global(target, source, env, for_signature):
+        def f_global2(target, source, env, for_signature):
             return SCons.Action.Action(GlobalFunc, varlist=['XYZ'])
 
-        def f_local(target, source, env, for_signature):
+        def f_local2(target, source, env, for_signature):
             return SCons.Action.Action(LocalFunc, varlist=['XYZ'])
 
         matches_foo = func_matches[sys.version_info[:2]] + b'foo'
 
-        a = self.factory(f_global)
+        a = self.factory(f_global2)
         c = a.get_contents(target=[], source=[], env=env)
         assert c in matches_foo, repr(c)
 
-        a = self.factory(f_local)
+        a = self.factory(f_local2)
         c = a.get_contents(target=[], source=[], env=env)
         assert c in matches_foo, repr(c)
 

--- a/src/engine/SCons/BuilderTests.py
+++ b/src/engine/SCons/BuilderTests.py
@@ -409,10 +409,6 @@ class BuilderTestCase(unittest.TestCase):
         builder = SCons.Builder.Builder(generator=generator)
         assert builder.action.generator == generator
 
-    def test_get_name(self):
-        """Test the get_name() method
-        """
-
     def test_cmp(self):
         """Test simple comparisons of Builder objects
         """
@@ -552,7 +548,7 @@ class BuilderTestCase(unittest.TestCase):
 
     def test_src_suffix(self):
         """Test Builder creation with a specified source file suffix
-        
+
         Make sure that the '.' separator is appended to the
         beginning if it isn't already present.
         """
@@ -685,7 +681,7 @@ class BuilderTestCase(unittest.TestCase):
                 pass
             if (len(source) == 1 and len(target) == 1):
                 env['CNT'][0] = env['CNT'][0] + 1
-                
+
         env = Environment()
         infiles = []
         outfiles = []
@@ -732,8 +728,8 @@ class BuilderTestCase(unittest.TestCase):
             pass
         else:
             assert 0
-        
-        
+
+
     def test_lists(self):
         """Testing handling lists of targets and source"""
         def function2(target, source, env, tlist = [outfile, outfile2], **kw):
@@ -881,7 +877,7 @@ class BuilderTestCase(unittest.TestCase):
 
         def func(self):
             pass
-        
+
         scanner = SCons.Scanner.Base(func, name='fooscan')
 
         b1 = SCons.Builder.Builder(action='bld', target_scanner=scanner)
@@ -890,8 +886,8 @@ class BuilderTestCase(unittest.TestCase):
 
         assert b1 == b2
         assert b1 != b3
-        
-    def test_src_scanner(slf):
+
+    def test_src_scanner(self):
         """Testing ability to set a source file scanner through a builder."""
         class TestScanner(object):
             def key(self, env):
@@ -1245,7 +1241,7 @@ class BuilderTestCase(unittest.TestCase):
             for t in target:
                 t.builder = nb
             return [nn], source
-            
+
         builder=SCons.Builder.Builder(action='foo',
                                       emitter=emit,
                                       target_factory=MyNode,
@@ -1321,7 +1317,7 @@ class BuilderTestCase(unittest.TestCase):
         builder2 = SCons.Builder.Builder(action='foo',
                                          emitter='$EMITTERLIST',
                                          node_factory=MyNode)
-                                         
+
         env = Environment(EMITTERLIST = [emit2a, emit2b])
 
         tgts = builder2(env, target='target-2', source='aaa.2')
@@ -1419,7 +1415,7 @@ class BuilderTestCase(unittest.TestCase):
         b6 = SCons.Builder.Builder(action='foo')
         assert isinstance(b4, SCons.Builder.CompositeBuilder)
         assert isinstance(b4.action, SCons.Action.CommandGeneratorAction)
-        
+
         env = Environment(BUILDERS={'bldr1': b1,
                                     'bldr2': b2,
                                     'bldr3': b3,
@@ -1481,7 +1477,7 @@ class CompositeBuilderTestCase(unittest.TestCase):
 
         tgt = builder(env, source=[])
         assert tgt == [], tgt
-        
+
         assert isinstance(builder, SCons.Builder.CompositeBuilder)
         assert isinstance(builder.action, SCons.Action.CommandGeneratorAction)
 

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -111,7 +111,7 @@ def CachePushFunc(target, source, env):
             # has beaten us creating the directory.
             if not fs.isdir(cachedir):
                 msg = errfmt % (str(target), cachefile)
-                raise SCons.Errors.EnvironmentError(msg)
+                raise SCons.Errors.SConsEnvironmentError(msg)
 
     try:
         if fs.islink(t.get_internal_path()):
@@ -177,8 +177,8 @@ class CacheDir(object):
                         # If someone else is trying to create the directory at
                         # the same time as me, bad things will happen
                         msg = "Failed to create cache directory " + path
-                        raise SCons.Errors.EnvironmentError(msg)
-                        
+                        raise SCons.Errors.SConsEnvironmentError(msg)
+
                 self.config['prefix_len'] = 2
                 if not os.path.exists(config_file):
                     try:
@@ -186,15 +186,15 @@ class CacheDir(object):
                             json.dump(self.config, config)
                     except:
                         msg = "Failed to write cache configuration for " + path
-                        raise SCons.Errors.EnvironmentError(msg)
+                        raise SCons.Errors.SConsEnvironmentError(msg)
         else:
             try:
                 with open(config_file) as config:
                     self.config = json.load(config)
             except ValueError:
                 msg = "Failed to read cache configuration for " + path
-                raise SCons.Errors.EnvironmentError(msg)
-            
+                raise SCons.Errors.SConsEnvironmentError(msg)
+
 
     def CacheDebug(self, fmt, target, cachefile):
         if cache_debug != self.current_cache_debug:

--- a/src/engine/SCons/DefaultsTests.py
+++ b/src/engine/SCons/DefaultsTests.py
@@ -69,11 +69,11 @@ class DefaultsTestCase(unittest.TestCase):
         test.write(file, "test\n")
         try:
             mkdir_func(file)
-        except os.error as e:
+        except OSError as e:
             pass
         else:
-            fail("expected os.error")
-        
+            self.fail("expected OSError")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -74,7 +74,7 @@ def diff_dict(d1, d2):
                    s2 = s2 + "    " + repr(k) + " : " + repr(d2[k]) + "\n"
            else:
                s1 = s1 + "    " + repr(k) + " : " + repr(d1[k]) + "\n"
-        elif k in env2:
+        elif k in d2:
            s2 = s2 + "    " + repr(k) + " : " + repr(d2[k]) + "\n"
     s1 = s1 + "}\n"
     s2 = s2 + "}\n"
@@ -263,39 +263,39 @@ class SubstitutionTestCase(unittest.TestCase):
         nodes = env.arg2nodes("Util.py UtilTests.py", Factory)
         assert len(nodes) == 1, nodes
         assert isinstance(nodes[0], X)
-        assert nodes[0].name == "Util.py UtilTests.py"
+        assert nodes[0].name == "Util.py UtilTests.py", nodes[0].name
 
         nodes = env.arg2nodes(u"Util.py UtilTests.py", Factory)
         assert len(nodes) == 1, nodes
         assert isinstance(nodes[0], X)
-        assert nodes[0].name == u"Util.py UtilTests.py"
+        assert nodes[0].name == u"Util.py UtilTests.py", nodes[0].name
 
         nodes = env.arg2nodes(["Util.py", "UtilTests.py"], Factory)
         assert len(nodes) == 2, nodes
         assert isinstance(nodes[0], X)
         assert isinstance(nodes[1], X)
-        assert nodes[0].name == "Util.py"
-        assert nodes[1].name == "UtilTests.py"
+        assert nodes[0].name == "Util.py", nodes[0].name
+        assert nodes[1].name == "UtilTests.py", nodes[1].name
 
         n1 = Factory("Util.py")
         nodes = env.arg2nodes([n1, "UtilTests.py"], Factory)
         assert len(nodes) == 2, nodes
         assert isinstance(nodes[0], X)
         assert isinstance(nodes[1], X)
-        assert nodes[0].name == "Util.py"
-        assert nodes[1].name == "UtilTests.py"
+        assert nodes[0].name == "Util.py", nodes[0].name
+        assert nodes[1].name == "UtilTests.py", nodes[1].name
 
         class SConsNode(SCons.Node.Node):
             pass
         nodes = env.arg2nodes(SConsNode())
         assert len(nodes) == 1, nodes
-        assert isinstance(nodes[0], SConsNode), node
+        assert isinstance(nodes[0], SConsNode), nodes[0]
 
         class OtherNode(object):
             pass
         nodes = env.arg2nodes(OtherNode())
         assert len(nodes) == 1, nodes
-        assert isinstance(nodes[0], OtherNode), node
+        assert isinstance(nodes[0], OtherNode), nodes[0]
 
         def lookup_a(str, F=Factory):
             if str[0] == 'a':
@@ -484,7 +484,7 @@ class SubstitutionTestCase(unittest.TestCase):
 
         env = SubstitutionEnvironment(AAA = '$BBB', BBB = '$CCC', CCC = 'c')
         l = env.subst_list("$AAA ${AAA}A ${AAA}B $BBB")
-        assert l == [["c", "cA", "cB", "c"]], mystr
+        assert l == [["c", "cA", "cB", "c"]], l
 
         env = SubstitutionEnvironment(AAA = '$BBB', BBB = '$CCC', CCC = [ 'a', 'b\nc' ])
         lst = env.subst_list([ "$AAA", "B $CCC" ])
@@ -1195,7 +1195,7 @@ env4.builder1.env, env3)
         test_it('foo.bar')
         test_it('foo-bar')
 
-    def test_autogenerate(dict):
+    def test_autogenerate(self):
         """Test autogenerating variables in a dictionary."""
 
         drive, p = os.path.splitdrive(os.getcwd())
@@ -1206,9 +1206,9 @@ env4.builder1.env, env3)
             drive, path = os.path.splitdrive(path)
             return drive.lower() + path
 
-        env = dict.TestEnvironment(LIBS = [ 'foo', 'bar', 'baz' ],
-                          LIBLINKPREFIX = 'foo',
-                          LIBLINKSUFFIX = 'bar')
+        env = self.TestEnvironment(LIBS = [ 'foo', 'bar', 'baz' ],
+                                   LIBLINKPREFIX = 'foo',
+                                   LIBLINKSUFFIX = 'bar')
 
         def RDirs(pathlist, fs=env.fs):
             return fs.Dir('xx').Rfindalldirs(pathlist)
@@ -3272,11 +3272,11 @@ def generate(env):
         s = e.src_builder()
         assert s is None, s
 
-    def test_SourceSignatures(type):
+    def test_SourceSignatures(self):
         """Test the SourceSignatures() method"""
         import SCons.Errors
 
-        env = type.TestEnvironment(M = 'MD5', T = 'timestamp')
+        env = self.TestEnvironment(M = 'MD5', T = 'timestamp')
 
         exc_caught = None
         try:
@@ -3312,7 +3312,7 @@ def generate(env):
 
     def test_Split(self):
         """Test the Split() method"""
-        env = self.TestEnvironment(FOO='fff', BAR='bbb')
+        env = self.TestEnvironment(FOO = 'fff', BAR = 'bbb')
         s = env.Split("foo bar")
         assert s == ["foo", "bar"], s
         s = env.Split("$FOO bar")
@@ -3326,11 +3326,11 @@ def generate(env):
         s = env.Split("$FOO$BAR")
         assert s == ["fffbbb"], s
 
-    def test_TargetSignatures(type):
+    def test_TargetSignatures(self):
         """Test the TargetSignatures() method"""
         import SCons.Errors
 
-        env = type.TestEnvironment(B = 'build', C = 'content')
+        env = self.TestEnvironment(B='build', C='content')
 
         exc_caught = None
         try:
@@ -3397,7 +3397,7 @@ def generate(env):
 
 
 
-    def test_Environment_global_variable(type):
+    def test_Environment_global_variable(self):
         """Test setting Environment variable to an Environment.Base subclass"""
         class MyEnv(SCons.Environment.Base):
             def xxx(self, string):

--- a/src/engine/SCons/Executor.py
+++ b/src/engine/SCons/Executor.py
@@ -41,10 +41,10 @@ from SCons.compat import with_metaclass, NoSlotsPyPy
 class Batch(object):
     """Remembers exact association between targets
     and sources of executor."""
-    
+
     __slots__ = ('targets',
                  'sources')
-    
+
     def __init__(self, targets=[], sources=[]):
         self.targets = targets
         self.sources = sources
@@ -127,13 +127,13 @@ def execute_action_list(obj, target, kw):
         status = act(*args, **kw)
         if isinstance(status, SCons.Errors.BuildError):
             status.executor = obj
-            raise status
+            raise status    # TODO pylint E0702: raising int not allowed
         elif status:
             msg = "Error %s" % status
             raise SCons.Errors.BuildError(
-                errstr=msg, 
+                errstr=msg,
                 node=obj.batches[0].targets,
-                executor=obj, 
+                executor=obj,
                 action=act)
     return status
 
@@ -597,7 +597,7 @@ class Null(object, with_metaclass(NoSlotsPyPy)):
     disassociate Builders from Nodes entirely, so we're not
     going to worry about unit tests for this--at least for now.
     """
-    
+
     __slots__ = ('pre_actions',
                  'post_actions',
                  'env',
@@ -613,7 +613,7 @@ class Null(object, with_metaclass(NoSlotsPyPy)):
                  'action_list',
                  '_do_execute',
                  '_execute_str')
-    
+
     def __init__(self, *args, **kw):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Executor.Null')
         self.batches = [Batch(kw['targets'][:], [])]
@@ -649,7 +649,7 @@ class Null(object, with_metaclass(NoSlotsPyPy)):
         """Morph this Null executor to a real Executor object."""
         batches = self.batches
         self.__class__ = Executor
-        self.__init__([])            
+        self.__init__([])
         self.batches = batches
 
     # The following methods require morphing this Null Executor to a

--- a/src/engine/SCons/JobTests.py
+++ b/src/engine/SCons/JobTests.py
@@ -73,7 +73,7 @@ class DummyLock(object):
     def release(self):
         pass
 
-class NoThreadsException(object):
+class NoThreadsException(Exception):
     "raised by the ParallelTestCase if threads are not supported"
 
     def __str__(self):
@@ -206,7 +206,7 @@ class Taskmaster(object):
         self.parallel_list = [0] * (n+1)
         self.found_parallel = False
         self.Task = Task
-        
+
         # 'guard' guards 'task_begin_list' and 'task_end_list'
         try:
             import threading

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -1072,7 +1072,7 @@ class FSTestCase(_tempdirTestCase):
 
             def Dir_test(lpath, path_, abspath_, up_path_, sep=sep, func=_do_Dir_test):
                 return func(lpath, path_, abspath_, up_path_, sep)
-            
+
             Dir_test('/',           '/',           '/',               '/')
             Dir_test('',            './',          sub_dir,           sub)
             Dir_test('foo',         'foo/',        sub_dir_foo,       './')
@@ -1834,7 +1834,7 @@ class FSTestCase(_tempdirTestCase):
         # Should be a normalized Windows UNC path as below.
         assert str(f) == r'\\servername\C$\foo', \
         'UNC path %s got looked up as %s'%(path, f)
- 
+
     def test_unc_drive_letter(self):
         """Test drive-letter lookup for windows UNC-style directories"""
         if sys.platform not in ('win32',):
@@ -3534,11 +3534,11 @@ class clearTestCase(unittest.TestCase):
         e = fs.Entry('e')
         assert not e.exists()
         assert not e.rexists()
-        assert str(e) == 'e', str(d)
+        assert str(e) == 'e', str(e)
         e.clear()
         assert not e.exists()
         assert not e.rexists()
-        assert str(e) == 'e', str(d)
+        assert str(e) == 'e', str(e)
 
         d = fs.Dir(test.workpath('d'))
         test.subdir('d')

--- a/src/engine/SCons/Node/NodeTests.py
+++ b/src/engine/SCons/Node/NodeTests.py
@@ -271,7 +271,7 @@ class NodeInfoBaseTestCase(unittest.TestCase):
 
         f = ni1.format()
         assert f == ['x', 'y', 'z'], f
- 
+
         field_list = ['xxx', 'zzz', 'aaa']
 
         f = ni1.format(field_list)
@@ -751,7 +751,7 @@ class NodeTestCase(unittest.TestCase):
         e = node.exists()
         assert e == 1, e
 
-    def test_exists(self):
+    def test_exists_repo(self):
         """Test evaluating whether a Node exists locally or in a repository.
         """
         node = SCons.Node.Node()

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -103,9 +103,9 @@ implicit_deps_changed = 0
 
 # A variable that can be set to an interface-specific function be called
 # to annotate a Node with information about its creation.
-def do_nothing(node): pass
+def do_nothing_node(node): pass
 
-Annotate = do_nothing
+Annotate = do_nothing_node
 
 # Gets set to 'True' if we're running in interactive mode. Is
 # currently used to release parts of a target's info during

--- a/src/engine/SCons/Platform/PlatformTests.py
+++ b/src/engine/SCons/Platform/PlatformTests.py
@@ -110,7 +110,7 @@ class PlatformTestCase(unittest.TestCase):
             p = SCons.Platform.Platform('_does_not_exist_')
         except SCons.Errors.UserError:
             pass
-        else:
+        else:   # TODO pylint E0704: bare raise not inside except
             raise
 
         env = Environment()

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -247,6 +247,7 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
         # ConfigureCacheError and if yes, reraise the exception
         exc_type = self.exc_info()[0]
         if issubclass(exc_type, SConfError):
+            # TODO pylint E0704: bare raise not inside except
             raise
         elif issubclass(exc_type, SCons.Errors.BuildError):
             # we ignore Build Errors (occurs, when a test doesn't pass)

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -68,6 +68,20 @@ import SCons.Warnings
 
 import SCons.Script.Interactive
 
+# Global variables
+first_command_start = None
+last_command_end = None
+print_objects = 0
+print_memoizer = 0
+print_stacktrace = 0
+print_time = 0
+sconscript_time = 0
+cumulative_command_time = 0
+exit_status = 0   # final exit status, assume success by default
+this_build_status = 0   # "exit status" of an individual build
+num_jobs = None
+delayed_warnings = []
+
 
 def fetch_win32_parallel_msg():
     # A subsidiary function that exists solely to isolate this import
@@ -87,14 +101,13 @@ def revert_io():
     sys.stderr = sys.__stderr__
     sys.stdout = sys.__stdout__
 
+
 class SConsPrintHelpException(Exception):
     pass
 
+
 display = SCons.Util.display
 progress_display = SCons.Util.DisplayEngine()
-
-first_command_start = None
-last_command_end = None
 
 
 class Progressor(object):
@@ -442,19 +455,6 @@ def python_version_unsupported(version=sys.version_info):
 def python_version_deprecated(version=sys.version_info):
     return version < deprecated_python_version
 
-
-# Global variables
-
-print_objects = 0
-print_memoizer = 0
-print_stacktrace = 0
-print_time = 0
-sconscript_time = 0
-cumulative_command_time = 0
-exit_status = 0 # final exit status, assume success by default
-this_build_status = 0 # "exit status" of an individual build
-num_jobs = None
-delayed_warnings = []
 
 class FakeOptionParser(object):
     """

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -226,39 +226,8 @@ class SConsOption(optparse.Option):
             fmt = "option %s: nargs='?' is incompatible with short options"
             raise SCons.Errors.UserError(fmt % self._short_opts[0])
 
-    try:
-        _orig_CONST_ACTIONS = optparse.Option.CONST_ACTIONS
-
-        _orig_CHECK_METHODS = optparse.Option.CHECK_METHODS
-
-    except AttributeError:
-        # optparse.Option had no CONST_ACTIONS before Python 2.5.
-
-        _orig_CONST_ACTIONS = ("store_const",)
-
-        def _check_const(self):
-            if self.action not in self.CONST_ACTIONS and self.const is not None:
-                raise OptionError(
-                    "'const' must not be supplied for action %r" % self.action,
-                    self)
-
-        # optparse.Option collects its list of unbound check functions
-        # up front.  This sucks because it means we can't just override
-        # the _check_const() function like a normal method, we have to
-        # actually replace it in the list.  This seems to be the most
-        # straightforward way to do that.
-
-        _orig_CHECK_METHODS = [optparse.Option._check_action,
-                     optparse.Option._check_type,
-                     optparse.Option._check_choice,
-                     optparse.Option._check_dest,
-                     _check_const,
-                     optparse.Option._check_nargs,
-                     optparse.Option._check_callback]
-
-    CHECK_METHODS = _orig_CHECK_METHODS + [_check_nargs_optional]
-
-    CONST_ACTIONS = _orig_CONST_ACTIONS + optparse.Option.TYPED_ACTIONS
+    CHECK_METHODS = optparse.Option.CHECK_METHODS + [_check_nargs_optional]
+    CONST_ACTIONS = optparse.Option.CONST_ACTIONS + optparse.Option.TYPED_ACTIONS
 
 class SConsOptionGroup(optparse.OptionGroup):
     """
@@ -364,7 +333,7 @@ class SConsOptionParser(optparse.OptionParser):
         in self.largs, so that any value overridden on the
         command line is immediately available if the user turns
         around and does a GetOption() right away.
-        
+
         We mimic the processing of the single args
         in the original OptionParser._process_args(), but here we
         allow exact matches for long-opts only (no partial
@@ -375,7 +344,7 @@ class SConsOptionParser(optparse.OptionParser):
         command-line arguments that
           1. haven't been processed so far (self.largs), but
           2. are possibly not added to the list of options yet.
-          
+
         So, when we only have a value for "--myargument" yet,
         a command-line argument of "--myarg=test" would set it.
         Responsible for this behaviour is the method
@@ -384,7 +353,7 @@ class SConsOptionParser(optparse.OptionParser):
         be unique.
         This would lead to further confusion, because we might want
         to add another option "--myarg" later on (see issue #2929).
-        
+
         """
         rargs = []
         largs_restore = []
@@ -401,7 +370,7 @@ class SConsOptionParser(optparse.OptionParser):
                     if "=" in l:
                         # Split into option and value
                         lopt = l.split("=", 1)
-                        
+
                     if lopt[0] in self._long_opt:
                         # Argument is already known
                         rargs.append('='.join(lopt))
@@ -416,7 +385,7 @@ class SConsOptionParser(optparse.OptionParser):
                         skip = True
                     else:
                         rargs.append(l)
-        
+
         # Parse the filtered list
         self.parse_args(rargs, self.values)
         # Restore the list of remaining arguments for the

--- a/src/engine/SCons/SubstTests.py
+++ b/src/engine/SCons/SubstTests.py
@@ -132,6 +132,7 @@ class SubstTestCase(unittest.TestCase):
         def __str__(self):
             return self.value
 
+    # only use of this is currently commented out below
     def function_foo(arg):
         pass
 
@@ -1046,7 +1047,7 @@ class scons_subst_list_TestCase(SubstTestCase):
         node = scons_subst_list("$NODE", env, mode=SUBST_SIG, conv=s, gvars=gvars)
         assert node == [[n1]], node
 
-    def test_subst_list_overriding_gvars(self):
+    def test_subst_list_overriding_gvars2(self):
         """Test scons_subst_list():  supplying an overriding gvars dictionary"""
         env = DummyEnv({'XXX' : 'xxx'})
         result = scons_subst_list('$XXX', env, gvars=env.Dictionary())

--- a/src/engine/SCons/Taskmaster.py
+++ b/src/engine/SCons/Taskmaster.py
@@ -27,10 +27,10 @@ import sys
 __doc__ = """
     Generic Taskmaster module for the SCons build engine.
     =====================================================
-    
+
     This module contains the primary interface(s) between a wrapping user
     interface and the SCons build engine.  There are two key classes here:
-    
+
     Taskmaster
     ----------
         This is the main engine for walking the dependency graph and
@@ -477,7 +477,7 @@ class Task(object):
                 for s in t.side_effects:
                     if s.get_state() == NODE_EXECUTING:
                         s.set_state(NODE_NO_STATE)
-                        
+
                     # The side-effects may have been transferred to
                     # NODE_NO_STATE by executed_with{,out}_callbacks, but was
                     # not taken out of the waiting parents/pending children
@@ -551,7 +551,7 @@ class Task(object):
         try:
             exc_type, exc_value, exc_traceback = exc
         except ValueError:
-            exc_type, exc_value = exc
+            exc_type, exc_value = exc  # pylint: disable=unbalanced-tuple-unpacking
             exc_traceback = None
 
         # raise exc_type(exc_value).with_traceback(exc_traceback)

--- a/src/engine/SCons/Tool/MSCommon/netframework.py
+++ b/src/engine/SCons/Tool/MSCommon/netframework.py
@@ -68,7 +68,7 @@ def query_versions():
             # sequence comparison in python is lexicographical
             # which is exactly what we want.
             # Note we sort backwards so the highest version is first.
-            return cmp(bbl,aal)
+            return (aal > bbl) - (aal < bbl)
 
         versions.sort(versrt)
     else:

--- a/src/engine/SCons/Tool/ToolTests.py
+++ b/src/engine/SCons/Tool/ToolTests.py
@@ -67,14 +67,14 @@ class ToolTestCase(unittest.TestCase):
             SCons.Tool.Tool()
         except TypeError:
             pass
-        else:
+        else:   # TODO pylint E0704: bare raise not inside except
             raise
 
         try:
             p = SCons.Tool.Tool('_does_not_exist_')
         except SCons.Errors.SConsEnvironmentError:
             pass
-        else:
+        else:   # TODO pylint E0704: bare raise not inside except
             raise
 
 

--- a/src/engine/SCons/Tool/intelc.py
+++ b/src/engine/SCons/Tool/intelc.py
@@ -37,7 +37,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import math, sys, os.path, glob, string, re
 
 is_windows = sys.platform == 'win32'
-is_win64 = is_windows and (os.environ['PROCESSOR_ARCHITECTURE'] == 'AMD64' or 
+is_win64 = is_windows and (os.environ['PROCESSOR_ARCHITECTURE'] == 'AMD64' or
                            ('PROCESSOR_ARCHITEW6432' in os.environ and
                             os.environ['PROCESSOR_ARCHITEW6432'] == 'AMD64'))
 is_linux = sys.platform.startswith('linux')
@@ -112,11 +112,6 @@ def check_abi(abi):
         raise SCons.Errors.UserError("Intel compiler: Invalid ABI %s, valid values are %s"% \
               (abi, list(valid_abis.keys())))
     return abi
-
-def vercmp(a, b):
-    """Compare strings as floats,
-    but Intel changed Linux naming convention at 9.0"""
-    return cmp(linux_ver_normalize(b), linux_ver_normalize(a))
 
 def get_version_from_list(v, vlist):
     """See if we can match v (string) in vlist (list of strings)
@@ -293,7 +288,7 @@ def get_all_compiler_versions():
             m = re.search(r'([0-9]{0,4})(?:_sp\d*)?\.([0-9][0-9.]*)$', d)
             if m:
                 versions.append("%s.%s"%(m.group(1), m.group(2)))
-            
+
     def keyfunc(str):
         """Given a dot-separated version string, return a tuple of ints representing it."""
         return [int(x) for x in str.split('.')]
@@ -383,7 +378,7 @@ def get_intel_compiler_top(version, abi):
                     top = d
                     break
             return top
-                    
+
         top = find_in_2016style_dir(version) or find_in_2011style_dir(version) or find_in_2010style_dir(version) or find_in_2008style_dir(version)
         # print "INTELC: top=",top
         if not top:

--- a/src/engine/SCons/Tool/packaging/__init__.py
+++ b/src/engine/SCons/Tool/packaging/__init__.py
@@ -38,8 +38,8 @@ import os
 import importlib
 
 __all__ = [
-    'src_targz', 'src_tarbz2', 'src_xz', 'src_zip',
-    'targz', 'tarbz2', 'xz', 'zip',
+    'src_targz', 'src_tarbz2', 'src_tarxz', 'src_zip',
+    'targz', 'tarbz2', 'tarxz', 'zip',
     'rpm', 'msi', 'ipk',
 ]
 

--- a/src/engine/SCons/Tool/packaging/ipk.py
+++ b/src/engine/SCons/Tool/packaging/ipk.py
@@ -3,7 +3,7 @@
 
 #
 # __COPYRIGHT__
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -117,17 +117,17 @@ def build_specfiles(source, target, env):
     #
     #
     opened_files={}
-    def open_file(needle, haystack):
+    def open_file(needle, haystack=None):
         try:
             return opened_files[needle]
         except KeyError:
             files = filter(lambda x: x.get_path().rfind(needle) != -1, haystack)
             # Py3: filter returns an iterable, not a list
             file = list(files)[0]
-            opened_files[needle]=open(file.get_abspath(), 'w')
+            opened_files[needle] = open(file.get_abspath(), 'w')
             return opened_files[needle]
 
-    control_file=open_file('control', target)
+    control_file = open_file('control', target)
 
     if 'X_IPK_DESCRIPTION' not in env:
         env['X_IPK_DESCRIPTION']="%s\n %s"%(env['SUMMARY'],
@@ -149,7 +149,7 @@ Description: $X_IPK_DESCRIPTION
     control_file.write(env.subst(content))
 
     #
-    # now handle the various other files, which purpose it is to set post-, 
+    # now handle the various other files, which purpose it is to set post-,
     # pre-scripts and mark files as config files.
     #
     # We do so by filtering the source files for files which are marked with
@@ -161,14 +161,14 @@ Description: $X_IPK_DESCRIPTION
     # into the same named file.
     #
     for f in [x for x in source if 'PACKAGING_CONFIG' in dir(x)]:
-        config=open_file('conffiles')
+        config = open_file('conffiles')
         config.write(f.PACKAGING_INSTALL_LOCATION)
         config.write('\n')
 
     for str in 'POSTRM PRERM POSTINST PREINST'.split():
         name="PACKAGING_X_IPK_%s"%str
         for f in [x for x in source if name in dir(x)]:
-            file=open_file(name)
+            file = open_file(name)
             file.write(env[str])
 
     #

--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -113,28 +113,28 @@ except AttributeError:
     # intern into the sys package
     sys.intern = intern
 
-# Preparing for 3.x. UserDict, UserList, UserString are in
-# collections for 3.x, but standalone in 2.7.x
+# UserDict, UserList, UserString are in # collections for 3.x,
+# but standalone in 2.7.x. Monkey-patch into collections for 2.7.
 import collections
 
 try:
     collections.UserDict
 except AttributeError:
-    exec ('from UserDict import UserDict as _UserDict')
+    from UserDict import UserDict as _UserDict
     collections.UserDict = _UserDict
     del _UserDict
 
 try:
     collections.UserList
 except AttributeError:
-    exec ('from UserList import UserList as _UserList')
+    from UserList import UserList as _UserList
     collections.UserList = _UserList
     del _UserList
 
 try:
     collections.UserString
 except AttributeError:
-    exec ('from UserString import UserString as _UserString')
+    from UserString import UserString as _UserString
     collections.UserString = _UserString
     del _UserString
 

--- a/src/engine/SCons/cpp.py
+++ b/src/engine/SCons/cpp.py
@@ -165,7 +165,7 @@ def CPP_to_Python(s):
     """
     s = CPP_to_Python_Ops_Expression.sub(CPP_to_Python_Ops_Sub, s)
     for expr, repl in CPP_to_Python_Eval_List:
-        s = expr.sub(repl, s)
+        s = re.sub(expr, repl, s)
     return s
 
 


### PR DESCRIPTION
Assorted fixups: exception types, redefined functions, globals, etc.

Some old code removed to resolve issues (hashlib is always present on modern Pythons; no longer need the code for 2.5-and-earlier optparse).

cmp is not a builtin function in Py3, drop one (unused) use; replace one.

Fix another instance of renaming to `SConsEnvironmentError`.

TODO flagged some instances of doing a raise without argument but not inside a try block - this is not considered legal, since raise with no argument is for re-raising an exception, but I don't know exactly how to resolve this in these cases. Also flagged an instance of raising an int instead of an exception class. We can either leave these as markers or update the PR.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
