### PR TITLE
Fix slow MD5-timestamp decider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ htmlcov
 *.bak
 *~
 !/test/Decider/switch-rebuild.py
+
+# Mac junk
+**/.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 
 install:
   # needed for Docbook tests, must be in virtualenv context
-  - pip install lxml
+  - pip install lxml==4.3.3
   # do the rest of the image setup
   - ./.travis/install.sh
 

--- a/SConstruct
+++ b/SConstruct
@@ -204,6 +204,11 @@ packaging_flavors = [
     ('zip',             "The normal .zip file for end-user installation."),
     ('local-zip',       "A .zip file for dropping into other software " +
                         "for local use."),
+    ('src-tar-gz',      "A .tar.gz file containing all the source " +
+                        "(including tests and documentation)."),
+    ('src-zip',         "A .zip file containing all the source " +
+                        "(including tests and documentation)."),
+
 ]
 
 test_tar_gz_dir       = os.path.join(build_dir, "test-tar-gz")
@@ -851,11 +856,9 @@ SConscript('doc/SConscript')
 #
 
 
-sfiles = None
-if git_status_lines:
-    slines = [l for l in git_status_lines if 'modified:' in l]
-    sfiles = [l.split()[-1] for l in slines]
-else:
+
+sfiles = [l.split()[-1] for l in git_status_lines]
+if not git_status_lines:
    print("Not building in a Git tree; skipping building src package.")
 
 if sfiles:

--- a/bin/upload-release-files.sh
+++ b/bin/upload-release-files.sh
@@ -35,12 +35,12 @@ $RSYNC $RSYNCOPTS \
   Announce.txt CHANGES.txt RELEASE.txt \
   $SF_USER@$SF_MACHINE:$SF_TOPDIR/scons-local/$VERSION/
 
-# Source packages:
-#$RSYNC $RSYNCOPTS \
-#  scons-src-$VERSION.tar.gz \
-#  scons-src-$VERSION.zip \
-#  Announce.txt CHANGES.txt RELEASE.txt \
-#  $SF_USER@$SF_MACHINE:$SF_TOPDIR/scons-src/$VERSION/
+ Source packages:
+$RSYNC $RSYNCOPTS \
+  scons-src-$VERSION.tar.gz \
+  scons-src-$VERSION.zip \
+  Announce.txt CHANGES.txt RELEASE.txt \
+  $SF_USER@$SF_MACHINE:$SF_TOPDIR/scons-src/$VERSION/
 
 # Readme
 $RSYNC $RSYNCOPTS \

--- a/doc/generated/examples/caching_ex-random_1.xml
+++ b/doc/generated/examples/caching_ex-random_1.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
-cc -o f3.o -c f3.c
-cc -o f2.o -c f2.c
-cc -o f1.o -c f1.c
 cc -o f4.o -c f4.c
+cc -o f2.o -c f2.c
+cc -o f3.o -c f3.c
 cc -o f5.o -c f5.c
+cc -o f1.o -c f1.c
 cc -o prog f1.o f2.o f3.o f4.o f5.o
 </screen>

--- a/doc/generated/examples/caching_ex-random_1.xml
+++ b/doc/generated/examples/caching_ex-random_1.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
+cc -o f3.o -c f3.c
 cc -o f2.o -c f2.c
 cc -o f1.o -c f1.c
-cc -o f5.o -c f5.c
 cc -o f4.o -c f4.c
-cc -o f3.o -c f3.c
+cc -o f5.o -c f5.c
 cc -o prog f1.o f2.o f3.o f4.o f5.o
 </screen>

--- a/doc/generated/examples/troubleshoot_explain1_3.xml
+++ b/doc/generated/examples/troubleshoot_explain1_3.xml
@@ -3,5 +3,5 @@
 cp file.in file.oout
 
 scons: warning: Cannot find target file.out after building
-File "/home/bdeegan/devel/scons/git/scons/bootstrap/src/script/scons.py", line 204, in &lt;module&gt;
+File "/Users/bdbaddog/devel/scons/git/scons-bugfixes-3/bootstrap/src/script/scons.py", line 204, in &lt;module&gt;
 </screen>

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -1139,6 +1139,17 @@ size, or content signature.
 </para>
 </listitem>
 </varlistentry>
+    <varlistentry>
+<term><parameter>repo_node</parameter></term>
+<listitem>
+<para>
+Use this node instead of the one specified by
+<varname>dependency</varname>
+    to determine if the dependency has changed.
+</para>
+</listitem>
+</varlistentry>
+
 </variablelist>
 </para>
 
