### PR TITLE
Use more idiomatic Python

### DIFF
--- a/src/engine/SCons/Scanner/LaTeX.py
+++ b/src/engine/SCons/Scanner/LaTeX.py
@@ -372,9 +372,9 @@ class LaTeX(SCons.Scanner.Base):
                     inc_list = include[2].split(',')
                 else:
                     inc_list = include[1].split(',')
-                for j in range(len(inc_list)):
-                    split_includes.append( (inc_type, inc_subdir, inc_list[j]) )
-            #
+                for inc in inc_list:
+                    split_includes.append((inc_type, inc_subdir, inc))
+
             includes = split_includes
             node.includes = includes
 


### PR DESCRIPTION
Minor: replace an instance of `for i in range(len(foo))` with the now preferred `for i in foo`.  This change didn't naturally fit with any of the other instances of this usage, so is submitted by itself.

No behavior change, didn't seem worth a CHANGES.txt edit.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
