### PR TITLE
fix CheckFunc detection code for MSVC

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -18,6 +18,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Turn previously deprecated debug options into failures:
       --debug=tree, --debug=dtree, --debug=stree, --debug=nomemoizer.
 
+  From Jacek Kuczera:
+    - Fix CheckFunc detection code for Visual 2019. Some functions
+      (e.g. memmove) were incorrectly recognized as not available.
 
 RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
 

--- a/src/engine/SCons/Conftest.py
+++ b/src/engine/SCons/Conftest.py
@@ -290,6 +290,10 @@ char %s();""" % function_name
 #include <assert.h>
 %(hdr)s
 
+#if _MSC_VER && !__INTEL_COMPILER
+    #pragma function(%(name)s)
+#endif
+
 int main(void) {
 #if defined (__stub_%(name)s) || defined (__stub___%(name)s)
   fail fail fail

--- a/test/Configure/config-h.py
+++ b/test/Configure/config-h.py
@@ -46,25 +46,27 @@ env.AppendENVPath('PATH', os.environ['PATH'])
 conf = Configure(env, config_h = 'config.h')
 r1 = conf.CheckFunc('printf')
 r2 = conf.CheckFunc('noFunctionCall')
-r3 = conf.CheckType('int')
-r4 = conf.CheckType('noType')
-r5 = conf.CheckCHeader('stdio.h', '<>')
-r6 = conf.CheckCHeader('hopefullynoc-header.h')
-r7 = conf.CheckCXXHeader('vector', '<>')
-r8 = conf.CheckCXXHeader('hopefullynocxx-header.h')
+r3 = conf.CheckFunc('memmove')
+r4 = conf.CheckType('int')
+r5 = conf.CheckType('noType')
+r6 = conf.CheckCHeader('stdio.h', '<>')
+r7 = conf.CheckCHeader('hopefullynoc-header.h')
+r8 = conf.CheckCXXHeader('vector', '<>')
+r9 = conf.CheckCXXHeader('hopefullynocxx-header.h')
 env = conf.Finish()
 conf = Configure(env, config_h = 'config.h')
-r9 = conf.CheckLib('%(lib)s', 'sin')
-r10 = conf.CheckLib('hopefullynolib', 'sin')
-r11 = conf.CheckLibWithHeader('%(lib)s', 'math.h', 'c')
-r12 = conf.CheckLibWithHeader('%(lib)s', 'hopefullynoheader2.h', 'c')
-r13 = conf.CheckLibWithHeader('hopefullynolib2', 'math.h', 'c')
+r10 = conf.CheckLib('%(lib)s', 'sin')
+r11 = conf.CheckLib('hopefullynolib', 'sin')
+r12 = conf.CheckLibWithHeader('%(lib)s', 'math.h', 'c')
+r13 = conf.CheckLibWithHeader('%(lib)s', 'hopefullynoheader2.h', 'c')
+r14 = conf.CheckLibWithHeader('hopefullynolib2', 'math.h', 'c')
 env = conf.Finish()
 """ % locals())
 
 expected_read_str = """\
 Checking for C function printf()... yes
 Checking for C function noFunctionCall()... no
+Checking for C function memmove()... yes
 Checking for C type int... yes
 Checking for C type noType... no
 Checking for C header file stdio.h... yes
@@ -95,6 +97,9 @@ expected_config_h = ("""\
 
 /* Define to 1 if the system has the function `noFunctionCall'. */
 /* #undef HAVE_NOFUNCTIONCALL */
+
+/* Define to 1 if the system has the function `memmove'. */
+#define HAVE_MEMMOVE 1
 
 /* Define to 1 if the system has the type `int'. */
 #define HAVE_INT 1


### PR DESCRIPTION
This patch fixes detection of some functions on Visual 2019 with optimizations (`/O2`) enabled.

For example: `memmove` is incorrectly detected as not available on Visual 2019 with `/O2` enabled because `/O2` enables `/Oi` which replaces `memmove` with a compiler intrinsic, which in turn causes the test code fail to compile. The `#pragma function` prevents replacing the tested function with a compiler intrinsic.