### PR TITLE
[WIP] Provide alternatives to md5 signatures

### DIFF
--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -27,7 +27,6 @@ __doc__ = """
 CacheDir support
 """
 
-import hashlib
 import json
 import os
 import stat

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -3575,7 +3575,10 @@ class CacheDirTestCase(unittest.TestCase):
 
         f9 = fs.File('f9')
         r = f9.get_cachedir_csig()
-        assert r == 'd41d8cd98f00b204e9800998ecf8427e', r
+        if SCons.Util.md5 == 'md5':
+            assert r == 'd41d8cd98f00b204e9800998ecf8427e', r
+        elif SCons.Util.md5 == 'sha1':
+            assert r == 'da39a3ee5e6b4b0d3255bfef95601890afd80709', r
 
 
 class clearTestCase(unittest.TestCase):

--- a/src/engine/SCons/Node/NodeTests.py
+++ b/src/engine/SCons/Node/NodeTests.py
@@ -595,7 +595,10 @@ class NodeTestCase(unittest.TestCase):
             node = SCons.Node.Node()
             node._func_get_contents = 4
             result = node.get_csig()
-            assert result == '550a141f12de6341fba65b0ad0433500', result
+            if SCons.Util.md5 == 'md5':
+                assert result == '550a141f12de6341fba65b0ad0433500', result
+            elif SCons.Util.md5 == 'sha1':
+                assert result == '9a3e61b6bcc8abec08f195526c3132d5a4a98cc0', result
         finally:
             SCons.Node.Node.NodeInfo = SCons.Node.NodeInfoBase
 
@@ -612,7 +615,10 @@ class NodeTestCase(unittest.TestCase):
             node = SCons.Node.Node()
             node._func_get_contents = 4
             result = node.get_cachedir_csig()
-            assert result == '15de21c670ae7c3f6f3f1f37029303c9', result
+            if SCons.Util.md5 == 'md5':
+                assert result == '15de21c670ae7c3f6f3f1f37029303c9', result
+            elif SCons.Util.md5 == 'sha1':
+                assert result == 'cfa1150f1787186742a9a884b73a43d8cf219f9b', result
         finally:
             SCons.Node.Node.NodeInfo = SCons.Node.NodeInfoBase
 

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -37,7 +37,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import SCons.compat
 
 import base64
-import hashlib
+import uuid
 import ntpath
 import os
 import pickle
@@ -79,23 +79,40 @@ def processIncludes(includes, env, target, source):
     return [env.Dir(i).abspath for i in
             SCons.PathList.PathList(includes).subst_path(env, target, source)]
 
+# Work-in-progress
+# individual elements each get a globally unique identifier.
+# however, there also are some "well known" guids that either
+# represent something, or are used as a namespace to base
+# generating guids that should be "in" the namespace
+#NAMESPACE_PROJECT   = uuid.UUID("{D9BD5916-F055-4D77-8C69-9448E02BF433}")
+#NAMESPACE_SLN_GROUP = uuid.UUID("{2D0C29E0-512F-47BE-9AC4-F4CAE74AE16E}")
+#NAMESPACE_INTERNAL  = uuid.UUID("{BAA4019E-6D67-4EF1-B3CB-AE6CD82E4060}")
+
+# Kinds of projects, as used in solution files
+#PROJECT_KIND_C      = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}"
+#PROJECT_KIND_PCL    = "{786C830F-07A1-408B-BD7F-6EE04809D6DB}"
+#NAMESPACE_PRJ_FOLDER = "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}"
+#NAMESPACE_SLN_FOLDER = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}"
+#NAMESPACE_TEST       = "{3AC096D0-A1C2-E12C-1390-A8335801FDAB}"
 
 external_makefile_guid = '{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}'
 
-def _generateGUID(slnfile, name):
-    """This generates a dummy GUID for the sln file to use.  It is
-    based on the MD5 signatures of the sln filename plus the name of
-    the project.  It basically just needs to be unique, and not
-    change with each invocation."""
-    m = hashlib.md5()
+def _generateGUID(slnfile, name, namespace=external_makefile_guid):
+    """Generates a GUID for the sln file to use.
+
+    The uuid5 function is used to combine an existing namespace uuid -
+    the one VS uses for C projects (external_makedile_guid) -
+    and a combination of the solution file name (slnfile) and the
+    project name (name).  We just need uniqueness/repeatability.
+
+    Returns (str) "displayable" GUID, already wrapped in braces"""
+
     # Normalize the slnfile path to a Windows path (\ separators) so
     # the generated file has a consistent GUID even if we generate
     # it on a non-Windows platform.