@@ -1175,7 +1186,7 @@ Example:
 </para>
 
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">
-def my_decider(dependency, target, prev_ni):
+def my_decider(dependency, target, prev_ni, repo_node=None):
     return not os.path.exists(str(target))
 
 env.Decider(my_decider)

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -779,19 +779,19 @@ Sets construction variables for the
 </para>
 <para>Sets:  &cv-link-AS;, &cv-link-ASCOM;, &cv-link-ASFLAGS;, &cv-link-ASPPCOM;, &cv-link-ASPPFLAGS;.</para><para>Uses:  &cv-link-ASCOMSTR;, &cv-link-ASPPCOMSTR;.</para></listitem>
   </varlistentry>
-  <varlistentry id="t-packaging">
-    <term>packaging</term>
-    <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-A framework for building binary and source packages.
-</para>
-</listitem>
-  </varlistentry>
   <varlistentry id="t-Packaging">
     <term>Packaging</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 Sets construction variables for the <function xmlns="http://www.scons.org/dbxsd/v1.0">Package</function> Builder.
+</para>
+</listitem>
+  </varlistentry>
+  <varlistentry id="t-packaging">
+    <term>packaging</term>
+    <listitem>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+A framework for building binary and source packages.
 </para>
 </listitem>
   </varlistentry>

--- a/doc/generated/tools.mod
+++ b/doc/generated/tools.mod
@@ -78,8 +78,8 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY t-mwcc "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>mwcc</literal>">
 <!ENTITY t-mwld "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>mwld</literal>">
 <!ENTITY t-nasm "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>nasm</literal>">
-<!ENTITY t-packaging "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>packaging</literal>">
 <!ENTITY t-Packaging "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>Packaging</literal>">
+<!ENTITY t-packaging "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>packaging</literal>">
 <!ENTITY t-pdf "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>pdf</literal>">
 <!ENTITY t-pdflatex "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>pdflatex</literal>">
 <!ENTITY t-pdftex "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>pdftex</literal>">
@@ -186,8 +186,8 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY t-link-mwcc "<link linkend='t-mwcc' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>mwcc</literal></link>">
 <!ENTITY t-link-mwld "<link linkend='t-mwld' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>mwld</literal></link>">
 <!ENTITY t-link-nasm "<link linkend='t-nasm' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>nasm</literal></link>">
-<!ENTITY t-link-packaging "<link linkend='t-packaging' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>packaging</literal></link>">
 <!ENTITY t-link-Packaging "<link linkend='t-Packaging' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>Packaging</literal></link>">
+<!ENTITY t-link-packaging "<link linkend='t-packaging' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>packaging</literal></link>">
 <!ENTITY t-link-pdf "<link linkend='t-pdf' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>pdf</literal></link>">
 <!ENTITY t-link-pdflatex "<link linkend='t-pdflatex' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>pdflatex</literal></link>">
 <!ENTITY t-link-pdftex "<link linkend='t-pdftex' xmlns='http://www.scons.org/dbxsd/v1.0'><literal>pdftex</literal></link>">

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -6789,6 +6789,16 @@ Example <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION">
 </para>
 </listitem>
   </varlistentry>
+  <varlistentry id="cv-SHLIBVERSIONFLAGS">
+    <term>SHLIBVERSIONFLAGS</term>
+    <listitem>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+Extra flags added to <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLINKCOM"><envar>$SHLINKCOM</envar></link> when building versioned
+<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link>. These flags are only used when <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> is
+set.
+</para>
+</listitem>
+  </varlistentry>
   <varlistentry id="cv-_SHLIBVERSIONFLAGS">
     <term>_SHLIBVERSIONFLAGS</term>
     <listitem>
