### PR TITLE
Fix some regexes for Python 3.8 complaints

### DIFF
--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -155,8 +155,8 @@ if not has_etree:
                 except ImportError:
                     raise ImportError("Failed to import ElementTree from any known place")
 
-re_entity = re.compile("\&([^;]+);")
-re_entity_header = re.compile("<!DOCTYPE\s+sconsdoc\s+[^\]]+\]>")
+re_entity = re.compile(r"\&([^;]+);")
+re_entity_header = re.compile(r"<!DOCTYPE\s+sconsdoc\s+[^\]]+\]>")
 
 # Namespace for the SCons Docbook XSD
 dbxsd="http://www.scons.org/dbxsd/v1.0"

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -64,6 +64,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix coding error in docbook tool only exercised when using python lxml 
     - Recognize two additional GNU compiler header directory options in
       ParseFlags: -iquote and -idirafter.
+    - Fix more re patterns that contain \ but not specified as raw strings
 
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -65,6 +65,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Recognize two additional GNU compiler header directory options in
       ParseFlags: -iquote and -idirafter.
     - Fix more re patterns that contain \ but not specified as raw strings
+      (affects scanners for D, LaTeX, swig)
 
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700

--- a/src/engine/SCons/Scanner/D.py
+++ b/src/engine/SCons/Scanner/D.py
@@ -46,7 +46,7 @@ class D(SCons.Scanner.Classic):
             name = "DScanner",
             suffixes = '$DSUFFIXES',
             path_variable = 'DPATH',
-            regex = '(?:import\s+)([\w\s=,.]+)(?:\s*:[\s\w,=]+)?(?:;)'
+            regex = r'(?:import\s+)([\w\s=,.]+)(?:\s*:[\s\w,=]+)?(?:;)'
         )
 
     def find_include(self, include, source_dir, path):

--- a/src/engine/SCons/Scanner/LaTeX.py
+++ b/src/engine/SCons/Scanner/LaTeX.py
@@ -348,7 +348,7 @@ class LaTeX(SCons.Scanner.Base):
         # Cache the includes list in node so we only scan it once:
         # path_dict = dict(list(path))
         # add option for whitespace (\s) before the '['
-        noopt_cre = re.compile('\s*\[.*$')
+        noopt_cre = re.compile(r'\s*\[.*$')
         if node.includes is not None:
             includes = node.includes
         else:

--- a/src/engine/SCons/Scanner/SWIG.py
+++ b/src/engine/SCons/Scanner/SWIG.py
@@ -34,7 +34,7 @@ import SCons.Scanner
 SWIGSuffixes = [ '.i' ]
 
 def SWIGScanner():
-    expr = '^[ \t]*%[ \t]*(?:include|import|extern)[ \t]*(<|"?)([^>\s"]+)(?:>|"?)'
+    expr = r'^[ \t]*%[ \t]*(?:include|import|extern)[ \t]*(<|"?)([^>\s"]+)(?:>|"?)'
     scanner = SCons.Scanner.ClassicCPP("SWIGScanner", ".i", "SWIGPATH", expr)
     return scanner
 


### PR DESCRIPTION
Regexes that contained unescaped backslashes and were not listed in raw string form  caused one more test failure when Python 3.8 was experimentally turned on in the Travis CI build.

Also one utility script had the same, not affecting tests - found through inspection.

No changed functionalty.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
