### PR TITLE
[WIP] Prototype of a more aggressive parallel scanner

### DIFF
--- a/src/engine/SCons/Job.py
+++ b/src/engine/SCons/Job.py
@@ -93,6 +93,7 @@ class Jobs(object):
         """
 
         self.job = None
+        tm_owns_caching = False
         if num > 1:
             stack_size = explicit_stack_size
             if stack_size is None:
@@ -101,6 +102,7 @@ class Jobs(object):
             try:
                 if parallel_v2:
                     self.job = ParallelV2(taskmaster, num, stack_size)
+                    tm_owns_caching = True
                 else:
                     self.job = Parallel(taskmaster, num, stack_size)
                 self.num_jobs = num
@@ -110,7 +112,7 @@ class Jobs(object):
             self.job = Serial(taskmaster)
             self.num_jobs = 1
 
-        taskmaster.set_tm_owns_caching(not isinstance(self.job, ParallelV2))
+        taskmaster.set_tm_owns_caching(tm_owns_caching)
 
     def run(self, postfunc=lambda: None):
         """Run the jobs.

--- a/src/engine/SCons/Job.py
+++ b/src/engine/SCons/Job.py
@@ -36,7 +36,6 @@ import SCons.Defaults
 import SCons.Util
 
 from collections import deque
-import datetime
 
 import os
 import signal
@@ -93,7 +92,7 @@ class Jobs(object):
         """
 
         self.job = None
-        tm_owns_caching = False
+        tm_owns_caching = True
         if num > 1:
             stack_size = explicit_stack_size
             if stack_size is None:
@@ -102,7 +101,7 @@ class Jobs(object):
             try:
                 if parallel_v2:
                     self.job = ParallelV2(taskmaster, num, stack_size)
-                    tm_owns_caching = True
+                    tm_owns_caching = False
                 else:
                     self.job = Parallel(taskmaster, num, stack_size)
                 self.num_jobs = num

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -2967,20 +2967,10 @@ class File(Base):
         if self.exists():
             self.get_build_env().get_CacheDir().push(self)
 
-    def retrieve_from_cache(self):
-        """Try to retrieve the node's content from a cache
-
-        This method is called from multiple threads in a parallel build,
-        so only do thread safe stuff here. Do thread unsafe stuff in
-        built().
-
-        Returns true if the node was successfully retrieved.
+    def should_retrieve_from_cache(self):
+        """Returns whether this node should be retrieved from the cache
         """
-        if self.nocache:
-            return None
-        if not self.is_derived():
-            return None
-        return self.get_build_env().get_CacheDir().retrieve(self)
+        return not self.nocache and self.is_derived()
 
     def visited(self):
         if self.exists() and self.executor is not None:

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -706,6 +706,14 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         """
         pass
 
+    def should_retrieve_from_cache(self):
+        """Returns whether this node should be retrieved from the cache
+
+        By default nodes are not cacheable. Child classes should override this
+        method if the CacheDir class supports them.
+        """
+        return False
+
     def retrieve_from_cache(self):
         """Try to retrieve the node's content from a cache
 
@@ -713,9 +721,10 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         so only do thread safe stuff here. Do thread unsafe stuff in
         built().
 
-        Returns true if the node was successfully retrieved.
+        Returns true iff the node was successfully retrieved.
         """
-        return 0
+        return self.should_retrieve_from_cache() and \
+            self.get_build_env().get_CacheDir().retrieve(self)
 
     #
     # Taskmaster interface subsystem

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -546,7 +546,7 @@ class SConfBase(object):
             SConfFS.set_max_drift(0)
             tm = SCons.Taskmaster.Taskmaster(nodes, SConfBuildTask)
             # we don't want to build tests in parallel
-            jobs = SCons.Job.Jobs(1, tm )
+            jobs = SCons.Job.Jobs(1, tm, False)
             jobs.run()
             for n in nodes:
                 state = n.get_state()

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -1270,7 +1270,7 @@ def _build_targets(fs, options, targets, target_top):
     # to check if python configured with threads.
     global num_jobs
     num_jobs = options.num_jobs
-    jobs = SCons.Job.Jobs(num_jobs, taskmaster)
+    jobs = SCons.Job.Jobs(num_jobs, taskmaster, options.parallel_v2)
     if num_jobs > 1:
         msg = None
         if sys.platform == 'win32':

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -583,6 +583,11 @@ def Parser(version):
                   action="store_true",
                   help="Print build actions for files from CacheDir.")
 
+    op.add_option('--parallel-v2',
+                  dest='parallel_v2', default=False,
+                  action="store_true",
+                  help="Use the newer, more aggressive parallel scheduler.")
+
     def opt_invalid(group, value, options):
         errmsg  = "`%s' is not a valid %s option type, try:\n" % (value, group)
         return errmsg + "    %s" % ", ".join(options)

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -583,11 +583,6 @@ def Parser(version):
                   action="store_true",
                   help="Print build actions for files from CacheDir.")
 
-    op.add_option('--parallel-v2',
-                  dest='parallel_v2', default=False,
-                  action="store_true",
-                  help="Use the newer, more aggressive parallel scheduler.")
-
     def opt_invalid(group, value, options):
         errmsg  = "`%s' is not a valid %s option type, try:\n" % (value, group)
         return errmsg + "    %s" % ", ".join(options)
@@ -778,6 +773,11 @@ def Parser(version):
                   dest='no_site_dir', default=False,
                   action="store_true",
                   help="Don't search or use the usual site_scons dir.")
+
+    op.add_option('--parallel-v2',
+                  dest='parallel_v2', default=False,
+                  action="store_true",
+                  help="Use the newer, more aggressive parallel scheduler.")
 
     op.add_option('--profile',
                   nargs=1,


### PR DESCRIPTION
This is a work-in-progress changeset for a more aggressive parallel scanner.
The current parallel scanner wastes time waiting for thread pool results when
it could have been more aggressively continuing to gather more tasks to
dispatch. The idea here is that if we have dispatched the maximum number of
jobs and none are done yet, we should gather more tasks instead of doing a
blocking wait on the thread pool. In my testing, I have seen a 4-5% improvement
in some VMware builds.

One upside of this change is that it paves the way for us to be able to
implement remote caching because we now ask the cache for groups of tasks
instead of one-at-a-time.

At VMware we don't have a good mechanism for testing upstream SCons changes so
this is a blind application of a patch I wrote. It passes some tests but
may have some bugs compared to the version I applied internally. More work
needed here; for now I just want to get people's thoughts on whether this is heading in the right direction.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
