### PR TITLE
Actually say it's the MIT license   [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to SCons
+
+First off, thanks for taking the time to contribute!
+
+Here are some pointers to get started, before more information gets moved here to this page.
+
+  * [Bugs and Feature Requests](https://scons.org/bugs.html)
+  * [Development](https://scons.org/dev.html)
+  * [SCons Developer's Guidelines](https://scons.org/guidelines.html)
+
+Various resources to contact are here:
+
+  * [Contacts](https://scons.org/contact.html)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-__COPYRIGHT__
+MIT License
+
+Copyright (c) 2001 - 2019 The SCons Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE-local
+++ b/LICENSE-local
@@ -3,6 +3,8 @@
         This copyright and license do not apply to any other software
         with which this software may have been included.
 
+MIT License
+
 __COPYRIGHT__
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/src/LICENSE.txt
+++ b/src/LICENSE.txt
@@ -1,3 +1,5 @@
+MIT License
+
 __COPYRIGHT__
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
A line "MIT License" is added to the license files, most places do it this way.

For the benefit of Github, the top-level `LICENSE` file, which it looks at but the packaging stuff does not, is filled-in. The packaging fills in `__COPYRIGHT__` from `src/LICENSE.txt` instead (and `LICENSE-local`).

Add a skeletal `CONTRIBUTING.md`

There are no operational changes (code, docs, tests).

Signed-off-by: Mats Wichmann <mats@linux.com>


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