-    m.update(bytearray(ntpath.normpath(str(slnfile)) + str(name),'utf-8'))
-    solution = m.hexdigest().upper()
-    # convert most of the signature to GUID form (discard the rest)
-    solution = "{" + solution[:8] + "-" + solution[8:12] + "-" + solution[12:16] + "-" + solution[16:20] + "-" + solution[20:32] + "}"
-    return solution
+    slnfile = ntpath.normpath(str(slnfile))
+    solution = uuid.uuid5(uuid.UUID(namespace), "%s-%s" %(slnfile, name))
+    return '{' + str(solution).upper() + '}'
 
 version_re = re.compile(r'(\d+\.\d+)(.*)')
 

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -161,7 +161,7 @@ def generate_guids(root):
     To handle this requirement, the uuid is generated with an md5 hashing the
     whole subtree of a xml node.
     """
-    from hashlib import md5
+    import uuid
 
     # specify which tags need a guid and in which attribute this should be stored.
     needs_id = { 'Product'   : 'Id',
@@ -175,10 +175,8 @@ def generate_guids(root):
         node_list = root.getElementsByTagName(key)
         attribute = value
         for node in node_list:
-            hash = md5(node.toxml()).hexdigest()
-            hash_str = '%s-%s-%s-%s-%s' % ( hash[:8], hash[8:12], hash[12:16], hash[16:20], hash[20:] )
-            node.attributes[attribute] = hash_str
-
+            hash = uuid.uuid5(uuid.NAMESPACE_URL, node.toxml())
+            node.attributes[attribute] = str(hash)
 
 
 def string_wxsfile(target, source, env):

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -1444,7 +1444,7 @@ def RenameFunction(function, name):
 
 
 if hasattr(hashlib, 'md5'):
-    md5 = True
+    md5 = 'md5'
     hashfunc = hashlib.md5
 elif hasattr(hashlib, 'sha1'):
     # failover to sha1 if md5 is missing
@@ -1479,7 +1479,7 @@ def MD5signature(s):
 
     try:
         m.update(to_bytes(s))
-    except TypeError as e:
+    except TypeError:
         m.update(to_bytes(str(s)))
 
     return m.hexdigest()

--- a/src/engine/SCons/UtilTests.py
+++ b/src/engine/SCons/UtilTests.py
@@ -776,17 +776,28 @@ class MD5TestCase(unittest.TestCase):
         """
         s = list(map(MD5signature, ('111', '222', '333')))
 
-        assert '698d51a19d8a121ce581499d7b701668' == MD5collect(s[0:1])
-        assert '8980c988edc2c78cc43ccb718c06efd5' == MD5collect(s[0:2])
-        assert '53fd88c84ff8a285eb6e0a687e55b8c7' == MD5collect(s)
+        if SCons.Util.md5 == 'md5':
+            assert MD5collect(s[0:1]) == '698d51a19d8a121ce581499d7b701668', MD5collect(s[0:1])
+            assert MD5collect(s[0:2]) == '8980c988edc2c78cc43ccb718c06efd5', MD5collect(s[0:2])
+            assert MD5collect(s) == '53fd88c84ff8a285eb6e0a687e55b8c7', MD5collect(s)
+        elif SCons.Util.md5 == 'sha1':
+            assert MD5collect(s[0:1]) == '6216f8a75fd5bb3d5f22b6f9958cdede3fc086c2', MD5collect(s[0:1])
+            assert MD5collect(s[0:2]) == '42eda1b5dcb3586bccfb1c69f22f923145271d97', MD5collect(s[0:2])
+            assert MD5collect(s) == '2eb2f7be4e883ebe52034281d818c91e1cf16256', MD5collect(s)
 
     def test_MD5signature(self):
         """Test generating a signature"""
         s = MD5signature('111')
-        assert '698d51a19d8a121ce581499d7b701668' == s, s
+        if SCons.Util.md5 == 'md5':
+            assert s == '698d51a19d8a121ce581499d7b701668', s
+        elif SCons.Util.md5 == 'sha1':
+            assert s == '6216f8a75fd5bb3d5f22b6f9958cdede3fc086c2', s
 
         s = MD5signature('222')
