### PR TITLE
Update Docbook test stylesheets

### DIFF
--- a/test/Docbook/basedir/htmlchunked/image/html.xsl
+++ b/test/Docbook/basedir/htmlchunked/image/html.xsl
@@ -24,11 +24,11 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunkfast.xsl"/> 
+	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunkfast.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +52,4 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
-
+</xsl:stylesheet>

--- a/test/Docbook/basedir/htmlhelp/image/htmlhelp.xsl
+++ b/test/Docbook/basedir/htmlhelp/image/htmlhelp.xsl
@@ -24,11 +24,11 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/htmlhelp/htmlhelp.xsl"/> 
+	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/htmlhelp/htmlhelp.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +52,4 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
-
+</xsl:stylesheet>

--- a/test/Docbook/basedir/slideshtml/image/slides.xsl
+++ b/test/Docbook/basedir/slideshtml/image/slides.xsl
@@ -24,11 +24,11 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/html/plain.xsl"/> 
+	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +52,4 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
-
+</xsl:stylesheet>

--- a/test/Docbook/rootname/htmlchunked/image/html.xsl
+++ b/test/Docbook/rootname/htmlchunked/image/html.xsl
@@ -24,11 +24,11 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunkfast.xsl"/> 
+	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunkfast.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +52,4 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
-
+</xsl:stylesheet>

--- a/test/Docbook/rootname/htmlhelp/image/htmlhelp.xsl
+++ b/test/Docbook/rootname/htmlhelp/image/htmlhelp.xsl
@@ -24,11 +24,11 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/htmlhelp/htmlhelp.xsl"/> 
+	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/htmlhelp/htmlhelp.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +52,4 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
-
+</xsl:stylesheet>

--- a/test/Docbook/rootname/slideshtml/image/slides.xsl
+++ b/test/Docbook/rootname/slideshtml/image/slides.xsl
@@ -24,11 +24,11 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/html/plain.xsl"/> 
+	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +52,4 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
-
+</xsl:stylesheet>


### PR DESCRIPTION
Real change to two files, as apparently a system stylesheet has moved (checked in multiple Ubuntu versions, and in upstream dockbook-xsl) from html to xhtml path. Or to be more precise, in old docbook-xsl packages, both subdirectories existed but in newer releases only the xhtml subdirectory exists.
```
-       <xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/html/plain.xsl"/>
+       <xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl"/>
```

The other changes were to change file to standard line endings (not Windows) and quiet git complaints about whitespace errors. Unfortunately the line-endings change makes it look like the files were 100% replaced.

This is a test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
