### PR TITLE
[WIP] clean some "for range(len(foo))" usage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -136,13 +136,21 @@ environment:
 # to fine tune the number and platforms tested
 matrix:	
   exclude:	
-    # test python 3.5, 3.6 on Visual Studio 2015 image
+    # test python 3.5 on Visual Studio 2015 image
     - image: Visual Studio 2015	
       WINPYTHON: "Python37"
+    - image: Visual Studio 2015	
+      WINPYTHON: "Python27"
+    - image: Visual Studio 2015	
+      WINPYTHON: "Python36"
 
     # test python 3.6 on Visual Studio 2019 image
     - image: Visual Studio 2019	
+      WINPYTHON: "Python37"
+    - image: Visual Studio 2019	
       WINPYTHON: "Python27"
+    - image: Visual Studio 2019	
+      WINPYTHON: "Python35"
 
     # test python 2.7, 3.7 on Visual Studio 2017 image
     - image: Visual Studio 2017

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ image:
   # - Ubuntu
   - Visual Studio 2015
   - Visual Studio 2017
+  - Visual Studio 2019
 
 cache:
   - downloads -> appveyor.yml
@@ -138,10 +139,12 @@ matrix:
     # test python 3.5, 3.6 on Visual Studio 2015 image
     - image: Visual Studio 2015	
       WINPYTHON: "Python37"
-    - image: Visual Studio 2015	
+
+    # test python 3.6 on Visual Studio 2019 image
+    - image: Visual Studio 2019	
       WINPYTHON: "Python27"
 
-    # test python 2.7, 3.7 on Visual Studio 2015 image
+    # test python 2.7, 3.7 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python35"
     - image: Visual Studio 2017	

--- a/bin/scons-diff.py
+++ b/bin/scons-diff.py
@@ -76,8 +76,8 @@ def quiet_diff(a, b, fromfile='', tofile='',
                fromfiledate='', tofiledate='', n=3, lineterm='\n'):
     """
     A function with the same calling signature as difflib.context_diff
-    (diff -c) and difflib.unified_diff (diff -u) but which prints
-    output like the simple, unadorned 'diff" command.
+    (diff -c) and difflib.unified_diff (diff -u) but which produces
+    output like the simple, unadorned 'diff" command with the -q option.
     """
     if a == b:
         return []
@@ -88,7 +88,7 @@ def simple_diff(a, b, fromfile='', tofile='',
                 fromfiledate='', tofiledate='', n=3, lineterm='\n'):
     """
     A function with the same calling signature as difflib.context_diff
-    (diff -c) and difflib.unified_diff (diff -u) but which prints
+    (diff -c) and difflib.unified_diff (diff -u) but which produces
     output like the simple, unadorned 'diff" command.
     """
     sm = difflib.SequenceMatcher(None, a, b)

--- a/src/engine/SCons/Scanner/LaTeX.py
+++ b/src/engine/SCons/Scanner/LaTeX.py
@@ -372,9 +372,9 @@ class LaTeX(SCons.Scanner.Base):
                     inc_list = include[2].split(',')
                 else:
                     inc_list = include[1].split(',')
-                for j in range(len(inc_list)):
-                    split_includes.append( (inc_type, inc_subdir, inc_list[j]) )
-            #
+                for inc in inc_list:
+                    split_includes.append((inc_type, inc_subdir, inc))
+
             includes = split_includes
             node.includes = includes
 

--- a/test/Batch/action-changed.py
+++ b/test/Batch/action-changed.py
@@ -43,12 +43,10 @@ import sys
 sep = sys.argv.index('--')
 targets = sys.argv[1:sep]
 sources = sys.argv[sep+1:]
-for i in range(len(targets)):
-    t = targets[i]
-    s = sources[i]
-    with open(t, 'wb') as fp, open(s, 'rb') as infp:
-        fp.write(bytearray('%s\\n','utf-8'))
-        fp.write(infp.read())
+for t, s in zip(targets, sources):
+    with open(t, 'wb') as ofp, open(s, 'rb') as ifp:
+        ofp.write(bytearray('%s\\n', 'utf-8'))
+        ofp.write(ifp.read())
 sys.exit(0)
 """
 

--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -427,7 +427,7 @@ test.must_exist(['listOfLists', 'listsTest', 'com', 'javasource', 'JavaFile3.cla
 test.must_exist(['listOfLists', 'listsTest', 'com', 'resource', 'resource1.txt'])
 test.must_exist(['listOfLists', 'listsTest', 'com', 'resource', 'resource2.txt'])
 test.must_exist(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'])
-test.must_contain(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'], b"MyManifestTest: Test" )
+test.must_contain(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'], "MyManifestTest: Test" )
 
 #######
 # test different style of passing in dirs

--- a/test/SConsignFile/use-gdbm.py
+++ b/test/SConsignFile/use-gdbm.py
@@ -36,11 +36,13 @@ test = TestSCons.TestSCons()
 
 try:
     import gdbm
+    use_dbm = "gdbm"
 except ImportError:
     try:
         import dbm.gnu
+        use_dbm = "dbm.gnu"
     except ImportError:
-        test.skip_test('No gdbm in this version of Python; skipping test.\n')
+        test.skip_test('No GNU dbm in this version of Python; skipping test.\n')
 
 test.subdir('subdir')
 
@@ -54,12 +56,8 @@ sys.exit(0)
 #
 test.write('SConstruct', """
 import sys
-try:
-    import gdbm
-    SConsignFile('.sconsign', gdbm)
-except ImportError:
-    import dbm.gnu
-    SConsignFile('.sconsign', dbm.gnu)
+import %(use_dbm)s
+SConsignFile('.sconsign', %(use_dbm)s)
 B = Builder(action = '%(_python_)s build.py $TARGETS $SOURCES')
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'f1.out', source = 'f1.in')

--- a/test/SWIG/build-dir.py
+++ b/test/SWIG/build-dir.py
@@ -132,8 +132,8 @@ public:
 
     %pythoncode %{
     def __iter__(self):
-        for i in range(len(self)):
-            yield self[i]
+        for s in self:
+            yield s
     %}
   }
 };

