### PR TITLE
test harness: fix TestCmd tests

### DIFF
--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -468,6 +468,14 @@ def pass_test(self=None, condition=1, function=None):
 
 def match_exact(lines=None, matches=None, newline=os.sep):
     """
+    Match function using exact match.
+
+    :param lines: data lines
+    :type lines: str or list[str]
+    :param matches: expected lines to match
+    :type matches: str or list[str]
+    :param newline: line separator
+    :returns: an object (1) on match, else None, like re.match
     """
 
     if isinstance(lines, bytes) or bytes is str:
@@ -478,30 +486,51 @@ def match_exact(lines=None, matches=None, newline=os.sep):
     if not is_List(matches):
         matches = matches.split(newline)
     if len(lines) != len(matches):
-        return
-    for i in range(len(lines)):
-        if lines[i] != matches[i]:
-            return
+        return None
+    for line, match in zip(lines, matches):
+        if line != match:
+            return None
     return 1
 
 
 def match_caseinsensitive(lines=None, matches=None):
     """
+    Match function using case-insensitive matching.
+
+    Only a simplistic comparison is done, based on lowercasing the
+    strings. This has plenty of holes for unicode data using
+    non-English languages.
+
+    TODO: casefold() is better than lower() if we don't need Py2 support.
+
+    :param lines: data lines
+    :type lines: str or list[str]
+    :param matches: expected lines to match
+    :type matches: str or list[str]
+    :returns: True or False
+    :returns: an object (1) on match, else None, like re.match
     """
     if not is_List(lines):
         lines = lines.split("\n")
     if not is_List(matches):
         matches = matches.split("\n")
     if len(lines) != len(matches):
-        return
-    for i in range(len(lines)):
-        if lines[i].lower() != matches[i].lower():
-            return
+        return None
+    for line, match in zip(lines, matches):
+        if line.lower() != match.lower():
+            return None
     return 1
 
 
 def match_re(lines=None, res=None):
     """
+    Match function using line-by-line regular expression match.
+
+    :param lines: data lines
+    :type lines: str or list[str]
+    :param res: regular expression(s) for matching
+    :type res: str or list[str]
+    :returns: an object (1) on match, else None, like re.match
     """
     if not is_List(lines):
         # CRs mess up matching (Windows) so split carefully
@@ -510,29 +539,39 @@ def match_re(lines=None, res=None):
         res = res.split("\n")
     if len(lines) != len(res):
         print("match_re: expected %d lines, found %d" % (len(res), len(lines)))
-        return
-    for i in range(len(lines)):
-        s = "^" + res[i] + "$"
+        return None
+    for i, (line, regex) in enumerate(zip(lines, res)):
+        s = r"^{}$".format(regex)
         try:
             expr = re.compile(s)
         except re.error as e:
             msg = "Regular expression error in %s: %s"
             raise re.error(msg % (repr(s), e.args[0]))
-        if not expr.search(lines[i]):
-            print("match_re: mismatch at line %d:\n  search re='%s'\n  line='%s'" % (
-                i, s, lines[i]))
-            return
+        if not expr.search(line):
+            miss_tmpl = "match_re: mismatch at line {}:\n  search re='{}'\n  line='{}'"
+            print(miss_tmpl.format(i, s, line))
+            return None
     return 1
 
 
 def match_re_dotall(lines=None, res=None):
     """
+    Match function using regular expression match.
+
+    Unlike match_re, the arguments are converted to strings (if necessary)
+    and must match exactly.
+
+    :param lines: data lines
+    :type lines: str or list[str]
+    :param res: regular expression(s) for matching
+    :type res: str or list[str]
+    :returns: a match object, or None as for re.match
     """
     if not isinstance(lines, str):
         lines = "\n".join(lines)
     if not isinstance(res, str):
         res = "\n".join(res)
-    s = "^" + res + "$"
+    s = r"^{}$".format(res)
     try:
         expr = re.compile(s, re.DOTALL)
     except re.error as e:
@@ -542,11 +581,32 @@ def match_re_dotall(lines=None, res=None):
 
 
 def simple_diff(a, b, fromfile='', tofile='',
-                fromfiledate='', tofiledate='', n=3, lineterm='\n'):
-    """
-    A function with the same calling signature as difflib.context_diff
-    (diff -c) and difflib.unified_diff (diff -u) but which prints
-    output like the simple, unadorned 'diff" command.
+                fromfiledate='', tofiledate='', n=0, lineterm=''):
+    r"""
+    Compare two sequences of lines; generate the delta as a simple diff.
+
+    Similar to difflib.context_diff and difflib.unified_diff but
+    output is like from the 'diff" command without arguments. The function
+    keeps the same signature as the difflib ones so they will be
+    interchangeable,  but except for lineterm, the arguments beyond the
+    two sequences are ignored in this version. By default, the
+    diff is not created with trailing newlines, set the lineterm
+    argument to '\n' to do so.
+
+    :raises re.error: if a regex fails to compile
+
+    Example:
+
+    >>> print(''.join(simple_diff('one\ntwo\nthree\nfour\n'.splitlines(True),
+    ...       'zero\none\ntree\nfour\n'.splitlines(True), lineterm='\n')))
+    0a1
+    > zero
+    2,3c3
+    < two
+    < three
+    ---
+    > tree
+
     """
     a = [to_str(q) for q in a]
     b = [to_str(q) for q in b]
@@ -554,25 +614,30 @@ def simple_diff(a, b, fromfile='', tofile='',
 
     def comma(x1, x2):
         return x1 + 1 == x2 and str(x2) or '%s,%s' % (x1 + 1, x2)
-    result = []
+
     for op, a1, a2, b1, b2 in sm.get_opcodes():
         if op == 'delete':
-            result.append("%sd%d" % (comma(a1, a2), b1))
-            result.extend(['< ' + l for l in a[a1:a2]])
+            yield "{}d{}{}".format(comma(a1, a2), b1, lineterm)
+            for l in a[a1:a2]:
+                yield '< ' + l
         elif op == 'insert':
-            result.append("%da%s" % (a1, comma(b1, b2)))
-            result.extend(['> ' + l for l in b[b1:b2]])
+            yield "{}a{}{}".format(a1, comma(b1, b2), lineterm)
+            for l in b[b1:b2]:
+                yield '> ' + l
         elif op == 'replace':
-            result.append("%sc%s" % (comma(a1, a2), comma(b1, b2)))
-            result.extend(['< ' + l for l in a[a1:a2]])
-            result.append('---')
-            result.extend(['> ' + l for l in b[b1:b2]])
-    return result
+            yield "{}c{}{}".format(comma(a1, a2), comma(b1, b2), lineterm)
+            for l in a[a1:a2]:
+                yield '< ' + l
+            yield '---{}'.format(lineterm)
+            for l in b[b1:b2]:
+                yield '> ' + l
 
 
 def diff_re(a, b, fromfile='', tofile='',
             fromfiledate='', tofiledate='', n=3, lineterm='\n'):
     """
