### PR TITLE
manpage: clarify that tools=[list] overrides [ci skip]

### DIFF
--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -139,7 +139,7 @@ Set construction variables for cygwin linker/loader.
     <term>default</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-Sets constuction variables for a default list of Tool modules.
+Sets <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction variables</literal> for a default list of Tool modules.
 Include <emphasis role="bold">default</emphasis>
 in the tools list to retain
 the tools that would have been available if no

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -140,22 +140,22 @@ Set construction variables for cygwin linker/loader.
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 Sets <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction variables</literal> for a default list of Tool modules.
-Include <emphasis role="bold">default</emphasis>
-in the tools list to retain
-the tools that would have been available if no
-<parameter>tools</parameter> parameter were supplied
-to an <emphasis role="bold">Environment</emphasis>
-or <emphasis role="bold">Clone</emphasis> call.
+Use <emphasis role="bold">default</emphasis>
+in the tools list to retain the original defaults,
+since the <parameter>tools</parameter> parameter
+is treated as a literal statement of the tools
+to be made available in that <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction environment</literal>, not an addition.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-The list of available tools from default is dependent both on
-the platform and what software is installed on the platform.
+The list of tools selected by default is not static,
+but is dependent both on
+the platform and on the software installed on the platform.
 Some tools will not initialize if an underlying command is
 not found, and some tools are selected from a list of choices
 on a first-found basis. The finished tool list can be
 examined by inspecting the <envar>TOOLS</envar> <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction variable</literal>
-variable in the <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction environment</literal>.
+in the <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction environment</literal>.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -168,7 +168,7 @@ tex, latex, pdflatex, pdftex, tar, zip, textfile.
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 On Linux systems, the default tools list selects
-(first-found) a C compiler from
+(first-found): a C compiler from
 gcc, intelc, icc, cc;
 a C++ compiler from
 g++, intelc, icc, cxx;
@@ -185,7 +185,7 @@ m4, rpm.
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 On Windows systems, the default tools list selects
-(first-found) a C compiler from
+(first-found): a C compiler from
 msvc, mingw, gcc, intelc, icl, icc, cc, bcc32;
 a C++ compiler from
 msvc, intelc, icc, g++, cxx, bcc32;
@@ -203,7 +203,7 @@ msvs, midl.
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 On MacOS systems, the default tools list selects
-(first-found) a C compiler from
+(first-found): a C compiler from
 gcc, cc;
 a C++ compiler from
 g++, cxx;
@@ -212,7 +212,7 @@ a linker from
 applelink, gnulink;
 a Fortran compiler from
 gfortran, f95, f90, g77;
-and a static archiver 'ar'.
+and a static archiver ar.
 It also selects all found from the list
 m4, rpm.
 </para>

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -711,7 +711,7 @@ Sets construction variables for the <application xmlns="http://www.scons.org/dbx
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 Sets construction variables for generic POSIX linkers. This is
 a "smart" linker tool which selects a compiler to complete the linking
-based on the type of source file.
+based on the types of source files.
 </para>
 <para>Sets:  &cv-link-LDMODULE;, &cv-link-LDMODULECOM;, &cv-link-LDMODULEFLAGS;, &cv-link-LDMODULENOVERSIONSYMLINKS;, &cv-link-LDMODULEPREFIX;, &cv-link-LDMODULESUFFIX;, &cv-link-LDMODULEVERSION;, &cv-link-LDMODULEVERSIONFLAGS;, &cv-link-LIBDIRPREFIX;, &cv-link-LIBDIRSUFFIX;, &cv-link-LIBLINKPREFIX;, &cv-link-LIBLINKSUFFIX;, &cv-link-LINK;, &cv-link-LINKCOM;, &cv-link-LINKFLAGS;, &cv-link-SHLIBSUFFIX;, &cv-link-SHLINK;, &cv-link-SHLINKCOM;, &cv-link-SHLINKFLAGS;, &cv-link-__LDMODULEVERSIONFLAGS;, &cv-link-__SHLIBVERSIONFLAGS;.</para><para>Uses:  &cv-link-LDMODULECOMSTR;, &cv-link-LINKCOMSTR;, &cv-link-SHLINKCOMSTR;.</para></listitem>
   </varlistentry>

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -91,7 +91,7 @@ Sets construction variables for the bcc32 compiler.
     <term>cc</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-Sets construction variables for generic POSIX C copmilers.
