### PR TITLE
Tweak a few tests

### DIFF
--- a/test/Batch/action-changed.py
+++ b/test/Batch/action-changed.py
@@ -43,12 +43,10 @@ import sys
 sep = sys.argv.index('--')
 targets = sys.argv[1:sep]
 sources = sys.argv[sep+1:]
-for i in range(len(targets)):
-    t = targets[i]
-    s = sources[i]
-    with open(t, 'wb') as fp, open(s, 'rb') as infp:
-        fp.write(bytearray('%s\\n','utf-8'))
-        fp.write(infp.read())
+for t, s in zip(targets, sources):
+    with open(t, 'wb') as ofp, open(s, 'rb') as ifp:
+        ofp.write(bytearray('%s\\n', 'utf-8'))
+        ofp.write(ifp.read())
 sys.exit(0)
 """
 

--- a/test/SConsignFile/use-gdbm.py
+++ b/test/SConsignFile/use-gdbm.py
@@ -36,8 +36,13 @@ test = TestSCons.TestSCons()
 
 try:
     import gdbm
+    use_dbm = "gdbm"
 except ImportError:
-    test.skip_test('No gdbm in this version of Python; skipping test.\n')
+    try:
+        import dbm.gnu
+        use_dbm = "dbm.gnu"
+    except ImportError:
+        test.skip_test('No GNU dbm in this version of Python; skipping test.\n')
 
 test.subdir('subdir')
 
@@ -51,8 +56,8 @@ sys.exit(0)
 #
 test.write('SConstruct', """
 import sys
-import gdbm
-SConsignFile('.sconsign', gdbm)
+import %(use_dbm)s
+SConsignFile('.sconsign', %(use_dbm)s)
 B = Builder(action = '%(_python_)s build.py $TARGETS $SOURCES')
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'f1.out', source = 'f1.in')
@@ -72,7 +77,7 @@ test.must_exist(test.workpath('.sconsign'))
 test.must_not_exist(test.workpath('.sconsign.dblite'))
 test.must_not_exist(test.workpath('subdir', '.sconsign'))
 test.must_not_exist(test.workpath('subdir', '.sconsign.dblite'))
-  
+
 test.must_match('f1.out', "f1.in\n")
 test.must_match('f2.out', "f2.in\n")
 test.must_match(['subdir', 'f3.out'], "subdir/f3.in\n")

--- a/test/SWIG/build-dir.py
+++ b/test/SWIG/build-dir.py
@@ -132,8 +132,8 @@ public:
 
     %pythoncode %{
     def __iter__(self):
-        for i in range(len(self)):
-            yield self[i]
+        for s in self:
+            yield s
     %}
   }
 };

--- a/test/Win32/bad-drive.py
+++ b/test/Win32/bad-drive.py
@@ -43,9 +43,9 @@ if sys.platform != 'win32':
     msg = "Skipping drive-letter test on non-Windows platform '%s'\n" % sys.platform
     test.skip_test(msg)
 
+# start at the end looking for unused drive letter
 bad_drive = None
-for i in range(len(ascii_uppercase)-1, -1, -1):
-    d = ascii_uppercase[i]
+for d in reversed(ascii_uppercase):
     if not os.path.isdir(d + ':' + os.sep):
         bad_drive = d + ':'
         break

--- a/test/option--C.py
+++ b/test/option--C.py
@@ -34,10 +34,10 @@ def match_normcase(lines, matches):
     if not isinstance(matches, list):
         matches = matches.split("\n")
     if len(lines) != len(matches):
-        return
-    for i in range(len(lines)):
-        if os.path.normcase(lines[i]) != os.path.normcase(matches[i]):
-            return
+        return None
+    for line, match in zip(lines, matches):
+        if os.path.normcase(line) != os.path.normcase(match):
+            return None
     return 1
 
 test = TestSCons.TestSCons(match=match_normcase)


### PR DESCRIPTION
`for i in range(len(foo))` idiom changed to iterate directly over lists instead of indexing them.  `zip() `generates the iterator in the case with two lists. `reversed()` used for the Windows drive-letter test.

`gdbm` is not gone, just renamed (`dbm.gnu`). change test to find under either name.

Use a context manager for closing `StringIO` objects opened for capturing standard I/O streams.

No changes to scons source, only tests, so no doc/CHANGES.txt edits.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
