### PR TITLE
msvs host-target fix + vs19 support

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -9,6 +9,10 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Joseph Brill:
+    - Code to supply correct version-specifier argument to vswhere for
+      VS version selection.
+
   From Peter Diener:
     - Additional fix to issue #3135 - Also handle 'pure' and 'elemental' type bound procedures
     - Fix issue #3135 - Handle Fortran submodules and type bound procedures
@@ -48,14 +52,18 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
           def my_decider(dependency, target, prev_ni, repo_node):
       Where repo_node is the repository (or other) node to use to check if the node is out of date instead of dependency.
 
-
-
   From Michael Hartmann:
     - Fix handling of Visual Studio Compilers to properly reject any unknown HOST_PLATFORM or TARGET_PLATFORM
+
+  From Bert Huijben:
+    - Added support for Visual Studio 2019 toolset.
 
   From Mathew Robinson:
     - Update cache debug output to include cache hit rate.
     - No longer unintentionally hide exceptions in Action.py
+
+  From Leonard de Ruijter:
+    - Add logic to derive correct version argument to vswhere
 
   From Lukas Schrangl:
     - Enable LaTeX scanner to find more than one include per line

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -189,11 +189,19 @@ def get_host_target(env):
 
 # If you update this, update SupportedVSList in Tool/MSCommon/vs.py, and the
 # MSVC_VERSION documentation in Tool/msvc.xml.