--- a/test/Win32/bad-drive.py
+++ b/test/Win32/bad-drive.py
@@ -43,9 +43,9 @@ if sys.platform != 'win32':
     msg = "Skipping drive-letter test on non-Windows platform '%s'\n" % sys.platform
     test.skip_test(msg)
 
+# try to find an unused drive letter
 bad_drive = None
-for i in range(len(ascii_uppercase)-1, -1, -1):
-    d = ascii_uppercase[i]
+for d in reversed(ascii_uppercase):
     if not os.path.isdir(d + ':' + os.sep):
         bad_drive = d + ':'
         break

--- a/test/option--C.py
+++ b/test/option--C.py
@@ -34,10 +34,10 @@ def match_normcase(lines, matches):
     if not isinstance(matches, list):
         matches = matches.split("\n")
     if len(lines) != len(matches):
-        return
-    for i in range(len(lines)):
-        if os.path.normcase(lines[i]) != os.path.normcase(matches[i]):
-            return
+        return None
+    for line, match in zip(lines, matches):
+        if os.path.normcase(line) != os.path.normcase(match):
+            return None
     return 1
 
 test = TestSCons.TestSCons(match=match_normcase)

--- a/test/option/option_profile.py
+++ b/test/option/option_profile.py
@@ -26,17 +26,16 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 
-if sys.version_info[0] < 3:
-    import io
-    _StringIO = io.StringIO
-    # TODO(2.6):  In 2.6 and beyond, the io.StringIO.write() method
-    # requires unicode strings.  This subclass can probably be removed
-    # when we drop support for Python 2.6.
-    class StringIO(_StringIO):
-        def write(self, s):
-            _StringIO.write(self, unicode(s))
-else:
+# TODO: Fixup StringIO usage when Py2.7 is dropped.
+# cheat a little bit: io.StringIO is "preferred" in Py2.7
+# since it forces you to be explicit about strings (it is unicode-only)
+# It's easier to use the unaware version. Which also doesn't come
+# with a context manager, so use contextlib.
+try:
+    from cStringIO import StringIO
+except ImportError:
     from io import StringIO
+import contextlib
 
 import TestSCons
 
@@ -61,14 +60,13 @@ test.must_contain_all_lines(test.stdout(), ['usage: scons [OPTION]'])
 
 try:
     save_stdout = sys.stdout
-    sys.stdout = StringIO()
+    with contextlib.closing(StringIO()) as sys.stdout:
+        stats = pstats.Stats(scons_prof)
+        stats.sort_stats('time')
 
-    stats = pstats.Stats(scons_prof)
-    stats.sort_stats('time')
+        stats.strip_dirs().print_stats()
 
-    stats.strip_dirs().print_stats()
-
-    s = sys.stdout.getvalue()
+        s = sys.stdout.getvalue()
 finally:
     sys.stdout = save_stdout
 
@@ -82,14 +80,13 @@ test.run(arguments = "--profile %s" % scons_prof)
 
 try:
     save_stdout = sys.stdout
-    sys.stdout = StringIO()
+    with contextlib.closing(StringIO()) as sys.stdout:
+        stats = pstats.Stats(scons_prof)
+        stats.sort_stats('time')
 
-    stats = pstats.Stats(scons_prof)
-    stats.sort_stats('time')
+        stats.strip_dirs().print_stats()
 
-    stats.strip_dirs().print_stats()
-
-    s = sys.stdout.getvalue()
+        s = sys.stdout.getvalue()
 finally:
     sys.stdout = save_stdout
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -497,6 +497,12 @@ def match_caseinsensitive(lines=None, matches=None):
     """
     Match function using case-insensitive matching.
 
+    Only a simplistic comparsion is done, based on lowercasing the
+    strings. This has plenty of holes for unicode data using non-English
+    languages.
+
+    TODO: casefold() is better than lower() if we don't need Py2 support.
+
     :param lines: regular expression(s) for matching
     :type lines: str or list[str]
     :param matches: retrieved output lines
@@ -511,7 +517,7 @@ def match_caseinsensitive(lines=None, matches=None):
     if len(lines) != len(matches):
         return None
     for line, match in zip(lines, matches):
-        if line != match:
+        if line.lower() != match.lower():
             return None
     return 1
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -497,9 +497,9 @@ def match_caseinsensitive(lines=None, matches=None):
     """
     Match function using case-insensitive matching.
 
-    Only a simplistic comparsion is done, based on lowercasing the
-    strings. This has plenty of holes for unicode data using non-English
-    languages.
+    Only a simplistic comparison is done, based on lowercasing the
+    strings. This has plenty of holes for unicode data using
+    non-English languages.
 
     TODO: casefold() is better than lower() if we don't need Py2 support.
 
@@ -526,9 +526,9 @@ def match_re(lines=None, res=None):
     """
     Match function using line-by-line regular expression match.
 
-    :param lines: regular expression(s) for matching
+    :param lines: data lines
     :type lines: str or list[str]
-    :param res: retrieved output lines
+    :param res: regular expression(s) for matching
     :type res: str or list[str]
     :returns: an object (1) on match, else None, like re.match
     """
@@ -540,8 +540,8 @@ def match_re(lines=None, res=None):
     if len(lines) != len(res):
         print("match_re: expected %d lines, found %d" % (len(res), len(lines)))
         return None
-    for i, (line, r) in enumerate(zip(lines, res)):
-        s = r"^{}$".format(r)
+    for i, (line, regex) in enumerate(zip(lines, res)):
+        s = r"^{}$".format(regex)
         try:
             expr = re.compile(s)
         except re.error as e:
@@ -549,7 +549,7 @@ def match_re(lines=None, res=None):
             raise re.error(msg % (repr(s), e.args[0]))
         if not expr.search(line):
             miss_tmpl = "match_re: mismatch at line {}:\n  search re='{}'\n  line='{}'"
-            print(miss_tmpl.format(i+1, s, line))
+            print(miss_tmpl.format(i, s, line))
             return None
     return 1
 
@@ -561,9 +561,9 @@ def match_re_dotall(lines=None, res=None):
     Unlike match_re, the arguments are converted to strings (if necessary)
     and must match exactly.
 
