### PR TITLE
Don't hide exceptions when command does not exist

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -69,6 +69,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Mathew Robinson:
     - Update cache debug output to include cache hit rate.
+    - No longer unintentionally hide exceptions in Action.py
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700
 

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -808,7 +808,7 @@ def _subproc(scons_env, cmd, error = 'ignore', **kw):
     kw['env'] = new_env
 
     try:
-        pobj =  subprocess.Popen(cmd, **kw)
+        pobj = subprocess.Popen(cmd, **kw)
     except EnvironmentError as e:
         if error == 'raise': raise
         # return a dummy Popen instance that only returns error
@@ -826,9 +826,10 @@ def _subproc(scons_env, cmd, error = 'ignore', **kw):
     finally:
         # clean up open file handles stored in parent's kw
         for k, v in kw.items():
-            if hasattr(v, 'close'):
+            if inspect.ismethod(getattr(v, 'close', None)):
                 v.close()
-        return pobj
+
+    return pobj
 
 
 class CommandAction(_ActionAction):

--- a/src/engine/SCons/ActionTests.py
+++ b/src/engine/SCons/ActionTests.py
@@ -44,6 +44,7 @@ import re
 import sys
 import types
 import unittest
+import subprocess
 
 import SCons.Action
 import SCons.Environment
@@ -2273,6 +2274,22 @@ class ObjectContentsTestCase(unittest.TestCase):
         assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(expected[
             sys.version_info[:2]])
 
+    def test_uncaught_exception_bubbles(self):
+        """Test that _subproc bubbles uncaught exceptions"""
+        try:
+            pobj = SCons.Action._subproc(Environment(),
+                                         None,
+                                         stdin='devnull',
+                                         stderr='devnull',
+                                         stdout=subprocess.PIPE)
+            pobj.wait()
+        except EnvironmentError:
+            pass
+        except Exception:
+            # pass the test
+            return
+
+        raise Exception("expected a non-EnvironmentError exception")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If an Action is and any non `EnvironmentError` exception occurs the current implementation hides this exception unintentionally. This is caused by using a finally block that returns pobj but pobj is not guaranteed to be assigned since if the try failed and an exception that's not caught by the catch is thrown then pobj never gets assigned but the finally still gets executed. This then throws yet another exception for trying to return an unassigned variable. This new exception prevents you from knowing what original exception caused the behavior in the first place leaving you with a useless error message.

An example case would be trying to create an Action with that uses a command that does not exist on the system you see:

```
UnboundLocalError: local variable 'pobj' referenced before assignment:
  File "/Users/mathewrobinson/Work/mongo/SConstruct", line 3643:
    env.Tool('icecream')
  File "/Users/mathewrobinson/Work/mongo/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Environment.py", line 1789:
    tool(self)
  File "/Users/mathewrobinson/Work/mongo/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Tool/__init__.py", line 296:
    self.generate(env, *args, **kw)
  File "/Users/mathewrobinson/Work/mongo/site_scons/site_tools/icecream.py", line 28:
    if not exists(env):
  File "/Users/mathewrobinson/Work/mongo/site_scons/site_tools/icecream.py", line 185:
    stderr='devnull', stdout=subprocess.PIPE)
  File "/Users/mathewrobinson/Work/mongo/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Action.py", line 825:
    return pobj
```

With this change the "real" exception will now bubble up giving you a more accurate stack trace:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType:
  File "/Users/mathewrobinson/Work/mongo/SConstruct", line 3643:
    env.Tool('icecream')
  File "/Users/mathewrobinson/Work/mongo/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Environment.py", line 1789:
    tool(self)
  File "/Users/mathewrobinson/Work/mongo/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Tool/__init__.py", line 296:
    self.generate(env, *args, **kw)
  File "/Users/mathewrobinson/Work/mongo/site_scons/site_tools/icecream.py", line 28:
    if not exists(env):
  File "/Users/mathewrobinson/Work/mongo/site_scons/site_tools/icecream.py", line 185:
    stderr='devnull', stdout=subprocess.PIPE)
  File "/Users/mathewrobinson/Work/mongo/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Action.py", line 805:
    pobj =  subprocess.Popen(cmd, **kw)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 775:
    restore_signals, start_new_session)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 1436:
    executable = os.fsencode(executable)
  File "/Users/mathewrobinson/.virtualenvs/mongo/bin/../lib/python3.7/os.py", line 809:
    filename = fspath(filename)  # Does type-checking of `filename`.
```

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
