### PR TITLE
Fix some lingering SCons.Errors.EnvironmentError usage

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -10,6 +10,14 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Whatever John Doe did.
 
+  From Mathew Robinson:
+
+    - Fix issue #3415 - Update remaining usages of EnvironmentError to SConsEnvironmentError
+      this patch fixes issues introduced in 3.1.0 where any of the
+      following would cause SCons to error and exit:
+        - CacheDir not write-able
+        - JSON encoding errors for CacheDir config
+        - JSON decoding errors for CacheDir config
 
 RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
 

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -33,6 +33,7 @@ import os
 import stat
 import sys
 
+import SCons
 import SCons.Action
 import SCons.Warnings
 from SCons.Util import PY3
@@ -185,7 +186,7 @@ class CacheDir(object):
             pass
         except OSError:
             msg = "Failed to create cache directory " + path
-            raise SCons.Errors.EnvironmentError(msg)
+            raise SCons.Errors.SConsEnvironmentError(msg)
 
         try:
             with open(config_file, 'x') as config:
@@ -194,14 +195,14 @@ class CacheDir(object):
                     json.dump(self.config, config)
                 except Exception:
                     msg = "Failed to write cache configuration for " + path
-                    raise SCons.Errors.EnvironmentError(msg)
+                    raise SCons.Errors.SConsEnvironmentError(msg)
         except FileExistsError:
             try:
                 with open(config_file) as config:
                     self.config = json.load(config)
             except ValueError:
                 msg = "Failed to read cache configuration for " + path
-                raise SCons.Errors.EnvironmentError(msg)
+                raise SCons.Errors.SConsEnvironmentError(msg)
 
 
     def _readconfig2(self, path):

--- a/src/engine/SCons/CacheDirTests.py
+++ b/src/engine/SCons/CacheDirTests.py
@@ -138,8 +138,6 @@ class ExceptionTestCase(unittest.TestCase):
             assert False, "Should have raised exception and did not"
         except SCons.Errors.SConsEnvironmentError as e:
             assert str(e) == "Failed to create cache directory {}".format(os.path.join(privileged_dir, "cache"))
-        except Exception as e:
-            assert False, "Got unexpected exception: {}".format(str(e))
         finally:
             os.chmod(privileged_dir, stat.S_IWRITE | stat.S_IEXEC | stat.S_IREAD)
             shutil.rmtree(privileged_dir)
@@ -178,8 +176,6 @@ class ExceptionTestCase(unittest.TestCase):
             assert False, "Should have raised exception and did not"
         except SCons.Errors.SConsEnvironmentError as e:
             assert str(e) == "Failed to write cache configuration for {}".format(self._CacheDir.path)
-        except Exception as e:
-            assert False, "Got unexpected exception: {}".format(str(e))
 
     def test_raise_environment_error_on_invalid_json(self):
         config_file = os.path.join(self._CacheDir.path, "config")
@@ -196,8 +192,6 @@ class ExceptionTestCase(unittest.TestCase):
             assert False, "Should have raised exception and did not"
         except SCons.Errors.SConsEnvironmentError as e:
             assert str(e) == "Failed to read cache configuration for {}".format(self._CacheDir.path)
-        except Exception as e:
-            assert False, "Got unexpected exception: {}".format(str(e))
 
 class FileTestCase(BaseTestCase):
     """


### PR DESCRIPTION
SCons.Errors.EnvironmentError was renamed to SCons.Errors.SConsEnvironmentError in 3.1.0 when testing the 3.1.0 upgrade at Mongo SCons crashed when hitting these leftover usages of the old name.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
