### PR TITLE
Allow builders to inherit from OverrideEnvironments

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -79,6 +79,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix more re patterns that contain \ but not specified as raw strings
       (affects scanners for D, LaTeX, swig)
 
+  From Mathew Robinson:
+    - Update cache debug output to include cache hit rate.
+    - No longer unintentionally hide exceptions in Action.py
+    - Allow builders and pseudo-builders to inherit from OverrideEnvironments
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700
 

--- a/src/RELEASE.txt
+++ b/src/RELEASE.txt
@@ -54,6 +54,14 @@
            ->Implicit
            Old:/usr/bin/python	New:/usr/bin/python
 
+
+    - Changed: Pseudo-builders now inherit OverrideEnvironments. For
+      example when calling a pseudo-builder from another
+      pseudo-builder the override variables passed to the first
+      pseudo-builder call had to be explicitly passed on to the
+      internal pseudo-builder call. Now the second pseudo-builder call
+      will automatically inherit these override values.
+
   FIXES
 
     - List fixes of outright bugs

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -2305,7 +2305,20 @@ class OverrideEnvironment(Base):
 
     # Methods that make this class act like a proxy.
     def __getattr__(self, name):
-        return getattr(self.__dict__['__subject'], name)
+        attr = getattr(self.__dict__['__subject'], name)
+        # Here we check if attr is one of the Wrapper classes. For
+        # example when a pseudo-builder is being called from an
+        # OverrideEnvironment.
+        #
+        # These wrappers when they're constructed capture the
+        # Environment they are being constructed with and so will not
+        # have access to overrided values. So we rebuild them with the
+        # OverrideEnvironment so they have access to overrided values.
+        if isinstance(attr, (MethodWrapper, BuilderWrapper)):
+            return attr.clone(self)
+        else:
+            return attr
+        
     def __setattr__(self, name, value):
         setattr(self.__dict__['__subject'], name, value)
 

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -3587,6 +3587,10 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
     def setUp(self):
         env = Environment()
         env._dict = {'XXX' : 'x', 'YYY' : 'y'}
+        def verify_value(env, key, value, *args, **kwargs):
+            """Verifies that key is value on the env this is called with."""
+            assert env[key] == value
+        env.AddMethod(verify_value)
         env2 = OverrideEnvironment(env, {'XXX' : 'x2'})
         env3 = OverrideEnvironment(env2, {'XXX' : 'x3', 'YYY' : 'y3', 'ZZZ' : 'z3'})
         self.envs = [ env, env2, env3 ]
@@ -3776,6 +3780,13 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
     #def test_WhereIs(self):
     #    """Test the OverrideEnvironment WhereIs() method"""
     #    pass
+
+    def test_PseudoBuilderInherits(self):
+        """Test that pseudo-builders inherit the overrided values."""
+        env, env2, env3 = self.envs
+        env.verify_value('XXX', 'x')
+        env2.verify_value('XXX', 'x2')
+        env3.verify_value('XXX', 'x3')
 
     def test_Dir(self):
         """Test the OverrideEnvironment Dir() method"""


### PR DESCRIPTION
Allow builders to inherit from override environments.

Using this [git repository as a repro](https://github.com/chasinglogic/Scons-psuedobuilder_no_override_access) we can see before this change:

```
(scons) @rocinante ➜  Scons-psuedobuilder_no_override_access git:(master) ✗ python ~/Work/scons/src/script/scons.py
scons: Reading SConscript files ...
constructing override env
Override id:4539871528
getattr called InstallInBinDirs
KeyError: 'TEST_VAR':
  File "/Users/chasinglogic/Code/Scons-psuedobuilder_no_override_access/SConstruct", line 20:
    oenv.InstallInBinDirs(env.Program("main.c"))  # installs hello in both bin dirs
  File "/Users/chasinglogic/Work/scons/src/script/../engine/SCons/Environment.py", line 224:
    return self.method(*nargs, **kwargs)
  File "/Users/chasinglogic/Code/Scons-psuedobuilder_no_override_access/SConstruct", line 11:
    print("TEST_VAR=%s" % env["TEST_VAR"])
  File "/Users/chasinglogic/Work/scons/src/script/../engine/SCons/Environment.py", line 410:
    return self._dict[key]
```

After this change:

```
(scons) @rocinante ➜  Scons-psuedobuilder_no_override_access git:(master) ✗ python ~/Work/scons/src/script/scons.py
scons: Reading SConscript files ...
Override id:4556668320
TEST_VAR=abc
scons: done reading SConscript files.
scons: Building targets ...
gcc -o main.o -c main.c
gcc -o main main.o
Install file: "main" as "localbin/main"
Install file: "main" as "mybin/main"
scons: done building targets.
```

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation