### PR TITLE
Fix regression in 3.1.0 with removal of DeciderNeedsNode

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -6,9 +6,9 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-  From John Doe:
+  From William Deegan:
 
-    - Whatever John Doe did.
+    - Remove obsoleted references to DeciderNeedsNode which could cause crash when using --debug=explain
 
 
 RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -10,6 +10,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
     - Remove obsoleted references to DeciderNeedsNode which could cause crash when using --debug=explain
 
+  From Jason Kenny
+
+    - Add Fix and test for regression in 3.1.0 when using Decider('MD5-timestamp') and --debug=explain
+
 
 RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
 
@@ -20,7 +24,7 @@ RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
   From William Deegan:
     - Enhanced --debug=explain output. Now the separate components of the dependency list are split up
       as follows:
-      
+
       scons: rebuilding `file3' because:
            the dependency order changed:
            ->Sources
@@ -91,7 +95,7 @@ RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
     - More fixes for newer Java versions (since 9): handle new jdk directory
       naming (jdk-X.Y instead of jdkX.Y) on Windows; handle two-digit major
       version. Docstrings improved.
-    - Fixups for pylint: exception types, redefined functions, 
+    - Fixups for pylint: exception types, redefined functions,
       globals, etc.  Some old code removed to resolve issues (hashlib is
       always present on modern Pythons; no longer need the code for
       2.5-and-earlier optparse). cmp is not a builtin function in Py3,
@@ -101,7 +105,7 @@ RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
     - Add a PY3-only function for setting up the cachedir that should be less
       prone to races. Add a hack to the PY2 version (from Issue #3351) to
       be less prone to a race in the check for old-style cache.
-    - Fix coding error in docbook tool only exercised when using python lxml 
+    - Fix coding error in docbook tool only exercised when using python lxml
     - Recognize two additional GNU compiler header directory options in
       ParseFlags: -iquote and -idirafter.
     - Fix more re patterns that contain \ but not specified as raw strings
@@ -148,7 +152,7 @@ From Daniel Moody:
 
   From Bernhard M. Wiedemann:
     - Do not store build host+user name if reproducible builds are wanted
-    
+
 
 RELEASE 3.0.4 - Mon, 20 Jan 2019 22:49:27 +0000
 
@@ -216,9 +220,9 @@ RELEASE 3.0.2 - Mon, 31 Dec 2018 16:00:12 -0700
     - Fix GH Issue #2580 - # in FRAMEWORKPATH doesn't get properly expanded. The # is left in the
       command line.
     - Fix issue #2980 with credit to Piotr Bartosik (and William Blevins).  This is an issue where using
-      TimeStamp-MD5 Decider and CacheDir can yield incorrect md5's being written into the .sconsign.  
-      The difference between Piotr Bartosik's patch and the current code is that the more complicated 
-      creation of file to csig map is only done when the count of children for the current node doesn't 
+      TimeStamp-MD5 Decider and CacheDir can yield incorrect md5's being written into the .sconsign.
+      The difference between Piotr Bartosik's patch and the current code is that the more complicated
+      creation of file to csig map is only done when the count of children for the current node doesn't
       match the previous count which is loaded from the sconsign.
     - Fix issue # 3106 MSVC if using MSVC_BATCH and target dir had a space would fail due to quirk in
       MSVC's handling of escaped targetdirs when batch compiling.
@@ -254,7 +258,7 @@ RELEASE 3.0.2 - Mon, 31 Dec 2018 16:00:12 -0700
     - Removed unused --warn options from the man page and source code.
 
   From Arda Fu
-    - Fix cpp scanner regex logic to treat ifndef for py3.5+. Previously it was 
+    - Fix cpp scanner regex logic to treat ifndef for py3.5+. Previously it was
       not properly differentiating between if, ifdef, and ifndef.
 
   From Philipp Maierhöfer
@@ -265,7 +269,7 @@ RELEASE 3.0.2 - Mon, 31 Dec 2018 16:00:12 -0700
   From Matthew Marinets:
     - Fixed an issue that caused the Java emitter to incorrectly parse arguments to constructors that
       implemented a class.
-      
+
   From Fredrik Medley:
     - Fix exception when printing of EnviromentError messages.
       Specifically, this fixes error reporting of the race condition when
@@ -386,7 +390,7 @@ RELEASE 3.0.2 - Mon, 31 Dec 2018 16:00:12 -0700
       filter type -> list in ipk
 
   From Bernhard M. Wiedemann:
-    - Update SCons' internal scons build logic to allow overriding build date 
+    - Update SCons' internal scons build logic to allow overriding build date
       with SOURCE_DATE_EPOCH for SCons itself.
     - Change the datestamps in SCons' docs and embedded in code use ISO 8601 format and UTC
 

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -3436,6 +3436,8 @@ class File(Base):
             Boolean - Indicates if node(File) has changed.
         """
 
+        if node is None:
+            node = self
         # Now get sconsign name -> csig map and then get proper prev_ni if possible
         bi = node.get_stored_info().binfo
         rebuilt = False

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -1661,10 +1661,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             if k not in old_bkids:
                 lines.append("`%s' is a new dependency\n" % stringify(k))
             else:
-                try:
-                    changed = _decider_map[k.changed_since_last_build](k, self, osig[k])
-                except DeciderNeedsNode as e:
-                    changed = e.decider(self, osig[k], node=self)
+                changed = _decider_map[k.changed_since_last_build](k, self, osig[k])
 
                 if changed:
                     lines.append("`%s' changed\n" % stringify(k))

--- a/test/Configure/option--config.py
+++ b/test/Configure/option--config.py
@@ -126,8 +126,6 @@ test.checkLogAndStdout(["Checking for C header file non_system_header0.h... ",
 test.file_fixture('test_main.c')
 
 # Check the combination of --config=force and Decider('MD5-timestamp')
-# On second run there was an issue where the decider would throw DeciderNeedsNode
-# exception which the configure code didn't handle.
 SConstruct_path = test.workpath('SConstruct')
 test.write(SConstruct_path, """
 env = Environment()

--- a/test/Decider/MD5-timestamp-explain.py
+++ b/test/Decider/MD5-timestamp-explain.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify behavior of the MD5-timestamp Decider() setting.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write('SConstruct', """\
+import random
+env = Environment()
+env.Decider('MD5-timestamp')
+# for testing use raw python API
+with open("hello.h.in","w") as outfile:
+    outfile.write("// {}".format(random.randint(1,100)))
+env.Command("hello.h","hello.h.in",[Copy("$TARGET","$SOURCE")])
+""")
+
+
+test.run(arguments = '--debug=explain')
+# this should not be up-to-date and it should not crash
+test.not_up_to_date(arguments = '--debug=explain')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Add a test and a check for when the node is none to fall back on to self

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