@@ -6799,16 +6809,6 @@ is set). <literal>_SHLIBVERSIONFLAGS</literal> usually adds <link xmlns="http://
 and some extra dynamically generated options (such as
 <literal>-Wl,-soname=$_SHLIBSONAME</literal>. It is unused by "plain"
 (unversioned) shared libraries.
-</para>
-</listitem>
-  </varlistentry>
-  <varlistentry id="cv-SHLIBVERSIONFLAGS">
-    <term>SHLIBVERSIONFLAGS</term>
-    <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Extra flags added to <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLINKCOM"><envar>$SHLINKCOM</envar></link> when building versioned
-<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link>. These flags are only used when <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> is
-set.
 </para>
 </listitem>
   </varlistentry>

--- a/doc/generated/variables.mod
+++ b/doc/generated/variables.mod
@@ -504,8 +504,8 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-_SHLIBSONAME "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$_SHLIBSONAME</envar>">
 <!ENTITY cv-SHLIBSUFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHLIBSUFFIX</envar>">
 <!ENTITY cv-SHLIBVERSION "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHLIBVERSION</envar>">
-<!ENTITY cv-_SHLIBVERSIONFLAGS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$_SHLIBVERSIONFLAGS</envar>">
 <!ENTITY cv-SHLIBVERSIONFLAGS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHLIBVERSIONFLAGS</envar>">
+<!ENTITY cv-_SHLIBVERSIONFLAGS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$_SHLIBVERSIONFLAGS</envar>">
 <!ENTITY cv-SHLINK "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHLINK</envar>">
 <!ENTITY cv-SHLINKCOM "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHLINKCOM</envar>">
 <!ENTITY cv-SHLINKCOMSTR "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHLINKCOMSTR</envar>">
@@ -1144,8 +1144,8 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-link-_SHLIBSONAME "<link linkend='cv-_SHLIBSONAME' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$_SHLIBSONAME</envar></link>">
 <!ENTITY cv-link-SHLIBSUFFIX "<link linkend='cv-SHLIBSUFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHLIBSUFFIX</envar></link>">
 <!ENTITY cv-link-SHLIBVERSION "<link linkend='cv-SHLIBVERSION' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHLIBVERSION</envar></link>">
-<!ENTITY cv-link-_SHLIBVERSIONFLAGS "<link linkend='cv-_SHLIBVERSIONFLAGS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$_SHLIBVERSIONFLAGS</envar></link>">
 <!ENTITY cv-link-SHLIBVERSIONFLAGS "<link linkend='cv-SHLIBVERSIONFLAGS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHLIBVERSIONFLAGS</envar></link>">
+<!ENTITY cv-link-_SHLIBVERSIONFLAGS "<link linkend='cv-_SHLIBVERSIONFLAGS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$_SHLIBVERSIONFLAGS</envar></link>">
 <!ENTITY cv-link-SHLINK "<link linkend='cv-SHLINK' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHLINK</envar></link>">
 <!ENTITY cv-link-SHLINKCOM "<link linkend='cv-SHLINKCOM' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHLINKCOM</envar></link>">
 <!ENTITY cv-link-SHLINKCOMSTR "<link linkend='cv-SHLINKCOMSTR' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHLINKCOMSTR</envar></link>">

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -67,6 +67,7 @@
 
 <!ENTITY Action "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>Action</classname>">
 <!ENTITY ActionBase "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>ActionBase</classname>">
+<!ENTITY BuildInfo "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>BuildInfo</classname>">
 <!ENTITY CommandAction "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>CommandAction</classname>">
 <!ENTITY FunctionAction "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>FunctionAction</classname>">
 <!ENTITY ListAction "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>ListAction</classname>">

--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -517,7 +517,7 @@ cc -o hello hello.o
       <scons_example name="depends_function">
         <file name="SConstruct" printme="1">
 Program('hello.c')
-def decide_if_changed(dependency, target, prev_ni):
+def decide_if_changed(dependency, target, prev_ni, repo_node=None):
     if dependency.get_timestamp() != prev_ni.timestamp:
         dep = str(dependency)
         tgt = str(target)

--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -561,6 +561,13 @@ int main() { printf("Hello, world!\n"); }
 
       </para>
 
+        <para>
+            The fourth argument <varname>repo_node</varname>,
+            is the &Node; to use if it is not None when comparing &BuildInfo;.
+            This is typically only set when the target node only exists in a
+            &Repository;
+        </para>
+
       <variablelist>
 
         <varlistentry>
@@ -637,7 +644,7 @@ int main() { printf("Hello, world!\n"); }
       <sconstruct>
 env = Environment()
 
-def config_file_decider(dependency, target, prev_ni):
+def config_file_decider(dependency, target, prev_ni, repo_node=None):
     import os.path
 
     # We always have to init the .csig value...

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -41,6 +41,14 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix Issue #3350 - mslink failing when too many objects.  This is resolved by adding TEMPFILEARGJOIN variable
       which specifies what character to join all the argements output into the tempfile. The default remains a space
       when mslink, msvc, or mslib tools are loaded they change the TEMPFILEARGJOIN to be a line separator (\r\n on win32)
+    - Fix performance degradation for MD5-timestamp decider.  NOTE: This changes the Decider() function arguments.
+      From:
+          def my_decider(dependency, target, prev_ni):
+      To:
+          def my_decider(dependency, target, prev_ni, repo_node):
+      Where repo_node is the repository (or other) node to use to check if the node is out of date instead of dependency.
+
+
 
     From Michael Hartmann:
     - Fix handling of Visual Studio Compilers to properly reject any unknown HOST_PLATFORM or TARGET_PLATFORM

--- a/src/RELEASE.txt
+++ b/src/RELEASE.txt
@@ -41,6 +41,14 @@
 
   CHANGED/ENHANCED EXISTING FUNCTIONALITY
 
+      - Fix performance degradation for MD5-timestamp decider.  NOTE: This changes the Decider() function arguments.
+      From:
+          def my_decider(dependency, target, prev_ni):
+      To:
+          def my_decider(dependency, target, prev_ni, repo_node):
+      Where repo_node is the repository (or other) node to use to check if the node is out of date instead of dependency.
+
+
     - Enhanced --debug=explain output. Now the separate components of the dependency list are split up
       as follows:
 

--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -534,7 +534,7 @@ class ActionBase(object):
         result = self.get_presig(target, source, env)
 
         if not isinstance(result,(bytes, bytearray)):
-            result = bytearray("",'utf-8').join([ SCons.Util.to_bytes(r) for r in result ])
+            result = bytearray(result, 'utf-8')
         else:
             # Make a copy and put in bytearray, without this the contents returned by get_presig
             # can be changed by the logic below, appending with each call and causing very

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -1445,13 +1445,13 @@ class Base(SubstitutionEnvironment):
     def _changed_content(self, dependency, target, prev_ni, repo_node=None):
         return dependency.changed_content(target, prev_ni, repo_node)
 
-    def _changed_source(self, dependency, target, prev_ni):
+    def _changed_source(self, dependency, target, prev_ni, repo_node=None):
         target_env = dependency.get_build_env()
         type = target_env.get_tgt_sig_type()
         if type == 'source':
-            return target_env.decide_source(dependency, target, prev_ni)
+            return target_env.decide_source(dependency, target, prev_ni, repo_node)
         else:
-            return target_env.decide_target(dependency, target, prev_ni)
+            return target_env.decide_target(dependency, target, prev_ni, repo_node)
 
     def _changed_timestamp_then_content(self, dependency, target, prev_ni, repo_node=None):
         return dependency.changed_timestamp_then_content(target, prev_ni, repo_node)

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -864,17 +864,20 @@ class SubstitutionEnvironment(object):
         return self
 
 
-def default_decide_source(dependency, target, prev_ni):
+def default_decide_source(dependency, target, prev_ni, repo_node=None):
     f = SCons.Defaults.DefaultEnvironment().decide_source
-    return f(dependency, target, prev_ni)
+    return f(dependency, target, prev_ni, repo_node)
 
-def default_decide_target(dependency, target, prev_ni):
+
+def default_decide_target(dependency, target, prev_ni, repo_node=None):
     f = SCons.Defaults.DefaultEnvironment().decide_target
-    return f(dependency, target, prev_ni)
+    return f(dependency, target, prev_ni, repo_node)
+
 
 def default_copy_from_cache(src, dst):
     f = SCons.Defaults.DefaultEnvironment().copy_from_cache
     return f(src, dst)
+
 
 class Base(SubstitutionEnvironment):
     """Base class for "real" construction Environments.  These are the
@@ -1434,13 +1437,13 @@ class Base(SubstitutionEnvironment):
             _warn_copy_deprecated = False
         return self.Clone(*args, **kw)
 
-    def _changed_build(self, dependency, target, prev_ni):
-        if dependency.changed_state(target, prev_ni):
+    def _changed_build(self, dependency, target, prev_ni, repo_node=None):
+        if dependency.changed_state(target, prev_ni, repo_node):
             return 1
-        return self.decide_source(dependency, target, prev_ni)
+        return self.decide_source(dependency, target, prev_ni, repo_node)
 
-    def _changed_content(self, dependency, target, prev_ni):
-        return dependency.changed_content(target, prev_ni)
+    def _changed_content(self, dependency, target, prev_ni, repo_node=None):
+        return dependency.changed_content(target, prev_ni, repo_node)
 
     def _changed_source(self, dependency, target, prev_ni):
         target_env = dependency.get_build_env()
@@ -1450,14 +1453,14 @@ class Base(SubstitutionEnvironment):
         else:
             return target_env.decide_target(dependency, target, prev_ni)
 
-    def _changed_timestamp_then_content(self, dependency, target, prev_ni):
-        return dependency.changed_timestamp_then_content(target, prev_ni)
+    def _changed_timestamp_then_content(self, dependency, target, prev_ni, repo_node=None):
+        return dependency.changed_timestamp_then_content(target, prev_ni, repo_node)
 
-    def _changed_timestamp_newer(self, dependency, target, prev_ni):
-        return dependency.changed_timestamp_newer(target, prev_ni)
+    def _changed_timestamp_newer(self, dependency, target, prev_ni, repo_node=None):
+        return dependency.changed_timestamp_newer(target, prev_ni, repo_node)
 
-    def _changed_timestamp_match(self, dependency, target, prev_ni):
-        return dependency.changed_timestamp_match(target, prev_ni)
+    def _changed_timestamp_match(self, dependency, target, prev_ni, repo_node=None):
+        return dependency.changed_timestamp_match(target, prev_ni, repo_node)
 
     def _copy_from_cache(self, src, dst):
         return self.fs.copy(src, dst)

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -1213,6 +1213,17 @@ size, or content signature.
 </para>
 </listitem>
 </varlistentry>
+    <varlistentry>
+<term><parameter>repo_node</parameter></term>
+<listitem>
+<para>
+Use this node instead of the one specified by
+<varname>dependency</varname>
+    to determine if the dependency has changed.
+</para>
+</listitem>
+</varlistentry>
+
 </variablelist>
 </para>
 
@@ -1249,7 +1260,7 @@ Example:
 </para>
 
 <example_commands>
-def my_decider(dependency, target, prev_ni):
+def my_decider(dependency, target, prev_ni, repo_node=None):
     return not os.path.exists(str(target))
 
 env.Decider(my_decider)

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3316,7 +3316,6 @@ class File(Base):
             len(binfo.bimplicitsigs)) == 0:
             return {}
 
-
         binfo.dependency_map = { child:signature for child, signature in zip(chain(binfo.bsources, binfo.bdepends, binfo.bimplicit),
                                      chain(binfo.bsourcesigs, binfo.bdependsigs, binfo.bimplicitsigs))}
 
@@ -3430,9 +3429,8 @@ class File(Base):
             self - dependency
             target - target
             prev_ni - The NodeInfo object loaded from previous builds .sconsign
-            node - Node instance.  This is the only changed* function which requires
-                   node to function. So if we detect that it's not passed.
-                   we throw DeciderNeedsNode, and caller should handle this and pass node.
+            node - Node instance.  Check this node for file existance/timestamp
+                   if specified.
 
         Returns:
             Boolean - Indicates if node(File) has changed.
@@ -3496,14 +3494,18 @@ class File(Base):
             return 1
 
     def is_up_to_date(self):
+        """Check for whether the Node is current
+           In all cases self is the target we're checking to see if it's up to date
+        """
+
         T = 0
         if T: Trace('is_up_to_date(%s):' % self)
         if not self.exists():
             if T: Trace(' not self.exists():')
-            # The file doesn't exist locally...
+            # The file (always a target) doesn't exist locally...
             r = self.rfile()
             if r != self:
-                # ...but there is one in a Repository...
+                # ...but there is one (always a target) in a Repository...
                 if not self.changed(r):
                     if T: Trace(' changed(%s):' % r)
                     # ...and it's even up-to-date...

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3429,7 +3429,7 @@ class File(Base):
             self - dependency
             target - target
             prev_ni - The NodeInfo object loaded from previous builds .sconsign
-            node - Node instance.  Check this node for file existance/timestamp
+            node - Node instance.  Check this node for file existence/timestamp
                    if specified.
 
         Returns:

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -2261,7 +2261,7 @@ class RootDir(Dir):
     this directory.
     """
 
-    __slots__ = ['_lookupDict']
+    __slots__ = ('_lookupDict', )
 
     def __init__(self, drive, fs):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Node.FS.RootDir')
@@ -2467,7 +2467,7 @@ class FileNodeInfo(SCons.Node.NodeInfoBase):
         """
         state = getattr(self, '__dict__', {}).copy()
         for obj in type(self).mro():
-            for name in getattr(obj,'__slots__',()):
+            for name in getattr(obj, '__slots__', ()):
                 if hasattr(self, name):
                     state[name] = getattr(self, name)
 
@@ -2511,7 +2511,7 @@ class FileBuildInfo(SCons.Node.BuildInfoBase):
                     or count of any of these could yield writing wrong csig, and then false positive
                     rebuilds
     """
-    __slots__ = ('dependency_map')
+    __slots__ = ('dependency_map', )
     current_version_id = 2
 
     def __setattr__(self, key, value):

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -57,7 +57,6 @@ import SCons.Util
 import SCons.Warnings
 
 from SCons.Debug import Trace
-from . import DeciderNeedsNode
 
 print_duplicate = 0
 
@@ -2511,7 +2510,7 @@ class FileBuildInfo(SCons.Node.BuildInfoBase):
                     or count of any of these could yield writing wrong csig, and then false positive
                     rebuilds
     """
-    __slots__ = ('dependency_map', )
+    __slots__ = ['dependency_map', ]
     current_version_id = 2
 
     def __setattr__(self, key, value):
@@ -2635,7 +2634,6 @@ class File(Base):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Node.FS.File')
         Base.__init__(self, name, directory, fs)
         self._morph()
-        self.attributes.changed_timestamp_then_content = None
 
     def Entry(self, name):
         """Create an entry node named 'name' relative to
@@ -3387,7 +3385,7 @@ class File(Base):
             if df:
                 return df
 
-        # Strings didn't existing in map, add them and try again
+        # Strings don't exist in map, add them and try again
         # If there are no strings in this dmap, then add them.
         # This may not be necessary, we could walk the nodes in the dmap and check each string
         # rather than adding ALL the strings to dmap. In theory that would be n/2 vs 2n str() calls on node

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -2635,6 +2635,7 @@ class File(Base):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Node.FS.File')
         Base.__init__(self, name, directory, fs)
         self._morph()
+        self.attributes.changed_timestamp_then_content = None
 
     def Entry(self, name):
         """Create an entry node named 'name' relative to
@@ -3283,14 +3284,14 @@ class File(Base):
             self._memo['changed'] = has_changed
         return has_changed
 
-    def changed_content(self, target, prev_ni):
+    def changed_content(self, target, prev_ni, repo_node=None):
         cur_csig = self.get_csig()
         try:
             return cur_csig != prev_ni.csig
         except AttributeError:
             return 1
 
-    def changed_state(self, target, prev_ni):
+    def changed_state(self, target, prev_ni, repo_node=None):
         return self.state != SCons.Node.up_to_date
 
 
@@ -3324,6 +3325,21 @@ class File(Base):
 
         return binfo.dependency_map
 
+    # @profile
+    def _add_strings_to_dependency_map(self, dmap):
+        """
+        In the case comparing node objects isn't sufficient, we'll add the strings for the nodes to the dependency map
+        :return:
+        """
+
+        first_string = str(next(iter(dmap)))
+
+        # print("DMAP:%s"%id(dmap))
+        if first_string not in dmap:
+                string_dict = {str(child): signature for child, signature in dmap.items()}
+                dmap.update(string_dict)
+        return dmap
+
     def _get_previous_signatures(self, dmap):
         """
         Return a list of corresponding csigs from previous
@@ -3342,37 +3358,62 @@ class File(Base):
         if len(dmap) == 0:
             if MD5_TIMESTAMP_DEBUG: print("Nothing dmap shortcutting")
             return None
+        elif MD5_TIMESTAMP_DEBUG: print("len(dmap):%d"%len(dmap))
 
-        if MD5_TIMESTAMP_DEBUG: print("len(dmap):%d"%len(dmap))
-        # First try the simple name for node
-        c_str = str(self)
-        if MD5_TIMESTAMP_DEBUG: print("Checking   :%s"%c_str)
-        df = dmap.get(c_str, None)
+
+        # First try retrieving via Node
+        if MD5_TIMESTAMP_DEBUG: print("Checking if self is in  map:%s id:%s type:%s"%(str(self), id(self), type(self)))
+        df = dmap.get(self, False)
         if df:
             return df
 
+        # Now check if self's repository file is in map.
+        rf = self.rfile()
+        if MD5_TIMESTAMP_DEBUG: print("Checking if self.rfile  is in  map:%s id:%s type:%s"%(str(rf), id(rf), type(rf)))
+        rfm = dmap.get(rf, False)
+        if rfm:
+            return rfm
+
+        # get default string for node and then also string swapping os.altsep for os.sep (/ for \)
+        c_strs = [str(self)]
+
         if os.altsep:
-            c_str = c_str.replace(os.sep, os.altsep)
-            df = dmap.get(c_str, None)
-            if MD5_TIMESTAMP_DEBUG: print("-->%s"%df)
+            c_strs.append(c_strs[0].replace(os.sep, os.altsep))
+
+        # In some cases the dependency_maps' keys are already strings check.
+        # Check if either string is now in dmap.
+        for s in c_strs:
+            if MD5_TIMESTAMP_DEBUG: print("Checking if str(self) is in map  :%s" % s)
+            df = dmap.get(s, False)
             if df:
                 return df
 
+        # Strings didn't existing in map, add them and try again
+        # If there are no strings in this dmap, then add them.
+        # This may not be necessary, we could walk the nodes in the dmap and check each string
+        # rather than adding ALL the strings to dmap. In theory that would be n/2 vs 2n str() calls on node
+        # if not dmap.has_strings:
+        dmap = self._add_strings_to_dependency_map(dmap)
+
+        # In some cases the dependency_maps' keys are already strings check.
+        # Check if either string is now in dmap.
+        for s in c_strs:
+            if MD5_TIMESTAMP_DEBUG: print("Checking if str(self) is in map (now with strings)  :%s" % s)
+            df = dmap.get(s, False)
+            if df:
+                return df
+
+        # Lastly use nodes get_path() to generate string and see if that's in dmap
         if not df:
             try:
                 # this should yield a path which matches what's in the sconsign
                 c_str = self.get_path()
-                df = dmap.get(c_str, None)
-                if MD5_TIMESTAMP_DEBUG: print("-->%s"%df)
-                if df:
-                    return df
-
                 if os.altsep:
                     c_str = c_str.replace(os.sep, os.altsep)
-                    df = dmap.get(c_str, None)
-                    if MD5_TIMESTAMP_DEBUG: print("-->%s"%df)
-                    if df:
-                        return df
+
+                if MD5_TIMESTAMP_DEBUG: print("Checking if self.get_path is in map (now with strings)  :%s" % s)
+
+                df = dmap.get(c_str, None)
 
             except AttributeError as e:
                 raise FileBuildInfoFileToCsigMappingError("No mapping from file name to content signature for :%s"%c_str)
@@ -3399,9 +3440,6 @@ class File(Base):
         Returns:
             Boolean - Indicates if node(File) has changed.
         """
-        if node is None:
-            # We need required node argument to get BuildInfo to function
-            raise DeciderNeedsNode(self.changed_timestamp_then_content)
 
         # Now get sconsign name -> csig map and then get proper prev_ni if possible
         bi = node.get_stored_info().binfo
@@ -3433,7 +3471,6 @@ class File(Base):
                 print("Mismatch self.changed_timestamp_match(%s, prev_ni) old:%s new:%s"%(str(target), old, new))
                 new_prev_ni = self._get_previous_signatures(dependency_map)
 
-
         if not new:
             try:
                 # NOTE: We're modifying the current node's csig in a query.
@@ -3443,13 +3480,13 @@ class File(Base):
             return False
         return self.changed_content(target, new_prev_ni)
 
-    def changed_timestamp_newer(self, target, prev_ni):
+    def changed_timestamp_newer(self, target, prev_ni, repo_node=None):
         try:
             return self.get_timestamp() > target.get_timestamp()
         except AttributeError:
             return 1
 
-    def changed_timestamp_match(self, target, prev_ni):
+    def changed_timestamp_match(self, target, prev_ni, repo_node=None):
         """
         Return True if the timestamps don't match or if there is no previous timestamp
         :param target:

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3319,8 +3319,7 @@ class File(Base):
             return {}
 
 
-        # store this info so we can avoid regenerating it.
-        binfo.dependency_map = { str(child):signature for child, signature in zip(chain(binfo.bsources, binfo.bdepends, binfo.bimplicit),
+        binfo.dependency_map = { child:signature for child, signature in zip(chain(binfo.bsources, binfo.bdepends, binfo.bimplicit),
                                      chain(binfo.bsourcesigs, binfo.bdependsigs, binfo.bimplicitsigs))}
 
         return binfo.dependency_map

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -253,21 +253,6 @@ _target_from_source_map = {0 : target_from_source_none,
 # used by it.
 #
 
-
-class DeciderNeedsNode(Exception):
-    """
-    Indicate that the decider needs the node as well as the target and the dependency.
-    Normally the node and the target are the same, but in the case of repository
-    They may be different. Also the NodeInfo is retrieved from the node
-    """
-    def __init__(self, call_this_decider):
-        """
-        :param call_this_decider: to return the decider to call directly since deciders
-               are called through several levels of indirection
-        """
-        self.decider = call_this_decider
-
-
 #
 # First, the single decider functions
 #

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -56,7 +56,6 @@ import SCons.Warnings
 import SCons.Conftest
 
 from SCons.Debug import Trace
-from SCons.Node import DeciderNeedsNode
 
 # Turn off the Conftest error logging
 SCons.Conftest.LogInputFiles = 0
@@ -407,12 +406,10 @@ class SConfBase(object):
             # that the correct .sconsign info will get calculated
             # and keep the build state consistent.
             def force_build(dependency, target, prev_ni,
-                            env_decider=env.decide_source,
-                            node=None):
+                            repo_node=None,
+                            env_decider=env.decide_source):
                 try:
-                    env_decider(dependency, target, prev_ni)
-                except DeciderNeedsNode as e:
-                    e.decider(target, prev_ni, node=target)
+                    env_decider(dependency, target, prev_ni, repo_node)
                 except Exception as e:
                     raise e
                 return True

--- a/test/Decider/Environment.py
+++ b/test/Decider/Environment.py
@@ -38,7 +38,7 @@ DefaultEnvironment(tools=[])
 import os.path
 env = Environment(tools=[])
 env.Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
-def my_decider(dependency, target, prev_ni):
+def my_decider(dependency, target, prev_ni, repo_node=None):
     return os.path.exists('has-changed')
 env.Decider(my_decider)
 """)

--- a/test/Decider/Node.py
+++ b/test/Decider/Node.py
@@ -38,7 +38,7 @@ import os.path
 file_in = File('file.in')
 file_out = File('file.out')
 Command(file_out, file_in, Copy('$TARGET', '$SOURCE'))
-def my_decider(dependency, target, prev_ni):
+def my_decider(dependency, target, prev_ni, repo_node):
     return os.path.exists('has-changed')
 file_in.Decider(my_decider)
 """)

--- a/test/Decider/default.py
+++ b/test/Decider/default.py
@@ -36,7 +36,7 @@ test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 import os.path
 Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
-def my_decider(dependency, target, prev_ni):
+def my_decider(dependency, target, prev_ni, repo_node=None):
     return os.path.exists('has-changed')
 Decider(my_decider)
 """)

--- a/test/Decider/mixed.py
+++ b/test/Decider/mixed.py
@@ -47,11 +47,11 @@ denv.Command('ddd.out', 'ddd.in',   Copy('$TARGET', '$SOURCE'))
 denv.Command('n2.out',  n2_in,      Copy('$TARGET', '$SOURCE'))
 env.Command( 'eee.out', 'eee.in',   Copy('$TARGET', '$SOURCE'))
 env.Command( 'n3.out',  n3_in,      Copy('$TARGET', '$SOURCE'))
-def default_decider(dependency, target, prev_ni):
+def default_decider(dependency, target, prev_ni, repo_node=None):
     return os.path.exists('default-has-changed')
-def env_decider(dependency, target, prev_ni):
+def env_decider(dependency, target, prev_ni, repo_node=None):
     return os.path.exists('env-has-changed')
-def node_decider(dependency, target, prev_ni):
+def node_decider(dependency, target, prev_ni, repo_node=None):
     return os.path.exists('node-has-changed')
 Decider(default_decider)
 env.Decider(env_decider)

--- a/test/packaging/rpm/explicit-target.py
+++ b/test/packaging/rpm/explicit-target.py
@@ -77,7 +77,7 @@ env.Package( NAME           = 'foo',
 
 expect = """
 scons: *** Setting target is not supported for rpm.
-""" + test.python_file_line(test.workpath('SConstruct'), 12)
+""" + test.python_file_line(test.workpath('SConstruct'), 23)
 
 test.run(arguments='', status=2, stderr=expect)
 


### PR DESCRIPTION
Recover lost performance in previous fix to md5-timestamp decider.

Additionally there's a fix for a performance issue with Action.get_content(). This sped up null incremental builds noticeably (for any decider).

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
