### PR TITLE
Update docs for parse_flags keywords

### DIFF
--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -480,7 +480,7 @@ string, in which case a list will be returned instead of a string.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-If 
+If
 <varname>delete_existing</varname>
 is 0, then adding a path that already exists
 will not move it to the end; it will stay where it is in the list.
@@ -518,7 +518,7 @@ then any value(s) that already exist in the
 construction variable will
 <emphasis>not</emphasis>
 be added again to the list.
-However, if delete_existing is 1, 
+However, if delete_existing is 1,
 existing matching values are removed first, so
 existing values in the arg list move to the end of the list.
 </para>
@@ -820,12 +820,14 @@ env4 = env.Clone(tools = ['msvc', MyTool])
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 The
 <varname>parse_flags</varname>
-keyword argument is also recognized:
+keyword argument is also recognized to allow merging command-line
+style arguments into the appropriate construction
+variables (see <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-MergeFlags"><function>env.MergeFlags</function></link>).
 </para>
 
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">
 # create an environment for compiling programs that use wxWidgets
-wx_env = env.Clone(parse_flags = '!wx-config --cflags --cxxflags')
+wx_env = env.Clone(parse_flags='!wx-config --cflags --cxxflags')
 </example_commands>
 </listitem>
   </varlistentry>
@@ -2531,9 +2533,9 @@ as the dependency.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-Note that this will only remove the dependencies listed from 
-the files built by default.  It will still be built if that 
-dependency is needed by another object being built. 
+Note that this will only remove the dependencies listed from
+the files built by default.  It will still be built if that
+dependency is needed by another object being built.
 See the third and forth examples below.
 </para>
 
@@ -3154,7 +3156,7 @@ then any value(s) that already exist in the
 construction variable will
 <emphasis>not</emphasis>
 be added again to the list.
-However, if delete_existing is 1, 
+However, if delete_existing is 1,
 existing matching values are removed first, so
 existing values in the arg list move to the front of the list.
 </para>

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -779,19 +779,19 @@ Sets construction variables for the
 </para>
 <para>Sets:  &cv-link-AS;, &cv-link-ASCOM;, &cv-link-ASFLAGS;, &cv-link-ASPPCOM;, &cv-link-ASPPFLAGS;.</para><para>Uses:  &cv-link-ASCOMSTR;, &cv-link-ASPPCOMSTR;.</para></listitem>
   </varlistentry>
-  <varlistentry id="t-Packaging">
-    <term>Packaging</term>
-    <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Sets construction variables for the <function xmlns="http://www.scons.org/dbxsd/v1.0">Package</function> Builder.
-</para>
-</listitem>
-  </varlistentry>
   <varlistentry id="t-packaging">
     <term>packaging</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A framework for building binary and source packages.
+</para>
+</listitem>
+  </varlistentry>
+  <varlistentry id="t-Packaging">
+    <term>Packaging</term>
+    <listitem>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+Sets construction variables for the <function xmlns="http://www.scons.org/dbxsd/v1.0">Package</function> Builder.
 </para>
 </listitem>
   </varlistentry>

--- a/doc/generated/tools.mod
+++ b/doc/generated/tools.mod
@@ -78,8 +78,8 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY t-mwcc "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>mwcc</literal>">
 <!ENTITY t-mwld "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>mwld</literal>">
 <!ENTITY t-nasm "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>nasm</literal>">
-<!ENTITY t-Packaging "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>Packaging</literal>">
 <!ENTITY t-packaging "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>packaging</literal>">
+<!ENTITY t-Packaging "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>Packaging</literal>">
 <!ENTITY t-pdf "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>pdf</literal>">
 <!ENTITY t-pdflatex "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>pdflatex</literal>">
 <!ENTITY t-pdftex "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>pdftex</literal>">
@@ -186,8 +186,8 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY t-link-mwcc "<link linkend='t-mwcc' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>mwcc</literal></link>">
 <!ENTITY t-link-mwld "<link linkend='t-mwld' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>mwld</literal></link>">
 <!ENTITY t-link-nasm "<link linkend='t-nasm' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>nasm</literal></link>">
-<!ENTITY t-link-Packaging "<link linkend='t-Packaging' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>Packaging</literal></link>">
 <!ENTITY t-link-packaging "<link linkend='t-packaging' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>packaging</literal></link>">
+<!ENTITY t-link-Packaging "<link linkend='t-Packaging' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>Packaging</literal></link>">
 <!ENTITY t-link-pdf "<link linkend='t-pdf' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>pdf</literal></link>">
 <!ENTITY t-link-pdflatex "<link linkend='t-pdflatex' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>pdflatex</literal></link>">
 <!ENTITY t-link-pdftex "<link linkend='t-pdftex' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>pdftex</literal></link>">

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -3298,7 +3298,7 @@ The command line used to call the Java archive tool.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 The string displayed when the Java archive tool
 is called
-If this is not set, then <envar xmlns="http://www.scons.org/dbxsd/v1.0">$JARCOM</envar> (the command line) is displayed.
+If this is not set, then <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-JARCOM"><envar>$JARCOM</envar></link> (the command line) is displayed.
 </para>
 
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -3308,7 +3308,7 @@ env = Environment(JARCOMSTR = "JARchiving $SOURCES into $TARGET")
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 The string displayed when the Java archive tool
 is called
-If this is not set, then <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-JARCOM"><envar>$JARCOM</envar></link> (the command line) is displayed.
+If this is not set, then <envar xmlns="http://www.scons.org/dbxsd/v1.0">$JARCOM</envar> (the command line) is displayed.
 </para>
 
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2043,7 +2043,7 @@ env['BAR'] = 'bar'
 construction variables may also be set or modified by the
 <emphasis>parse_flags</emphasis>
 keyword argument, which applies the
-<emphasis role="bold">ParseFlags</emphasis>
+&f-link-env-MergeFlags;
 method (described below) to the argument value
 after all other processing is completed.
 This is useful either if the exact content of the flags is unknown
@@ -2051,7 +2051,7 @@ This is useful either if the exact content of the flags is unknown
 or if the flags are distributed to a number of construction variables.</para>
 
 <literallayout class="monospaced">
-env = Environment(parse_flags = '-Iinclude -DEBUG -lm')
+env = Environment(parse_flags='-Iinclude -DEBUG -lm')
 </literallayout>
 
 <para>This example adds 'include' to
@@ -2439,10 +2439,14 @@ see the descriptions of these variables, below, for more information.)</para>
 
 <para>It is also possible to use the
 <emphasis>parse_flags</emphasis>