-    :param lines: regular expression(s) for matching
+    :param lines: data lines
     :type lines: str or list[str]
-    :param res: retrieved output lines
+    :param res: regular expression(s) for matching
     :type res: str or list[str]
     :returns: a match object, or None as for re.match
     """
@@ -583,9 +583,10 @@ def match_re_dotall(lines=None, res=None):
 def simple_diff(a, b, fromfile='', tofile='',
                 fromfiledate='', tofiledate='', n=3, lineterm='\n'):
     """
-    A function with the same calling signature as difflib.context_diff
-    (diff -c) and difflib.unified_diff (diff -u) but which prints
-    output like the simple, unadorned 'diff" command.
+    Compare a and b (lists of strings); return a delta in simple diff format.
+
+    Similar to difflib.context_diff and difflib.unified_diff but
+    output is like the simple, unadorned 'diff" command.
     """
     a = [to_str(q) for q in a]
     b = [to_str(q) for q in b]
@@ -612,6 +613,8 @@ def simple_diff(a, b, fromfile='', tofile='',
 def diff_re(a, b, fromfile='', tofile='',
             fromfiledate='', tofiledate='', n=3, lineterm='\n'):
     """
+    Compare a and b (lists of strings) where a are regexes.
+
     A simple "diff" of two sets of lines when the expected lines
     are regular expressions.  This is a really dumb thing that
     just compares each line in turn, so it doesn't look for