-        assert 'bcbe3365e6ac95ea2c0343a2395834dd' == s, s
+        if SCons.Util.md5 == 'md5':
+            assert s == 'bcbe3365e6ac95ea2c0343a2395834dd', s
+        elif SCons.Util.md5 == 'sha1':
+            assert s == '1c6637a8f2e1f75e06ff9984894d6bd16a3a36a9', s
 
 
 class NodeListTestCase(unittest.TestCase):

--- a/test/MSVS/vs-7.0-variant_dir.py
+++ b/test/MSVS/vs-7.0-variant_dir.py
@@ -56,7 +56,7 @@ test.write(['src', 'SConscript'], SConscript_contents%{'HOST_ARCH': host_arch})
 
 test.run(arguments=".")
 
-project_guid = "{25F6CE89-8E22-2910-8B6E-FFE6DC1E2792}"
+project_guid = "{CB4637F1-2205-50B7-B115-DCFA0DA68FB1}"
 vcproj = test.read(['src', 'Test.vcproj'], 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct',
                               project_guid=project_guid)

--- a/test/MSVS/vs-7.1-variant_dir.py
+++ b/test/MSVS/vs-7.1-variant_dir.py
@@ -56,7 +56,7 @@ test.write(['src', 'SConscript'], SConscript_contents%{'HOST_ARCH': host_arch})
 
 test.run(arguments=".")
 
-project_guid = "{25F6CE89-8E22-2910-8B6E-FFE6DC1E2792}"
+project_guid = "{CB4637F1-2205-50B7-B115-DCFA0DA68FB1}"
 vcproj = test.read(['src', 'Test.vcproj'], 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct',
                               project_guid=project_guid)

--- a/test/MSVS/vs-variant_dir.py
+++ b/test/MSVS/vs-variant_dir.py
@@ -58,7 +58,7 @@ SConscript('src/SConscript', variant_dir='build')
 
     test.run(arguments=".")
 
-    project_guid = "{25F6CE89-8E22-2910-8B6E-FFE6DC1E2792}"
+    project_guid = "{CB4637F1-2205-50B7-B115-DCFA0DA68FB1}"
     vcproj = test.read(['src', project_file], 'r')
     expect = test.msvs_substitute(expected_vcprojfile, vc_version, None, 'SConstruct',
                                   project_guid=project_guid)

--- a/test/sconsign/script/Configure.py
+++ b/test/sconsign/script/Configure.py
@@ -34,6 +34,7 @@ import re
 
 import TestSCons
 import TestSConsign
+import SCons.Util
 
 _obj = TestSCons._obj
 
@@ -67,7 +68,12 @@ env = conf.Finish()
 
 test.run(arguments = '.')
 
-sig_re = r'[0-9a-fA-F]{32}'
+if SCons.Util.md5 == 'md5':
+    sig_re = r'[0-9a-fA-F]{32}'
+elif SCons.Util.md5 == 'sha1':
+    sig_re = r'[0-9a-fA-F]{40}'
+elif SCons.Util.md5 == 'sha256':
+    sig_re = r'[0-9a-fA-F]{64}'
 date_re = r'\S+ \S+ [ \d]\d \d\d:\d\d:\d\d \d\d\d\d'
 
 # Note:  There's a space at the end of the '.*': line, because the

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -32,6 +32,7 @@ using the signatures in an SConsignFile().
 import re
 import TestSCons
 import TestSConsign
+import SCons.Util
 
 _python_ = TestSCons._python_
 
