### PR TITLE
Document and polish runtest.py

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -31,8 +31,8 @@ Options:
   -n --no-exec             No execute, just print command lines.
      --nopipefiles         Do not use the "file pipe" workaround for Popen()
                            for starting tests. WARNING: use only when too much
-                           file traffic is giving you trouble AND you can be 
-                           sure that none of your tests create output >65K 
+                           file traffic is giving you trouble AND you can be
+                           sure that none of your tests create output >65K
                            chars! You might run into some deadlocks else.
   -o --output FILE         Save the output from a test run to the log file.
   -P PYTHON                Use the specified Python interpreter.
@@ -678,7 +678,7 @@ else:
     tests.extend(unittests)
     tests.extend(endtests)
     tests.sort()
-    
+
 if not tests:
     sys.stderr.write(usagestr + """
 runtest.py:  No tests were found.
@@ -737,7 +737,7 @@ def log_result(t, io_lock=None):
     """ log the result of a test.
 
     "log" in this case means writing to stdout. Since we might be
-    called from from any of several diffrent threads (multi-job run),
+    called from from any of several different threads (multi-job run),
     we need to lock access to the log to avoid interleaving. The same
     would apply if output was a file.
 


### PR DESCRIPTION
This is a minor change to runtest, some slight rearrangements, adding a docstring, clarifying a few comments.  The subclass of Thread is now more precise in following the Thread constructor.

Test-only change, no effect on scons code or docs.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