+Sets construction variables for generic POSIX C compilers.
 </para>
 <para>Sets:  &cv-link-CC;, &cv-link-CCCOM;, &cv-link-CCFLAGS;, &cv-link-CFILESUFFIX;, &cv-link-CFLAGS;, &cv-link-CPPDEFPREFIX;, &cv-link-CPPDEFSUFFIX;, &cv-link-FRAMEWORKPATH;, &cv-link-FRAMEWORKS;, &cv-link-INCPREFIX;, &cv-link-INCSUFFIX;, &cv-link-SHCC;, &cv-link-SHCCCOM;, &cv-link-SHCCFLAGS;, &cv-link-SHCFLAGS;, &cv-link-SHOBJSUFFIX;.</para><para>Uses:  &cv-link-PLATFORM;.</para></listitem>
   </varlistentry>
@@ -139,9 +139,89 @@ Set construction variables for cygwin linker/loader.
     <term>default</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-Sets variables by calling a default list of Tool modules
-for the platform on which SCons is running.
+Sets constuction variables for a default list of Tool modules.
+Include <emphasis role="bold">default</emphasis>
+in the tools list to retain
+the tools that would have been available if no
+<parameter>tools</parameter> parameter were supplied
+to an <emphasis role="bold">Environment</emphasis>
+or <emphasis role="bold">Clone</emphasis> call.
 </para>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+The list of available tools from default is dependent both on
+the platform and what software is installed on the platform.
+Some tools will not initialize if an underlying command is
+not found, and some tools are selected from a list of choices
+on a first-found basis. The finished tool list can be
+examined by inspecting the <envar>TOOLS</envar> <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction variable</literal>
+variable in the <literal xmlns="http://www.scons.org/dbxsd/v1.0">construction environment</literal>.
+</para>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+On all platforms, all tools from the following list
+are selected whose respective conditions are met:
+filesystem, wix, lex, yacc, rpcgen, swig,
+jar, javac, javah, rmic, dvipdf, dvips, gs,
+tex, latex, pdflatex, pdftex, tar, zip, textfile.
+</para>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+On Linux systems, the default tools list selects
+(first-found) a C compiler from
+gcc, intelc, icc, cc;
+a C++ compiler from
+g++, intelc, icc, cxx;
+an assembler from
+gas, nasm, masm;
+a linker from
+gnulink, ilink;
+a Fortran compiler from
+gfortran, g77, ifort, ifl, f95, f90, f77;
+and a static archiver 'ar'.
+It also selects all found from the list
+m4, rpm.
+</para>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+On Windows systems, the default tools list selects
+(first-found) a C compiler from
+msvc, mingw, gcc, intelc, icl, icc, cc, bcc32;
+a C++ compiler from
+msvc, intelc, icc, g++, cxx, bcc32;
+an assembler from
+masm, nasm, gas, 386asm;
+a linker from
+mslink, gnulink, ilink, linkloc, ilink32;
+a Fortran compiler from
+gfortran, g77, ifl, cvf, f95, f90, fortran;
+and a static archiver from
+mslib, ar, tlib;
+It also selects all found from the list
+msvs, midl.
+</para>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+On MacOS systems, the default tools list selects
+(first-found) a C compiler from
+gcc, cc;
+a C++ compiler from
+g++, cxx;
+an assembler 'as';
+a linker from
+applelink, gnulink;
+a Fortran compiler from
+gfortran, f95, f90, g77;
+and a static archiver 'ar'.
+It also selects all found from the list
+m4, rpm.
+</para>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+Default lists for other platforms can be found by
+examining the source code for <filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>.
+</para>
+
 </listitem>
   </varlistentry>
   <varlistentry id="t-dmd">
@@ -627,7 +707,9 @@ Sets construction variables for the <application xmlns="http://www.scons.org/dbx
     <term>link</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-Sets construction variables for generic POSIX linkers.
