### PR TITLE
Add VS2019 to appveyor matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,11 @@
 #version: '3.0.1.{build}'
 
 image:
-  # linux builds disabled for now 
+  # linux builds done in Travis CI for now
   # - Ubuntu
   - Visual Studio 2015
   - Visual Studio 2017
+  - Visual Studio 2019
 
 cache:
   - downloads -> appveyor.yml
@@ -36,58 +37,37 @@ install:
   - sh: which python$PYTHON
   - sh: python$PYTHON --version
   - sh: export PYSITEDIR=$(python$PYTHON -m site --user-site)
-  - sh: python$PYTHON -m pip install --user -U --progress-bar off pip setuptools wheel 
+  - sh: python$PYTHON -m pip install --user -U --progress-bar off pip setuptools wheel
   - sh: python$PYTHON -m pip install --user -U --progress-bar off coverage codecov
   - sh: STATIC_DEPS=true python$PYTHON -m pip install --user -U --progress-bar off lxml
   - sh: ./.travis/install.sh
   - sh: printenv
 
-# build matrix will be number of images multiplied 
-# by each '-' below, split jobs into groups of 4
-# to avoid timeing out
+# build matrix will be number of images multiplied by each '-' below,
+# less any exclusions.
+# split builds into sets of four jobs due to appveyor per-job time limit
 environment:
   matrix:
     - WINPYTHON: "Python27"
       PYTHON: "2.7"
       PYVER: 27
       BUILD_JOB_NUM: 1
-      COVERAGE: 1
+      COVERAGE: 0
     - WINPYTHON: "Python27"
       PYTHON: "2.7"
       PYVER: 27
       BUILD_JOB_NUM: 2
-      COVERAGE: 1
+      COVERAGE: 0
     - WINPYTHON: "Python27"
       PYTHON: "2.7"
       PYVER: 27
       BUILD_JOB_NUM: 3
-      COVERAGE: 1
+      COVERAGE: 0
     - WINPYTHON: "Python27"
       PYTHON: "2.7"
       PYVER: 27
       BUILD_JOB_NUM: 4
-      COVERAGE: 1
-
-    - WINPYTHON: "Python36"
-      PYTHON: "3.6"
-      PYVER: 36
-      BUILD_JOB_NUM: 1
-      COVERAGE: 1
-    - WINPYTHON: "Python36"
-      PYTHON: "3.6"
-      PYVER: 36
-      BUILD_JOB_NUM: 2
-      COVERAGE: 1
-    - WINPYTHON: "Python36"
-      PYTHON: "3.6"
-      PYVER: 36
-      BUILD_JOB_NUM: 3
-      COVERAGE: 1
-    - WINPYTHON: "Python36"
-      PYTHON: "3.6"
-      PYVER: 36
-      BUILD_JOB_NUM: 4
-      COVERAGE: 1
+      COVERAGE: 0
 
     - WINPYTHON: "Python35"
       PYTHON: "3.5"
@@ -109,6 +89,27 @@ environment:
       PYVER: 35
       BUILD_JOB_NUM: 4
       COVERAGE: 0
+
+    - WINPYTHON: "Python36"
+      PYTHON: "3.6"
+      PYVER: 36
+      BUILD_JOB_NUM: 1
+      COVERAGE: 1
+    - WINPYTHON: "Python36"
+      PYTHON: "3.6"
+      PYVER: 36
+      BUILD_JOB_NUM: 2
+      COVERAGE: 1
+    - WINPYTHON: "Python36"
+      PYTHON: "3.6"
+      PYVER: 36
+      BUILD_JOB_NUM: 3
+      COVERAGE: 1
+    - WINPYTHON: "Python36"
+      PYTHON: "3.6"
+      PYVER: 36
+      BUILD_JOB_NUM: 4
+      COVERAGE: 1
 
     - WINPYTHON: "Python37"
       PYTHON: "3.7"
@@ -133,40 +134,49 @@ environment:
 
 # remove sets of build jobs based on critia below
 # to fine tune the number and platforms tested
