### PR TITLE
LaTeX scanner: Find > 1 includes per line

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -42,9 +42,15 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       which specifies what character to join all the argements output into the tempfile. The default remains a space
       when mslink, msvc, or mslib tools are loaded they change the TEMPFILEARGJOIN to be a line separator (\r\n on win32)
 
-    From Michael Hartmann:
+  From Michael Hartmann:
     - Fix handling of Visual Studio Compilers to properly reject any unknown HOST_PLATFORM or TARGET_PLATFORM
 
+  From Mathew Robinson:
+    - Update cache debug output to include cache hit rate.
+    - No longer unintentionally hide exceptions in Action.py
+
+  From Lukas Schrangl:
+    - Enable LaTeX scanner to find more than one include per line
 
   From Mats Wichmann:
     - scons-time takes more care closing files and uses safer mkdtemp to avoid
@@ -72,11 +78,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       ParseFlags: -iquote and -idirafter.
     - Fix more re patterns that contain \ but not specified as raw strings
       (affects scanners for D, LaTeX, swig)
-      
 
-  From Mathew Robinson:
-    - Update cache debug output to include cache hit rate.
-    - No longer unintentionally hide exceptions in Action.py
 
 RELEASE 3.0.5 - Mon, 26 Mar 2019 15:04:42 -0700
 

--- a/src/engine/SCons/Scanner/LaTeX.py
+++ b/src/engine/SCons/Scanner/LaTeX.py
@@ -179,13 +179,6 @@ class LaTeX(SCons.Scanner.Base):
                         'inputfrom', 'subinputfrom']
 
     def __init__(self, name, suffixes, graphics_extensions, *args, **kw):
-
-        # We have to include \n with the % we exclude from the first part
-        # part of the regex because the expression is compiled with re.M.
-        # Without the \n,  the ^ could match the beginning of a *previous*
-        # line followed by one or more newline characters (i.e. blank
-        # lines), interfering with a match on the next line.
-        # add option for whitespace before the '[options]' or the '{filename}'
         regex = r'''
             \\(
                 include

--- a/src/engine/SCons/Scanner/LaTeX.py
+++ b/src/engine/SCons/Scanner/LaTeX.py
@@ -187,7 +187,6 @@ class LaTeX(SCons.Scanner.Base):
         # lines), interfering with a match on the next line.
         # add option for whitespace before the '[options]' or the '{filename}'
         regex = r'''
-            ^[^%\n]*
             \\(
                 include
               | includegraphics(?:\s*\[[^\]]+\])?

--- a/src/engine/SCons/Scanner/LaTeXTests.py
+++ b/src/engine/SCons/Scanner/LaTeXTests.py
@@ -61,6 +61,12 @@ test.write('test3.latex',r"""
 \includegraphics[width=60mm]{inc5.xyz}
 """)
 
+test.write('test4.latex',r"""
+\include{inc1}\include{inc2}
+\only<1>{\includegraphics{inc5.xyz}}%
+\only<2>{\includegraphics{inc7.png}}
+""")
+
 test.subdir('subdir')
 
 test.write('inc1.tex',"\n")
@@ -73,6 +79,7 @@ test.write(['subdir', 'inc3c.tex'], "\n")
 test.write(['subdir', 'inc4.eps'], "\n")
 test.write('inc5.xyz', "\n")
 test.write('inc6.tex', "\n")
+test.write('inc7.png', "\n")
 test.write('incNO.tex', "\n")
 
 # define some helpers:
@@ -153,6 +160,15 @@ class LaTeXScannerTestCase3(unittest.TestCase):
          path = s.path(env)
          deps = s(env.File('test3.latex'), env, path)
          files = ['inc5.xyz', 'subdir/inc4.eps']
+         deps_match(self, deps, files)
+
+class LaTeXScannerTestCase4(unittest.TestCase):
+     def runTest(self):
+         env = DummyEnvironment(TEXINPUTS=[test.workpath("subdir")],LATEXSUFFIXES = [".tex", ".ltx", ".latex"])
+         s = SCons.Scanner.LaTeX.LaTeXScanner()
+         path = s.path(env)
+         deps = s(env.File('test4.latex'), env, path)
+         files = ['inc1.tex', 'inc2.tex', 'inc5.xyz', 'inc7.png']
          deps_match(self, deps, files)
 
 if __name__ == "__main__":


### PR DESCRIPTION
`^[^%\n]*` at the beginning of the reg ex would match all but the last include so that they were lost. There is no point checking for `%` since comments are stripped anyways (and this would also fail on lines containing an escaped percent sign `\%`, right?). Also, I don't see the point of checking for the newline, so I just removed that altogether.

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
