### PR TITLE
Add -iquote and -idirafter for CCFLAGS

### DIFF
--- a/doc/generated/examples/troubleshoot_Dump_2.xml
+++ b/doc/generated/examples/troubleshoot_Dump_2.xml
@@ -80,7 +80,7 @@ scons: Reading SConscript files ...
   'SHCXX': '$CXX',
   'SHCXXCOM': '${TEMPFILE("$SHCXX $_MSVC_OUTPUT_FLAG /c $CHANGED_SOURCES $SHCXXFLAGS $SHCCFLAGS $_CCCOMCOM","$SHCXXCOMSTR")}',
   'SHCXXFLAGS': ['$CXXFLAGS'],
-  'SHELL': None,
+  'SHELL': 'command',
   'SHLIBPREFIX': '',
   'SHLIBSUFFIX': '.dll',
   'SHOBJPREFIX': '$OBJPREFIX',

--- a/doc/generated/examples/troubleshoot_stacktrace_2.xml
+++ b/doc/generated/examples/troubleshoot_stacktrace_2.xml
@@ -4,10 +4,10 @@ scons: *** [prog.o] Source `prog.c' not found, needed by target `prog.o'.
 scons: internal stack trace:
   File "bootstrap/src/engine/SCons/Job.py", line 199, in start
     task.prepare()
-  File "bootstrap/src/engine/SCons/Script/Main.py", line 177, in prepare
+  File "bootstrap/src/engine/SCons/Script/Main.py", line 190, in prepare
     return SCons.Taskmaster.OutOfDateTask.prepare(self)
   File "bootstrap/src/engine/SCons/Taskmaster.py", line 198, in prepare
     executor.prepare()
-  File "bootstrap/src/engine/SCons/Executor.py", line 430, in prepare
+  File "bootstrap/src/engine/SCons/Executor.py", line 431, in prepare
     raise SCons.Errors.StopError(msg % (s, self.batches[0].targets[0]))
 </screen>

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -2941,6 +2941,9 @@ and added to the following construction variables:
 -frameworkdir=      FRAMEWORKPATH
 -include            CCFLAGS
 -isysroot           CCFLAGS, LINKFLAGS
