### PR TITLE
add -fmerge-all-constants flag to LINKFLAGS

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -10,6 +10,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Whatever John Doe did.
 
+  From Ben Reed:
+    - Added -fmerge-all-constants to flags that get included in both CCFLAGS and LINKFLAGS.
+
 
 RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
 

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -783,6 +783,7 @@ class SubstitutionEnvironment(object):
                 elif arg in ['-mno-cygwin',
                              '-pthread',
                              '-openmp',
+                             '-fmerge-all-constants',
                              '-fopenmp']:
                     dict['CCFLAGS'].append(arg)
                     dict['LINKFLAGS'].append(arg)

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -2306,6 +2306,7 @@ and added to the following construction variables:
 -framework              FRAMEWORKS
 -frameworkdir=          FRAMEWORKPATH
 -fmerge-all-constants   CCFLAGS, LINKFLAGS
+-fopenmp                CCFLAGS, LINKFLAGS
 -include                CCFLAGS
 -isysroot               CCFLAGS, LINKFLAGS
 -isystem                CCFLAGS
@@ -2316,6 +2317,7 @@ and added to the following construction variables:
 -L                      LIBPATH
 -mno-cygwin             CCFLAGS, LINKFLAGS
 -mwindows               LINKFLAGS
+-openmp                 CCFLAGS, LINKFLAGS
 -pthread                CCFLAGS, LINKFLAGS
 -std=                   CFLAGS
 -Wa,                    ASFLAGS, CCFLAGS

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -2301,30 +2301,31 @@ and added to the following construction variables:
 </para>
 
 <example_commands>
--arch               CCFLAGS, LINKFLAGS
--D                  CPPDEFINES
--framework          FRAMEWORKS
--frameworkdir=      FRAMEWORKPATH
--include            CCFLAGS
--isysroot           CCFLAGS, LINKFLAGS
--isystem            CCFLAGS
--iquote             CCFLAGS
--idirafter          CCFLAGS
--I                  CPPPATH
--l                  LIBS
--L                  LIBPATH
--mno-cygwin         CCFLAGS, LINKFLAGS
--mwindows           LINKFLAGS
--pthread            CCFLAGS, LINKFLAGS
--std=               CFLAGS
--Wa,                ASFLAGS, CCFLAGS
--Wl,-rpath=         RPATH
--Wl,-R,             RPATH
--Wl,-R              RPATH
--Wl,                LINKFLAGS
--Wp,                CPPFLAGS
--                   CCFLAGS
-+                   CCFLAGS, LINKFLAGS
+-arch                   CCFLAGS, LINKFLAGS
+-D                      CPPDEFINES
+-framework              FRAMEWORKS
+-frameworkdir=          FRAMEWORKPATH
+-fmerge-all-constants   CCFLAGS, LINKFLAGS
+-include                CCFLAGS
+-isysroot               CCFLAGS, LINKFLAGS
+-isystem                CCFLAGS
+-iquote                 CCFLAGS
+-idirafter              CCFLAGS
+-I                      CPPPATH
+-l                      LIBS
+-L                      LIBPATH
+-mno-cygwin             CCFLAGS, LINKFLAGS
+-mwindows               LINKFLAGS
+-pthread                CCFLAGS, LINKFLAGS
+-std=                   CFLAGS
+-Wa,                    ASFLAGS, CCFLAGS
+-Wl,-rpath=             RPATH
+-Wl,-R,                 RPATH
+-Wl,-R                  RPATH
+-Wl,                    LINKFLAGS
+-Wp,                    CPPFLAGS
+-                       CCFLAGS
++                       CCFLAGS, LINKFLAGS
 </example_commands>
 
 <para>

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -2027,6 +2027,7 @@ def generate(env):
                                  "-F fwd3 " + \
                                  "-pthread " + \
                                  "-mno-cygwin -mwindows " + \
+                                 "-fmerge-all-constants " + \
                                  "-arch i386 -isysroot /tmp " + \
                                  "-iquote /usr/include/foo1 " + \
                                  "-isystem /usr/include/foo2 " + \
@@ -2037,7 +2038,7 @@ def generate(env):
             assert save_command == ['fake command'], save_command
             assert env['ASFLAGS'] == ['assembler', '-as'], env['ASFLAGS']
             assert env['CCFLAGS'] == ['', '-X', '-Wa,-as',
-                                      '-pthread', '-mno-cygwin',
+                                      '-pthread', '-fmerge-all-constants', '-mno-cygwin',
                                       ('-arch', 'i386'), ('-isysroot', '/tmp'),
                                       ('-iquote', '/usr/include/foo1'),
                                       ('-isystem', '/usr/include/foo2'),
@@ -2051,6 +2052,7 @@ def generate(env):
             assert env['LIBPATH'] == ['list', '/usr/fax', 'foo'], env['LIBPATH']
             assert env['LIBS'] == ['xxx', 'yyy', env.File('abc')], env['LIBS']
             assert env['LINKFLAGS'] == ['', '-Wl,-link', '-pthread',
+                                        '-fmerge-all-constants',
                                         '-mno-cygwin', '-mwindows',
                                         ('-arch', 'i386'),
                                         ('-isysroot', '/tmp'),

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -2026,8 +2026,8 @@ def generate(env):
                                  "-Ffwd2 " + \
                                  "-F fwd3 " + \
                                  "-pthread " + \
-                                 "-mno-cygwin -mwindows " + \
                                  "-fmerge-all-constants " + \
+                                 "-mno-cygwin -mwindows " + \
                                  "-arch i386 -isysroot /tmp " + \
                                  "-iquote /usr/include/foo1 " + \
                                  "-isystem /usr/include/foo2 " + \

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -797,6 +797,7 @@ sys.exit(0)
             "-F fwd3 " + \
             "-dylib_file foo-dylib " + \
             "-pthread " + \
+            "-fmerge-all-constants " +\
             "-fopenmp " + \
             "-mno-cygwin -mwindows " + \
             "-arch i386 -isysroot /tmp " + \
@@ -811,7 +812,8 @@ sys.exit(0)
         assert d['ASFLAGS'] == ['-as'], d['ASFLAGS']
         assert d['CFLAGS']  == ['-std=c99']
         assert d['CCFLAGS'] == ['-X', '-Wa,-as',
-                                '-pthread', '-fopenmp', '-mno-cygwin',
+                                '-pthread', '-fmerge-all-constants',
+                                '-fopenmp', '-mno-cygwin',
                                 ('-arch', 'i386'), ('-isysroot', '/tmp'),
                                 ('-iquote', '/usr/include/foo1'),
                                 ('-isystem', '/usr/include/foo2'),
@@ -832,7 +834,7 @@ sys.exit(0)
         assert LIBS == ['xxx', 'yyy', 'ascend'], (d['LIBS'], LIBS)
         assert d['LINKFLAGS'] == ['-Wl,-link',
                                   '-dylib_file', 'foo-dylib',
-                                  '-pthread', '-fopenmp',
+                                  '-pthread', '-fmerge-all-constants', '-fopenmp',
                                   '-mno-cygwin', '-mwindows',
                                   ('-arch', 'i386'),
                                   ('-isysroot', '/tmp'),


### PR DESCRIPTION
-fmerge-all-constants doesn't fully work if it isn't also included
as part of the link step. This change will add -fmerge-all-constants
to both CCFLAGS and LINKFLAGS if it is specified as a build flag.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