-keyword argument in an override:</para>
+keyword argument in an override,
+to merge command-line style arguments
+into the appropriate construction variables
+(see &f-link-env-MergeFlags;).
+</para>
 
 <literallayout class="monospaced">
-env = Program('hello', 'hello.c', parse_flags = '-Iinclude -DEBUG -lm')
+env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
 </literallayout>
 
 <para>This example adds 'include' to

--- a/doc/user/less-simple.xml
+++ b/doc/user/less-simple.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sconsdoc [
     <!ENTITY % scons SYSTEM "../scons.mod">
     %scons;
-    
+
     <!ENTITY % builders-mod SYSTEM "../generated/builders.mod">
     %builders-mod;
     <!ENTITY % functions-mod SYSTEM "../generated/functions.mod">
@@ -257,7 +257,7 @@ Program('program', Glob('*.c'))
     (see <xref linkend="chap-variants"></xref>, below)
     and repositories
     (see <xref linkend="chap-repositories"></xref>, below),
-    excluding some files 
+    excluding some files
     and returning strings rather than Nodes.
 
     </para>
@@ -311,7 +311,7 @@ Program('hello', ['hello.c'])
     </para>
 
     <important>
-    
+
     <para>
 
     Although &SCons; functions
@@ -359,7 +359,7 @@ Program('program2', common_sources + ['program2.c'])
     <para>
 
     One drawback to the use of a Python list
-    for source files is that 
+    for source files is that
     each file name must be enclosed in quotes
     (either single quotes or double quotes).
     This can get cumbersome and difficult to read
@@ -675,8 +675,10 @@ env.SharedLibrary('word', 'word.cpp',
 
     <para>
 
-    It is also possible to use the <literal>parse_flags</literal> keyword argument in an
-    override:
+    It is also possible to use the <literal>parse_flags</literal>
+    keyword argument in an override to merge command-line
+    style arguments into the appropriate construction
+    variables (see &f-link-env-MergeFlags;).
 
     </para>
 
@@ -688,7 +690,7 @@ env.SharedLibrary('word', 'word.cpp',
     </para>
 
     <programlisting>
-env = Program('hello', 'hello.c', parse_flags = '-Iinclude -DEBUG -lm')
+env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
     </programlisting>
 
     <para>

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -549,7 +549,7 @@ string, in which case a list will be returned instead of a string.
 </para>
 
 <para>
-If 
+If
 <varname>delete_existing</varname>
 is 0, then adding a path that already exists
 will not move it to the end; it will stay where it is in the list.
@@ -588,7 +588,7 @@ then any value(s) that already exist in the
 construction variable will
 <emphasis>not</emphasis>
 be added again to the list.
-However, if delete_existing is 1, 
+However, if delete_existing is 1,
 existing matching values are removed first, so
 existing values in the arg list move to the end of the list.
 </para>
@@ -883,12 +883,14 @@ env4 = env.Clone(tools = ['msvc', MyTool])
 <para>
 The
 <varname>parse_flags</varname>
-keyword argument is also recognized:
+keyword argument is also recognized to allow merging command-line
+style arguments into the appropriate construction
+variables (see &f-link-env-MergeFlags;).
 </para>
 
 <example_commands>
 # create an environment for compiling programs that use wxWidgets
-wx_env = env.Clone(parse_flags = '!wx-config --cflags --cxxflags')
+wx_env = env.Clone(parse_flags='!wx-config --cflags --cxxflags')
 </example_commands>
 </summary>
 </scons_function>
@@ -1880,9 +1882,9 @@ as the dependency.
 </para>
 
 <para>
-Note that this will only remove the dependencies listed from 
-the files built by default.  It will still be built if that 
-dependency is needed by another object being built. 
+Note that this will only remove the dependencies listed from
+the files built by default.  It will still be built if that
+dependency is needed by another object being built.
 See the third and forth examples below.
 </para>
 
@@ -1954,8 +1956,8 @@ not as separate arguments to
 
 <para>
 New values are prepended to the environment variable by default,
-unless prepend=0 is specified.  
-Duplicate values are always eliminated, 
+unless prepend=0 is specified.
+Duplicate values are always eliminated,
 since this function calls
 &f-link-AppendENVPath;
 or
@@ -2492,7 +2494,7 @@ then any value(s) that already exist in the
 construction variable will
 <emphasis>not</emphasis>
 be added again to the list.
-However, if delete_existing is 1, 
+However, if delete_existing is 1,
 existing matching values are removed first, so
 existing values in the arg list move to the front of the list.
 </para>


### PR DESCRIPTION
The somewhat poorly named `parse_flags` keyword args actually work like the `MergeFlags` method - they don't just split like the `ParseFlags` method, but do the merging as well.  Tweak the docs and add a reference to `env.MergeFlags`.

This is a doc-only change (see checklist). Only two files with substantitve change (man.xml, Environment.xml), the others are trailing whitespace, rebuilds, or rebuild side effects.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
