### PR TITLE
Fix a syntax error in the documentation

### DIFF
--- a/doc/user/output.xml
+++ b/doc/user/output.xml
@@ -309,7 +309,7 @@ Linking foo
     <scons_example name="output_COMSTR-VERBOSE">
        <file name="SConstruct" printme="1">
 env = Environment()
-if ARGUMENTS.get('VERBOSE') != "1':
+if ARGUMENTS.get('VERBOSE') != '1':
     env['CCCOMSTR'] = "Compiling $TARGET"
     env['LINKCOMSTR'] = "Linking $TARGET"
 env.Program('foo.c')


### PR DESCRIPTION
Quotation marks do not match, which is a syntax error.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
