### PR TITLE
test harness: fix TestCommon tests

### DIFF
--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -427,7 +427,7 @@ test.must_exist(['listOfLists', 'listsTest', 'com', 'javasource', 'JavaFile3.cla
 test.must_exist(['listOfLists', 'listsTest', 'com', 'resource', 'resource1.txt'])
 test.must_exist(['listOfLists', 'listsTest', 'com', 'resource', 'resource2.txt'])
 test.must_exist(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'])
-test.must_contain(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'], b"MyManifestTest: Test" )
+test.must_contain(['listOfLists', 'listsTest', 'META-INF', 'MANIFEST.MF'], "MyManifestTest: Test" )
 
 #######
 # test different style of passing in dirs

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -1840,7 +1840,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*fail
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -1891,10 +1891,11 @@ class run_TestCase(TestCommonTestCase):
 
         expect_stdout = lstrip("""\
         STDOUT =========================================================================
+        None
         STDERR =========================================================================
         """)
 
-        expect_stderr = lstrip("""\
+        expect_stderr_py2 = lstrip("""\
         Exception trying to execute: \\[%s, '[^']*pass'\\]
         Traceback \\((innermost|most recent call) last\\):
           File "<stdin>", line \\d+, in (\\?|<module>)
@@ -1906,7 +1907,28 @@ class run_TestCase(TestCommonTestCase):
             raise e
         TypeError: forced TypeError
         """ % re.escape(repr(sys.executable)))
-        expect_stderr = re.compile(expect_stderr, re.M)
+
+
+        expect_stderr_py3 = lstrip("""\
+        Exception trying to execute: \\[%s, '[^']*pass'\\]
+        Traceback \\((innermost|most recent call) last\\):
+          File "<stdin>", line \\d+, in (\\?|<module>)
+          File "[^"]+TestCommon.py", line \\d+, in run
+            TestCmd.run\\(self, \\*\\*kw\\)
+          File "[^"]+TestCmd.py", line \\d+, in run
+            .*
+          File "[^"]+TestCommon.py", line \\d+, in start
+            raise e
+          File "[^"]+TestCommon.py", line \\d+, in start
+            .*
+          File "<stdin>", line \\d+, in raise_exception
+        TypeError: forced TypeError
+        """ % re.escape(repr(sys.executable)))
+
+        if TestCmd.IS_PY3:
+            expect_stderr = re.compile(expect_stderr_py3, re.M)
+        else:
+            expect_stderr = re.compile(expect_stderr_py2, re.M)
 
         self.run_execution_test(script, expect_stdout, expect_stderr)
 
@@ -2022,7 +2044,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*pass
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2052,7 +2074,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*fail
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2084,7 +2106,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*pass
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2118,7 +2140,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*stderr
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2172,7 +2194,11 @@ class run_TestCase(TestCommonTestCase):
         tc.run()
         """)
 
-        self.SIGTERM = signal.SIGTERM
+        try:
+            # PY3: these are enums now
+            self.SIGTERM = signal.SIGTERM.value
+        except AttributeError:
+            self.SIGTERM = signal.SIGTERM
 
         # Script returns the signal value as a negative number.
         expect_stdout = lstrip("""\


### PR DESCRIPTION
The `testing/harness/TestCommonTests.py` unit tests do not currently pass.  Note they are not run by the CI system, or in fact by doing `runtests -a,` since they're in a directory that is not searched.
After these changes, there are no fails.  This is a test-only change.

Also, the methods that used Google-style docbook markup are changed to REsT-style markup.  Our current doc producer, epydoc, does not understand the Google style, and we shouldn't mix styles; can convert them all in bulk later if we switch to Sphinx as the production tool.

Failure log excerpt:

```
1/1 (100.00%) /usr/bin/python3 testing/framework/TestCommonTests.py
......F.....................................FF.FF....................F............F.....

Ran 88 tests in 3.958s

FAILED (failures=7)

==> These fails are relatively minor nits:

1.  assert stdout == expect, repr(stdout)
AssertionError: "File `file1' does not contain required string.\nRequired string ================================================================\nb'1 c'\nfile1 contents =================================================================\nb'file1 does not match\\n'\n"

2.  assert stdout == expect, repr(stdout)
AssertionError: ''

3.  assert stdout == expect, repr(stdout)
AssertionError: ''

4.  assert stderr == "PASSED\n", stderr
...
    return subseq in seq
TypeError: a bytes-like object is required, not 'str'

5.  assert stderr == "PASSED\n", stderr
...
    return subseq in seq
TypeError: a bytes-like object is required, not 'str'

6. AssertionError: 
********************************************************************************
STDOUT =========================================================================
STDERR =========================================================================
********************************************************************************
STDOUT =========================================================================
None
STDERR =========================================================================
********************************************************************************

7. AssertionError: 
********************************************************************************
/tmp/testcmd.798442.c4mte451/sub dir/signal returned -Signals.SIGTERM
STDOUT =========================================================================

STDERR =========================================================================

********************************************************************************
/tmp/testcmd.798442.c4mte451/sub dir/signal returned -15
STDOUT =========================================================================

STDERR =========================================================================

********************************************************************************
```

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
