### PR TITLE
Avoid using cPickle on Windows

### DIFF
--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -80,7 +80,11 @@ def rename_module(new, old):
 
 # TODO: FIXME
 # In 3.x, 'pickle' automatically loads the fast version if available.
-rename_module('pickle', 'cPickle')
+if os.name != "nt":
+    # Windows needs to use the standard pickle module because cPickle
+    # does not have the dispatch dictionary. This will probably not be fixed
+    # in a future version of Python. See http://bugs.python.org/issue3385
+    rename_module('pickle', 'cPickle')
 
 # Default pickle protocol. Higher protocols are more efficient/featureful
 # but incompatible with older Python versions. On Python 2.7 this is 2.


### PR DESCRIPTION
This integrates a change from VMware introduced back in 2013.

The Windows Python multiprocessing module uses the standard Python pickle
module. Unfortunately, SCons compat code renames cPickle to pickle, and
they are slightly different in an incompatible way. End result is that
'import SCons' broke a VMware script called iscons on Windows. This change
tests for os.name == 'nt' and doesn't rename cPickle in this case.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
