### PR TITLE
[WIP] Improve performance of Executor.get_lvals by removing delayed loading/caching

### DIFF
--- a/src/engine/SCons/ExecutorTests.py
+++ b/src/engine/SCons/ExecutorTests.py
@@ -503,7 +503,7 @@ class ExecutorTestCase(unittest.TestCase):
                 'UNCHANGED_TARGETS': [] if should_build else [t1],
             }
 
-            self.assertEqual(str(actual_lvars), str(expected_lvars))
+            self.assertEqual(actual_lvars, expected_lvars)
 
 
     def test_lvars_for_multiple_targets(self):
@@ -544,7 +544,7 @@ class ExecutorTestCase(unittest.TestCase):
                 'UNCHANGED_SOURCES': [] if should_build else [s1, s2],
                 'UNCHANGED_TARGETS': [] if should_build else [t1, t2],
             }
-            self.assertEqual(str(actual_lvars), str(expected_lvars))
+            self.assertEqual(actual_lvars, expected_lvars)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is another integration of an old VMware change. Original change description:

The Executor class has a get_lvars() method, which returns a dictionary
of helper TSList and TSObject instances, which call various methods on
Executor to get source and target lists. Comments mention that they
were added to delay creation of NodeList objects until needed, but the
effect is the opposite - the lists are re-created just to get a single
element or even attributes of the list objects. Another potential issue
is that the returned list can be mutated by adding sources/targets.

Profiling shows that this is a huge bottleneck for null or incremental
Fusion builds because of repeated get_subst_proxy() and list creation.
This change completely removes TSList and TSObject, and simplifies the
get_lvars() method to build the node lists from the current sources
and targets, just like other methods do.

With the change, a null build of Fusion's 'player' target is reduced
from 150 to 74 seconds, or 110 to 32 seconds for interactive builds.
The --profile pstats output shows substantially fewer calls:
   Function           Old # Calls    New # Calls
   get_lvars               10,250     10,250
   _get_targets            44,732          0
   get_subst_proxy    191,835,290    126,216

ESX builds (esx-all) don't show as much time improvement because there
is a lot of noise in other parts of the build. The calls have reduced:
   Function           Old # Calls    New # Calls
   get_lvars               61,959     61,959
   _get_targets           144,272          0
   get_subst_proxy     13,789,472    413,515


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
