### PR TITLE
Fix a small error in docbook tool

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -61,6 +61,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add a PY3-only function for setting up the cachedir that should be less
       prone to races. Add a hack to the PY2 version (from Issue #3351) to
       be less prone to a race in the check for old-style cache.
+    - docbook tool small error in xslt variant
 
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700

--- a/src/engine/SCons/Tool/docbook/__init__.py
+++ b/src/engine/SCons/Tool/docbook/__init__.py
@@ -353,7 +353,7 @@ def __build_lxml(target, source, env):
 
     try:
         with open(str(target[0]), "wb") as of:
-            of.write(of.write(etree.tostring(result, pretty_print=True)))
+            of.write(etree.tostring(result, pretty_print=True))
     except:
         pass
 


### PR DESCRIPTION
The routine used in the builder if `lxml` is being used had a doubled write command likely to produce unexpected results.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