-matrix:	
-  exclude:	
-    # test python 3.5, 3.6 on Visual Studio 2015 image
-    - image: Visual Studio 2015	
-      WINPYTHON: "Python37"
-    - image: Visual Studio 2015	
+matrix:
+  exclude:
+    # test python 3.5 on Visual Studio 2015 image
+    - image: Visual Studio 2015
       WINPYTHON: "Python27"
+    - image: Visual Studio 2015
+      WINPYTHON: "Python36"
+    - image: Visual Studio 2015
+      WINPYTHON: "Python37"
 
-    # test python 2.7, 3.7 on Visual Studio 2015 image
+    # test python 2.7, 3.6 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python35"
-    - image: Visual Studio 2017	
+    - image: Visual Studio 2017
+      WINPYTHON: "Python37"
+
+    # test python 3.7 on Visual Studio 2019 image
+    - image: Visual Studio 2019
+      WINPYTHON: "Python27"
+    - image: Visual Studio 2019
+      WINPYTHON: "Python35"
+    - image: Visual Studio 2019
       WINPYTHON: "Python36"
 
     # test python 3.7 on Ubuntu
-    - image: Ubuntu	
-      WINPYTHON: "Python27"	
-    - image: Ubuntu		
+    - image: Ubuntu
+      WINPYTHON: "Python27"
+    - image: Ubuntu
       WINPYTHON: "Python35"
-    - image: Ubuntu		
+    - image: Ubuntu
       WINPYTHON: "Python36"
 
 # remove some binaries we dont to be found
 before_build:
     - ps: |