+    Compare a and b (lists of strings) where a are regexes.
+
     A simple "diff" of two sets of lines when the expected lines
     are regular expressions.  This is a really dumb thing that
     just compares each line in turn, so it doesn't look for
@@ -585,9 +650,8 @@ def diff_re(a, b, fromfile='', tofile='',
         a = a + [''] * (-diff)
     elif diff > 0:
         b = b + [''] * diff
-    i = 0
-    for aline, bline in zip(a, b):
-        s = "^" + aline + "$"
+    for i, (aline, bline) in enumerate(zip(a, b)):
+        s = r"^{}$".format(aline)
         try:
             expr = re.compile(s)
         except re.error as e:
@@ -598,7 +662,6 @@ def diff_re(a, b, fromfile='', tofile='',
             result.append('< ' + repr(a[i]))
             result.append('---')
             result.append('> ' + repr(b[i]))
-        i = i + 1
     return result
 
 
@@ -1030,7 +1093,7 @@ class TestCmd(object):
             condition = self.condition
         if self._preserve[condition]:
             for dir in self._dirlist:
-                print(u"Preserved directory " + dir + "\n")
+                print(u"Preserved directory " + dir)
         else:
             list = self._dirlist[:]
             list.reverse()
@@ -1246,6 +1309,7 @@ class TestCmd(object):
 
     def read(self, file, mode='rb', newline=None):
         """Reads and returns the contents of the specified file name.
+
         The file name may be a list, in which case the elements are
         concatenated with the os.path.join() method.  The file is
         assumed to be under the temporary working directory unless it
@@ -1265,6 +1329,7 @@ class TestCmd(object):
 
     def rmdir(self, dir):
         """Removes the specified dir name.
+
         The dir name may be a list, in which case the elements are
         concatenated with the os.path.join() method.  The dir is
         assumed to be under the temporary working directory unless it
@@ -1306,6 +1371,7 @@ class TestCmd(object):
         """Copies the contents of the specified folder srcdir from
         the directory of the called  script, to the current
         working directory.
+
         The srcdir name may be a list, in which case the elements are
         concatenated with the os.path.join() method.  The dstdir is
         assumed to be under the temporary working directory, it gets
@@ -1347,6 +1413,7 @@ class TestCmd(object):
     def file_fixture(self, srcfile, dstfile=None):
         """Copies the file srcfile from the directory of
         the called script, to the current working directory.
+
         The dstfile is assumed to be under the temporary working
         directory unless it is an absolute path name.
         If dstfile is specified its target directory gets created
@@ -1443,6 +1510,7 @@ class TestCmd(object):
     def fix_binary_stream(stream):
         """
         Handle stdout/stderr from popen when we specify universal_newlines = False.
+
         This will read from the pipes in binary mode, not decode the output,
         and not convert line endings to \n.
         We do this because in py3 (3.5) with universal_newlines=True, it will
@@ -1459,7 +1527,7 @@ class TestCmd(object):
             return stream
         # TODO: Run full tests on both platforms and see if this fixes failures
         # It seems that py3.6 still sets text mode if you set encoding.
-        elif sys.version_info[0] == 3:# TODO and sys.version_info[1] < 6:
+        elif sys.version_info[0] == 3:  # TODO and sys.version_info[1] < 6:
             stream = stream.decode('utf-8')
             stream = stream.replace('\r\n', '\n')
         elif sys.version_info[0] == 2:
@@ -1633,7 +1701,7 @@ class TestCmd(object):
             try:
                 os.mkdir(new)
             except OSError as e:
-                print("Got error creating dir:%s :%s"%(sub,e))
+                print("Got error creating dir: %s :%s" % (sub, e))
                 pass
             else:
                 count = count + 1

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -26,13 +26,22 @@ import os
 import shutil
 import signal
 import stat
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+from contextlib import closing
 import sys
 import tempfile
 import time
 import types
 import unittest
-from UserList import UserList
+try:
+    from collections import UserList
+except ImportError:
+    from UserList import UserList
+
+from SCons.Util import to_bytes, to_str
 
 
 # Strip the current directory so we get the right TestCmd.py module.
@@ -55,7 +64,7 @@ def _is_executable(path):
 def _clear_dict(dict, *keys):
     for key in keys:
         try:
-            dict[key] = ''  # del dict[key]
+            del dict[key]
         except KeyError:
             pass
 
@@ -156,9 +165,9 @@ class TestCmdTestCase(unittest.TestCase):
                              stdin=subprocess.PIPE,
                              stderr=subprocess.PIPE,
                              stdout=subprocess.PIPE)
-        stdout, stderr = p.communicate(input)
-        stdout = self.translate_newlines(stdout)
-        stderr = self.translate_newlines(stderr)
+        stdout, stderr = p.communicate(to_bytes(input))
+        stdout = self.translate_newlines(to_str(stdout))
+        stderr = self.translate_newlines(to_str(stderr))
         return stdout, stderr, p.returncode
 
     def popen_python(self, input, status=0, stdout="", stderr="", python=None):
@@ -181,7 +190,7 @@ class TestCmdTestCase(unittest.TestCase):
 
     def run_match(self, content, *args):
         expect = "%s:  %s:  %s:  %s\n" % args
-        content = self.translate_newlines(content)
+        content = self.translate_newlines(to_str(content))
         assert content == expect, \
                 "Expected %s ==========\n" % args[1] + expect + \
                 "Actual %s ============\n" % args[1] + content
@@ -257,6 +266,7 @@ result = TestCmd.TestCmd(workdir = '')
 sys.exit(0)
 """ % self.orig_cwd, stdout='my_exitfunc()\n')
 
+    @unittest.skipIf(TestCmd.IS_PY3, "No sys.exitfunc in Python 3")
     def test_exitfunc(self):
         """Test cleanup() when sys.exitfunc is set"""
         self.popen_python("""from __future__ import print_function
@@ -269,7 +279,6 @@ import TestCmd
 result = TestCmd.TestCmd(workdir = '')
 sys.exit(0)
 """ % self.orig_cwd, stdout='my_exitfunc()\n')
-
 
 
 class chmod_TestCase(TestCmdTestCase):
@@ -351,11 +360,8 @@ sys.stderr.write("run2 STDERR third line\\n")
             test = TestCmd.TestCmd(interpreter = 'python',
                                    workdir = '',
                                    combine = 1)
-            try:
-                output = test.stdout()
-            except IndexError:
-                pass
-            else:
+            output = test.stdout()
+            if output is not None:
                 raise IndexError("got unexpected output:\n\t`%s'\n" % output)
 
             # The underlying system subprocess implementations can combine
@@ -424,10 +430,13 @@ class diff_TestCase(TestCmdTestCase):
     def test_diff_re(self):
         """Test diff_re()"""
         result = TestCmd.diff_re(["abcde"], ["abcde"])
+        result = list(result)
         assert result == [], result
         result = TestCmd.diff_re(["a.*e"], ["abcde"])
+        result = list(result)
         assert result == [], result
         result = TestCmd.diff_re(["a.*e"], ["xxx"])
+        result = list(result)
         assert result == ['1c1', "< 'a.*e'", '---', "> 'xxx'"], result
 
     def test_diff_custom_function(self):
@@ -477,13 +486,13 @@ STDOUT==========================================================================
         script_input = """import sys
 sys.path = ['%s'] + sys.path
 import TestCmd
-assert TestCmd.diff_re(["a.*(e"], ["abcde"])
+assert TestCmd.diff_re([r"a.*(e"], ["abcde"])
 sys.exit(0)
 """ % self.orig_cwd
         stdout, stderr, status = self.call_python(script_input)
         assert status == 1, status
-        expect1 = "Regular expression error in '^a.*(e$': missing )\n"
-        expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis\n"
+        expect1 = "Regular expression error in '^a.*(e$': missing )"
+        expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
         assert (stderr.find(expect1) != -1 or
                 stderr.find(expect2) != -1), repr(stderr)
 
@@ -494,6 +503,7 @@ sys.path = ['%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.simple_diff(['a', 'b', 'c', 'e', 'f1'],
                                      ['a', 'c', 'd', 'e', 'f2'])
+result = list(result)
 expect = ['2d1', '< b', '3a3', '> d', '5c5', '< f1', '---', '> f2']
 assert result == expect, result
 sys.exit(0)
@@ -559,6 +569,7 @@ sys.path = ['%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.diff_re(['a', 'b', 'c', '.', 'f1'],
                                  ['a', 'c', 'd', 'e', 'f2'])
+result = list(result)
 expect = [
     '2c2',
     "< 'b'",
@@ -846,22 +857,22 @@ test.%s()
             _test_it(cwd, 'dir04', 'pass_test', 1)
             _test_it(cwd, 'dir05', 'fail_test', 1)
             _test_it(cwd, 'dir06', 'no_result', 1)
-            os.environ['PRESERVE'] = ''  # del os.environ['PRESERVE']
+            del os.environ['PRESERVE']
             os.environ['PRESERVE_PASS'] = '1'
             _test_it(cwd, 'dir07', 'pass_test', 1)
             _test_it(cwd, 'dir08', 'fail_test', 0)
             _test_it(cwd, 'dir09', 'no_result', 0)
-            os.environ['PRESERVE_PASS'] = ''  # del os.environ['PRESERVE_PASS']
+            del os.environ['PRESERVE_PASS']
             os.environ['PRESERVE_FAIL'] = '1'
             _test_it(cwd, 'dir10', 'pass_test', 0)
             _test_it(cwd, 'dir11', 'fail_test', 1)
             _test_it(cwd, 'dir12', 'no_result', 0)
-            os.environ['PRESERVE_FAIL'] = ''  # del os.environ['PRESERVE_FAIL']
+            del os.environ['PRESERVE_FAIL']
             os.environ['PRESERVE_NO_RESULT'] = '1'
             _test_it(cwd, 'dir13', 'pass_test', 0)
             _test_it(cwd, 'dir14', 'fail_test', 0)
             _test_it(cwd, 'dir15', 'no_result', 1)
-            os.environ['PRESERVE_NO_RESULT'] = '' # del os.environ['PRESERVE_NO_RESULT']
+            del os.environ['PRESERVE_NO_RESULT']
         finally:
             _clear_dict(os.environ, 'PRESERVE', 'PRESERVE_PASS', 'PRESERVE_FAIL', 'PRESERVE_NO_RESULT')
 
@@ -982,10 +993,10 @@ class match_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match = TestCmd.match_exact)
         assert not test.match("abcde\n", "a.*e\n")
         assert test.match("abcde\n", "abcde\n")
-        assert not test.match("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match(lines, regexes)
         assert test.match(lines, lines)
 
@@ -994,10 +1005,10 @@ class match_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match=TestCmd.TestCmd.match_exact)
         assert not test.match("abcde\n", "a.*e\n")
         assert test.match("abcde\n", "abcde\n")
-        assert not test.match("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match(lines, regexes)
         assert test.match(lines, lines)
 
@@ -1006,10 +1017,10 @@ class match_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match='match_exact')
         assert not test.match("abcde\n", "a.*e\n")
         assert test.match("abcde\n", "abcde\n")
-        assert not test.match("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match(lines, regexes)
         assert test.match(lines, lines)
 
@@ -1059,16 +1070,16 @@ class match_exact_TestCase(TestCmdTestCase):
 class match_re_dotall_TestCase(TestCmdTestCase):
     def test_match_re_dotall_function(self):
         """Test calling the TestCmd.match_re_dotall() function"""
-        assert TestCmd.match_re_dotall("abcde\nfghij\n", "a.*j\n")
+        assert TestCmd.match_re_dotall("abcde\nfghij\n", r"a.*j\n")
 
     def test_match_re_dotall_instance_method(self):
         """Test calling the TestCmd.TestCmd().match_re_dotall() instance method"""
         test = TestCmd.TestCmd()
-        test.match_re_dotall("abcde\\nfghij\\n", "a.*j\\n")
+        test.match_re_dotall("abcde\\nfghij\\n", r"a.*j\\n")
 
     def test_match_re_dotall_static_method(self):
         """Test calling the TestCmd.TestCmd.match_re_dotall() static method"""
-        assert TestCmd.TestCmd.match_re_dotall("abcde\nfghij\n", "a.*j\n")
+        assert TestCmd.TestCmd.match_re_dotall("abcde\nfghij\n", r"a.*j\n")
 
     def test_error(self):
         """Test handling a compilation error in TestCmd.match_re_dotall()"""
@@ -1081,13 +1092,13 @@ class match_re_dotall_TestCase(TestCmdTestCase):
             script_input = """import sys
 sys.path = ['%s'] + sys.path
 import TestCmd
-assert TestCmd.match_re_dotall("abcde", "a.*(e")
+assert TestCmd.match_re_dotall("abcde", r"a.*(e")
 sys.exit(0)
 """ % cwd
             stdout, stderr, status = self.call_python(script_input)
             assert status == 1, status
-            expect1 = "Regular expression error in '^a.*(e$': missing )\n"
-            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis\n"
+            expect1 = "Regular expression error in '^a.*(e$': missing )"
+            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
             assert (stderr.find(expect1) != -1 or
                     stderr.find(expect2) != -1), repr(stderr)
         finally:
@@ -1096,44 +1107,34 @@ sys.exit(0)
     def test_evaluation(self):
         """Test match_re_dotall() evaluation"""
         test = TestCmd.TestCmd()
-        assert test.match_re_dotall("abcde\nfghij\n", "a.*e\nf.*j\n")
-        assert test.match_re_dotall("abcde\nfghij\n", "a[^j]*j\n")
-        assert test.match_re_dotall("abcde\nfghij\n", "abcde\nfghij\n")
+        assert test.match_re_dotall("abcde\nfghij\n", r"a.*e\nf.*j\n")
+        assert test.match_re_dotall("abcde\nfghij\n", r"a[^j]*j\n")
+        assert test.match_re_dotall("abcde\nfghij\n", r"abcde\nfghij\n")
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    ["1[0-9]*5\n", "a.*e\n", "f.*j\n"])
+                                    [r"1[0-9]*5\n", r"a.*e\n", r"f.*j\n"])
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    ["1.*j\n"])
+                                    [r"1.*j\n"])
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    ["12345\n", "abcde\n", "fghij\n"])
-        assert test.match_re_dotall(UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]),
-                                    ["1[0-9]*5\n", "a.*e\n", "f.*j\n"])
-        assert test.match_re_dotall(UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]),
-                                    ["1.*j\n"])
-        assert test.match_re_dotall(UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]),
-                                    ["12345\n", "abcde\n", "fghij\n"])
+                                    [r"12345\n", r"abcde\n", r"fghij\n"])
+        assert test.match_re_dotall(UserList(["12345\n", "abcde\n", "fghij\n"]),
+                                    [r"1[0-9]*5\n", r"a.*e\n", r"f.*j\n"])
+        assert test.match_re_dotall(UserList(["12345\n", "abcde\n", "fghij\n"]),
+                                    [r"1.*j\n"])
+        assert test.match_re_dotall(UserList(["12345\n", "abcde\n", "fghij\n"]),
+                                    [r"12345\n", r"abcde\n", r"fghij\n"])
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    UserList(["1[0-9]*5\n",
-                                              "a.*e\n",
-                                              "f.*j\n"]))
+                                    UserList([r"1[0-9]*5\n", r"a.*e\n", r"f.*j\n"]))
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    UserList(["1.*j\n"]))
+                                    UserList([r"1.*j\n"]))
         assert test.match_re_dotall(["12345\n", "abcde\n", "fghij\n"],
-                                    UserList(["12345\n",
-                                              "abcde\n",
-                                              "fghij\n"]))
+                                    UserList([r"12345\n", r"abcde\n", r"fghij\n"]))
         assert test.match_re_dotall("12345\nabcde\nfghij\n",
-                                    "1[0-9]*5\na.*e\nf.*j\n")
-        assert test.match_re_dotall("12345\nabcde\nfghij\n", "1.*j\n")
+                                    r"1[0-9]*5\na.*e\nf.*j\n")
+        assert test.match_re_dotall("12345\nabcde\nfghij\n", r"1.*j\n")
         assert test.match_re_dotall("12345\nabcde\nfghij\n",
-                                    "12345\nabcde\nfghij\n")
+                                    r"12345\nabcde\nfghij\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_re_dotall(lines, regexes)
         assert test.match_re_dotall(lines, lines)
 