-_VCVER = ["14.1", "14.0", "14.0Exp", "12.0", "12.0Exp", "11.0", "11.0Exp", "10.0", "10.0Exp", "9.0", "9.0Exp","8.0", "8.0Exp","7.1", "7.0", "6.0"]
+_VCVER = ["14.2", "14.1", "14.0", "14.0Exp", "12.0", "12.0Exp", "11.0", "11.0Exp", "10.0", "10.0Exp", "9.0", "9.0Exp","8.0", "8.0Exp","7.1", "7.0", "6.0"]
+
+# if using vswhere, a further mapping is needed
+_VCVER_TO_VSWHERE_VER = {
+    '14.2' : '[16.0, 17.0)',
+    '14.1' : '[15.0, 16.0)',
+}
 
 _VCVER_TO_PRODUCT_DIR = {
+    '14.2' : [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')], # VS 2019 doesn't set this key
     '14.1' : [
-        (SCons.Util.HKEY_LOCAL_MACHINE, r'')], # Visual Studio 2017 doesn't set this registry key anymore
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')], # VS 2017 doesn't set this key
     '14.0' : [
         (SCons.Util.HKEY_LOCAL_MACHINE, r'Microsoft\VisualStudio\14.0\Setup\VC\ProductDir')],
     '14.0Exp' : [
@@ -254,42 +262,40 @@ def msvc_version_to_maj_min(msvc_version):
         raise ValueError("Unrecognized version %s (%s)" % (msvc_version,msvc_version_numeric))
 
 def is_host_target_supported(host_target, msvc_version):
-    """Check if the given (host, target) tuple is supported for given version.
+    """Check if (host, target) pair is supported for a VC version.
 
-    Args:
-        host_target: tuple
-            tuple of (canonalized) host-targets, e.g. ("x86", "amd64")
-            for cross compilation from 32 bit Windows to 64 bits.
-        msvc_version: str
-            msvc version (major.minor, e.g. 10.0)
-
-    Returns:
-        bool:
-
-    Note:
-        This only checks whether a given version *may* support the given (host,
+    :note: only checks whether a given version *may* support the given (host,
         target), not that the toolchain is actually present on the machine.
+    :param tuple host_target: canonalized host-targets pair, e.g.
+        ("x86", "amd64") for cross compilation from 32 bit Windows to 64 bits.
+    :param str msvc_version: Visual C++ version (major.minor), e.g. "10.0"
+    :returns: True or False
     """
     # We assume that any Visual Studio version supports x86 as a target
     if host_target[1] != "x86":
         maj, min = msvc_version_to_maj_min(msvc_version)
         if maj < 8:
             return False
-
     return True
 
 
 def find_vc_pdir_vswhere(msvc_version):
     """
-    Find the MSVC product directory using vswhere.exe.
+    Find the MSVC product directory using the vswhere program.
 
-    Run it asking for specified version and get MSVS  install location
-    :param msvc_version:
+    :param msvc_version: MSVC version to search for
     :return: MSVC install dir or None
+    :raises UnsupportedVersion: if the version is not known by this file
     """
 
+    try:
+        vswhere_version = _VCVER_TO_VSWHERE_VER[msvc_version]
+    except KeyError:
+        debug("Unknown version of MSVC: %s" % msvc_version)
+        raise UnsupportedVersion("Unknown version %s" % msvc_version)
+
     # For bug 3333 - support default location of vswhere for both 64 and 32 bit windows
-    # installs. 
+    # installs.
     for pf in ['Program Files (x86)', 'Program Files']:
         vswhere_path = os.path.join(
             'C:\\',
@@ -301,31 +307,36 @@ def find_vc_pdir_vswhere(msvc_version):
         if os.path.exists(vswhere_path):
             # If we found vswhere, then use it.
             break
+    else:
+        # No vswhere on system, no install info available
+        return None
 
-    vswhere_cmd = [vswhere_path, '-products', '*', '-version', msvc_version, '-property', 'installationPath']
+    vswhere_cmd = [vswhere_path,
+                   '-products', '*',
+                   '-version', vswhere_version,
+                   '-property', 'installationPath']
 
-    if os.path.exists(vswhere_path):
-        #TODO PY27 cannot use Popen as context manager
-        # try putting it back to the old way for now
-        sp = subprocess.Popen(vswhere_cmd,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
-        vsdir, err = sp.communicate()
-        if vsdir:
-            vsdir = vsdir.decode("mbcs").splitlines()
-            # vswhere could easily return multiple lines
-            # we could define a way to pick the one we prefer, but since
-            # this data is currently only used to make a check for existence,
-            # returning the first hit should be good enough for now.
-            vc_pdir = os.path.join(vsdir[0], 'VC')
-            return vc_pdir
+    #TODO PY27 cannot use Popen as context manager
+    # try putting it back to the old way for now
+    sp = subprocess.Popen(vswhere_cmd,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE)
+    vsdir, err = sp.communicate()
+    if vsdir:
+        vsdir = vsdir.decode("mbcs").splitlines()
+        # vswhere could easily return multiple lines
+        # we could define a way to pick the one we prefer, but since
+        # this data is currently only used to make a check for existence,
+        # returning the first hit should be good enough for now.
+        vc_pdir = os.path.join(vsdir[0], 'VC')
+        return vc_pdir
     else:
         # No vswhere on system, no install info available
         return None
 
 
 def find_vc_pdir(msvc_version):
-    """Find the product directory for the given version.
+    """Find the MSVC product directory for the given version.
 
     Tries to look up the path using a registry key from the table
     _VCVER_TO_PRODUCT_DIR; if there is no key, calls find_vc_pdir_wshere
@@ -462,7 +473,7 @@ def _check_cl_exists_in_vc_dir(env, vc_dir, msvc_version):
     host_platform = _ARCH_TO_CANONICAL[host_platform]
     target_platform = _ARCH_TO_CANONICAL[target_platform]
 
-    debug('_check_cl_exists_in_vc_dir(): host platform %s, target platform %s' % (host_platform, target_platform))
+    debug('_check_cl_exists_in_vc_dir(): host platform %s, target platform %s for version %s' % (host_platform, target_platform, msvc_version))
 
     ver_num = float(get_msvc_version_numeric(msvc_version))
 
@@ -510,7 +521,7 @@ def _check_cl_exists_in_vc_dir(env, vc_dir, msvc_version):
             # older versions of visual studio only had x86 binaries,
             # so if the host platform is amd64, we need to check cross
             # compile options (x86 binary compiles some other target on a 64 bit os)
-        
+
             # Set default value to be -1 as "" which is the value for x86/x86 yields true when tested
             # if not host_trgt_dir
             host_trgt_dir = _HOST_TARGET_TO_CL_DIR.get(('x86', target_platform), None)

--- a/src/engine/SCons/Tool/MSCommon/vs.py
+++ b/src/engine/SCons/Tool/MSCommon/vs.py
@@ -198,6 +198,17 @@ class VisualStudio(object):
 # Tool/MSCommon/vc.py, and the MSVC_VERSION documentation in Tool/msvc.xml.
 
 SupportedVSList = [
+    # Visual Studio 2019
+    VisualStudio('14.2',
+                 vc_version='14.2',
+                 sdk_version='10.0A',
+                 hkeys=[],
+                 common_tools_var='VS160COMNTOOLS',
+                 executable_path=r'Common7\IDE\devenv.com',
+                 batch_file_path=r'VC\Auxiliary\Build\vsvars32.bat',
+                 supported_arch=['x86', 'amd64', "arm"],
+                 ),
+
     # Visual Studio 2017
     VisualStudio('14.1',
                  vc_version='14.1',

--- a/src/engine/SCons/Tool/msvc.xml
+++ b/src/engine/SCons/Tool/msvc.xml
@@ -353,6 +353,7 @@ constructor; setting it later has no effect.
 
 <para>
 Valid values for Windows are
+<literal>14.2</literal>,
 <literal>14.1</literal>,
 <literal>14.0</literal>,
 <literal>14.0Exp</literal>,


### PR DESCRIPTION
This patch combines several bits of work - PR #3391 and the discussion/patch in Issue #3346 to improve the support of Visual Studio 2019.  VS 2019 is now a recognized version, and the selection of that version specifically should be working.  

If accepted, supersedes PR #3391.

I have tried to credit all three contributors to this work.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
