### PR TITLE
Some more lint-derived cleanups

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -30,7 +30,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       always present on modern Pythons; no longer need the code for
       2.5-and-earlier optparse). cmp is not a builtin function in Py3,
       drop one (unused) use; replace one.  Fix another instance of
-      renaming to SConsEnvironmentError.
+      renaming to SConsEnvironmentError. Trailing whitespace.
+      Consistently use not is/in (if not x is y -> if x is not y).
 
 
 

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -1091,7 +1091,7 @@ class LazyAction(CommandGeneratorAction, CommandAction):
 
     def get_parent_class(self, env):
         c = env.get(self.var)
-        if is_String(c) and not '\n' in c:
+        if is_String(c) and '\n' not in c:
             return CommandAction
         return CommandGeneratorAction
 

--- a/src/engine/SCons/Builder.py
+++ b/src/engine/SCons/Builder.py
@@ -274,7 +274,7 @@ def Builder(**kw):
 
     result = BuilderBase(**kw)
 
-    if not composite is None:
+    if composite is not None:
         result = CompositeBuilder(result, composite)
 
     return result
@@ -293,7 +293,7 @@ def _node_errors(builder, env, tlist, slist):
         if t.has_explicit_builder():
             # Check for errors when the environments are different
             # No error if environments are the same Environment instance