+Sets construction variables for generic POSIX linkers. This is
+a "smart" linker tool which selects a compiler to complete the linking
+based on the type of source file.
 </para>
 <para>Sets:  &cv-link-LDMODULE;, &cv-link-LDMODULECOM;, &cv-link-LDMODULEFLAGS;, &cv-link-LDMODULENOVERSIONSYMLINKS;, &cv-link-LDMODULEPREFIX;, &cv-link-LDMODULESUFFIX;, &cv-link-LDMODULEVERSION;, &cv-link-LDMODULEVERSIONFLAGS;, &cv-link-LIBDIRPREFIX;, &cv-link-LIBDIRSUFFIX;, &cv-link-LIBLINKPREFIX;, &cv-link-LIBLINKSUFFIX;, &cv-link-LINK;, &cv-link-LINKCOM;, &cv-link-LINKFLAGS;, &cv-link-SHLIBSUFFIX;, &cv-link-SHLINK;, &cv-link-SHLINKCOM;, &cv-link-SHLINKFLAGS;, &cv-link-__LDMODULEVERSIONFLAGS;, &cv-link-__SHLIBVERSIONFLAGS;.</para><para>Uses:  &cv-link-LDMODULECOMSTR;, &cv-link-LINKCOMSTR;, &cv-link-SHLINKCOMSTR;.</para></listitem>
   </varlistentry>

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -219,7 +219,9 @@ m4, rpm.
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 Default lists for other platforms can be found by
-examining the source code for <filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>.
+examining the <filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
+source code (see
+<filename>SCons/Tool/__init__.py</filename>).
 </para>
 
 </listitem>

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -4011,7 +4011,7 @@ The command line used to pass files to the Microsoft IDL compiler.
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 The string displayed when
-the Microsoft IDL copmiler is called.
+the Microsoft IDL compiler is called.
 If this is not set, then <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-MIDLCOM"><envar>$MIDLCOM</envar></link> (the command line) is displayed.
 </para>
 </listitem>
@@ -6518,16 +6518,6 @@ Example <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION">
 </para>
 </listitem>
   </varlistentry>
-  <varlistentry id="cv-SHLIBVERSIONFLAGS">
-    <term>SHLIBVERSIONFLAGS</term>
-    <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Extra flags added to <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLINKCOM"><envar>$SHLINKCOM</envar></link> when building versioned
-<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link>. These flags are only used when <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> is
-set.
-</para>
-</listitem>
-  </varlistentry>
   <varlistentry id="cv-_SHLIBVERSIONFLAGS">
     <term>_SHLIBVERSIONFLAGS</term>
     <listitem>
