### PR TITLE
test: Fix SyntaxWarnings on escapes in Python strings

### DIFF
--- a/test/Errors/execute-a-directory.py
+++ b/test/Errors/execute-a-directory.py
@@ -55,34 +55,34 @@ Bad command or file name
 unrecognized = """\
 '.+' is not recognized as an internal or external command,
 operable program or batch file.
-scons: \*\*\* \[%s\] Error 1
+scons: \\*\\*\\* \\[%s\\] Error 1
 """
 
 unspecified = """\
 The name specified is not recognized as an
 internal or external command, operable program or batch file.
-scons: \*\*\* \[%s\] Error 1
+scons: \\*\\*\\* \\[%s\\] Error 1
 """
 
 cannot_execute = """\
 (sh: )*.+: cannot execute
-scons: \*\*\* \[%s\] Error %s
+scons: \\*\\*\\* \\[%s\\] Error %s
 """
 
 permission_denied = """\
 .+: (p|P)ermission denied
-scons: \*\*\* \[%s\] Error %s
+scons: \\*\\*\\* \\[%s\\] Error %s
 """
 
 is_a_directory = """\
 .+: (i|I)s a directory
-scons: \*\*\* \[%s\] Error %s
+scons: \\*\\*\\* \\[%s\\] Error %s
 """
 
 konnte_nicht_gefunden_werden = """\
 Der Befehl ".+" ist entweder falsch geschrieben oder
 konnte nicht gefunden werden.
-scons: \*\*\* \[%s\] Error %s
+scons: \\*\\*\\* \\[%s\\] Error %s
 """
 
 test.description_set("Incorrect STDERR:\n%s\n" % test.stderr())

--- a/test/Errors/non-executable-file.py
+++ b/test/Errors/non-executable-file.py
@@ -44,29 +44,29 @@ Bad command or file name
 unrecognized = """\
 '.+' is not recognized as an internal or external command,
 operable program or batch file.
-scons: \*\*\* \[%s\] Error 1
+scons: \\*\\*\\* \\[%s\\] Error 1
 """
 
 unspecified = """\
 The name specified is not recognized as an
 internal or external command, operable program or batch file.
-scons: \*\*\* \[%s\] Error 1
+scons: \\*\\*\\* \\[%s\\] Error 1
 """
 
 cannot_execute = """\
 (sh: )*.+: cannot execute
-scons: \*\*\* \[%s\] Error %s
+scons: \\*\\*\\* \\[%s\\] Error %s
 """
 
 permission_denied = """\
 .+: (p|P)ermission denied
-scons: \*\*\* \[%s\] Error %s
+scons: \\*\\*\\* \\[%s\\] Error %s
 """
 
 konnte_nicht_gefunden_werden = """\
 Der Befehl ".+" ist entweder falsch geschrieben oder
 konnte nicht gefunden werden.
-scons: \*\*\* \[%s\] Error %s
+scons: \\*\\*\\* \\[%s\\] Error %s
 """
 
 test.write('SConstruct', r"""

--- a/test/Interactive/shell.py
+++ b/test/Interactive/shell.py
@@ -89,8 +89,8 @@ if sys.platform == 'win32':
 else:
     no_such_error = 'scons: no_such_command: No such file or directory'
 
-expect_stdout = """\
-scons>>> Copy\("foo.out", "foo.in"\)
+expect_stdout = \
+r"""scons>>> Copy\("foo.out", "foo.in"\)
 Touch\("1"\)
 scons>>> hello from shell_command.py
 scons>>> ![^"]+ ".*"

--- a/test/Interactive/version.py
+++ b/test/Interactive/version.py
@@ -40,7 +40,7 @@ test.write('SConstruct', "")
 # Standard copyright marker is mangled so it doesn't get replaced
 # by the packaging build.
 copyright_line = """\
-(_{2}COPYRIGHT__|Copyright \\(c\\) 2001[-\d, ]+ The SCons Foundation)
+(_{2}COPYRIGHT__|Copyright \\(c\\) 2001[-\\d, ]+ The SCons Foundation)
 """
 
 expect1 = """\
@@ -53,8 +53,8 @@ scons>>>
 scons>>> 
 """
 
-test.run(arguments = '-Q --interactive',
-         stdin = "version\nexit\n")
+test.run(arguments='-Q --interactive',
+         stdin="version\nexit\n")
 
 # Windows may or may not print a line for the script version
 # depending on whether it's invoked through scons.py or scons.bat.

--- a/test/Java/JARFLAGS.py
+++ b/test/Java/JARFLAGS.py
@@ -59,10 +59,10 @@ public class Example1
 """)
 
 expect = test.wrap_stdout("""\
-javac -d classes -sourcepath src src.Example1\.java
-jar cvf test.jar -C classes src.Example1\.class
+javac -d classes -sourcepath src src.Example1\\.java
+jar cvf test.jar -C classes src.Example1\\.class
 .*
-adding: src.Example1\.class.*
+adding: src.Example1\\.class.*
 """ % locals())
 
 

