### PR TITLE
Fix escaping to quiet py38 warnings about bad escapes

### DIFF
--- a/test/Subst/Literal.py
+++ b/test/Subst/Literal.py
@@ -33,14 +33,13 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment(PRE='pre=', MID=Literal('\$$ORIGIN'), SUF='')
+env = Environment(PRE='pre=', MID=Literal('\\\\$$ORIGIN'), SUF='')
 print(env.subst('${_concat(PRE, MID, SUF, __env__)}'))
 """)
 
 test.run()
 
-expect = """\
-pre=\$ORIGIN
+expect = r"""pre=\$ORIGIN
 """
 
 test.run(arguments='-Q -q', stdout=expect)


### PR DESCRIPTION
Fix  this improper escaping.

'\$$ORIGIN'

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
