### PR TITLE
Add cache hit rate to cache debugging

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -67,6 +67,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix more re patterns that contain \ but not specified as raw strings
       (affects scanners for D, LaTeX, swig)
 
+  From Mathew Robinson:
+    - Update cache debug output to include cache hit rate.
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700
 

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -47,10 +47,12 @@ def CacheRetrieveFunc(target, source, env):
     t = target[0]
     fs = t.fs
     cd = env.get_CacheDir()
+    cd.requests += 1
     cachedir, cachefile = cd.cachepath(t)
     if not fs.exists(cachefile):
         cd.CacheDebug('CacheRetrieve(%s):  %s not in cache\n', t, cachefile)
         return 1
+    cd.hits += 1
     cd.CacheDebug('CacheRetrieve(%s):  retrieving from %s\n', t, cachefile)
     if SCons.Action.execute_actions:
         if fs.islink(cachefile):
@@ -148,6 +150,8 @@ class CacheDir(object):
         one exists,  if not the config file is created and
         the default config is written, as well as saved in the object.
         """
+        self.requests = 0
+        self.hits = 0
         self.path = path
         self.current_cache_debug = None
         self.debugFP = None
@@ -269,6 +273,16 @@ class CacheDir(object):
             self.current_cache_debug = cache_debug
         if self.debugFP:
             self.debugFP.write(fmt % (target, os.path.split(cachefile)[1]))
+            self.debugFP.write("requests: %d, hits: %d, misses: %d, hit rate: %.2f%%\n" %
+                               (self.requests, self.hits, self.misses, self.hit_ratio))
+
+    @property
+    def hit_ratio(self):
+        return (100.0 * self.hits / self.requests if self.requests > 0 else 100)
+
+    @property
+    def misses(self):
+        return self.requests - self.hits
 
     def is_enabled(self):
         return cache_enabled and self.path is not None

--- a/test/CacheDir/debug.py
+++ b/test/CacheDir/debug.py
@@ -88,9 +88,13 @@ test.run(chdir='src',
 
 expect = \
 r"""CacheRetrieve\(aaa.out\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(bbb.out\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(ccc.out\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(all\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 """
 
 test.must_match(debug_out, expect, mode='r')
@@ -102,17 +106,25 @@ test.must_match(debug_out, expect, mode='r')
 
 expect = \
 r"""CacheRetrieve\(aaa.out\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 cat\(\["aaa.out"\], \["aaa.in"\]\)
 CachePush\(aaa.out\):  pushing to [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(bbb.out\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 cat\(\["bbb.out"\], \["bbb.in"\]\)
 CachePush\(bbb.out\):  pushing to [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(ccc.out\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 cat\(\["ccc.out"\], \["ccc.in"\]\)
 CachePush\(ccc.out\):  pushing to [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(all\):  [0-9a-fA-F]+ not in cache
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 cat\(\["all"\], \["aaa.out", "bbb.out", "ccc.out"\]\)
 CachePush\(all\):  pushing to [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 """
 
 test.run(chdir='src',
@@ -134,12 +146,16 @@ test.unlink(['src', 'cat.out'])
 expect = \
 r"""Retrieved `aaa.out' from cache
 CacheRetrieve\(aaa.out\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 Retrieved `bbb.out' from cache
 CacheRetrieve\(bbb.out\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 Retrieved `ccc.out' from cache
 CacheRetrieve\(ccc.out\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 Retrieved `all' from cache
 CacheRetrieve\(all\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 """
 
 test.run(chdir='src',
@@ -164,9 +180,13 @@ test.run(chdir='src',
 
 expect = \
 r"""CacheRetrieve\(aaa.out\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(bbb.out\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(ccc.out\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 CacheRetrieve\(all\):  retrieving from [0-9a-fA-F]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 """
 
 test.must_match(debug_out, expect, mode='r')

--- a/test/Interactive/cache-debug.py
+++ b/test/Interactive/cache-debug.py
@@ -106,6 +106,7 @@ scons>>> Removed foo.out
 scons>>> Touch\("4"\)
 scons>>> Retrieved `foo.out' from cache
 CacheRetrieve\(foo.out\):  retrieving from [0-9A-za-z]+
+requests: [0-9]+, hits: [0-9]+, misses: [0-9]+, hit rate: [0-9]+\.[0-9]{2,}%
 scons>>> Touch\("5"\)
 scons>>> 
 """


### PR DESCRIPTION
Adds hit rate logging when cache debugging is on via the `--cache-debug` flag.

Resulting output looks like:

```
CacheRetrieve(some_object_file.o):  retrieving from fb2c875662f617f57ca94b57ec38b561
requests: 3608, hits: 3437, misses: 171, hit rate: 95.26%
```

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