--- a/test/Java/JAVABOOTCLASSPATH.py
+++ b/test/Java/JAVABOOTCLASSPATH.py
@@ -84,8 +84,8 @@ public class Example2
 bootclasspath = os.pathsep.join(['dir1', 'dir2'])
 
 expect = """\
-javac -bootclasspath %(bootclasspath)s -d class -sourcepath com com.Example1\.java
-javac -bootclasspath %(bootclasspath)s -d class -sourcepath com com.Example2\.java
+javac -bootclasspath %(bootclasspath)s -d class -sourcepath com com.Example1\\.java
+javac -bootclasspath %(bootclasspath)s -d class -sourcepath com com.Example2\\.java
 """ % locals()
 
 test.run(arguments = '-Q -n .', stdout = expect, match=TestSCons.match_re)

--- a/test/Libs/SharedLibrary.py
+++ b/test/Libs/SharedLibrary.py
@@ -223,20 +223,17 @@ if sys.platform == 'cygwin':
 
 
 if sys.platform == 'win32' or sys.platform.find('irix') != -1:
-    test.run(arguments = '-f SConstructFoo')
+    test.run(arguments='-f SConstructFoo')
 else:
-    test.run(arguments = '-f SConstructFoo', status=2, stderr='''\
-scons: \*\*\* \[.*\] Source file: foo\..* is static and is not compatible with shared target: .*
-''',
-    match=TestSCons.match_re_dotall)
+    expect = r"scons: \*\*\* \[.*\] Source file: foo\..* is static and is not compatible with shared target: .*"
+    test.run(arguments='-f SConstructFoo', status=2, stderr=expect,
+             match=TestSCons.match_re_dotall)
     # Run it again to make sure that we still get the error
     # even though the static objects already exist.
-    test.run(arguments = '-f SConstructFoo', status=2, stderr='''\
-scons: \*\*\* \[.*\] Source file: foo\..* is static and is not compatible with shared target: .*
-''',
-    match=TestSCons.match_re_dotall)
+    test.run(arguments='-f SConstructFoo', status=2, stderr=expect,
+             match=TestSCons.match_re_dotall)
 
