### PR TITLE
Improve threading performance by sharing NodeInfo across threads

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -6,9 +6,11 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-  From John Doe:
+  From Mathew Robinson:
 
-    - Whatever John Doe did.
+    - Improved threading performance by ensuring NodeInfo is shared
+      across threads. Results in ~13% improvement for parallel builds
+      (-j# > 1) with many shared nodes.
 
 
 RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -2545,11 +2545,10 @@ class FileTestCase(_tempdirTestCase):
 
             def get_ninfo(self):
                 """ mocked to ensure csig will equal the filename"""
-                try:
+                if self.ninfo is not None:
                     return self.ninfo
-                except AttributeError:
-                    self.ninfo = FakeNodeInfo(self.name, self.timestamp)
-                    return self.ninfo
+                self.ninfo = FakeNodeInfo(self.name, self.timestamp)
+                return self.ninfo
 
             def get_csig(self):
                 ninfo = self.get_ninfo()

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -614,6 +614,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         self._func_rexists = 1
         self._func_get_contents = 0
         self._func_target_from_source = 0
+        self.ninfo = None
 
         self.clear_memoized_values()
 
@@ -1131,11 +1132,10 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         return ninfo
 
     def get_ninfo(self):
-        try:
+        if self.ninfo is not None:
             return self.ninfo
-        except AttributeError:
-            self.ninfo = self.new_ninfo()
-            return self.ninfo
+        self.ninfo = self.new_ninfo()
+        return self.ninfo
 
     def new_binfo(self):
         binfo = self.BuildInfo()


### PR DESCRIPTION
This is mildly work in progress but is based on results found [here](https://gist.github.com/chasinglogic/d43a1e12d43a7d8ca052fe2aa76f16a1)

The last section [Initializing NodeInfo at SCons.Node.FS.Base construction time](https://gist.github.com/chasinglogic/d43a1e12d43a7d8ca052fe2aa76f16a1) contains the relevant performance results.

The patch shown in that section however had some major flaws and this version maintains the same performance characteristics without side effects like loading SConsign before the SConstruct etc.

The observed behavior is that during a build all of the File nodes are passed out to threads, a single File node can be seen as a target or source multiple times. For instance one of our unit test binaries shows up 8 times in the DAG walk. The File node is shared across all threads and asked for it's `csig`. When calculating the `csig` the `NodeInfo` object is constructed because it does not exist. This object construction happens in each thread and so the `NodeInfo` is not actually shared across threads. I believe this is because of the use of `__slots__` since the `File` node does not see that it has a `self.ninfo` attribute but it's (multiple levels up) super class `Node` does.

Either way the content signature is calculated using a very expensive read and hash method then stored as the `csig` attribute on the `NodeInfo` object. This causes a long thread lock because the `File` node is the caller so is "doing the work". But since the `NodeInfo` object is not shared when the next thread sees this same `File` node it will cause the same long thread lock and do the same work again. This can repeat many many times.

You can see in the profile results in the above links that we go from spending `31.537` seconds locking threads and `22.198` on reading files to `9.494` seconds locking threads and `11.606` seconds reading files. Perhaps the biggest gains are on what we save with hashing. Time spent in `_hashlib.HASH` sees a reduction from `18.278` to less than 1 second:

```
    40289    0.689    0.000    0.689    0.000 {method 'update' of '_hashlib.HASH' objects}
```


I've seen thread locking times get as low as `4.738` seconds with some other SCons options like `--implicit-cache` and `--max-drift` settings set as according to the wiki.

When combined with the Subst rewrite in #3107 MongoDB builds could be sped up dramatically.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