-        if ($isWindows) 
-        {
+        if ($isWindows) {
           dir "C:\Program Files\Git\usr\bin\x*.exe"
           if (Test-Path "C:\Program Files\Git\usr\bin\xsltproc.EXE" ) {
             Remove-Item  "C:\Program Files\Git\usr\bin\xsltproc.EXE" -ErrorAction Ignore
           }
           dir "C:\Program Files\Git\usr\bin\x*.exe"
         }
-  
+
 build: off
 
 build_script:
@@ -174,18 +184,17 @@ build_script:
   - cmd: "C:\\%WINPYTHON%\\python.exe runtest.py -l -a > all_tests.txt"
   - sh: python$PYTHON runtest.py -l -a > all_tests.txt
 
-  # setup coverage by creating the coverage config file, and adding coverage 
+  # setup coverage by creating the coverage config file, and adding coverage
   # to the usercustomize so that all python processes start with coverage
   - ps: |
-      if ($env:COVERAGE -eq 1){ 
+      if ($env:COVERAGE -eq 1) {
         $env:COVERAGE_PROCESS_START = "$($env:APPVEYOR_BUILD_FOLDER)/.coveragerc";
         $env:PYTHONNOUSERSITE = "";
         New-Item -ItemType Directory -Force -Path "$($env:PYSITEDIR)";
         $env:COVERAGE_FILE = "$($env:APPVEYOR_BUILD_FOLDER)/.coverage";
         $usercustomizeText = "import os`r`nos.environ['COVERAGE_PROCESS_START'] = '$($env:COVERAGE_PROCESS_START)'`r`nimport coverage`r`ncoverage.process_startup()";
         $usercustomizeText|Set-Content "$($env:PYSITEDIR)/usercustomize.py";
-        if ($isWindows) 
-        {
+        if ($isWindows) {
           $coveragercFile = "[run]`r`nsource = $($env:APPVEYOR_BUILD_FOLDER)/src`r`nparallel = True`r`ndisable_warnings = trace-changed`r`nomit =`r`n`t*Tests.py`r`n`tsrc\test_*`r`n`tsrc\setup.py`r`n`r`n[path]`r`nsource = $($env:APPVEYOR_BUILD_FOLDER)`r`n[report]`r`nomit =`r`n`t*Tests.py`r`n`tsrc\test_*`r`n`tsrc\setup.py`r`n`r`n"
         }
         else
@@ -205,12 +214,12 @@ build_script:
       if ( $start -eq 0 ){ $start = 1 };
       get-content all_tests.txt | select -first ($end - $start) -skip ($start - 1) | Out-File -Encoding ASCII build_tests.txt;
 
-  # exclude VS 10.0 because it hangs the testing until this is resolved: 
+  # exclude VS 10.0 because it hangs the testing until this is resolved:
   # https://help.appveyor.com/discussions/problems/19283-visual-studio-2010-trial-license-has-expired
   - ps: |
       New-Item -Name exclude_list.txt -ItemType File
       $workaround_image = "Visual Studio 2015"
-      if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq $workaround_image){ 
+      if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq $workaround_image) {
         Add-Content -Path 'exclude_list.txt' -Value 'test\MSVS\vs-10.0-exec.py'
       }
 
@@ -223,17 +232,16 @@ build_script:
   # unset JAVA_TOOL_OPTIONS because newer java prints this to stderr
   - sh: |
       unset JAVA_TOOL_OPTIONS
-      if [ "$COVERAGE" -eq "1" ]; then 
-        coverage run -p --rcfile="$COVERAGE_PROCESS_START" runtest.py --exclude-list exclude_list.txt -f build_tests.txt || if [[ $? == 2 ]]; then true; else false; fi; 
+      if [ "$COVERAGE" -eq "1" ]; then
+        coverage run -p --rcfile="$COVERAGE_PROCESS_START" runtest.py --exclude-list exclude_list.txt -f build_tests.txt || if [[ $? == 2 ]]; then true; else false; fi;
       else
-        python$PYTHON runtest.py -j 2 --exclude-list exclude_list.txt -f build_tests.txt || if [[ $? == 2 ]]; then true; else false; fi; 
+        python$PYTHON runtest.py -j 2 --exclude-list exclude_list.txt -f build_tests.txt || if [[ $? == 2 ]]; then true; else false; fi;
       fi
 
 # run converage even if there was a test failure
 on_finish:
   - ps: |
-      if ($env:COVERAGE -eq 1)
-      { 
+      if ($env:COVERAGE -eq 1) {
         & coverage combine
         & coverage report
         & coverage xml -o coverage_xml.xml
@@ -244,5 +252,5 @@ on_finish:
   - sh: if [ $COVERAGE -eq 1 ]; then codecov -X gcov --file coverage_xml.xml; fi
     # not using coveralls, so leaving it commented out in case we switch back
     #- cmd: "C:\\%WINPYTHON%\\python.exe -m pip install --user -U coveralls"
-    #- sh: python$PYTHON -m pip install --user -U coveralls 
+    #- sh: python$PYTHON -m pip install --user -U coveralls
     #- ps: coveralls --rcfile="$($env:COVERAGE_PROCESS_START)"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -143,12 +143,18 @@ matrix:
       WINPYTHON: "Python36"
     - image: Visual Studio 2015
       WINPYTHON: "Python37"
+    # quick test: skip all
+    - image: Visual Studio 2015
+      WINPYTHON: "Python35"
 
     # test python 2.7, 3.6 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python35"
     - image: Visual Studio 2017
       WINPYTHON: "Python37"
+    # quick test: skip 2.7 as well
+    - image: Visual Studio 2017
+      WINPYTHON: "Python27"
 
     # test python 3.7 on Visual Studio 2019 image
     - image: Visual Studio 2019

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -143,18 +143,12 @@ matrix:
       WINPYTHON: "Python36"
     - image: Visual Studio 2015
       WINPYTHON: "Python37"
-    # quick test: skip all
-    - image: Visual Studio 2015
-      WINPYTHON: "Python35"
 
     # test python 2.7, 3.6 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python35"
     - image: Visual Studio 2017
       WINPYTHON: "Python37"
-    # quick test: skip 2.7 as well
-    - image: Visual Studio 2017
-      WINPYTHON: "Python27"
 
     # test python 3.7 on Visual Studio 2019 image
     - image: Visual Studio 2019

--- a/test/TaskMaster/bug_2811/fixture_dir/SConstruct
+++ b/test/TaskMaster/bug_2811/fixture_dir/SConstruct
@@ -10,6 +10,7 @@ This issue requires the following.
    Nth target's implicit lists changing when compared to SConsign's which have been loaded.
 7. This forces rebuild of source file and this propagates to massive recompile
 """
+import sys
 import SCons.Tool
 
 
@@ -27,12 +28,15 @@ def _dwo_emitter(target, source, env):
     targets = target + new_targets
     return (targets, source)
 
+build_string = '$MYCOPY $SOURCE $TARGET'
 
-bld = Builder(action='cp $SOURCE $TARGET')
 
-env = Environment(BUILDERS={'Foo': bld})
+bld = Builder(action=build_string)
 
-env['SHCCCOM'] = 'cp $SOURCE $TARGET && cp $SOURCE ${TARGETS[1]}'
+env = Environment(BUILDERS={'Foo': bld}, MYCOPY="%s mycopy.py"%sys.executable)
+
+env['SHCCCOM'] = '$MYCOPY $SOURCE $TARGET && $MYCOPY $SOURCE ${TARGETS[1]}'
+
 env['SHCCCOMSTR'] = env['SHCCCOM']
 
 

--- a/test/TaskMaster/bug_2811/fixture_dir/mycopy.py
+++ b/test/TaskMaster/bug_2811/fixture_dir/mycopy.py
@@ -1,0 +1,8 @@
+import sys
+import shutil
+
+ffrom = sys.argv[1]
+to = sys.argv[2]
+shutil.copyfile(ffrom, to)
+
+sys.exit(0)

--- a/test/packaging/guess-package-name.py
+++ b/test/packaging/guess-package-name.py
@@ -92,10 +92,9 @@ test.must_exist('src.tar.gz')
 #
 # Windows 10 since at least 1803 supplies bsdtar, so tool
 # detection will find it - but doesn't supply bzip2, so a
-# test using it will fail. Check for bzip2 first.
+# test using it will fail. As a hack, just skip.
 
-bz2 = test.where_is('bzip2')
-if bz2:
+if sys.platform != 'win32':
     test.write('SConstruct', """
 env=Environment(tools=['default', 'packaging'])
 env.Program( 'src/main.c' )

--- a/test/packaging/guess-package-name.py
+++ b/test/packaging/guess-package-name.py
@@ -33,6 +33,8 @@ Also overriding this default package name is tested
 Furthermore that targz is the default packager is tested.
 """
 
+import sys
+
 import TestSCons
 
 python = TestSCons.python
@@ -88,8 +90,13 @@ test.must_exist('src.tar.gz')
 #
 # TEST: default package name creation with overridden packager.
 #
+# Windows 10 since at least 1803 supplies bsdtar, so tool
+# detection will find it - but doesn't supply bzip2, so a
+# test using it will fail. Check for bzip2 first.
 
-test.write('SConstruct', """
+bz2 = test.where_is('bzip2')
+if bz2:
+    test.write('SConstruct', """
 env=Environment(tools=['default', 'packaging'])
 env.Program( 'src/main.c' )
 env.Package( NAME        = 'libfoo',
@@ -98,15 +105,19 @@ env.Package( NAME        = 'libfoo',
              source      = [ 'src/main.c', 'SConstruct' ] )
 """)
 
-test.run(stderr=None)
+    test.run(stderr=None)
 
-test.must_exist('libfoo-1.2.3.tar.bz2')
+    test.must_exist('libfoo-1.2.3.tar.bz2')
 
 #
 # TEST: default package name creation with another packager.
 #
+# Windows 10 since at least 1803 supplies bsdtar, so tool
+# detection will find it - but it doesn't support xz
+# compression so test using it will fail. As a hack, just skip.
 
-test.write('SConstruct', """
+if sys.platform != 'win32':
+    test.write('SConstruct', """
 env=Environment(tools=['default', 'packaging'])
 env.Program( 'src/main.c' )
 env.Package( NAME        = 'libfoo',
@@ -115,9 +126,9 @@ env.Package( NAME        = 'libfoo',
              source      = [ 'src/main.c', 'SConstruct' ] )
 """)
 
-test.run(stderr=None)
+    test.run(stderr=None)
 
-test.must_exist('libfoo-1.2.3.tar.xz')
+    test.must_exist('libfoo-1.2.3.tar.xz')
 
 test.pass_test()
 

--- a/test/packaging/tar/bz2_packaging.py
+++ b/test/packaging/tar/bz2_packaging.py
@@ -31,6 +31,9 @@ This tests the SRC bz2 packager, which does the following:
 
 import TestSCons
 
+import os
+import sys
+
 python = TestSCons.python
 
 test = TestSCons.TestSCons()
@@ -39,12 +42,16 @@ tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
-bz2 = test.where_is('bzip2')
-#if not bz2:
-#    test.skip_test('tar found, but helper bzip2 not found, skipping test\n')
-
-tar = test.where_is('tar')
-test.skip_test('DEBUG: found TAR at %s, BZIP2 at %s\n' % (tar, bz2))
+if sys.platform == 'win32':
+    # windows 10 causes fresh problems by supplying a tar, not bzip2
+    # but if git is installed, there's a bzip2 there, but can't be used
+    bz2 = test.where_is('bzip2')
+    if not bz2:
+        test.skip_test('tar found, but helper bzip2 not found, skipping test\n')
+    bz2 = os.path.splitdrive(bz2)[1]
+    tar = os.path.splitdrive(test.where_is('tar'))[1]
+    if tar[:8] != bz2[:8]:   # catch one in \WINDOWS, one not
+        test.skip_test('tar found, but usable bzip2 not, skipping test\n')
 
 test.subdir('src')
 

--- a/test/packaging/tar/bz2_packaging.py
+++ b/test/packaging/tar/bz2_packaging.py
@@ -40,8 +40,11 @@ if not tar:
     test.skip_test('tar not found, skipping test\n')
 
 bz2 = test.where_is('bzip2')
-if not bz2:
-    test.skip_test('tar found, but helper bzip2 not found, skipping test\n')
+#if not bz2:
+#    test.skip_test('tar found, but helper bzip2 not found, skipping test\n')
+
+tar = test.where_is('tar')
+test.skip_test('DEBUG: found TAR at %s, BZIP2 at %s\n' % (tar, bz2))
 
 test.subdir('src')
 

--- a/test/packaging/tar/xz_packaging.py
+++ b/test/packaging/tar/xz_packaging.py
@@ -40,8 +40,11 @@ if not tar:
     test.skip_test('tar not found, skipping test\n')
 
 xz = test.where_is('xz')
-if not xz:
-    test.skip_test('tar found, but helper xz not found, skipping test\n')
+#if not xz:
+#    test.skip_test('tar found, but helper xz not found, skipping test\n')
+
+tar = test.where_is('tar')
+test.skip_test('DEBUG: found TAR at %s, XZ at %s\n' % (tar, xz))
 
 test.subdir('src')
 

--- a/test/packaging/tar/xz_packaging.py
+++ b/test/packaging/tar/xz_packaging.py
@@ -39,12 +39,12 @@ tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
+# Windows 10 now supplies tar, but doesn't support xz compression
+# assume it's just okay to check for an xz command, because don't
+# want to probe the command itself to see what it supports
 xz = test.where_is('xz')
-#if not xz:
-#    test.skip_test('tar found, but helper xz not found, skipping test\n')
-
-tar = test.where_is('tar')
-test.skip_test('DEBUG: found TAR at %s, XZ at %s\n' % (tar, xz))
+if not xz:
+    test.skip_test('tar found, but helper xz not found, skipping test\n')
 
 test.subdir('src')
 


### PR DESCRIPTION
Try to rearrange the appveyor matrix to include using the Visual Studio 2019 image.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