-            if (not t.env is None and not t.env is env and
+            if (t.env is not None and t.env is not env and
                     # Check OverrideEnvironment case - no error if wrapped Environments
                     # are the same instance, and overrides lists match
                     not (getattr(t.env, '__subject', 0) is getattr(env, '__subject', 1) and
@@ -309,7 +309,7 @@ def _node_errors(builder, env, tlist, slist):
                 else:
                     try:
                         msg = "Two environments with different actions were specified for the same target: %s\n(action 1: %s)\n(action 2: %s)" % (t,t_contents.decode('utf-8'),contents.decode('utf-8'))
-                    except UnicodeDecodeError as e:
+                    except UnicodeDecodeError:
                         msg = "Two environments with different actions were specified for the same target: %s"%t
                     raise UserError(msg)
             if builder.multi:
@@ -424,7 +424,7 @@ class BuilderBase(object):
         if name:
             self.name = name
         self.executor_kw = {}
-        if not chdir is _null:
+        if chdir is not _null:
             self.executor_kw['chdir'] = chdir
         self.is_explicit = is_explicit
 
@@ -554,8 +554,10 @@ class BuilderBase(object):
             result = []
             if target is None: target = [None]*len(source)
             for tgt, src in zip(target, source):
-                if not tgt is None: tgt = [tgt]
-                if not src is None: src = [src]
+                if tgt is not None:
+                    tgt = [tgt]
+                if src is not None:
+                    src = [src]
                 result.extend(self._execute(env, tgt, src, overwarn))
             return SCons.Node.NodeList(result)
 
@@ -744,7 +746,7 @@ class BuilderBase(object):
         for s in SCons.Util.flatten(source):
             if SCons.Util.is_String(s):
                 match_suffix = match_src_suffix(env.subst(s))
-                if not match_suffix and not '.' in s:
+                if not match_suffix and '.' not in s:
                     src_suf = self.get_src_suffix(env)
                     s = self._adjustixes(s, None, src_suf)[0]
             else:

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -209,7 +209,7 @@ class CacheDir(object):
             self.debugFP.write(fmt % (target, os.path.split(cachefile)[1]))
 
     def is_enabled(self):
-        return cache_enabled and not self.path is None
+        return cache_enabled and self.path is not None
 
     def is_readonly(self):
         return cache_readonly

--- a/src/engine/SCons/Conftest.py
+++ b/src/engine/SCons/Conftest.py
@@ -354,7 +354,7 @@ def CheckHeader(context, header_name, header = None, language = None,
 
     context.Display("Checking for %s header file %s... " % (lang, header_name))
     ret = context.CompileProg(text, suffix)
-    _YesNoResult(context, ret, "HAVE_" + header_name, text, 
+    _YesNoResult(context, ret, "HAVE_" + header_name, text,
                  "Define to 1 if you have the <%s> header file." % header_name)
     return ret
 
@@ -439,7 +439,7 @@ def CheckTypeSize(context, type_name, header = None, language = None, expect = N
         Returns:
             status : int
                 0 if the check failed, or the found size of the type if the check succeeded."""
-    
+
     # Include "confdefs.h" first, so that the header can use HAVE_HEADER_H.
     if context.headerfilename:
         includetext = '#include "%s"' % context.headerfilename
@@ -454,8 +454,8 @@ def CheckTypeSize(context, type_name, header = None, language = None, expect = N
         context.Display("Cannot check for %s type: %s\n" % (type_name, msg))
         return msg
 
-    src = includetext + header 
-    if not expect is None:
+    src = includetext + header
+    if expect is not None:
         # Only check if the given size is the right one
         context.Display('Checking %s is %d bytes... ' % (type_name, expect))
 
@@ -477,7 +477,7 @@ int main(void)
         st = context.CompileProg(src % (type_name, expect), suffix)
         if not st:
             context.Display("yes\n")
-            _Have(context, "SIZEOF_%s" % type_name, expect, 
+            _Have(context, "SIZEOF_%s" % type_name, expect,
                   "The size of `%s', as computed by sizeof." % type_name)
             return expect
         else:
@@ -541,7 +541,7 @@ def CheckDeclaration(context, symbol, includes = None, language = None):
     Returns:
         status : bool
             True if the check failed, False if succeeded."""
-    
+
     # Include "confdefs.h" first, so that the header can use HAVE_HEADER_H.
     if context.headerfilename:
         includetext = '#include "%s"' % context.headerfilename
@@ -556,7 +556,7 @@ def CheckDeclaration(context, symbol, includes = None, language = None):
         context.Display("Cannot check for declaration %s: %s\n" % (symbol, msg))
         return msg
 
-    src = includetext + includes 
+    src = includetext + includes
     context.Display('Checking whether %s is declared... ' % symbol)
 
     src = src + r"""
@@ -677,7 +677,7 @@ return 0;
                      "Define to 1 if you have the `%s' library." % lib_name)
         if oldLIBS != -1 and (ret or not autoadd):
             context.SetLIBS(oldLIBS)
-            
+
         if not ret:
             return ret
 
@@ -751,7 +751,7 @@ def _Have(context, key, have, comment = None):
         line = "#define %s %d\n" % (key_up, have)
     else:
         line = "#define %s %s\n" % (key_up, str(have))
-    
+
     if comment is not None:
         lines = "\n/* %s */\n" % comment + line
     else:

--- a/src/engine/SCons/Defaults.py
+++ b/src/engine/SCons/Defaults.py
@@ -193,7 +193,7 @@ def chmod_func(dest, mode):
     SCons.Node.FS.invalidate_node_memos(dest)
     if not SCons.Util.is_List(dest):
         dest = [dest]
-    if SCons.Util.is_String(mode) and not 0 in [i in digits for i in mode]:
+    if SCons.Util.is_String(mode) and 0 not in [i in digits for i in mode]:
         mode = int(mode, 8)
     if not SCons.Util.is_String(mode):
         for element in dest:

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -608,7 +608,7 @@ class SubstitutionEnvironment(object):
         Removes the specified function's MethodWrapper from the
         added_methods list, so we don't re-bind it when making a clone.
         """
-        self.added_methods = [dm for dm in self.added_methods if not dm.method is function]
+        self.added_methods = [dm for dm in self.added_methods if dm.method is not function]
 
     def Override(self, overrides):
         """
@@ -1342,7 +1342,7 @@ class Base(SubstitutionEnvironment):
                             dk = list(filter(lambda x, val=val: x not in val, dk))
                             self._dict[key] = dk + [val]
                         else:
-                            if not val in dk:
+                            if val not in dk:
                                 self._dict[key] = dk + [val]
                 else:
                     if key == 'CPPDEFINES':
@@ -1722,7 +1722,7 @@ class Base(SubstitutionEnvironment):
                         dk = [x for x in dk if x not in val]
                         self._dict[key] = [val] + dk
                     else:
-                        if not val in dk:
+                        if val not in dk:
                             self._dict[key] = [val] + dk
                 else:
                     if delete_existing:

--- a/src/engine/SCons/Executor.py
+++ b/src/engine/SCons/Executor.py
@@ -36,6 +36,7 @@ import SCons.Debug
 from SCons.Debug import logInstanceCreation
 import SCons.Errors
 import SCons.Memoize
+import SCons.Util
 from SCons.compat import with_metaclass, NoSlotsPyPy
 
 class Batch(object):
@@ -71,7 +72,7 @@ class TSList(collections.UserList):
         return nl[i]
     def __getslice__(self, i, j):
         nl = self.func()
-        i = max(i, 0); j = max(j, 0)
+        i, j = max(i, 0), max(j, 0)
         return nl[i:j]
     def __str__(self):
         nl = self.func()
@@ -572,7 +573,6 @@ def AddBatchExecutor(key, executor):
 nullenv = None
 
 
-import SCons.Util
 class NullEnvironment(SCons.Util.Null):
     import SCons.CacheDir
     _CacheDir_path = None
@@ -615,7 +615,8 @@ class Null(object, with_metaclass(NoSlotsPyPy)):
                  '_execute_str')
 
     def __init__(self, *args, **kw):
-        if SCons.Debug.track_instances: logInstanceCreation(self, 'Executor.Null')
+        if SCons.Debug.track_instances:
+            logInstanceCreation(self, 'Executor.Null')
         self.batches = [Batch(kw['targets'][:], [])]
     def get_build_env(self):
         return get_NullEnvironment()

--- a/src/engine/SCons/Job.py
+++ b/src/engine/SCons/Job.py
@@ -53,14 +53,14 @@ interrupt_msg = 'Build interrupted.'
 
 
 class InterruptState(object):
-   def __init__(self):
-       self.interrupted = False
+    def __init__(self):
+        self.interrupted = False
 
-   def set(self):
-       self.interrupted = True
+    def set(self):
+        self.interrupted = True
 
-   def __call__(self):
-       return self.interrupted
+    def __call__(self):
+        return self.interrupted
 
 
 class Jobs(object):
@@ -87,7 +87,7 @@ class Jobs(object):
             stack_size = explicit_stack_size
             if stack_size is None:
                 stack_size = default_stack_size
-                
+
             try:
                 self.job = Parallel(taskmaster, num, stack_size)
                 self.num_jobs = num
@@ -172,14 +172,14 @@ class Serial(object):
     """
 
     def __init__(self, taskmaster):
-        """Create a new serial job given a taskmaster. 
+        """Create a new serial job given a taskmaster.
 
         The taskmaster's next_task() method should return the next task
         that needs to be executed, or None if there are no more tasks. The
         taskmaster's executed() method will be called for each task when it
         is successfully executed, or failed() will be called if it failed to
         execute (e.g. execute() raised an exception)."""
-        
+
         self.taskmaster = taskmaster
         self.interrupted = InterruptState()
 
@@ -188,7 +188,7 @@ class Serial(object):
         and executing them, and return when there are no more tasks. If a task
         fails to execute (i.e. execute() raises an exception), then the job will
         stop."""
-        
+
         while True:
             task = self.taskmaster.next_task()
 
@@ -199,7 +199,7 @@ class Serial(object):
                 task.prepare()
                 if task.needs_execute():
                     task.execute()
-            except Exception as e:
+            except Exception:
                 if self.interrupted():
                     try:
                         raise SCons.Errors.BuildError(
@@ -269,7 +269,7 @@ else:
 
         def __init__(self, num, stack_size, interrupted):
             """Create the request and reply queues, and 'num' worker threads.
-            
+
             One must specify the stack size of the worker threads. The
             stack size is specified in kilobytes.
             """
@@ -277,11 +277,11 @@ else:
             self.resultsQueue = queue.Queue(0)
 
             try:
-                prev_size = threading.stack_size(stack_size*1024) 
+                prev_size = threading.stack_size(stack_size*1024)
             except AttributeError as e:
                 # Only print a warning if the stack size has been
                 # explicitly set.
-                if not explicit_stack_size is None:
+                if explicit_stack_size is not None:
                     msg = "Setting stack size is unsupported by this version of Python:\n    " + \
                         e.args[0]
                     SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
@@ -322,7 +322,7 @@ else:
                 self.requestQueue.put(None)
 
             # Wait for all of the workers to terminate.
-            # 
+            #
             # If we don't do this, later Python versions (2.4, 2.5) often
             # seem to raise exceptions during shutdown.  This happens
             # in requestQueue.get(), as an assertion failure that
@@ -339,7 +339,7 @@ else:
             self.workers = []
 
     class Parallel(object):
-        """This class is used to execute tasks in parallel, and is somewhat 
+        """This class is used to execute tasks in parallel, and is somewhat
         less efficient than Serial, but is appropriate for parallel builds.
 
         This class is thread safe.
@@ -373,7 +373,7 @@ else:
             an exception), then the job will stop."""
 
             jobs = 0
-            
+
             while True:
                 # Start up as many available tasks as we're
                 # allowed to.

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -282,7 +282,7 @@ def set_duplicate(duplicate):
         'copy' : _copy_func
     }
 
-    if not duplicate in Valid_Duplicates:
+    if duplicate not in Valid_Duplicates:
         raise SCons.Errors.InternalError("The argument of set_duplicate "
                                            "should be in Valid_Duplicates")
     global Link_Funcs
@@ -531,7 +531,7 @@ class EntryProxy(SCons.Util.Proxy):
         except KeyError:
             try:
                 attr = SCons.Util.Proxy.__getattr__(self, name)
-            except AttributeError as e:
+            except AttributeError:
                 # Raise our own AttributeError subclass with an
                 # overridden __str__() method that identifies the
                 # name of the entry that caused the exception.
@@ -699,13 +699,13 @@ class Base(SCons.Node.Node):
 
     @SCons.Memoize.CountMethodCall
     def stat(self):
-        try: 
+        try:
             return self._memo['stat']
-        except KeyError: 
+        except KeyError:
             pass
-        try: 
+        try:
             result = self.fs.stat(self.get_abspath())
-        except os.error: 
+        except os.error:
             result = None
 
         self._memo['stat'] = result
@@ -719,16 +719,16 @@ class Base(SCons.Node.Node):
 
     def getmtime(self):
         st = self.stat()
-        if st: 
+        if st:
             return st[stat.ST_MTIME]
-        else: 
+        else:
             return None
 
     def getsize(self):
         st = self.stat()
-        if st: 
+        if st:
             return st[stat.ST_SIZE]
-        else: 
+        else:
             return None
 
     def isdir(self):
@@ -1689,7 +1689,7 @@ class Dir(Base):
         return result
 
     def addRepository(self, dir):
-        if dir != self and not dir in self.repositories:
+        if dir != self and dir not in self.repositories:
             self.repositories.append(dir)
             dir._tpath = '.'
             self.__clearRepositoryCache()
@@ -1729,7 +1729,7 @@ class Dir(Base):
         if self is other:
             result = '.'
 
-        elif not other in self._path_elements:
+        elif other not in self._path_elements:
             try:
                 other_dir = other.get_dir()
             except AttributeError:
@@ -3350,7 +3350,7 @@ class File(Base):
         df = dmap.get(c_str, None)
         if df:
             return df
-        
+
         if os.altsep:
             c_str = c_str.replace(os.sep, os.altsep)
             df = dmap.get(c_str, None)
@@ -3387,7 +3387,7 @@ class File(Base):
               file and just copy the prev_ni provided.  If the prev_ni
               is wrong. It will propagate it.
               See: https://github.com/SCons/scons/issues/2980
-        
+
         Args:
             self - dependency
             target - target
@@ -3396,7 +3396,7 @@ class File(Base):
                    node to function. So if we detect that it's not passed.
                    we throw DeciderNeedsNode, and caller should handle this and pass node.
 
-        Returns: 
+        Returns:
             Boolean - Indicates if node(File) has changed.
         """
         if node is None:

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1160,7 +1160,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             binfo.bactsig = SCons.Util.MD5signature(executor.get_contents())
 
         if self._specific_sources:
-            sources = [s for s in self.sources if not s in ignore_set]
+            sources = [s for s in self.sources if s not in ignore_set]
 
         else:
             sources = executor.get_unignored_sources(self, self.ignore)
@@ -1647,14 +1647,14 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
 
         lines = []
 
-        removed = [x for x in old_bkids if not x in new_bkids]
+        removed = [x for x in old_bkids if x not in new_bkids]
         if removed:
             removed = [stringify(r) for r in removed]
             fmt = "`%s' is no longer a dependency\n"
             lines.extend([fmt % s for s in removed])
 
         for k in new_bkids:
-            if not k in old_bkids:
+            if k not in old_bkids:
                 lines.append("`%s' is a new dependency\n" % stringify(k))
             else:
                 try:

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -788,7 +788,7 @@ class SConfBase(object):
 
         self.active = 0
         sconf_global = None
-        if not self.config_h is None:
+        if self.config_h is not None:
             _ac_config_hs[self.config_h] = self.config_h_text
         self.env.fs = self.lastEnvFs
 

--- a/src/engine/SCons/SConsign.py
+++ b/src/engine/SCons/SConsign.py
@@ -76,7 +76,8 @@ def Get_DataBase(dir):
                 except KeyError:
                     path = d.entry_abspath(DB_Name)
                     try: db = DataBase[d] = DB_Module.open(path, mode)
-                    except (IOError, OSError): pass
+                    except (IOError, OSError):
+                        pass
                     else:
                         if mode != "r":
                             DB_sync_list.append(db)
@@ -334,7 +335,7 @@ class DirFile(Dir):
             Dir.__init__(self, fp, dir)
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             SCons.Warnings.warn(SCons.Warnings.CorruptSConsignWarning,
                                 "Ignoring corrupt .sconsign file: %s"%self.sconsign)
 
@@ -417,7 +418,7 @@ def File(name, dbm_module=None):
     else:
         ForDirectory = DB
         DB_Name = name
-        if not dbm_module is None:
+        if dbm_module is not None:
             DB_Module = dbm_module
 
 # Local Variables:

--- a/src/engine/SCons/Scanner/__init__.py
+++ b/src/engine/SCons/Scanner/__init__.py
@@ -207,7 +207,7 @@ class Base(object):
 
         self = self.select(node)
 
-        if not self.argument is _null:
+        if self.argument is not _null:
             node_list = self.function(node, env, path, self.argument)
         else:
             node_list = self.function(node, env, path)

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -1170,7 +1170,7 @@ def _build_targets(fs, options, targets, target_top):
                 # -U, local SConscript Default() targets
                 target_top = fs.Dir(target_top)
                 def check_dir(x, target_top=target_top):
-                    if hasattr(x, 'cwd') and not x.cwd is None:
+                    if hasattr(x, 'cwd') and x.cwd is not None:
                         cwd = x.cwd.srcnode()
                         return cwd == target_top
                     else:

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -147,7 +147,7 @@ class SConsValues(optparse.Values):
         """
         Sets an option from an SConscript file.
         """
-        if not name in self.settable:
+        if name not in self.settable:
             raise SCons.Errors.UserError("This option is not settable from a SConscript file: %s"%name)
 
         if name == 'num_jobs':
@@ -167,7 +167,7 @@ class SConsValues(optparse.Values):
                 value = str(value)
             except ValueError:
                 raise SCons.Errors.UserError("A string is required: %s"%repr(value))
-            if not value in SCons.Node.FS.Valid_Duplicates:
+            if value not in SCons.Node.FS.Valid_Duplicates:
                 raise SCons.Errors.UserError("Not a valid duplication style: %s" % value)
             # Set the duplicate style right away so it can affect linking
             # of SConscript files.
@@ -659,7 +659,7 @@ def Parser(version):
                   metavar="TYPE")
 
     def opt_duplicate(option, opt, value, parser):
-        if not value in SCons.Node.FS.Valid_Duplicates:
+        if value not in SCons.Node.FS.Valid_Duplicates:
             raise OptionValueError(opt_invalid('duplication', value,
                                               SCons.Node.FS.Valid_Duplicates))
         setattr(parser.values, option.dest, value)

--- a/src/engine/SCons/Subst.py
+++ b/src/engine/SCons/Subst.py
@@ -350,7 +350,7 @@ _rm_split = re.compile(r'(?<!\$)(\$[()])')
 _regex_remove = [ _rm, None, _rm_split ]
 
 def _rm_list(list):
-    return [l for l in list if not l in ('$(', '$)')]
+    return [l for l in list if l not in ('$(', '$)')]
 
 def _remove_list(list):
     result = []
@@ -468,7 +468,7 @@ def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={
                             s = lvars[key]
                         elif key in self.gvars:
                             s = self.gvars[key]
-                        elif not NameError in AllowableExceptions:
+                        elif NameError not in AllowableExceptions:
                             raise_exception(NameError(key), lvars['TARGETS'], s)
                         else:
                             return ''
@@ -690,7 +690,7 @@ def scons_subst_list(strSubst, env, mode=SUBST_RAW, target=None, source=None, gv
                             s = lvars[key]
                         elif key in self.gvars:
                             s = self.gvars[key]
-                        elif not NameError in AllowableExceptions:
+                        elif NameError not in AllowableExceptions:
                             raise_exception(NameError(), lvars['TARGETS'], s)
                         else:
                             return

--- a/src/engine/SCons/Tool/GettextCommon.py
+++ b/src/engine/SCons/Tool/GettextCommon.py
@@ -4,7 +4,7 @@ Used by several tools of `gettext` toolset.
 """
 
 # __COPYRIGHT__
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -12,10 +12,10 @@ Used by several tools of `gettext` toolset.
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
 # KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
 # WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -71,7 +71,7 @@ SCons.Warnings.enableWarningClass(MsgfmtNotFound)
 #############################################################################
 class _POTargetFactory(object):
     """ A factory of `PO` target files.
-    
+
     Factory defaults differ from these of `SCons.Node.FS.FS`.  We set `precious`
     (this is required by builders and actions gettext) and `noclean` flags by
     default for all produced nodes.
@@ -80,9 +80,9 @@ class _POTargetFactory(object):
     def __init__(self, env, nodefault=True, alias=None, precious=True
                  , noclean=True):
         """ Object constructor.
-    
+
         **Arguments**
-    
+
             - *env* (`SCons.Environment.Environment`)
             - *nodefault* (`boolean`) - if `True`, produced nodes will be ignored
               from default target `'.'`
@@ -160,13 +160,13 @@ from SCons.Builder import BuilderBase
 #############################################################################
 class _POFileBuilder(BuilderBase):
     """ `PO` file builder.
-  
+
     This is multi-target single-source builder. In typical situation the source
     is single `POT` file, e.g. `messages.pot`, and there are multiple `PO`
     targets to be updated from this `POT`. We must run
     `SCons.Builder.BuilderBase._execute()` separatelly for each target to track
     dependencies separatelly for each target file.
-    
+
     **NOTE**: if we call `SCons.Builder.BuilderBase._execute(.., target, ...)`
     with target being list of all targets, all targets would be rebuilt each time
     one of the targets from this list is missing. This would happen, for example,
@@ -198,29 +198,29 @@ class _POFileBuilder(BuilderBase):
     #  After that it calls emitter (which is quite too late). The emitter is
     #  also called in each iteration, what makes things yet worse.
     def __init__(self, env, **kw):
-        if not 'suffix' in kw:
+        if 'suffix' not in kw:
             kw['suffix'] = '$POSUFFIX'
-        if not 'src_suffix' in kw:
+        if 'src_suffix' not in kw:
             kw['src_suffix'] = '$POTSUFFIX'
-        if not 'src_builder' in kw:
+        if 'src_builder' not in kw:
             kw['src_builder'] = '_POTUpdateBuilder'
-        if not 'single_source' in kw:
+        if 'single_source' not in kw:
             kw['single_source'] = True
         alias = None
         if 'target_alias' in kw:
             alias = kw['target_alias']
             del kw['target_alias']
-        if not 'target_factory' in kw:
+        if 'target_factory' not in kw:
             kw['target_factory'] = _POTargetFactory(env, alias=alias).File
         BuilderBase.__init__(self, **kw)
 
     def _execute(self, env, target, source, *args, **kw):
         """ Execute builder's actions.
-        
-        Here we append to `target` the languages read from `$LINGUAS_FILE` and 
+
+        Here we append to `target` the languages read from `$LINGUAS_FILE` and
         apply `SCons.Builder.BuilderBase._execute()` separatelly to each target.
         The arguments and return value are same as for
-        `SCons.Builder.BuilderBase._execute()`. 
+        `SCons.Builder.BuilderBase._execute()`.
         """
         import SCons.Util
         import SCons.Node
@@ -272,7 +272,7 @@ def _translate(env, target=None, source=SCons.Environment._null, *args, **kw):
 class RPaths(object):
     """ Callable object, which returns pathnames relative to SCons current
     working directory.
-  
+
     It seems like `SCons.Node.FS.Base.get_path()` returns absolute paths
     for nodes that are outside of current working directory (`env.fs.getcwd()`).
     Here, we often have `SConscript`, `POT` and `PO` files within `po/`
@@ -285,17 +285,17 @@ class RPaths(object):
     the references would be correct only on the machine, where `POT` file was
     recently re-created. For such reason, we need a function, which always
     returns relative paths. This is the purpose of `RPaths` callable object.
-  
+
     The `__call__` method returns paths relative to current working directory, but
     we assume, that *xgettext(1)* is run from the directory, where target file is
     going to be created.
-  
+
     Note, that this may not work for files distributed over several hosts or
     across different drives on windows. We assume here, that single local
     filesystem holds both source files and target `POT` templates.
-  
+
     Intended use of `RPaths` - in `xgettext.py`::
-  
+
       def generate(env):
           from GettextCommon import RPaths
           ...
@@ -318,9 +318,9 @@ class RPaths(object):
 
     def __init__(self, env):
         """ Initialize `RPaths` callable object.
-    
+
           **Arguments**:
-    
+
             - *env* - a `SCons.Environment.Environment` object, defines *current
               working dir*.
         """
@@ -329,16 +329,16 @@ class RPaths(object):
     # FIXME: I'm not sure, how it should be implemented (what the *args are in
     # general, what is **kw).
     def __call__(self, nodes, *args, **kw):
-        """ Return nodes' paths (strings) relative to current working directory. 
-        
+        """ Return nodes' paths (strings) relative to current working directory.
+
           **Arguments**:
-    
+
             - *nodes* ([`SCons.Node.FS.Base`]) - list of nodes.
             - *args* -  currently unused.
             - *kw* - currently unused.
-    
+
           **Returns**:
-    
+
            - Tuple of strings, which represent paths relative to current working
              directory (for given environment).
         """

--- a/src/engine/SCons/Tool/JavaCommon.py
+++ b/src/engine/SCons/Tool/JavaCommon.py
@@ -98,7 +98,7 @@ if java_parsing:
 
         def __init__(self, version=default_java_version):
 
-            if not version in ('1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7',
+            if version not in ('1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7',
                                '1.8', '5', '6', '9.0', '10.0', '11.0', '12.0'):
                 msg = "Java version %s not supported" % version
                 raise NotImplementedError(msg)

--- a/src/engine/SCons/Tool/MSCommon/common.py
+++ b/src/engine/SCons/Tool/MSCommon/common.py
@@ -117,7 +117,7 @@ def normalize_env(env, keys, force=False):
             normenv[k] = copy.deepcopy(env[k])
 
         for k in keys:
-            if k in os.environ and (force or not k in normenv):
+            if k in os.environ and (force or k not in normenv):
                 normenv[k] = os.environ[k]
 
     # This shouldn't be necessary, since the default environment should include system32,

--- a/src/engine/SCons/Tool/MSCommon/vs.py
+++ b/src/engine/SCons/Tool/MSCommon/vs.py
@@ -520,7 +520,7 @@ def get_default_arch(env):
 
     if not msvs:
         arch = 'x86'
-    elif not arch in msvs.get_supported_arch():
+    elif arch not in msvs.get_supported_arch():
         fmt = "Visual Studio version %s does not support architecture %s"
         raise SCons.Errors.UserError(fmt % (env['MSVS_VERSION'], arch))
 

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -86,7 +86,7 @@ def jarFlags(target, source, env, for_signature):
     for src in source:
         contents = src.get_text_contents()
         if contents.startswith("Manifest-Version"):
-            if not 'm' in jarflags:
+            if 'm' not in jarflags:
                 return jarflags + 'm'
             break
     return jarflags
@@ -106,7 +106,7 @@ def Jar(env, target = None, source = [], *args, **kw):
         source = target
         target = None
 
-    # mutiple targets pass so build each target the same from the 
+    # mutiple targets pass so build each target the same from the
     # same source
     #TODO Maybe this should only be done once, and the result copied
     #     for each target since it should result in the same?
@@ -184,7 +184,7 @@ def Jar(env, target = None, source = [], *args, **kw):
                 continue
             except:
                 pass
-            
+
             try:
                 # source is string try to covnert it to dir
                 target_nodes.extend(dir_to_class(env.fs.Dir(s)))
@@ -193,7 +193,7 @@ def Jar(env, target = None, source = [], *args, **kw):
                 pass
 
             SCons.Warnings.Warning("File: " + str(s) + " could not be identified as File or Directory, skipping.")
-            
+
     # at this point all our sources have been converted to classes or directories of class
     # so pass it to the Jar builder
     return env.JarFile(target = target, source = target_nodes, *args, **kw)

--- a/src/engine/SCons/Tool/mingw.py
+++ b/src/engine/SCons/Tool/mingw.py
@@ -65,7 +65,7 @@ def shlib_generator(target, source, env, for_signature):
 
     def_target = env.FindIxes(target, 'WINDOWSDEFPREFIX', 'WINDOWSDEFSUFFIX')
     insert_def = env.subst("$WINDOWS_INSERT_DEF")
-    if not insert_def in ['', '0', 0] and def_target: \
+    if insert_def not in ['', '0', 0] and def_target: \
             cmd.append('-Wl,--output-def,' + def_target.get_string(for_signature))
 
     return [cmd]

--- a/src/engine/SCons/Tool/mslink.py
+++ b/src/engine/SCons/Tool/mslink.py
@@ -108,7 +108,7 @@ def _dllEmitter(target, source, env, paramtp):
         raise SCons.Errors.UserError('A shared library should have exactly one target with the suffix: %s' % env.subst('$%sSUFFIX' % paramtp))
 
     insert_def = env.subst("$WINDOWS_INSERT_DEF")
-    if not insert_def in ['', '0', 0] and \
+    if insert_def not in ['', '0', 0] and \
        not env.FindIxes(source, "WINDOWSDEFPREFIX", "WINDOWSDEFSUFFIX"):
 
         # append a def file to the list of sources
@@ -159,7 +159,7 @@ def windowsLibEmitter(target, source, env):
 
 def ldmodEmitter(target, source, env):
     """Emitter for loadable modules.
-    
+
     Loadable modules are identical to shared libraries on Windows, but building
     them is subject to different parameters (LDMODULE*).
     """
@@ -220,7 +220,7 @@ def embedManifestDllCheck(target, source, env):
     if env.get('WINDOWS_EMBED_MANIFEST', 0):
         manifestSrc = target[0].get_abspath() + '.manifest'
         if os.path.exists(manifestSrc):
-            ret = (embedManifestDllAction) ([target[0]],None,env)        
+            ret = (embedManifestDllAction) ([target[0]],None,env)
             if ret:
                 raise SCons.Errors.UserError("Unable to embed manifest into %s" % (target[0]))
             return ret

--- a/src/engine/SCons/Tool/msvc.py
+++ b/src/engine/SCons/Tool/msvc.py
@@ -162,7 +162,7 @@ def msvc_batch_key(action, env, target, source):
     # Note we need to do the env.subst so $MSVC_BATCH can be a reference to
     # another construction variable, which is why we test for False and 0
     # as strings.
-    if not 'MSVC_BATCH' in env or env.subst('$MSVC_BATCH') in ('0', 'False', '', None):
+    if 'MSVC_BATCH' not in env or env.subst('$MSVC_BATCH') in ('0', 'False', '', None):
         # We're not using batching; return no key.
         return None
     t = target[0]
@@ -188,7 +188,7 @@ def msvc_output_flag(target, source, env, for_signature):
     # len(source)==1 as batch mode can compile only one file
     # (and it also fixed problem with compiling only one changed file
     # with batch mode enabled)
-    if not 'MSVC_BATCH' in env or env.subst('$MSVC_BATCH') in ('0', 'False', '', None):
+    if 'MSVC_BATCH' not in env or env.subst('$MSVC_BATCH') in ('0', 'False', '', None):
         return '/Fo$TARGET'
     else:
         # The Visual C/C++ compiler requires a \ at the end of the /Fo

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -397,7 +397,7 @@ class _DSPGenerator(object):
         elif SCons.Util.is_List(env['variant']):
             variants = env['variant']
 
-        if 'buildtarget' not in env or env['buildtarget'] == None:
+        if 'buildtarget' not in env or env['buildtarget'] is None:
             buildtarget = ['']
         elif SCons.Util.is_String(env['buildtarget']):
             buildtarget = [env['buildtarget']]
@@ -418,7 +418,7 @@ class _DSPGenerator(object):
             for _ in variants:
                 buildtarget.append(bt)
 
-        if 'outdir' not in env or env['outdir'] == None:
+        if 'outdir' not in env or env['outdir'] is None:
             outdir = ['']
         elif SCons.Util.is_String(env['outdir']):
             outdir = [env['outdir']]
@@ -439,7 +439,7 @@ class _DSPGenerator(object):
             for v in variants:
                 outdir.append(s)
 
-        if 'runfile' not in env or env['runfile'] == None:
+        if 'runfile' not in env or env['runfile'] is None:
             runfile = buildtarget[-1:]
         elif SCons.Util.is_String(env['runfile']):
             runfile = [env['runfile']]
@@ -462,7 +462,7 @@ class _DSPGenerator(object):
 
         self.sconscript = env['MSVSSCONSCRIPT']
 
-        if 'cmdargs' not in env or env['cmdargs'] == None:
+        if 'cmdargs' not in env or env['cmdargs'] is None:
             cmdargs = [''] * len(variants)
         elif SCons.Util.is_String(env['cmdargs']):
             cmdargs = [env['cmdargs']] * len(variants)
@@ -537,7 +537,7 @@ class _DSPGenerator(object):
         self.platforms = []
         for key in list(self.configs.keys()):
             platform = self.configs[key].platform
-            if not platform in self.platforms:
+            if platform not in self.platforms:
                 self.platforms.append(platform)
 
     def Build(self):
@@ -553,16 +553,16 @@ V6DSPHeader = """\
 CFG=%(name)s - Win32 %(confkey)s
 !MESSAGE This is not a valid makefile. To build this project using NMAKE,
 !MESSAGE use the Export Makefile command and run
-!MESSAGE 
+!MESSAGE
 !MESSAGE NMAKE /f "%(name)s.mak".
-!MESSAGE 
+!MESSAGE
 !MESSAGE You can specify a configuration when running NMAKE
 !MESSAGE by defining the macro CFG on the command line. For example:
-!MESSAGE 
+!MESSAGE
 !MESSAGE NMAKE /f "%(name)s.mak" CFG="%(name)s - Win32 %(confkey)s"
-!MESSAGE 
+!MESSAGE
 !MESSAGE Possible choices for configuration are:
-!MESSAGE 
+!MESSAGE
 """
 
 class _GenerateV6DSP(_DSPGenerator):
@@ -580,7 +580,7 @@ class _GenerateV6DSP(_DSPGenerator):
         for kind in confkeys:
             self.file.write('!MESSAGE "%s - Win32 %s" (based on "Win32 (x86) External Target")\n' % (name, kind))
 
-        self.file.write('!MESSAGE \n\n')
+        self.file.write('!MESSAGE\n\n')
 
     def PrintProject(self):
         name = self.name
@@ -637,7 +637,7 @@ class _GenerateV6DSP(_DSPGenerator):
                 first = 1
             else:
                 self.file.write('!ELSEIF  "$(CFG)" == "%s - Win32 %s"\n\n' % (name,kind))
-        self.file.write('!ENDIF \n\n')
+        self.file.write('!ENDIF\n\n')
         self.PrintSourceFiles()
         self.file.write('# End Target\n'
                         '# End Project\n')
@@ -1451,7 +1451,7 @@ class _GenerateV7DSW(_DSWGenerator):
         self.platforms = []
         for key in list(self.configs.keys()):
             platform = self.configs[key].platform
-            if not platform in self.platforms:
+            if platform not in self.platforms:
                 self.platforms.append(platform)
 
         def GenerateProjectFilesInfo(self):
@@ -1730,7 +1730,7 @@ def GenerateProject(target, source, env):
     dspfile = builddspfile.srcnode()
 
     # this detects whether or not we're using a VariantDir
-    if not dspfile is builddspfile:
+    if dspfile is not builddspfile:
         try:
             bdsp = open(str(builddspfile), "w+")
         except IOError as detail:
@@ -1745,7 +1745,7 @@ def GenerateProject(target, source, env):
         builddswfile = target[1]
         dswfile = builddswfile.srcnode()
 
-        if not dswfile is builddswfile:
+        if dswfile is not builddswfile:
 
             try:
                 bdsw = open(str(builddswfile), "w+")
@@ -1785,7 +1785,7 @@ def projectEmitter(target, source, env):
         includepath = xmlify(';'.join([str(x) for x in includepath_Dirs]))
         source = source + "; ppdefs:%s incpath:%s"%(preprocdefs, includepath)
 
-        if 'buildtarget' in env and env['buildtarget'] != None:
+        if 'buildtarget' in env and env['buildtarget'] is not None:
             if SCons.Util.is_String(env['buildtarget']):
                 source = source + ' "%s"' % env['buildtarget']
             elif SCons.Util.is_List(env['buildtarget']):
@@ -1799,7 +1799,7 @@ def projectEmitter(target, source, env):
                 try: source = source + ' "%s"' % env['buildtarget'].get_abspath()
                 except AttributeError: raise SCons.Errors.InternalError("buildtarget can be a string, a node, a list of strings or nodes, or None")
 
-        if 'outdir' in env and env['outdir'] != None:
+        if 'outdir' in env and env['outdir'] is not None:
             if SCons.Util.is_String(env['outdir']):
                 source = source + ' "%s"' % env['outdir']
             elif SCons.Util.is_List(env['outdir']):

--- a/src/engine/SCons/Tool/qt.py
+++ b/src/engine/SCons/Tool/qt.py
@@ -97,7 +97,7 @@ def checkMocIncluded(target, source, env):
     # not really sure about the path transformations (moc.cwd? cpp.cwd?) :-/
     path = SCons.Defaults.CScan.path(env, moc.cwd)
     includes = SCons.Defaults.CScan(cpp, env, path)
-    if not moc in includes:
+    if moc not in includes:
         SCons.Warnings.warn(
             GeneratedMocFileNotIncluded,
             "Generated moc file '%s' is not included by '%s'" %
@@ -118,7 +118,7 @@ class _Automoc(object):
 
     def __init__(self, objBuilderName):
         self.objBuilderName = objBuilderName
-        
+
     def __call__(self, target, source, env):
         """
         Smart autoscan function. Gets the list of objects for the Program
@@ -133,25 +133,25 @@ class _Automoc(object):
             debug = int(env.subst('$QT_DEBUG'))
         except ValueError:
             debug = 0
-        
+
         # some shortcuts used in the scanner
         splitext = SCons.Util.splitext
         objBuilder = getattr(env, self.objBuilderName)
-  
+
         # some regular expressions:
         # Q_OBJECT detection
-        q_object_search = re.compile(r'[^A-Za-z0-9]Q_OBJECT[^A-Za-z0-9]') 
+        q_object_search = re.compile(r'[^A-Za-z0-9]Q_OBJECT[^A-Za-z0-9]')
         # cxx and c comment 'eater'
         #comment = re.compile(r'(//.*)|(/\*(([^*])|(\*[^/]))*\*/)')
         # CW: something must be wrong with the regexp. See also bug #998222
         #     CURRENTLY THERE IS NO TEST CASE FOR THAT
-        
+
         # The following is kind of hacky to get builders working properly (FIXME)
         objBuilderEnv = objBuilder.env
         objBuilder.env = env
         mocBuilderEnv = env.Moc.env
         env.Moc.env = env
-        
+
         # make a deep copy for the result; MocH objects will be appended
         out_sources = source[:]
 
@@ -164,7 +164,7 @@ class _Automoc(object):
             cpp = obj.sources[0]
             if not splitext(str(cpp))[1] in cxx_suffixes:
                 if debug:
-                    print("scons: qt: '%s' is no cxx file. Discarded." % str(cpp)) 
+                    print("scons: qt: '%s' is no cxx file. Discarded." % str(cpp))
                 # c or fortran source
                 continue
             #cpp_contents = comment.sub('', cpp.get_text_contents())
@@ -260,7 +260,7 @@ def uicScannerFunc(node, env, path):
     return result
 
 uicScanner = SCons.Scanner.Base(uicScannerFunc,
-                                name = "UicScanner", 
+                                name = "UicScanner",
                                 node_class = SCons.Node.FS.File,
                                 node_factory = SCons.Node.FS.File,
                                 recursive = 0)
@@ -336,7 +336,7 @@ def generate(env):
         mocBld.prefix[cxx] = '$QT_MOCCXXPREFIX'
         mocBld.suffix[cxx] = '$QT_MOCCXXSUFFIX'
 
-    # register the builders 
+    # register the builders
     env['BUILDERS']['Uic'] = uicBld
     env['BUILDERS']['Moc'] = mocBld
     static_obj, shared_obj = SCons.Tool.createObjBuilders(env)

--- a/src/engine/SCons/Tool/tex.py
+++ b/src/engine/SCons/Tool/tex.py
@@ -781,7 +781,7 @@ def tex_emitter_core(target, source, env, graphics_extensions):
         # add side effects if feature is present.If file is to be generated,add all side effects
         if Verbose and theSearch:
             print("check side effects for ",suffix_list[-1])
-        if (theSearch != None) or (not source[0].exists() ):
+        if theSearch is not None or not source[0].exists():
             file_list = [targetbase,]
             # for bibunit we need a list of files
             if suffix_list[-1] == 'bibunit':

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -886,7 +886,7 @@ def PrependPath(oldpath, newpath, sep = os.pathsep,
         # now we add them only if they are unique
         for path in newpaths:
             normpath = os.path.normpath(os.path.normcase(path))
-            if path and not normpath in normpaths:
+            if path and normpath not in normpaths:
                 paths.append(path)
                 normpaths.append(normpath)
 
@@ -966,7 +966,7 @@ def AppendPath(oldpath, newpath, sep = os.pathsep,
         # now we add them only if they are unique
         for path in newpaths:
             normpath = os.path.normpath(os.path.normcase(path))
-            if path and not normpath in normpaths:
+            if path and normpath not in normpaths:
                 paths.append(path)
                 normpaths.append(normpath)
         paths.reverse()
@@ -1537,7 +1537,7 @@ def silent_intern(x):
 class Null(object):
     """ Null objects always and reliably "do nothing." """
     def __new__(cls, *args, **kwargs):
-        if not '_instance' in vars(cls):
+        if '_instance' not in vars(cls):
             cls._instance = super(Null, cls).__new__(cls, *args, **kwargs)
         return cls._instance
     def __init__(self, *args, **kwargs):

--- a/src/engine/SCons/Variables/EnumVariable.py
+++ b/src/engine/SCons/Variables/EnumVariable.py
@@ -45,7 +45,7 @@ __all__ = ['EnumVariable',]
 import SCons.Errors
 
 def _validator(key, val, env, vals):
-    if not val in vals:
+    if val not in vals:
         raise SCons.Errors.UserError(
             'Invalid value for option %s: %s.  Valid values are: %s' % (key, val, vals))
 

--- a/src/engine/SCons/Variables/ListVariable.py
+++ b/src/engine/SCons/Variables/ListVariable.py
@@ -96,7 +96,7 @@ def _converter(val, allowedElems, mapdict):
     else:
         val = [_f for _f in val.split(',') if _f]
         val = [mapdict.get(v, v) for v in val]
-        notAllowed = [v for v in val if not v in allowedElems]
+        notAllowed = [v for v in val if v not in allowedElems]
         if notAllowed:
             raise ValueError("Invalid value(s) for option: %s" %
                              ','.join(notAllowed))

--- a/src/engine/SCons/Variables/__init__.py
+++ b/src/engine/SCons/Variables/__init__.py
@@ -99,7 +99,7 @@ class Variables(object):
         option.converter = converter
 
         self.options.append(option)
-        
+
         # options might be added after the 'unknown' dict has been set up,
         # so we remove the key and all its aliases from that dict
         for alias in list(option.aliases) + [ option.key ]:
@@ -168,7 +168,7 @@ class Variables(object):
 
         # first set the defaults:
         for option in self.options:
-            if not option.default is None:
+            if option.default is not None:
                 values[option.key] = option.default
 
         # next set the value specified in the options file
@@ -288,7 +288,7 @@ class Variables(object):
 
         env - an environment that is used to get the current values
               of the options.
-        cmp - Either a function as follows: The specific sort function should take two arguments and return -1, 0 or 1 
+        cmp - Either a function as follows: The specific sort function should take two arguments and return -1, 0 or 1
               or a boolean to indicate if it should be sorted.
         """
 

--- a/src/engine/SCons/Warnings.py
+++ b/src/engine/SCons/Warnings.py
@@ -193,9 +193,10 @@ def warn(clazz, *args):
             break
 
 def process_warn_strings(arguments):
-    """Process string specifications of enabling/disabling warnings,
-    as passed to the --warn option or the SetOption('warn') function.
-    
+    """Process requests to enable/disable warnings.
+
+    The requests are strings passed to the --warn option or the
+    SetOption('warn') function.
 
     An argument to this option should be of the form <warning-class>
     or no-<warning-class>.  The warning class is munged in order
@@ -210,7 +211,6 @@ def process_warn_strings(arguments):
 
     As a special case, --warn=all and --warn=no-all will enable or
     disable (respectively) the base Warning class of all warnings.
-
     """
 
     def _capitalize(s):

--- a/src/engine/SCons/cpp.py
+++ b/src/engine/SCons/cpp.py
@@ -210,7 +210,7 @@ class FunctionEvaluator(object):
 
         parts = []
         for s in self.expansion:
-            if not s in self.args:
+            if s not in self.args:
                 s = repr(s)
             parts.append(s)
         statement = ' + '.join(parts)

--- a/src/script/scons-time.py
+++ b/src/script/scons-time.py
@@ -107,7 +107,7 @@ class Line(object):
             # in the line's index number.  We might want to represent
             # this some way rather than just drawing the line straight
             # between the two points on either side.
-            if not y is None:
+            if y is not None:
                 print(fmt % (x, y))
         print('e')
 
@@ -141,13 +141,13 @@ class Gnuplotter(Plotter):
         result = []
         for line in self.lines:
             result.extend(line.get_x_values())
-        return [r for r in result if not r is None]
+        return [r for r in result if r is not None]
 
     def get_all_y_values(self):
         result = []
         for line in self.lines:
             result.extend(line.get_y_values())
-        return [r for r in result if not r is None]
+        return [r for r in result if r is not None]
 
     def get_min_x(self):
         try:
@@ -252,7 +252,7 @@ def tee_to_file(command, log):
     return '%s 2>&1 | tee %s' % (command, log)
 
 
-    
+
 class SConsTimer(object):
     """
     Usage: scons-time SUBCOMMAND [ARGUMENTS]
@@ -348,7 +348,7 @@ class SConsTimer(object):
         'SCons'         : 'Total SCons execution time',
         'commands'      : 'Total command execution time',
     }
-    
+
     time_string_all = 'Total .* time'
 
     #
@@ -629,7 +629,7 @@ class SConsTimer(object):
             return None
         result = re.findall(r'%s: ([\d\.]*)' % search_string, contents)[-4:]
         result = [ float(r) for r in result ]
-        if not time_string is None:
+        if time_string is not None:
             try:
                 result = result[0]
             except IndexError:
@@ -921,7 +921,7 @@ class SConsTimer(object):
             elif o in ('-p', '--prefix'):
                 self.prefix = a
             elif o in ('--stage',):
-                if not a in self.stages:
+                if a not in self.stages:
                     sys.stderr.write('%s: mem: Unrecognized stage "%s".\n' % (self.name, a))
                     sys.exit(1)
                 stage = a
@@ -1035,7 +1035,7 @@ class SConsTimer(object):
             elif o in ('-p', '--prefix'):
                 self.prefix = a
             elif o in ('--stage',):
-                if not a in self.stages:
+                if a not in self.stages:
                     sys.stderr.write('%s: obj: Unrecognized stage "%s".\n' % (self.name, a))
                     sys.stderr.write('%s       Type "%s help obj" for help.\n' % (self.name_spaces, self.name))
                     sys.exit(1)
@@ -1423,7 +1423,7 @@ class SConsTimer(object):
             elif o in ('--title',):
                 self.title = a
             elif o in ('--which',):
-                if not a in list(self.time_strings.keys()):
+                if a not in list(self.time_strings.keys()):
                     sys.stderr.write('%s: time: Unrecognized timer "%s".\n' % (self.name, a))
                     sys.stderr.write('%s  Type "%s help time" for help.\n' % (self.name_spaces, self.name))
                     sys.exit(1)

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -117,7 +117,7 @@ else:
         # check `pwd`/lib/scons*.
         temp.append(os.getcwd())
     else:
-        if script_dir == '.' or script_dir == '':
+        if script_dir in ('.', ''):
             script_dir = os.getcwd()
         head, tail = os.path.split(script_dir)
         if tail == "bin":
@@ -261,7 +261,7 @@ def default_mapper(entry, name):
     """
     try:
         val = eval("entry." + name)
-    except:
+    except AttributeError:
         val = None
     if sys.version_info.major >= 3 and isinstance(val, bytes):
         # This is a dirty hack for py 2/3 compatibility. csig is a bytes object
@@ -596,7 +596,7 @@ for o, a in opts:
                     # this was handled by calling my_import('SCons.dblite')
                     # again in earlier versions...
                     SCons.dblite.ignore_corrupt_dbfiles = 0
-            except:
+            except ImportError:
                 sys.stderr.write("sconsign: illegal file format `%s'\n" % a)
                 print(helpstr)
                 sys.exit(2)

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -38,18 +38,18 @@ expected_dspfile_6_0 = '''\
 CFG=Test - Win32 Release
 !MESSAGE This is not a valid makefile. To build this project using NMAKE,
 !MESSAGE use the Export Makefile command and run
-!MESSAGE 
+!MESSAGE
 !MESSAGE NMAKE /f "Test.mak".
-!MESSAGE 
+!MESSAGE
 !MESSAGE You can specify a configuration when running NMAKE
 !MESSAGE by defining the macro CFG on the command line. For example:
-!MESSAGE 
+!MESSAGE
 !MESSAGE NMAKE /f "Test.mak" CFG="Test - Win32 Release"
-!MESSAGE 
+!MESSAGE
 !MESSAGE Possible choices for configuration are:
-!MESSAGE 
+!MESSAGE
 !MESSAGE "Test - Win32 Release" (based on "Win32 (x86) External Target")
-!MESSAGE 
+!MESSAGE
 
 # Begin Project
 # PROP AllowPerConfigDependencies 0
@@ -85,7 +85,7 @@ CFG=Test - Win32 Release
 
 !IF  "$(CFG)" == "Test - Win32 Release"
 
-!ENDIF 
+!ENDIF
 
 # Begin Group "Header Files"
 
@@ -1150,7 +1150,7 @@ import SCons.Tool.MSCommon
 print("self.scons_version =%%s"%%repr(SCons.__%s__))
 print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
 """ % 'version'
-        
+
             self.run(arguments = '-n -q -Q -f -', stdin = input)
             exec(self.stdout())
 
@@ -1233,11 +1233,11 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
         finally:
             os.environ['SCONSFLAGS'] = save_sconsflags or ''
         return result
-    
+
     def get_vs_host_arch(self):
         """ Get an MSVS, SDK , and/or MSVS acceptable platform arch
         """
-        
+
         # Dict to 'canonalize' the arch
         _ARCH_TO_CANONICAL = {
             "x86": "x86",
@@ -1255,21 +1255,19 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
         # PROCESSOR_ARCHITECTURE.
         if not host_platform:
             host_platform = os.environ.get('PROCESSOR_ARCHITECTURE', '')
-                
-            
+
         try:
             host = _ARCH_TO_CANONICAL[host_platform]
         except KeyError as e:
             # Default to x86 for all other platforms
             host = 'x86'
-    
-   
+
         return host
 
     def validate_msvs_file(self,  file):
         try:
             x = ElementTree.parse(file)
-        except: 
+        except:
             print("--------------------------------------------------------------")
             print("--------------------------------------------------------------")
             print(traceback.format_exc())


### PR DESCRIPTION
Consistently use "not is" and "not in", many instances used the form "not x is y" instead, which pylint objected to.
A couple of bare `except` clauses got a qualifier.
Files otherwise touched had trailing whitespace cleaned up as well.

These are all things that sider would complain about if a change happened nearby, so this is pre-emptive.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