@@ -624,9 +627,8 @@ def diff_re(a, b, fromfile='', tofile='',
         a = a + [''] * (-diff)
     elif diff > 0:
         b = b + [''] * diff
-    i = 0
-    for aline, bline in zip(a, b):
-        s = "^" + aline + "$"
+    for i, (aline, bline) in enumerate(zip(a, b)):
+        s = r"^{}$".format(aline)
         try:
             expr = re.compile(s)
         except re.error as e:
@@ -637,7 +639,6 @@ def diff_re(a, b, fromfile='', tofile='',
             result.append('< ' + repr(a[i]))
             result.append('---')
             result.append('> ' + repr(b[i]))
-        i = i + 1
     return result
 
 
@@ -1069,7 +1070,7 @@ class TestCmd(object):
             condition = self.condition
         if self._preserve[condition]:
             for dir in self._dirlist:
-                print(u"Preserved directory " + dir + "\n")
+                print(u"Preserved directory " + dir)
         else:
             list = self._dirlist[:]
             list.reverse()

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -38,7 +38,7 @@ import types
 import unittest
 try:
     from collections import UserList
-except:
+except ImportError:
     from UserList import UserList
 
 from SCons.Util import to_bytes, to_str

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -26,13 +26,22 @@ import os
 import shutil
 import signal
 import stat
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+from contextlib import closing
 import sys
 import tempfile
 import time
 import types
 import unittest
-from UserList import UserList
+try:
+    from collections import UserList
+except:
+    from UserList import UserList
+
+from SCons.Util import to_bytes, to_str
 
 
 # Strip the current directory so we get the right TestCmd.py module.
@@ -55,7 +64,7 @@ def _is_executable(path):
 def _clear_dict(dict, *keys):
     for key in keys:
         try:
-            dict[key] = ''  # del dict[key]
+            del dict[key]
         except KeyError:
             pass
 
@@ -156,9 +165,9 @@ class TestCmdTestCase(unittest.TestCase):
                              stdin=subprocess.PIPE,
                              stderr=subprocess.PIPE,
                              stdout=subprocess.PIPE)
-        stdout, stderr = p.communicate(input)
-        stdout = self.translate_newlines(stdout)
-        stderr = self.translate_newlines(stderr)
+        stdout, stderr = p.communicate(to_bytes(input))
+        stdout = self.translate_newlines(to_str(stdout))
+        stderr = self.translate_newlines(to_str(stderr))
         return stdout, stderr, p.returncode
 
     def popen_python(self, input, status=0, stdout="", stderr="", python=None):
@@ -181,7 +190,7 @@ class TestCmdTestCase(unittest.TestCase):
 
     def run_match(self, content, *args):
         expect = "%s:  %s:  %s:  %s\n" % args
-        content = self.translate_newlines(content)
+        content = self.translate_newlines(to_str(content))
         assert content == expect, \
                 "Expected %s ==========\n" % args[1] + expect + \
                 "Actual %s ============\n" % args[1] + content
@@ -257,6 +266,7 @@ result = TestCmd.TestCmd(workdir = '')
 sys.exit(0)
 """ % self.orig_cwd, stdout='my_exitfunc()\n')
 
+    @unittest.skipIf(TestCmd.IS_PY3, "No sys.exitfunc in Python 3")
     def test_exitfunc(self):
         """Test cleanup() when sys.exitfunc is set"""
         self.popen_python("""from __future__ import print_function
@@ -269,7 +279,6 @@ import TestCmd
 result = TestCmd.TestCmd(workdir = '')
 sys.exit(0)
 """ % self.orig_cwd, stdout='my_exitfunc()\n')
-
 
 
 class chmod_TestCase(TestCmdTestCase):
@@ -351,11 +360,8 @@ sys.stderr.write("run2 STDERR third line\\n")
             test = TestCmd.TestCmd(interpreter = 'python',
                                    workdir = '',
                                    combine = 1)
-            try:
-                output = test.stdout()
-            except IndexError:
-                pass
-            else:
+            output = test.stdout()
+            if output is not None:
                 raise IndexError("got unexpected output:\n\t`%s'\n" % output)
 
             # The underlying system subprocess implementations can combine
@@ -424,10 +430,13 @@ class diff_TestCase(TestCmdTestCase):
     def test_diff_re(self):
         """Test diff_re()"""
         result = TestCmd.diff_re(["abcde"], ["abcde"])
+        result = list(result)
         assert result == [], result
         result = TestCmd.diff_re(["a.*e"], ["abcde"])
+        result = list(result)
         assert result == [], result
         result = TestCmd.diff_re(["a.*e"], ["xxx"])
+        result = list(result)
         assert result == ['1c1', "< 'a.*e'", '---', "> 'xxx'"], result
 
     def test_diff_custom_function(self):
@@ -477,13 +486,13 @@ STDOUT==========================================================================
         script_input = """import sys
 sys.path = ['%s'] + sys.path
 import TestCmd
-assert TestCmd.diff_re(["a.*(e"], ["abcde"])
+assert TestCmd.diff_re([r"a.*(e"], ["abcde"])
 sys.exit(0)
 """ % self.orig_cwd
         stdout, stderr, status = self.call_python(script_input)
         assert status == 1, status
-        expect1 = "Regular expression error in '^a.*(e$': missing )\n"
-        expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis\n"
+        expect1 = "Regular expression error in '^a.*(e$': missing )"
+        expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
         assert (stderr.find(expect1) != -1 or
                 stderr.find(expect2) != -1), repr(stderr)
 
@@ -494,6 +503,7 @@ sys.path = ['%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.simple_diff(['a', 'b', 'c', 'e', 'f1'],
                                      ['a', 'c', 'd', 'e', 'f2'])
+result = list(result)
 expect = ['2d1', '< b', '3a3', '> d', '5c5', '< f1', '---', '> f2']
 assert result == expect, result
 sys.exit(0)
@@ -559,6 +569,7 @@ sys.path = ['%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.diff_re(['a', 'b', 'c', '.', 'f1'],
                                  ['a', 'c', 'd', 'e', 'f2'])
+result = list(result)
 expect = [
     '2c2',
     "< 'b'",
@@ -846,22 +857,22 @@ test.%s()
             _test_it(cwd, 'dir04', 'pass_test', 1)
             _test_it(cwd, 'dir05', 'fail_test', 1)
             _test_it(cwd, 'dir06', 'no_result', 1)
-            os.environ['PRESERVE'] = ''  # del os.environ['PRESERVE']
+            del os.environ['PRESERVE']
             os.environ['PRESERVE_PASS'] = '1'
             _test_it(cwd, 'dir07', 'pass_test', 1)
             _test_it(cwd, 'dir08', 'fail_test', 0)
             _test_it(cwd, 'dir09', 'no_result', 0)
-            os.environ['PRESERVE_PASS'] = ''  # del os.environ['PRESERVE_PASS']
+            del os.environ['PRESERVE_PASS']
             os.environ['PRESERVE_FAIL'] = '1'
             _test_it(cwd, 'dir10', 'pass_test', 0)
             _test_it(cwd, 'dir11', 'fail_test', 1)
             _test_it(cwd, 'dir12', 'no_result', 0)
-            os.environ['PRESERVE_FAIL'] = ''  # del os.environ['PRESERVE_FAIL']
+            del os.environ['PRESERVE_FAIL']
             os.environ['PRESERVE_NO_RESULT'] = '1'
             _test_it(cwd, 'dir13', 'pass_test', 0)
             _test_it(cwd, 'dir14', 'fail_test', 0)
             _test_it(cwd, 'dir15', 'no_result', 1)
-            os.environ['PRESERVE_NO_RESULT'] = '' # del os.environ['PRESERVE_NO_RESULT']
+            del os.environ['PRESERVE_NO_RESULT']
         finally:
             _clear_dict(os.environ, 'PRESERVE', 'PRESERVE_PASS', 'PRESERVE_FAIL', 'PRESERVE_NO_RESULT')
 
@@ -982,10 +993,10 @@ class match_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match = TestCmd.match_exact)
         assert not test.match("abcde\n", "a.*e\n")
         assert test.match("abcde\n", "abcde\n")
-        assert not test.match("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match(lines, regexes)
         assert test.match(lines, lines)
 
@@ -994,10 +1005,10 @@ class match_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match=TestCmd.TestCmd.match_exact)
         assert not test.match("abcde\n", "a.*e\n")
         assert test.match("abcde\n", "abcde\n")
-        assert not test.match("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match(lines, regexes)
         assert test.match(lines, lines)
 
@@ -1006,10 +1017,10 @@ class match_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match='match_exact')
         assert not test.match("abcde\n", "a.*e\n")
         assert test.match("abcde\n", "abcde\n")
-        assert not test.match("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match(lines, regexes)
         assert test.match(lines, lines)
 
@@ -1059,16 +1070,16 @@ class match_exact_TestCase(TestCmdTestCase):
 class match_re_dotall_TestCase(TestCmdTestCase):
     def test_match_re_dotall_function(self):
         """Test calling the TestCmd.match_re_dotall() function"""
-        assert TestCmd.match_re_dotall("abcde\nfghij\n", "a.*j\n")
+        assert TestCmd.match_re_dotall("abcde\nfghij\n", r"a.*j\n")
 
     def test_match_re_dotall_instance_method(self):
         """Test calling the TestCmd.TestCmd().match_re_dotall() instance method"""
         test = TestCmd.TestCmd()
-        test.match_re_dotall("abcde\\nfghij\\n", "a.*j\\n")
+        test.match_re_dotall("abcde\\nfghij\\n", r"a.*j\\n")
 
     def test_match_re_dotall_static_method(self):
         """Test calling the TestCmd.TestCmd.match_re_dotall() static method"""
-        assert TestCmd.TestCmd.match_re_dotall("abcde\nfghij\n", "a.*j\n")
+        assert TestCmd.TestCmd.match_re_dotall("abcde\nfghij\n", r"a.*j\n")
 
     def test_error(self):
         """Test handling a compilation error in TestCmd.match_re_dotall()"""
@@ -1081,13 +1092,13 @@ class match_re_dotall_TestCase(TestCmdTestCase):
             script_input = """import sys
 sys.path = ['%s'] + sys.path
 import TestCmd
-assert TestCmd.match_re_dotall("abcde", "a.*(e")
+assert TestCmd.match_re_dotall("abcde", r"a.*(e")
 sys.exit(0)
 """ % cwd
             stdout, stderr, status = self.call_python(script_input)
             assert status == 1, status
-            expect1 = "Regular expression error in '^a.*(e$': missing )\n"
-            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis\n"
+            expect1 = "Regular expression error in '^a.*(e$': missing )"
+            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
             assert (stderr.find(expect1) != -1 or
                     stderr.find(expect2) != -1), repr(stderr)
         finally:
@@ -1096,44 +1107,34 @@ sys.exit(0)
     def test_evaluation(self):
         """Test match_re_dotall() evaluation"""
         test = TestCmd.TestCmd()
-        assert test.match_re_dotall("abcde\nfghij\n", "a.*e\nf.*j\n")
-        assert test.match_re_dotall("abcde\nfghij\n", "a[^j]*j\n")
-        assert test.match_re_dotall("abcde\nfghij\n", "abcde\nfghij\n")
+        assert test.match_re_dotall("abcde\nfghij\n", r"a.*e\nf.*j\n")
+        assert test.match_re_dotall("abcde\nfghij\n", r"a[^j]*j\n")
+        assert test.match_re_dotall("abcde\nfghij\n", r"abcde\nfghij\n")
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    ["1[0-9]*5\n", "a.*e\n", "f.*j\n"])
+                                    [r"1[0-9]*5\n", r"a.*e\n", r"f.*j\n"])
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    ["1.*j\n"])
+                                    [r"1.*j\n"])
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    ["12345\n", "abcde\n", "fghij\n"])
-        assert test.match_re_dotall(UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]),
-                                    ["1[0-9]*5\n", "a.*e\n", "f.*j\n"])
-        assert test.match_re_dotall(UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]),
-                                    ["1.*j\n"])
-        assert test.match_re_dotall(UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]),
-                                    ["12345\n", "abcde\n", "fghij\n"])
+                                    [r"12345\n", r"abcde\n", r"fghij\n"])
+        assert test.match_re_dotall(UserList(["12345\n", "abcde\n", "fghij\n"]),
+                                    [r"1[0-9]*5\n", r"a.*e\n", r"f.*j\n"])
+        assert test.match_re_dotall(UserList(["12345\n", "abcde\n", "fghij\n"]),
+                                    [r"1.*j\n"])
+        assert test.match_re_dotall(UserList(["12345\n", "abcde\n", "fghij\n"]),
+                                    [r"12345\n", r"abcde\n", r"fghij\n"])
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    UserList(["1[0-9]*5\n",
-                                              "a.*e\n",
-                                              "f.*j\n"]))
+                                    UserList([r"1[0-9]*5\n", r"a.*e\n", r"f.*j\n"]))
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    UserList(["1.*j\n"]))
+                                    UserList([r"1.*j\n"]))
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]))
+                                    UserList([r"12345\n", r"abcde\n", r"fghij\n"]))
         assert test.match_re_dotall("12345\nabcde\nfghij\n",
-                                    "1[0-9]*5\na.*e\nf.*j\n")
-        assert test.match_re_dotall("12345\nabcde\nfghij\n", "1.*j\n")
+                                    r"1[0-9]*5\na.*e\nf.*j\n")
+        assert test.match_re_dotall("12345\nabcde\nfghij\n", r"1.*j\n")
         assert test.match_re_dotall("12345\nabcde\nfghij\n",
-                                    "12345\nabcde\nfghij\n")
+                                    r"12345\nabcde\nfghij\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_re_dotall(lines, regexes)
         assert test.match_re_dotall(lines, lines)
 
@@ -1169,8 +1170,8 @@ sys.exit(0)
 """ % cwd
             stdout, stderr, status = self.call_python(script_input)
             assert status == 1, status
-            expect1 = "Regular expression error in '^a.*(e$': missing )\n"
-            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis\n"
+            expect1 = "Regular expression error in '^a.*(e$': missing )"
+            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
             assert (stderr.find(expect1) != -1 or
                     stderr.find(expect2) != -1), repr(stderr)
         finally:
@@ -1194,7 +1195,7 @@ sys.exit(0)
         assert test.match_re("12345\nabcde\n", "1[0-9]*5\na.*e\n")
         assert test.match_re("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_re(lines, regexes)
         assert test.match_re(lines, lines)
 
@@ -1207,7 +1208,7 @@ class match_stderr_TestCase(TestCmdTestCase):
         assert test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stderr(lines, regexes)
 
     def test_match_stderr_not_affecting_match_stdout(self):
@@ -1219,14 +1220,14 @@ class match_stderr_TestCase(TestCmdTestCase):
         assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
         assert test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stdout(lines, regexes)
 
     def test_match_stderr_custom_function(self):
@@ -1239,7 +1240,7 @@ class match_stderr_TestCase(TestCmdTestCase):
         assert not test.match_stderr("123\n123\n", "1\n1\n")
         assert test.match_stderr("123\n123\n", "111\n111\n")
         lines = ["123\n", "123\n"]
-        regexes = ["1\n", "1\n"]
+        regexes = [r"1\n", r"1\n"]
         assert test.match_stderr(lines, regexes)    # equal numbers of lines
 
     def test_match_stderr_TestCmd_function(self):
@@ -1247,10 +1248,10 @@ class match_stderr_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stderr = TestCmd.match_exact)
         assert not test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("abcde\n", "abcde\n")
-        assert not test.match_stderr("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
@@ -1259,10 +1260,10 @@ class match_stderr_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stderr=TestCmd.TestCmd.match_exact)
         assert not test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("abcde\n", "abcde\n")
-        assert not test.match_stderr("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
@@ -1271,10 +1272,10 @@ class match_stderr_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stderr='match_exact')
         assert not test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("abcde\n", "abcde\n")
-        assert not test.match_stderr("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
@@ -1287,7 +1288,7 @@ class match_stdout_TestCase(TestCmdTestCase):
         assert test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stdout(lines, regexes)
 
     def test_match_stdout_not_affecting_match_stderr(self):
@@ -1299,14 +1300,14 @@ class match_stdout_TestCase(TestCmdTestCase):
         assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
         assert test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stderr(lines, regexes)
 
     def test_match_stdout_custom_function(self):
@@ -1319,7 +1320,7 @@ class match_stdout_TestCase(TestCmdTestCase):
         assert not test.match_stdout("123\n123\n", "1\n1\n")
         assert test.match_stdout("123\n123\n", "111\n111\n")
         lines = ["123\n", "123\n"]
-        regexes = ["1\n", "1\n"]
+        regexes = [r"1\n", r"1\n"]
         assert test.match_stdout(lines, regexes)    # equal numbers of lines
 
     def test_match_stdout_TestCmd_function(self):
@@ -1327,10 +1328,10 @@ class match_stdout_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stdout = TestCmd.match_exact)
         assert not test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("abcde\n", "abcde\n")
-        assert not test.match_stdout("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
@@ -1339,10 +1340,10 @@ class match_stdout_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stdout=TestCmd.TestCmd.match_exact)
         assert not test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("abcde\n", "abcde\n")
-        assert not test.match_stdout("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
@@ -1351,10 +1352,10 @@ class match_stdout_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stdout='match_exact')
         assert not test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("abcde\n", "abcde\n")
-        assert not test.match_stdout("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
@@ -1470,20 +1471,20 @@ class preserve_TestCase(TestCmdTestCase):
     def test_preserve(self):
         """Test preserve()"""
         def cleanup_test(test, cond=None, stdout=""):
-            io = StringIO()
             save = sys.stdout
-            sys.stdout = io
-            try:
-                if cond:
-                    test.cleanup(cond)
-                else:
-                    test.cleanup()
-                o = io.getvalue()
-                assert o == stdout, "o = `%s', stdout = `%s'" % (o, stdout)
-            finally:
-                sys.stdout = save
+            with closing(StringIO()) as io:
+                sys.stdout = io
+                try:
+                    if cond:
+                        test.cleanup(cond)
+                    else:
+                        test.cleanup()
+                    o = io.getvalue()
+                    assert o == stdout, "o = `%s', stdout = `%s'" % (o, stdout)
+                finally:
+                    sys.stdout = save
 
-        test = TestCmd.TestCmd(workdir = '')
+        test = TestCmd.TestCmd(workdir='')
         wdir = test.workdir
         try:
             test.write('file1', "Test file #1\n")
@@ -1492,10 +1493,10 @@ class preserve_TestCase(TestCmdTestCase):
             assert not os.path.exists(wdir)
         finally:
             if os.path.exists(wdir):
-                shutil.rmtree(wdir, ignore_errors = 1)
+                shutil.rmtree(wdir, ignore_errors=1)
                 test._dirlist.remove(wdir)
 
-        test = TestCmd.TestCmd(workdir = '')
+        test = TestCmd.TestCmd(workdir='')
         wdir = test.workdir
         try:
             test.write('file2', "Test file #2\n")
@@ -1579,15 +1580,15 @@ class read_TestCase(TestCmdTestCase):
         wdir_file5 = os.path.join(test.workdir, 'file5')
 
         with open(wdir_file1, 'wb') as f:
-            f.write("")
+            f.write(to_bytes(""))
         with open(wdir_file2, 'wb') as f:
-            f.write("Test\nfile\n#2.\n")
+            f.write(to_bytes("Test\nfile\n#2.\n"))
         with open(wdir_foo_file3, 'wb') as f:
-            f.write("Test\nfile\n#3.\n")
+            f.write(to_bytes("Test\nfile\n#3.\n"))
         with open(wdir_file4, 'wb') as f:
-            f.write("Test\nfile\n#4.\n")
+            f.write(to_bytes("Test\nfile\n#4.\n"))
         with open(wdir_file5, 'wb') as f:
-            f.write("Test\r\nfile\r\n#5.\r\n")
+            f.write(to_bytes("Test\r\nfile\r\n#5.\r\n"))
 
         try:
             contents = test.read('no_file')
@@ -1604,6 +1605,7 @@ class read_TestCase(TestCmdTestCase):
             raise
 
         def _file_matches(file, contents, expected):
+            contents = to_str(contents)
             assert contents == expected, \
                 "Expected contents of " + str(file) + "==========\n" + \
                 expected + \
@@ -1874,29 +1876,25 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            test.run(arguments = ['arg1 arg2'])
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                assert expect == e, (expect, e)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
                                     verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            testx.run(arguments = ['arg1 arg2'])
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                assert expect == e, (expect, e)
 
             # Test calling TestCmd() with an explicit verbose = 2.
 
@@ -1925,43 +1923,39 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 2)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
                                     verbose = 2)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
 
