### PR TITLE
Use TempFileMunge to link and compile under posix systems

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -6,6 +6,9 @@
 
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
+  
+  From Bernd Kast:
+    - TempFileMunge is used to handle linking of larger projects (https://github.com/Nuitka/Nuitka/issues/279)
 
   From Peter Diener:
     - Additional fix to issue #3135 - Also handle 'pure' and 'elemental' type bound procedures

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,7 +8,7 @@
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
   
   From Bernd Kast:
-    - TempFileMunge is used to handle linking of larger projects (https://github.com/Nuitka/Nuitka/issues/279)
+    - TempFileMunge is used to handle linking of larger projects (https://github.com/Nuitka/Nuitka/issues/279, https://jira.mongodb.org/browse/SERVER-13829)
 
   From Peter Diener:
     - Additional fix to issue #3135 - Also handle 'pure' and 'elemental' type bound procedures

--- a/src/engine/SCons/Tool/cc.py
+++ b/src/engine/SCons/Tool/cc.py
@@ -81,10 +81,11 @@ def generate(env):
     if 'CC' not in env:
         env['CC']    = env.Detect(compilers) or compilers[0]
     env['CFLAGS']    = SCons.Util.CLVar('')
-    env['CCCOM']     = '$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES'
+    env["CCCOM"]     = "${TEMPFILE('$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES', '$CC')}"
+
     env['SHCC']      = '$CC'
     env['SHCFLAGS'] = SCons.Util.CLVar('$CFLAGS')
-    env['SHCCCOM']   = '$SHCC -o $TARGET -c $SHCFLAGS $SHCCFLAGS $_CCCOMCOM $SOURCES'
+    env['SHCCCOM']   = "${TEMPFILE('$SHCC -o $TARGET -c $SHCFLAGS $SHCCFLAGS $_CCCOMCOM $SOURCES', '$SHCC')}"   
 
     env['CPPDEFPREFIX']  = '-D'
     env['CPPDEFSUFFIX']  = ''

--- a/src/engine/SCons/Tool/cc.py
+++ b/src/engine/SCons/Tool/cc.py
@@ -81,11 +81,10 @@ def generate(env):
     if 'CC' not in env:
         env['CC']    = env.Detect(compilers) or compilers[0]
     env['CFLAGS']    = SCons.Util.CLVar('')
-    env["CCCOM"]     = "${TEMPFILE('$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES', '$CC')}"
-
+    env['CCCOM']     = '$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES'
     env['SHCC']      = '$CC'
     env['SHCFLAGS'] = SCons.Util.CLVar('$CFLAGS')
-    env['SHCCCOM']   = "${TEMPFILE('$SHCC -o $TARGET -c $SHCFLAGS $SHCCFLAGS $_CCCOMCOM $SOURCES', '$SHCC')}"   
+    env['SHCCCOM']   = '$SHCC -o $TARGET -c $SHCFLAGS $SHCCFLAGS $_CCCOMCOM $SOURCES'
 
     env['CPPDEFPREFIX']  = '-D'
     env['CPPDEFSUFFIX']  = ''

--- a/src/engine/SCons/Tool/link.py
+++ b/src/engine/SCons/Tool/link.py
@@ -312,7 +312,7 @@ def generate(env):
 
     env['SHLINK'] = '$LINK'
     env['SHLINKFLAGS'] = SCons.Util.CLVar('$LINKFLAGS -shared')
-    env['SHLINKCOM'] = "${TEMPFILE('$SHLINK -o $TARGET $SHLINKFLAGS $__SHLIBVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS'), '$SHLINK')}"
+    env['SHLINKCOM'] = "${TEMPFILE('$SHLINK -o $TARGET $SHLINKFLAGS $__SHLIBVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS', '$SHLINK')}"
 
     # don't set up the emitter, because AppendUnique will generate a list
     # starting with None :-(

--- a/src/engine/SCons/Tool/link.py
+++ b/src/engine/SCons/Tool/link.py
@@ -312,7 +312,7 @@ def generate(env):
 
     env['SHLINK'] = '$LINK'
     env['SHLINKFLAGS'] = SCons.Util.CLVar('$LINKFLAGS -shared')
-    env['SHLINKCOM'] = '$SHLINK -o $TARGET $SHLINKFLAGS $__SHLIBVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS'
+    env['SHLINKCOM'] = "${TEMPFILE('$SHLINK -o $TARGET $SHLINKFLAGS $__SHLIBVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS'), '$SHLINK')}"
 
     # don't set up the emitter, because AppendUnique will generate a list
     # starting with None :-(
@@ -323,7 +323,7 @@ def generate(env):
     env['LINKFLAGS'] = SCons.Util.CLVar('')
 
     # __RPATH is only set to something ($_RPATH typically) on platforms that support it.
-    env['LINKCOM'] = '$LINK -o $TARGET $LINKFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS'
+    env['LINKCOM'] = "${TEMPFILE('$LINK -o $TARGET $LINKFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS', '$LINK')}"
     env['LIBDIRPREFIX'] = '-L'
     env['LIBDIRSUFFIX'] = ''
     env['_LIBFLAGS'] = '${_stripixes(LIBLINKPREFIX, LIBS, LIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES, __env__)}'
@@ -344,8 +344,7 @@ def generate(env):
     env['LDMODULEPREFIX'] = '$SHLIBPREFIX'
     env['LDMODULESUFFIX'] = '$SHLIBSUFFIX'
     env['LDMODULEFLAGS'] = '$SHLINKFLAGS'
-    env[
-        'LDMODULECOM'] = '$LDMODULE -o $TARGET $LDMODULEFLAGS $__LDMODULEVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS'
+    env['LDMODULECOM'] = "${TEMPFILE('$LDMODULE -o $TARGET $LDMODULEFLAGS $__LDMODULEVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS','$LDMODULE')}"
     env['LDMODULEVERSION'] = '$SHLIBVERSION'
     env['LDMODULENOVERSIONSYMLINKS'] = '$SHLIBNOVERSIONSYMLINKS'
 


### PR DESCRIPTION
Scons doesn't use TempFileMunge to link targets under posix systems at the moment. This results in "argument list too long" errors for larger projets.
This commit solves this bug/adds the feature to handle larger projets

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality. (already covered)
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation (no additional documentation required => rather a bug fix than a new feature)