@@ -1169,8 +1170,8 @@ sys.exit(0)
 """ % cwd
             stdout, stderr, status = self.call_python(script_input)
             assert status == 1, status
-            expect1 = "Regular expression error in '^a.*(e$': missing )\n"
-            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis\n"
+            expect1 = "Regular expression error in '^a.*(e$': missing )"
+            expect2 = "Regular expression error in '^a.*(e$': unbalanced parenthesis"
             assert (stderr.find(expect1) != -1 or
                     stderr.find(expect2) != -1), repr(stderr)
         finally:
@@ -1194,7 +1195,7 @@ sys.exit(0)
         assert test.match_re("12345\nabcde\n", "1[0-9]*5\na.*e\n")
         assert test.match_re("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_re(lines, regexes)
         assert test.match_re(lines, lines)
 
@@ -1207,7 +1208,7 @@ class match_stderr_TestCase(TestCmdTestCase):
         assert test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stderr(lines, regexes)
 
     def test_match_stderr_not_affecting_match_stdout(self):
@@ -1219,14 +1220,14 @@ class match_stderr_TestCase(TestCmdTestCase):
         assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
         assert test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stdout(lines, regexes)
 
     def test_match_stderr_custom_function(self):
@@ -1239,7 +1240,7 @@ class match_stderr_TestCase(TestCmdTestCase):
         assert not test.match_stderr("123\n123\n", "1\n1\n")
         assert test.match_stderr("123\n123\n", "111\n111\n")
         lines = ["123\n", "123\n"]
-        regexes = ["1\n", "1\n"]
+        regexes = [r"1\n", r"1\n"]
         assert test.match_stderr(lines, regexes)    # equal numbers of lines
 
     def test_match_stderr_TestCmd_function(self):
@@ -1247,10 +1248,10 @@ class match_stderr_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stderr = TestCmd.match_exact)
         assert not test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("abcde\n", "abcde\n")
-        assert not test.match_stderr("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
@@ -1259,10 +1260,10 @@ class match_stderr_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stderr=TestCmd.TestCmd.match_exact)
         assert not test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("abcde\n", "abcde\n")
-        assert not test.match_stderr("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
@@ -1271,10 +1272,10 @@ class match_stderr_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stderr='match_exact')
         assert not test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("abcde\n", "abcde\n")
-        assert not test.match_stderr("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stderr("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stderr(lines, regexes)
         assert test.match_stderr(lines, lines)
 
@@ -1287,7 +1288,7 @@ class match_stdout_TestCase(TestCmdTestCase):
         assert test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stdout(lines, regexes)
 
     def test_match_stdout_not_affecting_match_stderr(self):
@@ -1299,14 +1300,14 @@ class match_stdout_TestCase(TestCmdTestCase):
         assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
         assert test.match_stderr("abcde\n", "a.*e\n")
         assert test.match_stderr("12345\nabcde\n", "1\\d+5\na.*e\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert test.match_stderr(lines, regexes)
 
     def test_match_stdout_custom_function(self):
@@ -1319,7 +1320,7 @@ class match_stdout_TestCase(TestCmdTestCase):
         assert not test.match_stdout("123\n123\n", "1\n1\n")
         assert test.match_stdout("123\n123\n", "111\n111\n")
         lines = ["123\n", "123\n"]
-        regexes = ["1\n", "1\n"]
+        regexes = [r"1\n", r"1\n"]
         assert test.match_stdout(lines, regexes)    # equal numbers of lines
 
     def test_match_stdout_TestCmd_function(self):
@@ -1327,10 +1328,10 @@ class match_stdout_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stdout = TestCmd.match_exact)
         assert not test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("abcde\n", "abcde\n")
-        assert not test.match_stdout("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
@@ -1339,10 +1340,10 @@ class match_stdout_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stdout=TestCmd.TestCmd.match_exact)
         assert not test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("abcde\n", "abcde\n")
-        assert not test.match_stdout("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
@@ -1351,10 +1352,10 @@ class match_stdout_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(match_stdout='match_exact')
         assert not test.match_stdout("abcde\n", "a.*e\n")
         assert test.match_stdout("abcde\n", "abcde\n")
-        assert not test.match_stdout("12345\nabcde\n", "1\d+5\na.*e\n")
+        assert not test.match_stdout("12345\nabcde\n", "1\\d+5\na.*e\n")
         assert test.match_stdout("12345\nabcde\n", "12345\nabcde\n")
         lines = ["vwxyz\n", "67890\n"]
-        regexes = ["v[^a-u]*z\n", "6[^ ]+0\n"]
+        regexes = [r"v[^a-u]*z\n", r"6[^ ]+0\n"]
         assert not test.match_stdout(lines, regexes)
         assert test.match_stdout(lines, lines)
 
@@ -1470,20 +1471,20 @@ class preserve_TestCase(TestCmdTestCase):
     def test_preserve(self):
         """Test preserve()"""
         def cleanup_test(test, cond=None, stdout=""):
-            io = StringIO()
             save = sys.stdout
-            sys.stdout = io
-            try:
-                if cond:
-                    test.cleanup(cond)
-                else:
-                    test.cleanup()
-                o = io.getvalue()
-                assert o == stdout, "o = `%s', stdout = `%s'" % (o, stdout)
-            finally:
-                sys.stdout = save
+            with closing(StringIO()) as io:
+                sys.stdout = io
+                try:
+                    if cond:
+                        test.cleanup(cond)
+                    else:
+                        test.cleanup()
+                    o = io.getvalue()
+                    assert o == stdout, "o = `%s', stdout = `%s'" % (o, stdout)
+                finally:
+                    sys.stdout = save
 
-        test = TestCmd.TestCmd(workdir = '')
+        test = TestCmd.TestCmd(workdir='')
         wdir = test.workdir
         try:
             test.write('file1', "Test file #1\n")
@@ -1492,10 +1493,10 @@ class preserve_TestCase(TestCmdTestCase):
             assert not os.path.exists(wdir)
         finally:
             if os.path.exists(wdir):
-                shutil.rmtree(wdir, ignore_errors = 1)
+                shutil.rmtree(wdir, ignore_errors=1)
                 test._dirlist.remove(wdir)
 
-        test = TestCmd.TestCmd(workdir = '')
+        test = TestCmd.TestCmd(workdir='')
         wdir = test.workdir
         try:
             test.write('file2', "Test file #2\n")
@@ -1579,15 +1580,15 @@ class read_TestCase(TestCmdTestCase):
         wdir_file5 = os.path.join(test.workdir, 'file5')
 
         with open(wdir_file1, 'wb') as f:
-            f.write("")
+            f.write(to_bytes(""))
         with open(wdir_file2, 'wb') as f:
-            f.write("Test\nfile\n#2.\n")
+            f.write(to_bytes("Test\nfile\n#2.\n"))
         with open(wdir_foo_file3, 'wb') as f:
-            f.write("Test\nfile\n#3.\n")
+            f.write(to_bytes("Test\nfile\n#3.\n"))
         with open(wdir_file4, 'wb') as f:
-            f.write("Test\nfile\n#4.\n")
+            f.write(to_bytes("Test\nfile\n#4.\n"))
         with open(wdir_file5, 'wb') as f:
-            f.write("Test\r\nfile\r\n#5.\r\n")
+            f.write(to_bytes("Test\r\nfile\r\n#5.\r\n"))
 
         try:
             contents = test.read('no_file')
@@ -1604,6 +1605,7 @@ class read_TestCase(TestCmdTestCase):
             raise
 
         def _file_matches(file, contents, expected):
+            contents = to_str(contents)
             assert contents == expected, \
                 "Expected contents of " + str(file) + "==========\n" + \
                 expected + \
@@ -1874,29 +1876,25 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            test.run(arguments = ['arg1 arg2'])
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                assert expect == e, (expect, e)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
                                     verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            testx.run(arguments = ['arg1 arg2'])
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                assert expect == e, (expect, e)
 
             # Test calling TestCmd() with an explicit verbose = 2.
 
@@ -1925,43 +1923,39 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 2)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
                                     verbose = 2)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
 
-            testx.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             # Test calling TestCmd() with an explicit verbose = 3.
 
@@ -1970,41 +1964,37 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 2)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                expect = out_fmt % (len(stdout_line), stdout_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            expect = out_fmt % (len(stdout_line), stdout_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
-            assert e == expect, (e, expect)
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
+                assert e == expect, (e, expect)
 
             test = TestCmd.TestCmd(program = t.scriptout,
                                    interpreter = 'python',
                                    workdir = '',
                                    verbose = 3)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       '0', '')
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptout:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   '0', '')
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
-            assert e == expect, (e, expect)
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
+                assert e == expect, (e, expect)
 
             # Test letting TestCmd() pick up verbose = 2 from the environment.
 
@@ -2014,42 +2004,38 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    interpreter = 'python',
                                    workdir = '')
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
 
-            test.run(arguments = ['arg1 arg2'])
+                line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "script:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '')
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
 
-            testx.run(arguments = ['arg1 arg2'])
+                line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
+                stdout_line = line_fmt % ('STDOUT', t.sub_dir)
+                stderr_line = line_fmt % ('STDERR', t.sub_dir)
+                expect = outerr_fmt % (len(stdout_line), stdout_line,
+                                       len(stderr_line), stderr_line)
+                o = sys.stdout.getvalue()
+                assert expect == o, (expect, o)
 
-            line_fmt = "scriptx.bat:  %s:  %s:  ['arg1 arg2']\n"
-            stdout_line = line_fmt % ('STDOUT', t.sub_dir)
-            stderr_line = line_fmt % ('STDERR', t.sub_dir)
-            expect = outerr_fmt % (len(stdout_line), stdout_line,
-                                   len(stderr_line), stderr_line)
-            o = sys.stdout.getvalue()
-            assert expect == o, (expect, o)
-
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            e = sys.stderr.getvalue()
-            assert e == expect, (e, expect)
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                e = sys.stderr.getvalue()
+                assert e == expect, (e, expect)
 
             # Test letting TestCmd() pick up verbose = 1 from the environment.
 
@@ -2060,29 +2046,25 @@ class run_verbose_TestCase(TestCmdTestCase):
                                    workdir = '',
                                    verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            test.run(arguments = ['arg1 arg2'])
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            expect = 'python "%s" "arg1 arg2"\n' % t.script_path
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                test.run(arguments = ['arg1 arg2'])
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                expect = 'python "%s" "arg1 arg2"\n' % t.script_path
+                assert expect == e, (expect, e)
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
                                     verbose = 1)
 
-            sys.stdout = StringIO()
-            sys.stderr = StringIO()
-
-            testx.run(arguments = ['arg1 arg2'])
-            expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
-            o = sys.stdout.getvalue()
-            assert o == '', o
-            e = sys.stderr.getvalue()
-            assert expect == e, (expect, e)
+            with closing(StringIO()) as sys.stdout, closing(StringIO()) as sys.stderr:
+                testx.run(arguments = ['arg1 arg2'])
+                expect = '"%s" "arg1 arg2"\n' % t.scriptx_path
+                o = sys.stdout.getvalue()
+                assert o == '', o
+                e = sys.stderr.getvalue()
+                assert expect == e, (expect, e)
 
         finally:
             sys.stdout = save_stdout
@@ -2624,11 +2606,11 @@ script_recv:  STDERR:  input
 
             p = test.start(stdin=1)
             input = 'stdin.write() input to the receive script\n'
-            p.stdin.write(input)
+            p.stdin.write(to_bytes(input))
             p.stdin.close()
             p.wait()
             with open(t.recv_out_path, 'rb') as f:
-                result = f.read()
+                result = to_str(f.read())
             expect = 'script_recv:  ' + input
             assert result == expect, repr(result)
 
@@ -2638,7 +2620,7 @@ script_recv:  STDERR:  input
             p.stdin.close()
             p.wait()
             with open(t.recv_out_path, 'rb') as f:
-                result = f.read()
+                result = to_str(f.read())
             expect = 'script_recv:  ' + input
             assert result == expect, repr(result)
 
@@ -2754,11 +2736,8 @@ sys.stderr.write("run2 STDERR second line\\n")
         # Everything before this prepared our "source directory."
         # Now do the real test.
         test = TestCmd.TestCmd(interpreter = 'python', workdir = '')
-        try:
-            output = test.stdout()
-        except IndexError:
-            pass
-        else:
+        output = test.stdout()
+        if output is not None:
             raise IndexError("got unexpected output:\n\t`%s'\n" % output)
         test.program_set('run1')
         test.run(arguments = 'foo bar')
@@ -3330,9 +3309,11 @@ class write_TestCase(TestCmdTestCase):
             assert not os.path.exists(test.workpath('file10'))
 
         with open(test.workpath('file8'), 'r') as f:
-            assert f.read() == "Test file #8.\n"
+            res = f.read()
+            assert res == "Test file #8.\n", res
         with open(test.workpath('file9'), 'rb') as f:
-            assert f.read() == "Test file #9.\r\n"
+            res = to_str(f.read())
+            assert res == "Test file #9.\r\n", res
 
 
 class variables_TestCase(TestCmdTestCase):


### PR DESCRIPTION
The `testing/harness/TestCmdTests.py` unit tests do not currently pass. Note they are not run by the CI system, or in fact by doing `runtests -a`, since they're in a directory that is not searched.  After these changes, there are no fails. This is a test-only change.  This is the companion to PR #3382, which was for the `TestCommon` portions of the harness.

The method `simple_diff`, modeled on difflib functions, is converted to a generator to match difflib, and now has a doctest as well.  This means calls to it which aren't going to iterate needs to convert the return with `list()`, but that just makes usage more consistent, since the calls to `difflib.context_diff` and `difflib.unified_diff` already had to do so.

Also, the methods that used Google-style docbook markup are changed to REsT-style markup. Our current doc producer, epydoc, does not understand the Google style, and we shouldn't mix styles; can convert them all in bulk later if we switch to Sphinx as the production tool.

Pre-change failure log excerpt (after fixing issues with imports that keep the tests from even starting):

```
1/1 (100.00%) /usr/bin/python3 testing/framework/TestCmdTests.py
..E.E...E..EE.EEEEEEEEEEEEEEEEEEE..........E....E................EEF.E....EEE.....EEEE..E..............F...

Ran 107 tests in 43.825s

FAILED (failures=2, errors=37)
```

1.  This fail:

```
  File "/usr/lib64/python3.7/subprocess.py", line 1666, in _communicate
    input_view = memoryview(self._input)
TypeError: memoryview: a bytes-like object is required, not 'str'
```
affects all of these tests:

```
ERROR: test_context_diff_static_method (__main__.diff_TestCase)
Test calling the TestCmd.TestCmd.context_diff() static method

ERROR: test_diff_custom_function (__main__.diff_TestCase)
Test diff() using a custom function

ERROR: test_diff_re_static_method (__main__.diff_TestCase)
Test calling the TestCmd.TestCmd.diff_re() static method

ERROR: test_diff_string (__main__.diff_TestCase)

ERROR: test_error (__main__.diff_TestCase)
Test handling a compilation error in TestCmd.diff_re()

ERROR: test_simple_diff_static_method (__main__.diff_TestCase)
Test calling the TestCmd.TestCmd.simple_diff() static method

ERROR: test_unified_diff_static_method (__main__.diff_TestCase)
Test calling the TestCmd.TestCmd.unified_diff() static method

ERROR: test_diff_stderr_TestCmd_function (__main__.diff_stderr_TestCase)
Test diff_stderr() using a TestCmd function

ERROR: test_diff_stderr_custom_function (__main__.diff_stderr_TestCase)

ERROR: test_diff_stderr_default (__main__.diff_stderr_TestCase)
Test diff_stderr() default behavior

ERROR: test_diff_stderr_not_affecting_diff_stdout (__main__.diff_stderr_TestCase)
Test diff_stderr() not affecting diff_stdout() behavior

ERROR: test_diff_stderr_static_method (__main__.diff_stderr_TestCase)
Test diff_stderr() using a static method

ERROR: test_diff_stderr_string (__main__.diff_stderr_TestCase)
Test diff_stderr() using a string to fetch the diff method

ERROR: test_diff_stdout_TestCmd_function (__main__.diff_stdout_TestCase)
Test diff_stdout() using a TestCmd function

ERROR: test_diff_stdout_custom_function (__main__.diff_stdout_TestCase)
Test diff_stdout() using a custom function

ERROR: test_diff_stdout_default (__main__.diff_stdout_TestCase)
Test diff_stdout() default behavior

ERROR: test_diff_stdout_not_affecting_diff_stderr (__main__.diff_stdout_TestCase)
Test diff_stdout() not affecting diff_stderr() behavior

ERROR: test_diff_stdout_static_method (__main__.diff_stdout_TestCase)
Test diff_stdout() using a static method

ERROR: test_diff_stdout_string (__main__.diff_stdout_TestCase)
Test diff_stdout() using a string to fetch the diff method

ERROR: test_exit (__main__.exit_TestCase)
Test exit()

ERROR: test_fail_test (__main__.fail_test_TestCase)
Test fail_test()

ERROR: test_error (__main__.match_re_dotall_TestCase)
Test handling a compilation error in TestCmd.match_re_dotall()

ERROR: test_error (__main__.match_re_TestCase)
Test handling a compilation error in TestCmd.match_re()

ERROR: test_no_result (__main__.no_result_TestCase)
Test no_result()

ERROR: test_pass_test (__main__.pass_test_TestCase)
Test pass_test()

ERROR: test_set_diff_function (__main__.set_diff_function_TestCase)
Test set_diff_function()

ERROR: test_set_diff_function_stderr (__main__.set_diff_function_TestCase)
Test set_diff_function():  stderr

ERROR: test_set_diff_function_stdout (__main__.set_diff_function_TestCase)
Test set_diff_function():  stdout
```

2. Python3 needs bytes for files read/written in binary mode:

```
ERROR: test_read (__main__.read_TestCase)
Test read()
    f.write("")
TypeError: a bytes-like object is required, not 'str'

ERROR: test_recv (__main__.start_TestCase)
Test the recv() method of objects returned by start()
    data = data.replace("\r\n", "\n")
TypeError: a bytes-like object is required, not 'str'

ERROR: test_recv_err (__main__.start_TestCase)
Test the recv_err() method of objects returned by start()
    data = data.replace("\r\n", "\n")
TypeError: a bytes-like object is required, not 'str'

ERROR: test_send (__main__.start_TestCase)
Test the send() method of objects returned by start()
    p.stdin.write(input)
TypeError: a bytes-like object is required, not 'str'

ERROR: test_start (__main__.start_TestCase)
Test start()
    data = data.replace("\r\n", "\n")
TypeError: a bytes-like object is required, not 'str'
```

3. `TestCmd` has changed, now returns None in a place the tests don't expect:

```
ERROR: test_combine (__main__.combine_TestCase)
Test combining stdout and stderr
IndexError: got unexpected output:
        `None'

ERROR: test_stdout (__main__.stdout_TestCase)
Test stdout()
IndexError: got unexpected output:
        `None'
```

4. `TestCmd` does a `print` of a string which includes a newline, test does not expect two newlines.

```
FAIL: test_preserve (__main__.preserve_TestCase)
Test preserve()
  File "testing/framework/TestCmdTests.py", line 1488, in cleanup_test
    assert o == stdout, "o = `%s', stdout = `%s'" % (o, stdout)
AssertionError: o = `Preserved directory /tmp/testcmd.1078055.ft3z_g2c

', stdout = `Preserved directory /tmp/testcmd.1078055.ft3z_g2c
'
```

5. type mismatch - assert statement does not print failed data,
but it needed to be converted to string after reading in
bytes mode.

```
FAIL: test_write (__main__.write_TestCase)
Test write()
  File "testing/framework/TestCmdTests.py", line 3341, in test_write
    assert f.read() == "Test file #9.\r\n"
AssertionError
```

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