-test.run(arguments = '-f SConstructFoo2',
+test.run(arguments='-f SConstructFoo2',
          stderr=TestSCons.noisy_ar,
          match=TestSCons.match_re_dotall)
 

--- a/test/Scanner/CrossLanguageNoExtension.py
+++ b/test/Scanner/CrossLanguageNoExtension.py
@@ -34,7 +34,7 @@ test = TestSCons.TestSCons()
 # for nodes that do not have mappings from their scanner_key
 # to a scanner instance
 
-test.write('SConstruct', """
+test.write('SConstruct', r"""
 import re
 
 include_re = re.compile(r'^include\s+(\S+)$', re.M)
@@ -77,7 +77,7 @@ env2.Append(SCANNERS = [ k2scan2 ] )
 env2.Command( 'k2', 'foo.k', Copy( '$TARGET', '$SOURCE' ) )
 """)
 
-test.write('foo.k', 
+test.write('foo.k',
 """foo.k 1 line 1
 include xxx.k
 include yyy

--- a/test/Scanner/FindPathDirs.py
+++ b/test/Scanner/FindPathDirs.py
@@ -71,7 +71,7 @@ test.write('SConstruct', """\
 SConscript('SConscript')
 """)
 
-test.write('SConscript', """\
+test.write('SConscript', r"""
 import os.path
 import re
 
@@ -86,7 +86,7 @@ def kfile_scan(node, env, path, arg):
     for inc in includes:
         for dir in path:
             file = str(dir) + os.sep + inc
-            if os.path.exists(file):  
+            if os.path.exists(file):
                 results.append(file)
                 break
     return results
@@ -109,7 +109,7 @@ env.Command('foo', 'foo.k', r'%(_python_)s build.py "$KPATH" $SOURCES $TARGET')
 
 
 
-test.write('foo.k', 
+test.write('foo.k',
 """foo.k 1 line 1
 include xxx
 include yyy

--- a/test/Scanner/Scanner.py
+++ b/test/Scanner/Scanner.py
@@ -60,7 +60,7 @@ test.write('SConstruct', """
 SConscript('SConscript')
 """, mode='w')
 
-test.write('SConscript', """
+test.write('SConscript', r"""
 import re
 
 include_re = re.compile(r'^include\s+(\S+)\s*$', re.M)
@@ -137,7 +137,7 @@ Alias('make_ork', ork)
 
 """ % locals(),mode='w')
 
-test.write('foo.k', 
+test.write('foo.k',
 """foo.k 1 line 1
 include xxx
 include yyy
@@ -151,7 +151,7 @@ bar.in 1 line 3
 include zzz
 """, mode='w')
 
-test.write('junk.k2', 
+test.write('junk.k2',
 """include yyy
 junk.k2 1 line 2
 junk.k2 1 line 3

--- a/test/Scanner/dictionary.py
+++ b/test/Scanner/dictionary.py
@@ -61,7 +61,7 @@ test.write('SConstruct', """
 SConscript('SConscript')
 """)
 
-test.write('SConscript', """
+test.write('SConscript', r"""
 import re
 
 include1_re = re.compile(r'^include1\s+(\S+)$', re.M)
@@ -100,7 +100,7 @@ env.Command('bbb', 'bbb.k2', r'%(_python_)s build.py $SOURCES $TARGET')
 env.Command('ccc', 'ccc.k3', r'%(_python_)s build.py $SOURCES $TARGET')
 """ % locals())
 
-test.write('aaa.k1', 
+test.write('aaa.k1',
 """aaa.k1 1
 line 2
 include1 xxx
@@ -109,7 +109,7 @@ include3 zzz
 line 6
 """)
 
-test.write('bbb.k2', 
+test.write('bbb.k2',
 """bbb.k2 1
 line 2
 include1 xxx
@@ -118,7 +118,7 @@ include3 zzz
 line 6
 """)
 
-test.write('ccc.k3', 
+test.write('ccc.k3',
 """ccc.k3 1
 line 2
 include1 xxx

--- a/test/Scanner/exception.py
+++ b/test/Scanner/exception.py
@@ -37,7 +37,7 @@ test.write('SConstruct', """
 SConscript('SConscript')
 """)
 
-test.write('SConscript', """
+test.write('SConscript', r"""
 import re
 
 include_re = re.compile(r'^include\s+(\S+)$', re.M)
@@ -82,14 +82,14 @@ bar_in = File('bar.in')
 env.Cat('bar', bar_in)
 """)
 
-test.write('foo.k', 
+test.write('foo.k',
 """foo.k 1 line 1
 include xxx
 include yyy
 foo.k 1 line 4
 """)
 
-test.write('bar.in', 
+test.write('bar.in',
 """include yyy
 bar.in 1 line 2
 bar.in 1 line 3

--- a/test/Scanner/generated.py
+++ b/test/Scanner/generated.py
@@ -188,7 +188,7 @@ env = env.Clone()    # Yes, clobber intentionally
 
 """)
 
-test.write(['src', 'lib_geng', 'SConscript'], """\
+test.write(['src', 'lib_geng', 'SConscript'], r"""
 # --- Begin SConscript boilerplate ---
 import sys
 import Mylib
@@ -280,7 +280,7 @@ env.Command(generated_hdrs.split(),
             cmd_generated)
 recurse_env.Command([lib_fullname] + lib_objs,
                     lib_srcs + (generated_hdrs + " " + static_hdrs).split(),
-                    cmd_justlib) 
+                    cmd_justlib)
 """)
 
 test.write(['src', 'lib_geng', 'MAKE-HEADER.py'], """\
@@ -395,7 +395,7 @@ int g_1()
 
 test.write(['src', 'lib_geng', 'libg_2.c'], """\
 #include <libg_w.h>
-#include <libg_gx.h> 
+#include <libg_gx.h>
 #include <libg_gy.h>
 #include <libg_gz.h>
 

--- a/test/Scanner/multi-env.py
+++ b/test/Scanner/multi-env.py
@@ -37,7 +37,7 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 
 
-test.write('SConstruct', """
+test.write('SConstruct', r"""
 import re
 
 include_re = re.compile(r'^include\s+(\S+)$', re.M)

--- a/test/Scanner/no-Dir-node.py
+++ b/test/Scanner/no-Dir-node.py
@@ -89,7 +89,7 @@ Command('list.out', 'subdir', foo, source_scanner = DirScanner)
 SConscript('subdir/SConscript')
 """)
 
-test.write(['subdir', 'SConscript'], """\
+test.write(['subdir', 'SConscript'], r"""
 import SCons.Scanner
 kscan = SCons.Scanner.Classic(name = 'kfile',
                               suffixes = ['.k'],

--- a/test/Scanner/source_scanner-dict.py
+++ b/test/Scanner/source_scanner-dict.py
@@ -65,7 +65,7 @@ test.write('SConstruct', """
 SConscript('SConscript')
 """)
 
-test.write('SConscript', """
+test.write('SConscript', r"""
 import re
 
 include1_re = re.compile(r'^include1\s+(\S+)$', re.M)
@@ -101,7 +101,7 @@ env.Build('ccc', 'ccc.k3')
 env.Build('ddd', ['ddd.k4', 'aaa.k1', 'bbb.k2', 'ccc.k3'])
 """ % locals())
 
-test.write('aaa.k1', 
+test.write('aaa.k1',
 """aaa.k1 1
 line 2
 include1 xxx
@@ -110,7 +110,7 @@ include3 zzz
 line 6
 """)
 
-test.write('bbb.k2', 
+test.write('bbb.k2',
 """bbb.k2 1
 line 2
 include1 xxx
@@ -119,7 +119,7 @@ include3 zzz
 line 6
 """)
 
-test.write('ccc.k3', 
+test.write('ccc.k3',
 """ccc.k3 1
 line 2
 include1 xxx
@@ -128,7 +128,7 @@ include3 zzz
 line 6
 """)
 
-test.write('ddd.k4', 
+test.write('ddd.k4',
 """ddd.k4 1
 line 2
 line 3

--- a/test/Scanner/unicode.py
+++ b/test/Scanner/unicode.py
@@ -77,7 +77,7 @@ with open(sys.argv[2], 'w') as ofp:
 sys.exit(0)
 """)
 
-test.write('SConstruct', """
+test.write('SConstruct', r"""
 import re
 
 include_re = re.compile(r'^include\s+(\S+)$', re.M)

--- a/test/explain/basic.py
+++ b/test/explain/basic.py
@@ -51,7 +51,7 @@ inc_bbb_k = test.workpath('inc', 'bbb.k')
 
 
 
-test.write(cat_py, r"""\
+test.write(cat_py, r"""
 from __future__ import print_function
 
 import sys
@@ -81,7 +81,7 @@ sys.exit(0)
 """)
 
 
-SConstruct_contents = """\
+SConstruct_contents = r"""
 DefaultEnvironment(tools=[])
 import re
 
@@ -130,7 +130,7 @@ AlwaysBuild(file6)
 env.Cat('subdir/file7', 'subdir/file7.in')
 env.OneCat('subdir/file8', ['subdir/file7.in', env.Value(%(test_value)s)] )
 env.OneCat('subdir/file9', ['subdir/file7.in', env.Value(7)] )
-""" % valueDict )
+""" % valueDict)
 
 test_value = '"first"'
 WriteInitialTest( locals() )

--- a/test/explain/save-info.py
+++ b/test/explain/save-info.py
@@ -70,7 +70,7 @@ with open(sys.argv[1], 'w') as ofp:
 sys.exit(0)
 """)
 
-test.write(['src', 'SConstruct'], """\
+test.write(['src', 'SConstruct'], r"""
 DefaultEnvironment(tools=[])
 import re
 

--- a/test/import.py
+++ b/test/import.py
@@ -114,8 +114,8 @@ scons: warning: Can't find Intel compiler top dir for version='None', abi='[^']*
 """ + TestSCons.file_expr
 
 # Intel no license directory warning
-intel_license_warning = re.escape("""
-scons: warning: Intel license dir was not found.  Tried using the INTEL_LICENSE_FILE environment variable (), the registry () and the default path (C:\Program Files\Common Files\Intel\Licenses).  Using the default path as a last resort.
+intel_license_warning = re.escape(
+r"""scons: warning: Intel license dir was not found.  Tried using the INTEL_LICENSE_FILE environment variable (), the registry () and the default path (C:\Program Files\Common Files\Intel\Licenses).  Using the default path as a last resort.
 """) + TestSCons.file_expr
 
 intel_warnings = [

--- a/test/option-v.py
+++ b/test/option-v.py
@@ -35,7 +35,7 @@ test.write('SConstruct', "")
 # Standard copyright marker is mangled so it doesn't get replaced
 # by the packaging build.
 copyright_line = """\
-(_{2}COPYRIGHT__|Copyright \\(c\\) 2001[-\d, ]+ The SCons Foundation)
+(_{2}COPYRIGHT__|Copyright \\(c\\) 2001[-\\d, ]+ The SCons Foundation)
 """
 
 # Windows may or may not print a line for the script version
@@ -64,7 +64,7 @@ if not test.match_re(stdout, expect1) and not test.match_re(stdout, expect2):
     test.fail_test()
 
 test.pass_test()
- 
+
 
 # Local Variables:
 # tab-width:4

--- a/test/runtest/xml/output.py
+++ b/test/runtest/xml/output.py
@@ -65,7 +65,7 @@ expect = """\
 </stdout>
       <stderr>FAILING TEST STDERR
 </stderr>
-      <time>\\d+\.\d</time>
+      <time>\\d+\\.\\d</time>
     </test>
     <test>
       <file_name>%(test_no_result_py)s</file_name>
@@ -75,7 +75,7 @@ expect = """\
 </stdout>
       <stderr>NO RESULT TEST STDERR
 </stderr>
-      <time>\\d+\.\d</time>
+      <time>\\d+\\.\\d</time>
     </test>
     <test>
       <file_name>%(test_pass_py)s</file_name>
@@ -85,9 +85,9 @@ expect = """\
 </stdout>
       <stderr>PASSING TEST STDERR
 </stderr>
-      <time>\\d+\.\d</time>
+      <time>\\d+\\.\\d</time>
     </test>
-  <time>\\d+\.\d</time>
+  <time>\\d+\\.\\d</time>
   </results>
 """ % locals()
 

--- a/test/srcchange.py
+++ b/test/srcchange.py
@@ -42,13 +42,13 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-test.write('getrevision', """
+test.write('getrevision', r"""
 from __future__ import print_function
-with open('revnum.in','r') as f:
+with open('revnum.in', 'r') as f:
     print(f.read().strip(), end='')
 """)
 
-test.write('SConstruct', """
+test.write('SConstruct', r"""
 import re
 
 def subrevision(target, source ,env):
@@ -63,7 +63,7 @@ SubRevision = Action(subrevision)
 
 env=Environment()
 content_env=env.Clone()
-content_env.Command('revision.in', [], r'%(_python_)s getrevision > $TARGET')
+content_env.Command('revision.in', [], '%(_python_)s getrevision > $TARGET')
 content_env.AlwaysBuild('revision.in')
 env.Precious('main.c')
 env.Command('main.c', 'revision.in', SubRevision)


### PR DESCRIPTION
This is the remaining batch of `SyntaxWarning` cleanups in the test/ directory, as flagged by Python 3.8 (now tested with 3.8.0b4).  Most of these are escapes in strings that are not recognized as Python-language escapes up front, due to the embedded nature of testing - tests write a string to a file which is actually Python (code or sconscript) which is later to be executed.

Also changed the timestamp-fallback test to eliminate an imp module DeprecationWarning: since in all supported Python versions haslib is stdlib, drop that skip check; the md5 skip check can be a simple import now.

My test runs with 3.8 show no SyntaxWarnings after this.

No doc impacts; no changes in the src/ tree.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