@@ -6538,6 +6528,16 @@ is set). <literal>_SHLIBVERSIONFLAGS</literal> usually adds <link xmlns="http://
 and some extra dynamically generated options (such as
 <literal>-Wl,-soname=$_SHLIBSONAME</literal>. It is unused by "plain"
 (unversioned) shared libraries.
+</para>
+</listitem>
+  </varlistentry>
+  <varlistentry id="cv-SHLIBVERSIONFLAGS">
+    <term>SHLIBVERSIONFLAGS</term>
+    <listitem>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+Extra flags added to <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLINKCOM"><envar>$SHLINKCOM</envar></link> when building versioned
+<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link>. These flags are only used when <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> is
+set.
 </para>
 </listitem>
   </varlistentry>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -209,12 +209,12 @@ that you want to use to build your target files
 are not in standard system locations,
 <command>scons</command>
 will not find them unless
-you explicitly set the PATH
+you explicitly set the <envar>PATH</envar>
 to include those locations.
 Whenever you create an
 <command>scons</command>
 construction environment,
-you can propagate the value of PATH
+you can propagate the value of <envar>PATH</envar>
 from your external environment as follows:</para>
 
 <literallayout class="monospaced">
@@ -223,13 +223,20 @@ env = Environment(ENV = {'PATH' : os.environ['PATH']})
 </literallayout>
 
 <para>Similarly, if the commands use external environment variables
-like $PATH, $HOME, $JAVA_HOME, $LANG, $SHELL, $TERM, etc.,
+like
+<envar>PATH</envar>,
+<envar>HOME</envar>,
+<envar>JAVA_HOME</envar>,
+<envar>LANG</envar>,
+<envar>SHELL</envar>,
+<envar>TERM</envar>,
+etc.,
 these variables can also be explicitly propagated:</para>
 
 <literallayout class="monospaced">
 import os
-env = Environment(ENV = {'PATH' : os.environ['PATH'],
-                         'HOME' : os.environ['HOME']})
+env = Environment(ENV = {'PATH': os.environ['PATH'],
+                         'HOME': os.environ['HOME']})
 </literallayout>
 
 <para>Or you may explicitly propagate the invoking user's
@@ -2112,36 +2119,59 @@ env = Environment(platform = my_platform)
 
 <para>Additionally, a specific set of tools
 with which to initialize the environment
-may be specified as an optional keyword argument:</para>
+may be specified using the optional keyword argument
+<parameter>tools</parameter>:</para>
 
 <literallayout class="monospaced">
-env = Environment(tools = ['msvc', 'lex'])
+env = Environment(tools=['msvc', 'lex'])
 </literallayout>
 
-<para>Non-built-in tools may be specified using the toolpath argument:</para>
+<para>
+The <parameter>tools</parameter> argument overrides
+the tool list, it does not add to it, so be
+sure to include all the tools you need.
+For example if you are  building a c/c++ program
+you must  add a tool for both compiler and linker,
+as in <literal>tools=['clang', 'link']</literal>.
+The tool name <literal>'default'</literal> can
+be used to retain the default list.
+</para>
+
+<para>Non-built-in tools may be specified using the
+optional <parameter>toolpath</parameter> keyword argument:</para>
 
 <literallayout class="monospaced">
-env = Environment(tools = ['default', 'foo'], toolpath = ['tools'])
+env = Environment(tools=['default', 'foo'], toolpath=['tools'])
 </literallayout>
 
-<para>This looks for a tool specification in tools/foo.py (as well as
-using the ordinary default tools for the platform).  foo.py should
-have two functions: generate(env, **kw) and exists(env).
+<para>
+This looks for a tool specification in <filename>tools/foo.py</filename>
+as well as using the ordinary default tools for the platform.
+</para>
+
+<para>
+A tool specification must include two functions:
+<function>generate(env, **kw)</function>
+and <function>exists(env)</function>.
 The
-<function>generate()</function>
+<function>generate</function>
 function
-modifies the passed-in environment
+modifies the environment referenced by <parameter>env</parameter>
 to set up variables so that the tool
 can be executed;
 it may use any keyword arguments
-that the user supplies (see below)
+that the user supplies in <parameter>kw</parameter> (see below)
 to vary its initialization.
 The
-<function>exists()</function>
+<function>exists</function>
 function should return a true
 value if the tool is available.
+</para>
+
+<para>
 Tools in the toolpath are used before
-any of the built-in ones.  For example, adding gcc.py to the toolpath
+any of the built-in ones.  For example, adding
+<filename>gcc.py</filename> to the toolpath
 would override the built-in gcc tool.
 Also note that the toolpath is
 stored in the environment for use
@@ -2149,7 +2179,8 @@ by later calls to
 <emphasis role="bold">Clone</emphasis>()
 and
 <emphasis role="bold">Tool</emphasis>()
-methods:</para>
+methods:
+</para>
 
 <literallayout class="monospaced">
 base = Environment(toolpath=['custom_path'])
@@ -2192,8 +2223,9 @@ or otherwise changing its initialization.</para>
 def generate(env, **kw):
   # Sets MY_TOOL to the value of keyword argument 'arg1' or 1.
   env['MY_TOOL'] = kw.get('arg1', '1')
+
 def exists(env):
-  return 1
+  return True
 
 # in SConstruct:
 env = Environment(tools = ['default', ('my_tool', {'arg1': 'abc'})],
@@ -2256,17 +2288,6 @@ env.SomeTool(targets, sources)
 
 <!-- '\" END GENERATED TOOL DESCRIPTIONS -->
 <!-- '\""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""" -->
-
-<para>Additionally, there is a "tool" named
-<emphasis role="bold">default</emphasis>
-which configures the
-environment with a default set of tools for the current platform.</para>
-
-<para>On posix and cygwin platforms
-the GNU tools (e.g. gcc) are preferred by SCons,
-on Windows the Microsoft tools (e.g. msvc)
-followed by MinGW are preferred by SCons,
-and in OS/2 the IBM tools (e.g. icc) are preferred by SCons.</para>
 
 </refsect2>
 

--- a/src/engine/SCons/Tool/cc.xml
+++ b/src/engine/SCons/Tool/cc.xml
@@ -26,7 +26,7 @@ See its __doc__ string for a discussion of the format.
 <tool name="cc">
 <summary>
 <para>
-Sets construction variables for generic POSIX C copmilers.
+Sets construction variables for generic POSIX C compilers.
 </para>
 </summary>
 <sets>

--- a/src/engine/SCons/Tool/default.xml
+++ b/src/engine/SCons/Tool/default.xml
@@ -27,22 +27,22 @@ See its __doc__ string for a discussion of the format.
 <summary>
 <para>
 Sets &consvars; for a default list of Tool modules.
-Include <emphasis role="bold">default</emphasis>
-in the tools list to retain
-the tools that would have been available if no
-<parameter>tools</parameter> parameter were supplied
-to an <emphasis role="bold">Environment</emphasis>
-or <emphasis role="bold">Clone</emphasis> call.
+Use <emphasis role="bold">default</emphasis>
+in the tools list to retain the original defaults,
+since the <parameter>tools</parameter> parameter
+is treated as a literal statement of the tools
+to be made available in that &consenv;, not an addition.
 </para>
 
 <para>
-The list of available tools from default is dependent both on
-the platform and what software is installed on the platform.
+The list of tools selected by default is not static,
+but is dependent both on
+the platform and on the software installed on the platform.
 Some tools will not initialize if an underlying command is
 not found, and some tools are selected from a list of choices
 on a first-found basis. The finished tool list can be
 examined by inspecting the <envar>TOOLS</envar> &consvar;
-variable in the &consenv;.
+in the &consenv;.
 </para>
 
 <para>
@@ -55,7 +55,7 @@ tex, latex, pdflatex, pdftex, tar, zip, textfile.
 
 <para>
 On Linux systems, the default tools list selects
-(first-found) a C compiler from
+(first-found): a C compiler from
 gcc, intelc, icc, cc;
 a C++ compiler from
 g++, intelc, icc, cxx;
@@ -72,7 +72,7 @@ m4, rpm.
 
 <para>
 On Windows systems, the default tools list selects
-(first-found) a C compiler from
+(first-found): a C compiler from
 msvc, mingw, gcc, intelc, icl, icc, cc, bcc32;
 a C++ compiler from
 msvc, intelc, icc, g++, cxx, bcc32;
@@ -90,7 +90,7 @@ msvs, midl.
 
 <para>
 On MacOS systems, the default tools list selects
-(first-found) a C compiler from
+(first-found): a C compiler from
 gcc, cc;
 a C++ compiler from
 g++, cxx;
@@ -99,7 +99,7 @@ a linker from
 applelink, gnulink;
 a Fortran compiler from
 gfortran, f95, f90, g77;
-and a static archiver 'ar'.
+and a static archiver ar.
 It also selects all found from the list
 m4, rpm.
 </para>

--- a/src/engine/SCons/Tool/default.xml
+++ b/src/engine/SCons/Tool/default.xml
@@ -106,7 +106,9 @@ m4, rpm.
 
 <para>
 Default lists for other platforms can be found by
-examining the source code for &scons;.
+examining the &scons;
+source code (see
+<filename>SCons/Tool/__init__.py</filename>).
 </para>
 
 </summary>

--- a/src/engine/SCons/Tool/default.xml
+++ b/src/engine/SCons/Tool/default.xml
@@ -26,7 +26,7 @@ See its __doc__ string for a discussion of the format.
 <tool name="default">
 <summary>
 <para>
-Sets constuction variables for a default list of Tool modules.
+Sets &consvars; for a default list of Tool modules.
 Include <emphasis role="bold">default</emphasis>
 in the tools list to retain
 the tools that would have been available if no

--- a/src/engine/SCons/Tool/default.xml
+++ b/src/engine/SCons/Tool/default.xml
@@ -26,10 +26,89 @@ See its __doc__ string for a discussion of the format.
 <tool name="default">
 <summary>
 <para>
-Sets variables by calling a default list of Tool modules
-for the platform on which SCons is running.
+Sets constuction variables for a default list of Tool modules.
+Include <emphasis role="bold">default</emphasis>
+in the tools list to retain
+the tools that would have been available if no
+<parameter>tools</parameter> parameter were supplied
+to an <emphasis role="bold">Environment</emphasis>
+or <emphasis role="bold">Clone</emphasis> call.
 </para>
+
+<para>
+The list of available tools from default is dependent both on
+the platform and what software is installed on the platform.
+Some tools will not initialize if an underlying command is
+not found, and some tools are selected from a list of choices
+on a first-found basis. The finished tool list can be
+examined by inspecting the <envar>TOOLS</envar> &consvar;
+variable in the &consenv;.
+</para>
+
+<para>
+On all platforms, all tools from the following list
+are selected whose respective conditions are met:
+filesystem, wix, lex, yacc, rpcgen, swig,
+jar, javac, javah, rmic, dvipdf, dvips, gs,
+tex, latex, pdflatex, pdftex, tar, zip, textfile.
+</para>
+
+<para>
+On Linux systems, the default tools list selects
+(first-found) a C compiler from
+gcc, intelc, icc, cc;
+a C++ compiler from
+g++, intelc, icc, cxx;
+an assembler from
+gas, nasm, masm;
+a linker from
+gnulink, ilink;
+a Fortran compiler from
+gfortran, g77, ifort, ifl, f95, f90, f77;
+and a static archiver 'ar'.
+It also selects all found from the list
+m4, rpm.
+</para>
+
+<para>
+On Windows systems, the default tools list selects
+(first-found) a C compiler from
+msvc, mingw, gcc, intelc, icl, icc, cc, bcc32;
+a C++ compiler from
+msvc, intelc, icc, g++, cxx, bcc32;
+an assembler from
+masm, nasm, gas, 386asm;
+a linker from
+mslink, gnulink, ilink, linkloc, ilink32;
+a Fortran compiler from
+gfortran, g77, ifl, cvf, f95, f90, fortran;
+and a static archiver from
+mslib, ar, tlib;
+It also selects all found from the list
+msvs, midl.
+</para>
+
+<para>
+On MacOS systems, the default tools list selects
+(first-found) a C compiler from
+gcc, cc;
+a C++ compiler from
+g++, cxx;
+an assembler 'as';
+a linker from
+applelink, gnulink;
+a Fortran compiler from
+gfortran, f95, f90, g77;
+and a static archiver 'ar'.
+It also selects all found from the list
+m4, rpm.
+</para>
+
+<para>
+Default lists for other platforms can be found by
+examining the source code for &scons;.
+</para>
+
 </summary>
 </tool>
-
 </sconsdoc>

--- a/src/engine/SCons/Tool/link.xml
+++ b/src/engine/SCons/Tool/link.xml
@@ -26,7 +26,9 @@ See its __doc__ string for a discussion of the format.
 <tool name="link">
 <summary>
 <para>
-Sets construction variables for generic POSIX linkers.
+Sets construction variables for generic POSIX linkers. This is
+a "smart" linker tool which selects a compiler to complete the linking
+based on the type of source file.
 </para>
 </summary>
 <sets>

--- a/src/engine/SCons/Tool/link.xml
+++ b/src/engine/SCons/Tool/link.xml
@@ -28,7 +28,7 @@ See its __doc__ string for a discussion of the format.
 <para>
 Sets construction variables for generic POSIX linkers. This is
 a "smart" linker tool which selects a compiler to complete the linking
-based on the type of source file.
+based on the types of source files.
 </para>
 </summary>
 <sets>

--- a/src/engine/SCons/Tool/midl.xml
+++ b/src/engine/SCons/Tool/midl.xml
@@ -86,7 +86,7 @@ The command line used to pass files to the Microsoft IDL compiler.
 <summary>
 <para>
 The string displayed when
-the Microsoft IDL copmiler is called.
+the Microsoft IDL compiler is called.
 If this is not set, then &cv-link-MIDLCOM; (the command line) is displayed.
 </para>
 </summary>


### PR DESCRIPTION
Also some formatting tweaks, and a couple of typos.

The description of the default tool now lists some of what that may include. The expanded default description appears in both the manpage and the user guide, since they both pull from the generated file (`doc/generated/tools.gen`) that contains that text.  Looked into conditional text, but it seems to be rather complicated, maybe for another change if it's too much for the user guide.

This is a doc-only change.  

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