+-isystem            CCFLAGS
+-iquote             CCFLAGS
+-idirafter          CCFLAGS
 -I                  CPPPATH
 -l                  LIBS
 -L                  LIBPATH

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -62,6 +62,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       prone to races. Add a hack to the PY2 version (from Issue #3351) to
       be less prone to a race in the check for old-style cache.
     - Fix coding error in docbook tool only exercised when using python lxml 
+    - Recognize two additional GNU compiler header directory options:
+      -iquote and -idirafter.
 
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -62,8 +62,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       prone to races. Add a hack to the PY2 version (from Issue #3351) to
       be less prone to a race in the check for old-style cache.
     - Fix coding error in docbook tool only exercised when using python lxml 
-    - Recognize two additional GNU compiler header directory options:
-      -iquote and -idirafter.
+    - Recognize two additional GNU compiler header directory options in
+      ParseFlags: -iquote and -idirafter.
 
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -719,6 +719,12 @@ class SubstitutionEnvironment(object):
                    elif append_next_arg_to == '-isystem':
                        t = ('-isystem', arg)
                        dict['CCFLAGS'].append(t)
+                   elif append_next_arg_to == '-iquote':
+                       t = ('-iquote', arg)
+                       dict['CCFLAGS'].append(t)
+                   elif append_next_arg_to == '-idirafter':
+                       t = ('-idirafter', arg)
+                       dict['CCFLAGS'].append(t)
                    elif append_next_arg_to == '-arch':
                        t = ('-arch', arg)
                        dict['CCFLAGS'].append(t)
@@ -791,7 +797,7 @@ class SubstitutionEnvironment(object):
                 elif arg[0] == '+':
                     dict['CCFLAGS'].append(arg)
                     dict['LINKFLAGS'].append(arg)
-                elif arg in ['-include', '-isysroot', '-isystem', '-arch']:
+                elif arg in ['-include', '-isysroot', '-isystem', '-iquote', '-idirafter', '-arch']:
                     append_next_arg_to = arg
                 else:
                     dict['CCFLAGS'].append(arg)

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -2294,6 +2294,9 @@ and added to the following construction variables:
 -frameworkdir=      FRAMEWORKPATH
 -include            CCFLAGS
 -isysroot           CCFLAGS, LINKFLAGS
+-isystem            CCFLAGS
+-iquote             CCFLAGS
+-idirafter          CCFLAGS
 -I                  CPPPATH
 -l                  LIBS
 -L                  LIBPATH

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -800,7 +800,9 @@ sys.exit(0)
             "-fopenmp " + \
             "-mno-cygwin -mwindows " + \
             "-arch i386 -isysroot /tmp " + \
-            "-isystem /usr/include/foo " + \
+            "-iquote /usr/include/foo1 " + \
+            "-isystem /usr/include/foo2 " + \
+            "-idirafter /usr/include/foo3 " + \
             "+DD64 " + \
             "-DFOO -DBAR=value -D BAZ "
 
@@ -809,10 +811,12 @@ sys.exit(0)
         assert d['ASFLAGS'] == ['-as'], d['ASFLAGS']
         assert d['CFLAGS']  == ['-std=c99']
         assert d['CCFLAGS'] == ['-X', '-Wa,-as',
-                                  '-pthread', '-fopenmp', '-mno-cygwin',
-                                  ('-arch', 'i386'), ('-isysroot', '/tmp'),
-                                  ('-isystem', '/usr/include/foo'),
-                                  '+DD64'], repr(d['CCFLAGS'])
+                                '-pthread', '-fopenmp', '-mno-cygwin',
+                                ('-arch', 'i386'), ('-isysroot', '/tmp'),
+                                ('-iquote', '/usr/include/foo1'),
+                                ('-isystem', '/usr/include/foo2'),
+                                ('-idirafter', '/usr/include/foo3'),
+                                '+DD64'], repr(d['CCFLAGS'])
         assert d['CXXFLAGS'] == ['-std=c++0x'], repr(d['CXXFLAGS'])
         assert d['CPPDEFINES'] == ['FOO', ['BAR', 'value'], 'BAZ'], d['CPPDEFINES']
         assert d['CPPFLAGS'] == ['-Wp,-cpp'], d['CPPFLAGS']
@@ -2022,7 +2026,9 @@ def generate(env):
                                  "-pthread " + \
                                  "-mno-cygwin -mwindows " + \
                                  "-arch i386 -isysroot /tmp " + \
-                                 "-isystem /usr/include/foo " + \
+                                 "-iquote /usr/include/foo1 " + \
+                                 "-isystem /usr/include/foo2 " + \
+                                 "-idirafter /usr/include/foo3 " + \
                                  "+DD64 " + \
                                  "-DFOO -DBAR=value")
             env.ParseConfig("fake $COMMAND")
@@ -2031,7 +2037,9 @@ def generate(env):
             assert env['CCFLAGS'] == ['', '-X', '-Wa,-as',
                                       '-pthread', '-mno-cygwin',
                                       ('-arch', 'i386'), ('-isysroot', '/tmp'),
-                                      ('-isystem', '/usr/include/foo'),
+                                      ('-iquote', '/usr/include/foo1'),
+                                      ('-isystem', '/usr/include/foo2'),
+                                      ('-idirafter', '/usr/include/foo3'),
                                       '+DD64'], env['CCFLAGS']
             assert env['CPPDEFINES'] == ['FOO', ['BAR', 'value']], env['CPPDEFINES']
             assert env['CPPFLAGS'] == ['', '-Wp,-cpp'], env['CPPFLAGS']


### PR DESCRIPTION
Recognize two additional GNU compiler header directory search options: `-iquote` and `-idirafter`. Each takes a following arg, which scons now recognizes and adds together with the option to `CCFLAGS`.  Note that (similar to `-isystem` which was added in git commit f8614aa2), this does not tell scons itself anything special, it only recognizes the flag + argument so it can be passed on to the compiler.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
