### PR TITLE
Modify CI build to add Python 3.8-dev as a fail-allowed build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   allow_failures:
     - python: pypy
     - python: pypy3
+    - python: 3.8-dev
     - stage: Coverage
 
 # run coverage first as its still useful to collect
@@ -85,7 +86,15 @@ jobs:
         - PYVER=37
         - PYTHON=3.7
       sudo: required
-      dist: xenial  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      dist: xenial  # required for Python >= 3.7
+
+    - <<: *test_job
+      python: 3.8-dev
+      env: 
+        - PYVER=38
+        - PYTHON=3.8
+      sudo: required
+      dist: xenial  # required for Python >= 3.7
 
 
     - &coverage_jobs


### PR DESCRIPTION
Proposed change is only to the CI system, does not touch scons itself at all.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