-            testx.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             # Test calling TestCmd() with an explicit verbose = 3.
 
@@ -1970,41 +1964,37 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 2)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                expect = out_fmt % (len(stdout_line), stdout_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            expect = out_fmt % (len(stdout_line), stdout_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
-            assert e == expect, (e, expect)
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
+                assert e == expect, (e, expect)
 
             test = TestCmd.TestCmd(program = t.scriptout,
                                    interpreter = 'python',
                                    workdir = '',
                                    verbose = 3)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       '0', '')
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   '0', '')
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
-            assert e == expect, (e, expect)
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
+                assert e == expect, (e, expect)
 
             # Test letting TestCmd() pick up verbose = 2 from the environment.
 
@@ -2014,42 +2004,38 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    interpreter = 'python',
                                    workdir = '')
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '')
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
 
-            testx.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             # Test letting TestCmd() pick up verbose = 1 from the environment.
 
@@ -2060,29 +2046,25 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            test.run(arguments = ['arg1 arg2'])
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                assert expect == e, (expect, e)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
                                     verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            testx.run(arguments = ['arg1 arg2'])
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                assert expect == e, (expect, e)
 
         finally:
             sys.stdout = save_stdout
@@ -2624,11 +2606,11 @@ script_recv:  STDERR:  input
 
             p = test.start(stdin=1)
             input = 'stdin.write() input to the receive script\n'
