### PR TITLE
Fix value node when used as part of a build on python3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Dirk Baechle:
     - Added Docker images for building and testing SCons. (issue #3585)
 
+  From Jason Kenny
+    - Fix python3 crash when Value node get_text_content when child content does not have decode()
+
   From James Benton:
     - Improve Visual Studio solution/project generation code to add support
       for a per-variant cppflags. Intellisense can be affected by cppflags,

--- a/SCons/Node/Python.py
+++ b/SCons/Node/Python.py
@@ -144,7 +144,8 @@ class Value(SCons.Node.Node):
         ###TODO: something reasonable about universal newlines
         contents = str(self.value)
         for kid in self.children(None):
-            contents = contents + kid.get_contents().decode()
+            # Get csig() value of child as this is more efficent
+            contents = contents + kid.get_csig()
         return contents
 
     def get_contents(self):

--- a/test/Value/GetContent.py
+++ b/test/Value/GetContent.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Test the Value node as a build target
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write('SConstruct', """
+import SCons.Script
+def null_build(target, source, env):
+    pass
+env = DefaultEnvironment()
+env['BUILDERS']['ValueBuilder'] =  SCons.Builder.Builder(
+    action=SCons.Action.Action(null_build),
+    target_factory=SCons.Node.Python.Value,    
+)    
+v = env.ValueBuilder("myvalue",env.Dir("#"))
+v[0].get_text_contents()
+""")
+
+test.run()
+test.pass_test()
+


### PR DESCRIPTION
Fixes problem with Value not not able to get child content when used in a builder

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
