### PR TITLE
fix typo: missing quote in a manpage example

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -4572,7 +4572,7 @@ incl = Dir('include')
 f = incl.File('header.h')
 
 # Get a Node for a subdirectory within a directory
-dist = Dir('project-3.2.1)
+dist = Dir('project-3.2.1')
 src = dist.Dir('src')
 
 # Get a Node for a file in the same directory


### PR DESCRIPTION
doc-only change 

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