-            p.stdin.write(input)
+            p.stdin.write(to_bytes(input))
             p.stdin.close()
             p.wait()
             with open(t.recv_out_path, 'rb') as f:
-                result = f.read()
+                result = to_str(f.read())
             expect = 'script_recv:  ' + input
             assert result == expect, repr(result)
 
@@ -2638,7 +2620,7 @@ script_recv:  STDERR:  input
             p.stdin.close()
             p.wait()
             with open(t.recv_out_path, 'rb') as f:
-                result = f.read()
+                result = to_str(f.read())
             expect = 'script_recv:  ' + input
             assert result == expect, repr(result)
 
@@ -2754,11 +2736,8 @@ sys.stderr.write("run2 STDERR second line\\n")
         # Everything before this prepared our "source directory."
         # Now do the real test.
         test = TestCmd.TestCmd(interpreter = 'python', workdir = '')
-        try:
-            output = test.stdout()
-        except IndexError:
-            pass
-        else:
+        output = test.stdout()
+        if output is not None:
             raise IndexError("got unexpected output:\n\t`%s'\n" % output)
         test.program_set('run1')
         test.run(arguments = 'foo bar')
@@ -3330,9 +3309,11 @@ class write_TestCase(TestCmdTestCase):
             assert not os.path.exists(test.workpath('file10'))
 
         with open(test.workpath('file8'), 'r') as f:
