### PR TITLE
Run latex after bibtex/biber only when necessary

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1066,6 +1066,9 @@ RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
         - JSON encoding errors for CacheDir config
         - JSON decoding errors for CacheDir config
 
+  From Lukas Schrangl:
+    - Run LaTeX after biber/bibtex only if necessary
+
 
 RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Ryan Saunders:
     - Fixed runtest.py failure on Windows caused by excessive escaping of the path to python.exe.
 
+  From Lukas Schrangl:
+    - Run LaTeX after biber/bibtex only if necessary
+
   From Flaviu Tamas:
     - Added -fsanitize support to ParseFlags().  This will propagate to CCFLAGS and LINKFLAGS.
 
@@ -1065,10 +1068,6 @@ RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
         - CacheDir not write-able
         - JSON encoding errors for CacheDir config
         - JSON decoding errors for CacheDir config
-
-  From Lukas Schrangl:
-    - Run LaTeX after biber/bibtex only if necessary
-
 
 RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,6 +44,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - Migrated logging logic for --taskmastertrace to use Python's logging module. Added logging
   to NewParallel Job class (Andrew Morrow's new parallel job implementation)
 - Preliminary support for Python 3.12.
+- Run LaTeX after biber/bibtex only if necessary
 
 
 FIXES
@@ -53,7 +54,7 @@ FIXES
 - A list argument as the source to the Copy() action function is now handled.
   Both the implementation and the strfunction which prints the progress
   message were adjusted.
-- The Java Scanner processing of JAVACLASSPATH for dependencies (behavior
+- The Java Scanner processing of JAVACLASSPATH for dep qendencies (behavior
   that was introduced in SCons 4.4.0) is adjusted to split on the system's
   search path separator instead of on a space. The previous behavior meant
   that a path containing spaces (e.g. r"C:\somepath\My Classes") would

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -54,7 +54,7 @@ FIXES
 - A list argument as the source to the Copy() action function is now handled.
   Both the implementation and the strfunction which prints the progress
   message were adjusted.
-- The Java Scanner processing of JAVACLASSPATH for dep qendencies (behavior
+- The Java Scanner processing of JAVACLASSPATH for dependencies (behavior
   that was introduced in SCons 4.4.0) is adjusted to split on the system's
   search path separator instead of on a space. The previous behavior meant
   that a path containing spaces (e.g. r"C:\somepath\My Classes") would

--- a/SCons/Tool/tex.py
+++ b/SCons/Tool/tex.py
@@ -253,10 +253,10 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
     # .aux files already processed by BibTex
     already_bibtexed = []
 
-    #
-    # routine to update MD5 hash and compare
-    #
-    def check_MD5(filenode, suffix):
+    def check_content_hash(filenode, suffix):
+        """
+        Routine to update content hash and compare
+        """
         global must_rerun_latex
         # two calls to clear old csig
         filenode.clear_memoized_values()
@@ -294,7 +294,6 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
         if os.path.isfile(logfilename):
             with open(logfilename, "rb") as f:
                 logContent = f.read().decode(errors='replace')
-
 
         # Read the fls file to find all .aux files
         flsfilename = targetbase + '.fls'
@@ -345,7 +344,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                         result = BibTeXAction(bibfile, bibfile, env)
                         if result != 0:
                             check_file_error_message(env['BIBTEX'], 'blg')
-                        check_MD5(suffix_nodes[".bbl"], ".bbl")
+                        check_content_hash(suffix_nodes[".bbl"], ".bbl")
 
         # Now decide if biber will need to be run.
         # When the backend for biblatex is biber (by choice or default) the
@@ -369,10 +368,10 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                         result = BiberAction(bibfile, bibfile, env)
                         if result != 0:
                             check_file_error_message(env['BIBER'], 'blg')
-                        check_MD5(suffix_nodes[".bbl"], ".bbl")
+                        check_content_hash(suffix_nodes[".bbl"], ".bbl")
 
         # Now decide if latex will need to be run again due to index.
-        if check_MD5(suffix_nodes['.idx'],'.idx') or (count == 1 and run_makeindex):
+        if check_content_hash(suffix_nodes['.idx'], '.idx') or (count == 1 and run_makeindex):
             # We must run makeindex
             if Verbose:
                 print("Need to run makeindex")
@@ -387,10 +386,10 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
         # Harder is case is where an action needs to be called -- that should be rare (I hope?)
 
         for index in check_suffixes:
-            check_MD5(suffix_nodes[index],index)
+            check_content_hash(suffix_nodes[index], index)
 
         # Now decide if latex will need to be run again due to nomenclature.
-        if check_MD5(suffix_nodes['.nlo'],'.nlo') or (count == 1 and run_nomenclature):
+        if check_content_hash(suffix_nodes['.nlo'], '.nlo') or (count == 1 and run_nomenclature):
             # We must run makeindex
             if Verbose:
                 print("Need to run makeindex for nomenclature")
@@ -402,7 +401,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                 #return result
 
         # Now decide if latex will need to be run again due to glossary.
-        if check_MD5(suffix_nodes['.glo'],'.glo') or (count == 1 and run_glossaries) or (count == 1 and run_glossary):
+        if check_content_hash(suffix_nodes['.glo'], '.glo') or (count == 1 and run_glossaries) or (count == 1 and run_glossary):
             # We must run makeindex
             if Verbose:
                 print("Need to run makeindex for glossary")
@@ -414,7 +413,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                 #return result
 
         # Now decide if latex will need to be run again due to acronyms.
-        if check_MD5(suffix_nodes['.acn'],'.acn') or (count == 1 and run_acronyms):
+        if check_content_hash(suffix_nodes['.acn'], '.acn') or (count == 1 and run_acronyms):
             # We must run makeindex
             if Verbose:
                 print("Need to run makeindex for acronyms")
@@ -427,7 +426,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
 
         # Now decide if latex will need to be run again due to newglossary command.
         for ng in newglossary_suffix:
-            if check_MD5(suffix_nodes[ng[2]], ng[2]) or (count == 1):
+            if check_content_hash(suffix_nodes[ng[2]], ng[2]) or (count == 1):
                 # We must run makeindex
                 if Verbose:
                     print("Need to run makeindex for newglossary")

--- a/SCons/Tool/tex.py
+++ b/SCons/Tool/tex.py
@@ -345,7 +345,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                         result = BibTeXAction(bibfile, bibfile, env)
                         if result != 0:
                             check_file_error_message(env['BIBTEX'], 'blg')
-                        must_rerun_latex = True
+                        check_MD5(suffix_nodes[".bbl"], ".bbl")
 
         # Now decide if biber will need to be run.
         # When the backend for biblatex is biber (by choice or default) the
@@ -369,7 +369,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
                         result = BiberAction(bibfile, bibfile, env)
                         if result != 0:
                             check_file_error_message(env['BIBER'], 'blg')
-                        must_rerun_latex = True
+                        check_MD5(suffix_nodes[".bbl"], ".bbl")
 
         # Now decide if latex will need to be run again due to index.
         if check_MD5(suffix_nodes['.idx'],'.idx') or (count == 1 and run_makeindex):

--- a/test/TEX/biber_biblatex2.py
+++ b/test/TEX/biber_biblatex2.py
@@ -72,7 +72,7 @@ sources_bib_content = r"""
 """
 test.write(['ref.bib'],sources_bib_content % '2013' )
 
-test.write(['bibertest.tex'],r"""
+sources_tex_content = r"""
 \documentclass{article}
 
 \usepackage{biblatex}
@@ -80,13 +80,14 @@ test.write(['bibertest.tex'],r"""
 
 \begin{document}
 
-Hello. This is boring.
+Hello. This is %s boring.
 \cite{mybook}
 And even more boring.
 
 \printbibliography
 \end{document}
-""")
+"""
+test.write(['bibertest.tex'], sources_tex_content % "")
 
 
 test.run()
@@ -110,7 +111,17 @@ for f in files:
 pdf_output_1 = test.read('bibertest.pdf')
 
 
+# Change tex, but don't change bib. In this case, pdf should still be rebuilt.
+test.write(['bibertest.tex'], sources_tex_content % "very")
+test.run()
+pdf_output_1a = test.read('bibertest.pdf')
+# If the PDF file is the same as it was previously, then it didn't
+# pick up the change in the tex file, so fail.
+test.fail_test(pdf_output_1 == pdf_output_1a)
 
+
+# Change bib.
+test.write(['bibertest.tex'], sources_tex_content % "")
 test.write(['ref.bib'],sources_bib_content % '1982')
 
 test.run()

--- a/test/TEX/bibtex-latex-rerun.py
+++ b/test/TEX/bibtex-latex-rerun.py
@@ -47,14 +47,14 @@ env = Environment(tools=['pdftex', 'tex'])
 env.PDF( 'bibtest.tex' )
 """)
 
-test.write(['bibtest.tex'], r"""
+sources_tex_content = r"""
 \documentclass{article}
 \begin{document}
-Learn about cool math in \cite{koblitz:elliptic_curves}.
+Learn about %s cool math in \cite{koblitz:elliptic_curves}.
 \bibliographystyle{alpha}
 \bibliography{sources}
 \end{document}
-""")
+"""
 
 sources_bib_content = r"""
 @book{koblitz:elliptic_curves,
@@ -67,14 +67,24 @@ sources_bib_content = r"""
 
 
 
+test.write(['bibtest.tex'], sources_tex_content % "")
 test.write('sources.bib', sources_bib_content % '1981')
 
 test.run()
 
 pdf_output_1 = test.read('bibtest.pdf')
 
+# Change tex, but don't change bib. In this case, pdf should still be rebuilt.
+test.write(['bibtest.tex'], sources_tex_content % "really")
+test.run()
+pdf_output_1a = test.read('bibtest.pdf')
+# If the PDF file is the same as it was previously, then it didn't
+# pick up the change in the tex file, so fail.
+test.fail_test(pdf_output_1 == pdf_output_1a)
 
 
+# Change bib.
+test.write(['bibtest.tex'], sources_tex_content % "")
 test.write('sources.bib', sources_bib_content % '1982')
 
 test.run()


### PR DESCRIPTION
Although comments in src/engine/SCons/Tool/tex.py indicated that latex
should only be run after biber/bibtex if the .bbl file had changed, it
was always run.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] No documentation to update
