### PR TITLE
Update Travis config: py38, lxml, docbook, ldc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ os:
   - linux
 
 install:
+  # needed for Docbook tests, must be in virtualenv context
+  - pip install lxml
+  # do the rest of the image setup
   - ./.travis/install.sh
 
 # pypy is not passing atm, but still report build success for now
@@ -21,7 +24,6 @@ matrix:
   allow_failures:
     - python: pypy
     - python: pypy3
-    - python: 3.8-dev
     - stage: Coverage
 
 # run coverage first as its still useful to collect

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -22,21 +22,19 @@ else
     # dependencies for gdc tests
     sudo apt-get -y install gdc
     # dependencies for docbook tests
-    sudo apt-get -y install docbook-xml xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf
+    sudo apt-get -y install docbook-xml docbook-xsl xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf docbook-slides
     # dependencies for latex tests (try to skip the huge doc pkgs)
     sudo apt-get -y --no-install-recommends install texlive texlive-latex3 biber texmaker ghostscript
     # need some things for building dependencies for other tests
     sudo apt-get -y install python-pip python-dev build-essential libpcre3-dev autoconf automake libtool bison subversion git
-    # dependencies for docbook tests continued
-    sudo pip install lxml
     # dependencies for D tests
     sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
     wget -qO - https://dlang.org/d-keyring.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get -y --allow-unauthenticated install dmd-bin
     # dependencies for ldc tests
-    wget https://github.com/ldc-developers/ldc/releases/download/v1.4.0/ldc2-1.4.0-linux-x86_64.tar.xz
-    tar xf ldc2-1.4.0-linux-x86_64.tar.xz
-    sudo cp -rf ldc2-1.4.0-linux-x86_64/* /
+    wget https://github.com/ldc-developers/ldc/releases/download/v1.15.0/ldc2-1.15.0-linux-x86_64.tar.xz
+    tar xf ldc2-1.15.0-linux-x86_64.tar.xz
+    sudo cp -rf ldc2-1.15.0-linux-x86_64/* /
 
     ls -l /usr/lib/*python*{so,a}*
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -30,9 +30,7 @@ else
     # docbook-slides should be added but triggers GH #3393 so left out for now.
 
     # dependencies for latex tests (try to skip the huge doc pkgs)
-    sudo apt-get -y --no-install-recommends install texlive texlive-latex3 biber texmaker ghostscript
-    # Should add the following, holding off since it slows down provisioning:
-    # texlive-bibtex-extra texlive-latex-extra texlive-font-utils
+    sudo apt-get -y --no-install-recommends install texlive texlive-latex3 biber texmaker ghostscript texlive-bibtex-extra texlive-latex-extra texlive-font-utils
     # texlive-latex3 no longer exists, failover to texlive-latex-recommended
 
     # need some things for building dependencies for other tests

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -21,16 +21,28 @@ else
 
     # dependencies for gdc tests
     sudo apt-get -y install gdc
+
+    # dependencies for fortran tests
+    sudo apt-get -y install gfortran
+
     # dependencies for docbook tests
-    sudo apt-get -y install docbook-xml docbook-xsl xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf docbook-slides
+    sudo apt-get -y install docbook-xml docbook-xsl xsltproc libxml2-dev libxslt-dev fop docbook-xsl-doc-pdf
+    # docbook-slides should be added but triggers GH #3393 so left out for now.
+
     # dependencies for latex tests (try to skip the huge doc pkgs)
     sudo apt-get -y --no-install-recommends install texlive texlive-latex3 biber texmaker ghostscript
+    # Should add the following, holding off since it slows down provisioning:
+    # texlive-bibtex-extra texlive-latex-extra texlive-font-utils
+    # texlive-latex3 no longer exists, failover to texlive-latex-recommended
+
     # need some things for building dependencies for other tests
     sudo apt-get -y install python-pip python-dev build-essential libpcre3-dev autoconf automake libtool bison subversion git
+
     # dependencies for D tests
     sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
     wget -qO - https://dlang.org/d-keyring.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get -y --allow-unauthenticated install dmd-bin
+
     # dependencies for ldc tests
     wget https://github.com/ldc-developers/ldc/releases/download/v1.15.0/ldc2-1.15.0-linux-x86_64.tar.xz
     tar xf ldc2-1.15.0-linux-x86_64.tar.xz
@@ -45,6 +57,4 @@ else
         tar xzf rel-3.0.12.tar.gz
         cd swig-rel-3.0.12 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ..
     fi
-
-    which dvipdf
 fi


### PR DESCRIPTION
- Py3.8 taken off "allowed to fail" list
- lxml installed in the Python virtualenv context, not the distro context (else won't be found)
- Provision with a couple of additional docbook pkgs
- Bump the version of the reference D compiler to current.

No change to scons itself, this is a CI-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