-            assert f.read() == "Test file #8.\n"
+            res = f.read()
+            assert res == "Test file #8.\n", res
         with open(test.workpath('file9'), 'rb') as f:
-            assert f.read() == "Test file #9.\r\n"
+            res = to_str(f.read())
+            assert res == "Test file #9.\r\n", res
 
 
 class variables_TestCase(TestCmdTestCase):

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -278,6 +278,7 @@ class TestCommon(TestCmd):
 
     def must_be_writable(self, *files):
         """Ensures that the specified file(s) exist and are writable.
+
         An individual file can be specified as a list of directory names,
         in which case the pathname will be constructed by concatenating
         them.  Exits FAILED if any of the files does not exist or is
@@ -292,46 +293,47 @@ class TestCommon(TestCmd):
             print("Unwritable files: `%s'" % "', `".join(unwritable))
         self.fail_test(missing + unwritable)
 
-    def must_contain(self, file, required, mode='rb', find=None):
-        """Ensures specified file contains the required text.
-
-        Args:
-            file (string): name of file to search in.
-            required (string): text to search for. For the default
-              find function, type must match the return type from
-              reading the file; current implementation will convert.
-            mode (string): file open mode.
-            find (func): optional custom search routine. Must take the
-              form "find(output, line)" non-negative integer on success
-              and None, False, or -1, on failure.
+    def must_contain(self, fname, required, mode='rb', find=None):
+        """Ensures a file contains the required text.
 
         Calling test exits FAILED if search result is false
+
+        :param str fname: name of file to search in.
+        :param required: text to search for. For the default
+            find function, type must match the return type from
+            reading the file; current implementation will convert.
+        :type required: str or bytes
+        :param str mode: file open mode.
+        :param callable find: (optional) custom search routine. Must take the
+            form "find(output, line)", returning a true value on success
+            and a false value on failure.
         """
         if 'b' in mode:
-            # Python 3: reading a file in binary mode returns a 
+            # Python 3: reading a file in binary mode returns a
             # bytes object. We cannot find the index of a different
             # (str) type in that, so convert.
             required = to_bytes(required)
-        file_contents = self.read(file, mode)
+        file_contents = self.read(fname, mode)
 
         if not contains(file_contents, required, find):
             print("File `%s' does not contain required string." % file)
             print(self.banner('Required string '))
             print(required)
-            print(self.banner('%s contents ' % file))
+            print(self.banner('%s contents ' % fname))
             print(file_contents)
             self.fail_test()
 
     def must_contain_all(self, output, input, title=None, find=None):
-        """Ensures that the specified output string (first argument)
-        contains all of the specified input as a block (second argument).
+        """Ensures the output contains the input text as a block.
 
-        An optional third argument can be used to describe the type
-        of output being searched, and only shows up in failure output.
-
-        An optional fourth argument can be used to supply a different
-        function, of the form "find(output, line)", to use when searching
-        for lines in the output.
+        :param output: the text to search in
+        :type output: str or list[str]
+        :param str input: the text to searh for
+        :param str title: (optional) describe the type of output being
+            searched. Only used in failure reports.
+        :param callable find: (optional) custom search routine. Must take the
+            form "find(output, line)", returning a true value on success
+            and a false value on failure.
         """
         if is_List(output):
             output = os.newline.join(output)
@@ -595,6 +597,9 @@ class TestCommon(TestCmd):
         """
         Post-processes running a subcommand, checking for failure
         status and displaying output appropriately.
+
+        Calls the supplied match function if expected stdout/stderr
+        was supplied.
         """
         if _failed(self, status):
             expect = ''

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -109,10 +109,12 @@ try:
     from collections import UserList
 except ImportError:
     # no 'collections' module or no UserList in collections
-    exec('from UserList import UserList')
+    from UserList import UserList
 
 from TestCmd import *
 from TestCmd import __all__
+
+from SCons.Util import to_str
 
 __all__.extend([ 'TestCommon',
                  'exe_suffix',
@@ -499,7 +501,7 @@ class TestCommon(TestCmd):
         if not match:
             match = self.match
         try:
-            self.fail_test(not match(to_str(file_contents), to_str(expect)), message=message)
+            self.fail_test(not match(file_contents, expect), message=message)
         except KeyboardInterrupt:
             raise
         except:

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -308,15 +308,15 @@ class TestCommon(TestCmd):
             form "find(output, line)", returning a true value on success
             and a false value on failure.
         """
+        file_contents = self.read(fname, mode)
         if 'b' in mode:
             # Python 3: reading a file in binary mode returns a
             # bytes object. We cannot find the index of a different
             # (str) type in that, so convert.
-            required = to_bytes(required)
-        file_contents = self.read(fname, mode)
+            file_contents = to_str(file_contents)
 
         if not contains(file_contents, required, find):
-            print("File `%s' does not contain required string." % file)
+            print("File `%s' does not contain required string." % fname)
             print(self.banner('Required string '))
             print(required)
             print(self.banner('%s contents ' % fname))
@@ -484,13 +484,18 @@ class TestCommon(TestCmd):
         print("Missing one of: `%s'" % "', `".join(missing))
         self.fail_test(missing)
 
-    def must_match(self, file, expect, mode = 'rb', match=None, message=None, newline=None):
+    def must_match(self, fname, expect, mode='rb', match=None, message=None, newline=None):
         """Matches the contents of the specified file (first argument)
         against the expected contents (second argument).  The expected
         contents are a list of lines or a string which will be split
         on newlines.
         """