@@ -137,7 +138,12 @@ test.write(['sub2', 'inc2.h'], r"""\
 
 test.run(arguments = '--implicit-cache .')
 
-sig_re = r'[0-9a-fA-F]{32}'
+if SCons.Util.md5 == 'md5':
+    sig_re = r'[0-9a-fA-F]{32}'
+elif SCons.Util.md5 == 'sha1':
+    sig_re = r'[0-9a-fA-F]{40}'
+elif SCons.Util.md5 == 'sha256':
+    sig_re = r'[0-9a-fA-F]{64}'
 
 test.run_sconsign(arguments = ".sconsign",
          stdout = r"""=== .:

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -32,6 +32,7 @@ value of Decider('timestamp-newer').
 
 import TestSCons
 import TestSConsign
+import SCons.Util
 
 _python_ = TestSCons._python_
 
@@ -143,7 +144,12 @@ test.sleep()
 
 test.run(arguments = '. --max-drift=1')
 
-sig_re = r'[0-9a-fA-F]{32}'
+if SCons.Util.md5 == 'md5':
+    sig_re = r'[0-9a-fA-F]{32}'
+elif SCons.Util.md5 == 'sha1':
+    sig_re = r'[0-9a-fA-F]{40}'
+elif SCons.Util.md5 == 'sha256':
+    sig_re = r'[0-9a-fA-F]{64}'
 date_re = r'\S+ \S+ [ \d]\d \d\d:\d\d:\d\d \d\d\d\d'
 
 test.run_sconsign(arguments = "-e hello.exe -e hello.obj sub1/.sconsign",

--- a/test/sconsign/script/dblite.py
+++ b/test/sconsign/script/dblite.py
@@ -32,6 +32,7 @@ the default dblite module and default .dblite suffix work correctly.
 import re,sys
 
 import TestSConsign
+import SCons.Util
 
 test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
 
@@ -109,7 +110,12 @@ test.sleep()
 
 test.run(arguments = '. --max-drift=1')
 
-sig_re = r'[0-9a-fA-F]{32}'
+if SCons.Util.md5 == 'md5':
+    sig_re = r'[0-9a-fA-F]{32}'
+elif SCons.Util.md5 == 'sha1':
+    sig_re = r'[0-9a-fA-F]{40}'
+elif SCons.Util.md5 == 'sha256':
+    sig_re = r'[0-9a-fA-F]{64}'
 date_re = r'\S+ \S+ [ \d]\d \d\d:\d\d:\d\d \d\d\d\d'
 
 if sys.platform == 'win32':

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -31,6 +31,7 @@ Verify that the sconsign script works when using an individual
 
 import TestSCons
 import TestSConsign
+import SCons.Util
 
 _python_ = TestSCons._python_
 
@@ -143,7 +144,12 @@ test.write(['sub2', 'inc2.h'], r"""\
 
 test.run(arguments = '--implicit-cache --tree=prune .')
 
-sig_re = r'[0-9a-fA-F]{32}'
+if SCons.Util.md5 == 'md5':
+    sig_re = r'[0-9a-fA-F]{32}'
+elif SCons.Util.md5 == 'sha1':
+    sig_re = r'[0-9a-fA-F]{40}'
+elif SCons.Util.md5 == 'sha256':
+    sig_re = r'[0-9a-fA-F]{64}'
 
 expect = r"""hello.c: %(sig_re)s \d+ \d+
 hello.exe: %(sig_re)s \d+ \d+

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -699,7 +699,7 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
             python = sys.executable
 
         if project_guid is None:
-            project_guid = "{E5466E26-0003-F18B-8F8A-BCD76C86388D}"
+            project_guid = "{B0CC4EE9-0174-51CD-A06A-41D0713E928A}"
 
         if 'SCONS_LIB_DIR' in os.environ:
             exec_script_main = "from os.path import join; import sys; sys.path = [ r'%s' ] + sys.path; import SCons.Script; SCons.Script.main()" % os.environ['SCONS_LIB_DIR']


### PR DESCRIPTION
Work in progress (see TODO)

Broadly, two changes

1. in the Visual Studio area, use uuid (Python standard library) to generate GUID identifiers instead of specifically using md5. Simplifies things as uuid lib can provide already formatted strings and that does not have to be done in place. TODO: some of the wired-in GUIDs in tests need to change to what is being produced now.
2. For use by file hashes, fall back to sha1 if md5 is not available (rare, but documented in Python documentation as being possible in a "FIPS Compliant" build of Python, and actually encountered by an scons user); while considering hashslib itself always present.  Like uuid, this is Python standard library since well before the oldest supported Python version (both added in 2.5).  Util.py now describes the hash being used in Util.md5, this is used to distinguish expected values in tests. Except for tests, nobody should need to look inside: Util.md5 will still evaluate True.

Security comment: the hashes are not used for any security purpose whatsoever, only for file-change detection, which in turn is used only for rebuild calculations, not for tampering detection. Thus the alternative is sha1, which also is "not secure", but which is as fast (in recent Py3 apparently even faster) as md5 hash computation. An additional fallback, should anyone develop problems with sha1 is sha256. 

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
