### PR TITLE
Fix subprocess result bytes not being decoded in SunOS/Solaris related tools.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -18,6 +18,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Turn previously deprecated debug options into failures:
       --debug=tree, --debug=dtree, --debug=stree, --debug=nomemoizer.
 
+  From Jakub Kulik
+    - Fix subprocess result bytes not being decoded in SunOS/Solaris related tools.
+
 
 RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
 

--- a/src/engine/SCons/Tool/suncxx.py
+++ b/src/engine/SCons/Tool/suncxx.py
@@ -74,7 +74,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
         except EnvironmentError:
             pass
         else:
-            pkginfo_contents = p.communicate()[0]
+            pkginfo_contents = p.communicate()[0].decode()
             version_re = re.compile(r'^ *VERSION:\s*(.*)$', re.M)
             version_match = version_re.search(pkginfo_contents)
             if version_match:
@@ -88,7 +88,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
             except EnvironmentError:
                 pass
             else:
-                pkgchk_contents = p.communicate()[0]
+                pkgchk_contents = p.communicate()[0].decode()
                 pathname_re = re.compile(r'^Pathname:\s*(.*/bin/CC)$', re.M)
                 pathname_match = pathname_re.search(pkgchk_contents)
                 if pathname_match:


### PR DESCRIPTION
We recently updated to the latest version of SCons and switched to Python 3.7 and found out that no matter the SConstruct file content, we are getting str/bytes errors.

The reason for that is that whole `sunxx.py` file works with strings, however output from subprocess is not being decoded, thus breaking regex few lines bellow. This simple change fixes these issues.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality. (This can be tested simply by running it, but my guess is that you don't have a Solaris machine to test it on anyway and thus there is not much to do.)
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] No documentation to update