-        file_contents = self.read(file, mode, newline)
+        file_contents = self.read(fname, mode, newline)
+        if 'b' in mode:
+            # Python 3: reading a file in binary mode returns a
+            # bytes object. We cannot find the index of a different
+            # (str) type in that, so convert.
+            file_contents = to_str(file_contents)
         if not match:
             match = self.match
         try:
@@ -498,20 +503,25 @@ class TestCommon(TestCmd):
         except KeyboardInterrupt:
             raise
         except:
-            print("Unexpected contents of `%s'" % file)
+            print("Unexpected contents of `%s'" % fname)
             self.diff(expect, file_contents, 'contents ')
             raise
 
-    def must_not_contain(self, file, banned, mode = 'rb', find = None):
+    def must_not_contain(self, fname, banned, mode='rb', find=None):
         """Ensures that the specified file doesn't contain the banned text.
         """
-        file_contents = self.read(file, mode)
+        file_contents = self.read(fname, mode)
+        if 'b' in mode:
+            # Python 3: reading a file in binary mode returns a
+            # bytes object. We cannot find the index of a different
+            # (str) type in that, so convert.
+            file_contents = to_str(file_contents)
 
         if contains(file_contents, banned, find):
-            print("File `%s' contains banned string." % file)
+            print("File `%s' contains banned string." % fname)
             print(self.banner('Banned string '))
             print(banned)
-            print(self.banner('%s contents ' % file))
+            print(self.banner('%s contents ' % fname))
             print(file_contents)
             self.fail_test()
 
@@ -656,7 +666,7 @@ class TestCommon(TestCmd):
             sys.stderr.write('Exception trying to execute: %s\n' % cmd_args)
             raise e
 
-    def finish(self, popen, stdout = None, stderr = '', status = 0, **kw):
+    def finish(self, popen, stdout=None, stderr='', status=0, **kw):
         """
         Finishes and waits for the process being run under control of
         the specified popen argument.  Additional arguments are similar
@@ -679,8 +689,8 @@ class TestCommon(TestCmd):
         self._complete(self.stdout(), stdout,
                        self.stderr(), stderr, status, match)
 
-    def run(self, options = None, arguments = None,
-                  stdout = None, stderr = '', status = 0, **kw):
+    def run(self, options=None, arguments=None,
+                  stdout=None, stderr='', status=0, **kw):
         """Runs the program under test, checking that the test succeeded.
 
         The parameters are the same as the base TestCmd.run() method,
@@ -701,9 +711,9 @@ class TestCommon(TestCmd):
                         command.  A value of None means don't
                         test exit status.
 
-        By default, this expects a successful exit (status = 0), does
-        not test standard output (stdout = None), and expects that error
-        output is empty (stderr = "").
+        By default, this expects a successful exit (status=0), does
+        not test standard output (stdout=None), and expects that error
+        output is empty (stderr="").
         """
         kw['arguments'] = self.options_arguments(options, arguments)
         try:

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -1840,7 +1840,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*fail
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -1891,10 +1891,11 @@ class run_TestCase(TestCommonTestCase):
 
         expect_stdout = lstrip("""\
         STDOUT =========================================================================
+        None
         STDERR =========================================================================
         """)
 
-        expect_stderr = lstrip("""\
+        expect_stderr_py2 = lstrip("""\
         Exception trying to execute: \\[%s, '[^']*pass'\\]
         Traceback \\((innermost|most recent call) last\\):
           File "<stdin>", line \\d+, in (\\?|<module>)
@@ -1906,7 +1907,28 @@ class run_TestCase(TestCommonTestCase):
             raise e
         TypeError: forced TypeError
         """ % re.escape(repr(sys.executable)))
-        expect_stderr = re.compile(expect_stderr, re.M)
+
+
+        expect_stderr_py3 = lstrip("""\
+        Exception trying to execute: \\[%s, '[^']*pass'\\]
+        Traceback \\((innermost|most recent call) last\\):
+          File "<stdin>", line \\d+, in (\\?|<module>)
+          File "[^"]+TestCommon.py", line \\d+, in run
+            TestCmd.run\\(self, \\*\\*kw\\)
+          File "[^"]+TestCmd.py", line \\d+, in run
+            .*
+          File "[^"]+TestCommon.py", line \\d+, in start
+            raise e
+          File "[^"]+TestCommon.py", line \\d+, in start
+            .*
+          File "<stdin>", line \\d+, in raise_exception
+        TypeError: forced TypeError
+        """ % re.escape(repr(sys.executable)))
+        
+        if TestCmd.IS_PY3:
+            expect_stderr = re.compile(expect_stderr_py3, re.M)
+        else:
+            expect_stderr = re.compile(expect_stderr_py2, re.M)
 
         self.run_execution_test(script, expect_stdout, expect_stderr)
 
@@ -2022,7 +2044,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*pass
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2052,7 +2074,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*fail
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2084,7 +2106,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*pass
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2118,7 +2140,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*stderr
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2172,7 +2194,11 @@ class run_TestCase(TestCommonTestCase):
         tc.run()
         """)
 
-        self.SIGTERM = signal.SIGTERM
+        try:
+            # PY3: these are enums now
+            self.SIGTERM = signal.SIGTERM.value
+        except AttributeError:
+            self.SIGTERM = signal.SIGTERM
 
         # Script returns the signal value as a negative number.
         expect_stdout = lstrip("""\


### PR DESCRIPTION
NOTE: this is being pushed to have a PR to try experiments on the `Interactive/configure.py` test. There's nothing wrong with the subject of the PR as such, but it's not high prio at all - I'll update this summary if the state changes.  The configure test does use one of the match functions which got some updates, though the current updates should not affect the test behavior. Making it a draft since apparently appveyor builds still trigger on drafts, and that'e where we are seeing the fail.

====
Looping over a range given by the length of an object is no longer the preferred idiom; instead just loop over the object, using `enumerate` if we *really* need the index as well.

Along the way, document some test functions, and update the docs on some other test functions.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
