### PR TITLE
enable experimental persistent caching of vcvars on win32

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - cmd: set STATIC_DEPS=true & C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off lxml
   # install 3rd party tools to test with
   - cmd: choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc winflexbison
-  - cmd: set SCONS_CACHE_MSVC_CONFIG="true"
+  - cmd: set SCONS_CACHE_MSVC_CONFIG=true
   - cmd: set
 
   ### LINUX ###

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - cmd: set STATIC_DEPS=true & C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off lxml
   # install 3rd party tools to test with
   - cmd: choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc winflexbison
-  - cmd: set SCONS_CACHE_MSVC_CONFIG=true
+  - cmd: set SCONS_CACHE_MSVC_CONFIG="true"
   - cmd: set
 
   ### LINUX ###

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,7 @@ install:
   - cmd: set STATIC_DEPS=true & C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off lxml
   # install 3rd party tools to test with
   - cmd: choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc winflexbison
+  - cmd: set SCONS_CACHE_MSVC_CONFIG=true
   - cmd: set
 
   ### LINUX ###

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -7218,26 +7218,32 @@ in addition to those passed on the command line.</para>
   <varlistentry>
     <term>SCONS_CACHE_MSVC_CONFIG</term>
     <listitem>
-<para>If set, save the shell environment variables generated
-in setting up the Microsoft Visual C++ compiler (and/or Build Tools),
-to give these settings, which are expensive to generate, persistence
+<para>(Windows only). If set, save the shell environment variables
+generated when setting up the Microsoft Visual C++ compiler
+(and/or Build Tools) to a file to give these settings, 
+which are expensive to generate, persistence
 across &scons; invocations.
-If set to a True-like value (<literal>"1"</literal>,
+Use of this option is primarily intended to aid performance
+in tightly controlled Continuous Integration setups.</para>
+
+<para>If set to a True-like value (<literal>"1"</literal>,
 <literal>"true"</literal> or
 <literal>"True"</literal>) will cache to a file named
 <filename>.scons_msvc_cache</filename> in the user's home directory.
 If set to a pathname, will use that pathname for the cache.</para>
-<para>
-Note: this behavior is not enabled by default because it
-might be somewhat fragile: while each major tool version
-(e.g. Visual Studio 2018 vs 2019) will get separate
-entries, if toolset updates cause a change
+
+<para>Note: use this cache with caution as it
+might be somewhat fragile: while each major toolset version
+(e.g. Visual Studio 2017 vs 2019) and architecture pair will get separate
+cache entries, if toolset updates cause a change
 to settings within a given release series, &scons; will not
-detect this and will fetch old settings.
-In case of problems, just remove the cache file.
-Use of this option is primarily intended to aid performance
-for tightly controlled Continuous Integration setups.
-</para>
+detect the change and will reuse old settings.
+Remove the cache file in case of problems with this.
+&scons; will ignore failures reading or writing the file
+and will silently revert to non-cached behavior in such cases.</para>
+
+<para>Since &scons; 3.1.</para>
+
     </listitem>
   </varlistentry>
 </variablelist>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -7191,7 +7191,7 @@ env.Program('MyApp', ['Foo.cpp', 'Bar.cpp'])
 <refsect1 id='environment'><title>ENVIRONMENT</title>
 
 <para>In general, &scons; is not controlled by environment
-variables set shell used to invoke it, leaving it
+variables set in the shell used to invoke it, leaving it
 up to the SConscript file author to import those if desired.
 However the following variables are imported by
 &scons; itself if set:
@@ -7220,13 +7220,24 @@ in addition to those passed on the command line.</para>
     <listitem>
 <para>If set, save the shell environment variables generated
 in setting up the Microsoft Visual C++ compiler (and/or Build Tools),
-to give these settings (expensive to generate) persistence
-between runs of &scons;.
-If set to a True-like value (<literal>1</literal>,
-<literal>true</literal> or
-<literal>True</literal>) will cache to a file named
+to give these settings, which are expensive to generate, persistence
+across &scons; invocations.
+If set to a True-like value (<literal>"1"</literal>,
+<literal>"true"</literal> or
+<literal>"True"</literal>) will cache to a file named
 <filename>.scons_msvc_cache</filename> in the user's home directory.
 If set to a pathname, will use that pathname for the cache.</para>
+<para>
+Note: this behavior is not enabled by default because it
+might be somewhat fragile: while each major tool version
+(e.g. Visual Studio 2018 vs 2019) will get separate
+entries, if toolset updates cause a change
+to settings within a given release series, &scons; will not
+detect this and will fetch old settings.
+In case of problems, just remove the cache file.
+Use of this option is primarily intended to aid performance
+for tightly controlled Continuous Integration setups.
+</para>
     </listitem>
   </varlistentry>
 </variablelist>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -7189,22 +7189,45 @@ env.Program('MyApp', ['Foo.cpp', 'Bar.cpp'])
 </refsect1>
 
 <refsect1 id='environment'><title>ENVIRONMENT</title>
+
+<para>In general, &scons; is not controlled by environment
+variables set shell used to invoke it, leaving it
+up to the SConscript file author to import those if desired.
+However the following variables are imported by
+&scons; itself if set:
+</para>
+
 <variablelist>
   <varlistentry>
-  <term>SCONS_LIB_DIR</term>
-  <listitem>
-<para>Specifies the directory that contains the SCons Python module directory
-(e.g. /home/aroach/scons-src-0.01/src/engine).</para>
-
-  </listitem>
+    <term>SCONS_LIB_DIR</term>
+    <listitem>
+<para>Specifies the directory that contains the &scons;
+Python module directory (for example,
+<filename>/home/aroach/scons-src-0.01/src/engine</filename>).</para>
+    </listitem>
   </varlistentry>
-  <varlistentry>
-  <term>SCONSFLAGS</term>
-  <listitem>
-<para>A string of options that will be used by scons in addition to those passed
-on the command line.</para>
 
-  </listitem>
+  <varlistentry>
+    <term>SCONSFLAGS</term>
+    <listitem>
+<para>A string of options that will be used by &scons;
+in addition to those passed on the command line.</para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term>SCONS_CACHE_MSVC_CONFIG</term>
+    <listitem>
+<para>If set, save the shell environment variables generated
+in setting up the Microsoft Visual C++ compiler (and/or Build Tools),
+to give these settings (expensive to generate) persistence
+between runs of &scons;.
+If set to a True-like value (<literal>1</literal>,
+<literal>true</literal> or
+<literal>True</literal>) will cache to a file named
+<filename>.scons_msvc_cache</filename> in the user's home directory.
+If set to a pathname, will use that pathname for the cache.</para>
+    </listitem>
   </varlistentry>
 </variablelist>
 </refsect1>
@@ -7220,8 +7243,9 @@ source code.</para>
 </refsect1>
 
 <refsect1 id='authors'><title>AUTHORS</title>
-<para>Originally: Steven Knight &lt;knight@baldmt.com&gt; and Anthony Roach &lt;aroach@electriceyeball.com&gt;
-Since 2010: The SCons Development Team &lt;scons-dev@scons.org&gt;
+<para>Originally: Steven Knight <email>knight@baldmt.com</email>
+and Anthony Roach <email>aroach@electriceyeball.com</email>.
+Since 2010: The SCons Development Team <email>scons-dev@scons.org</email>.
 </para>
 </refsect1>
 </refentry>

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -17,6 +17,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       the index from find() was not used.
     - Turn previously deprecated debug options into failures:
       --debug=tree, --debug=dtree, --debug=stree, --debug=nomemoizer.
+    - If SCONS_CACHE_MSVC_CONFIG env var is set, scons will cache the
+      results of past calls to vcvarsall.bat to a file; integrates with
+      existing memoizing of such vars. On vs2019 saves 5+ seconds per
+      scons invocation, which really helps test suite runs.
 
   From Jacek Kuczera:
     - Fix CheckFunc detection code for Visual 2019. Some functions

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -17,10 +17,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       the index from find() was not used.
     - Turn previously deprecated debug options into failures:
       --debug=tree, --debug=dtree, --debug=stree, --debug=nomemoizer.
-    - If SCONS_CACHE_MSVC_CONFIG env var is set, scons will cache the
-      results of past calls to vcvarsall.bat to a file; integrates with
-      existing memoizing of such vars. On vs2019 saves 5+ seconds per
-      scons invocation, which really helps test suite runs.
+    - If SCONS_CACHE_MSVC_CONFIG shell environment variable is set,
+      scons will cache the results of past calls to vcvarsall.bat to
+      a file; integrates with existing memoizing of such vars.
+      On vs2019 saves 5+ seconds per scons invocation, which really
+      helps test suite runs.
 
   From Jacek Kuczera:
     - Fix CheckFunc detection code for Visual 2019. Some functions

--- a/src/engine/SCons/Tool/MSCommon/common.py
+++ b/src/engine/SCons/Tool/MSCommon/common.py
@@ -32,6 +32,8 @@ import json
 import os
 import subprocess
 import re
+import subprocess
+import sys
 
 import SCons.Util
 
@@ -56,13 +58,23 @@ CONFIG_CACHE = os.environ.get('SCONS_CACHE_MSVC_CONFIG')
 if CONFIG_CACHE in ('1', 'true', 'True'):
     CONFIG_CACHE = os.path.join(os.path.expanduser('~'), '.scons_msvc_cache')
 
+# !@$#@$? Python2
+if sys.version_info[0] == 2:
+    def str_hook(obj):
+        return {k.encode('utf-8') if isinstance(k, unicode) else k :
+                v.encode('utf-8') if isinstance(v, unicode) else v
+                for k,v in obj}
+
 def read_script_env_cache():
     """ fetch cached msvc env vars if requested, else return empty dict """
     envcache = {}
     if CONFIG_CACHE:
         try:
             with open(CONFIG_CACHE, 'r') as f:
-                envcache = json.load(f)
+                if sys.version_info[0] == 2:
+                    envcache = json.load(f, object_pairs_hook=str_hook)
+                else:
+                    envcache = json.load(f)
         #TODO can use more specific FileNotFoundError when py2 dropped
         except IOError:
             pass

--- a/src/engine/SCons/Tool/MSCommon/common.py
+++ b/src/engine/SCons/Tool/MSCommon/common.py
@@ -30,7 +30,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import copy
 import json
 import os
-import subprocess
 import re
 import subprocess
 import sys
@@ -58,23 +57,13 @@ CONFIG_CACHE = os.environ.get('SCONS_CACHE_MSVC_CONFIG')
 if CONFIG_CACHE in ('1', 'true', 'True'):
     CONFIG_CACHE = os.path.join(os.path.expanduser('~'), '.scons_msvc_cache')
 
-# !@$#@$? Python2
-if sys.version_info[0] == 2:
-    def str_hook(obj):
-        return {k.encode('utf-8') if isinstance(k, unicode) else k :
-                v.encode('utf-8') if isinstance(v, unicode) else v
-                for k,v in obj}
-
 def read_script_env_cache():
     """ fetch cached msvc env vars if requested, else return empty dict """
     envcache = {}
     if CONFIG_CACHE:
         try:
             with open(CONFIG_CACHE, 'r') as f:
-                if sys.version_info[0] == 2:
-                    envcache = json.load(f, object_pairs_hook=str_hook)
-                else:
-                    envcache = json.load(f)
+                envcache = json.load(f)
         #TODO can use more specific FileNotFoundError when py2 dropped
         except IOError:
             pass
@@ -244,7 +233,6 @@ def get_output(vcbat, args = None, env = None):
     if stderr:
         # TODO: find something better to do with stderr;
         # this at least prevents errors from getting swallowed.
-        import sys
         sys.stderr.write(stderr)
     if popen.wait() != 0:
         raise IOError(stderr.decode("mbcs"))

--- a/src/engine/SCons/Tool/MSCommon/common.py
+++ b/src/engine/SCons/Tool/MSCommon/common.py
@@ -36,7 +36,7 @@ import sys
 
 import SCons.Util
 
-# internal-use so undocumented:
+# SCONS_MSCOMMON_DEBUG is internal-use so undocumented:
 # set to '-' to print to console, else set to filename to log to
 LOGFILE = os.environ.get('SCONS_MSCOMMON_DEBUG')
 if LOGFILE == '-':
@@ -53,6 +53,7 @@ else:
     debug = lambda x: None
 
 
+# SCONS_CACHE_MSVC_CONFIG is public, and is documented.
 CONFIG_CACHE = os.environ.get('SCONS_CACHE_MSVC_CONFIG')
 if CONFIG_CACHE in ('1', 'true', 'True'):
     CONFIG_CACHE = os.path.join(os.path.expanduser('~'), '.scons_msvc_cache')
@@ -66,6 +67,7 @@ def read_script_env_cache():
                 envcache = json.load(f)
         #TODO can use more specific FileNotFoundError when py2 dropped
         except IOError:
+            # don't fail if no cache file, just proceed without it
             pass
     return envcache
 

--- a/src/engine/SCons/Tool/MSCommon/sdk.py
+++ b/src/engine/SCons/Tool/MSCommon/sdk.py
@@ -118,11 +118,11 @@ class SDKDefinition(object):
         if (host_arch != target_arch):
             arch_string='%s_%s'%(host_arch,target_arch)
 
-        debug("sdk.py: get_sdk_vc_script():arch_string:%s host_arch:%s target_arch:%s"%(arch_string,
+        debug("get_sdk_vc_script():arch_string:%s host_arch:%s target_arch:%s"%(arch_string,
                                                            host_arch,
                                                            target_arch))
         file=self.vc_setup_scripts.get(arch_string,None)
-        debug("sdk.py: get_sdk_vc_script():file:%s"%file)
+        debug("get_sdk_vc_script():file:%s"%file)
         return file
 
 class WindowsSDK(SDKDefinition):
@@ -286,14 +286,14 @@ InstalledSDKMap = None
 def get_installed_sdks():
     global InstalledSDKList
     global InstalledSDKMap
-    debug('sdk.py:get_installed_sdks()')
+    debug('get_installed_sdks()')
     if InstalledSDKList is None:
         InstalledSDKList = []
         InstalledSDKMap = {}
         for sdk in SupportedSDKList:
-            debug('MSCommon/sdk.py: trying to find SDK %s' % sdk.version)
+            debug('trying to find SDK %s' % sdk.version)
             if sdk.get_sdk_dir():
-                debug('MSCommon/sdk.py:found SDK %s' % sdk.version)
+                debug('found SDK %s' % sdk.version)
                 InstalledSDKList.append(sdk)
                 InstalledSDKMap[sdk.version] = sdk
     return InstalledSDKList
@@ -346,13 +346,13 @@ def get_default_sdk():
     return InstalledSDKList[0]
 
 def mssdk_setup_env(env):
-    debug('sdk.py:mssdk_setup_env()')
+    debug('mssdk_setup_env()')
     if 'MSSDK_DIR' in env:
         sdk_dir = env['MSSDK_DIR']
         if sdk_dir is None:
             return
         sdk_dir = env.subst(sdk_dir)
-        debug('sdk.py:mssdk_setup_env: Using MSSDK_DIR:{}'.format(sdk_dir))
+        debug('mssdk_setup_env: Using MSSDK_DIR:{}'.format(sdk_dir))
     elif 'MSSDK_VERSION' in env:
         sdk_version = env['MSSDK_VERSION']
         if sdk_version is None:
@@ -364,22 +364,22 @@ def mssdk_setup_env(env):
             msg = "SDK version %s is not installed" % sdk_version
             raise SCons.Errors.UserError(msg)
         sdk_dir = mssdk.get_sdk_dir()
-        debug('sdk.py:mssdk_setup_env: Using MSSDK_VERSION:%s'%sdk_dir)
+        debug('mssdk_setup_env: Using MSSDK_VERSION:%s'%sdk_dir)
     elif 'MSVS_VERSION' in env:
         msvs_version = env['MSVS_VERSION']
-        debug('sdk.py:mssdk_setup_env:Getting MSVS_VERSION from env:%s'%msvs_version)
+        debug('mssdk_setup_env:Getting MSVS_VERSION from env:%s'%msvs_version)
         if msvs_version is None:
-            debug('sdk.py:mssdk_setup_env thinks msvs_version is None')
+            debug('mssdk_setup_env thinks msvs_version is None')
             return
         msvs_version = env.subst(msvs_version)
         from . import vs
         msvs = vs.get_vs_by_version(msvs_version)
-        debug('sdk.py:mssdk_setup_env:msvs is :%s'%msvs)
+        debug('mssdk_setup_env:msvs is :%s'%msvs)
         if not msvs:
-            debug('sdk.py:mssdk_setup_env: no VS version detected, bailingout:%s'%msvs)
+            debug('mssdk_setup_env: no VS version detected, bailingout:%s'%msvs)
             return
         sdk_version = msvs.sdk_version
-        debug('sdk.py:msvs.sdk_version is %s'%sdk_version)
+        debug('msvs.sdk_version is %s'%sdk_version)
         if not sdk_version:
             return
         mssdk = get_sdk_by_version(sdk_version)
@@ -388,13 +388,13 @@ def mssdk_setup_env(env):
             if not mssdk:
                 return
         sdk_dir = mssdk.get_sdk_dir()
-        debug('sdk.py:mssdk_setup_env: Using MSVS_VERSION:%s'%sdk_dir)
+        debug('mssdk_setup_env: Using MSVS_VERSION:%s'%sdk_dir)
     else:
         mssdk = get_default_sdk()
         if not mssdk:
             return
         sdk_dir = mssdk.get_sdk_dir()
-        debug('sdk.py:mssdk_setup_env: not using any env values. sdk_dir:%s'%sdk_dir)
+        debug('mssdk_setup_env: not using any env values. sdk_dir:%s'%sdk_dir)
 
     set_sdk_by_directory(env, sdk_dir)
 

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -591,12 +591,15 @@ def reset_installed_vcs():
 # we can greatly improve the speed of the second and subsequent Environment
 # (or Clone) calls by memoizing the environment variables set by vcvars*.bat.
 #
-# Updated: by 2018, vcvarsall.bat had gotten so expensive it was breaking
-# CI builds because the test suite starts scons so many times and the existing
-# memo logic only helped with repeated calls within the same scons run;
-# with VS2019 it got even slower and an optional cache file was introduced.
-# The cache now also stores only the parsed vars, not the entire output
-# of running the batch file - saves a bit of time not parsing every time.
+# Updated: by 2018, vcvarsall.bat had gotten so expensive (vs2017 era)
+# it was breaking CI builds because the test suite starts scons so many
+# times and the existing memo logic only helped with repeated calls
+# within the same scons run. Windows builds on the CI system were split
+# into chunks to get around single-build time limits.
+# With VS2019 it got even slower and an optional persistent cache file
+# was introduced. The cache now also stores only the parsed vars, 
+# not the entire output of running the batch file - saves a bit
+# of time not parsing every time.
 
 script_env_cache = None
 
@@ -621,7 +624,8 @@ def script_env(script, args=None):
         # once we updated cache, give a chance to write out if user wanted
         common.write_script_env_cache(script_env_cache)
     else:
-        # if we "hit" data from the json file, we have a Py2 problem:
+        #TODO: Python 2 cleanup
+        # If we "hit" data from the json file, we have a Py2 problem:
         # keys & values will be unicode. don't detect, just convert.
         if sys.version_info[0] == 2:
             def convert(data):
@@ -635,6 +639,7 @@ def script_env(script, args=None):
                     return data
 
             cache_data = convert(cache_data)
+ 
     return cache_data
 
 def get_default_version(env):

--- a/src/engine/SCons/Tool/MSCommon/vs.py
+++ b/src/engine/SCons/Tool/MSCommon/vs.py
@@ -465,14 +465,14 @@ def get_vs_by_version(msvs):
     global InstalledVSMap
     global SupportedVSMap
 
-    debug('vs.py:get_vs_by_version()')
+    debug('get_vs_by_version()')
     if msvs not in SupportedVSMap:
         msg = "Visual Studio version %s is not supported" % repr(msvs)
         raise SCons.Errors.UserError(msg)
     get_installed_visual_studios()
     vs = InstalledVSMap.get(msvs)
     debug('InstalledVSMap:%s'%InstalledVSMap)
-    debug('vs.py:get_vs_by_version: found vs:%s'%vs)
+    debug('get_vs_by_version: found vs:%s'%vs)
     # Some check like this would let us provide a useful error message
     # if they try to set a Visual Studio version that's not installed.
     # However, we also want to be able to run tests (like the unit

--- a/test/MSVS/vs-14.2-exec.py
+++ b/test/MSVS/vs-14.2-exec.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Test that we can actually build a simple program using our generated
+Visual Studio 14.0 project (.vcxproj) and solution (.sln) files
+using Visual Studio 14.2
+"""
+
+import os
+import sys
+
+import TestSConsMSVS
+
+test = TestSConsMSVS.TestSConsMSVS()
+
+if sys.platform != 'win32':
+    msg = "Skipping Visual Studio test on non-Windows platform '%s'\n" % sys.platform
+    test.skip_test(msg)
+
+msvs_version = '14.2'
+
+if not msvs_version in test.msvs_versions():
+    msg = "Visual Studio %s not installed; skipping test.\n" % msvs_version
+    test.skip_test(msg)
+
+
+
+# Let SCons figure out the Visual Studio environment variables for us and
+# print out a statement that we can exec to suck them into our external
+# environment so we can execute devenv and really try to build something.
+
+test.run(arguments = '-n -q -Q -f -', stdin = """\
+env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
+if env.WhereIs('cl'):
+    print("os.environ.update(%%s)" %% repr(env['ENV']))
+""" % locals())
+
+if(test.stdout() == ""):
+    msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
+    test.skip_test(msg)
+
+exec(test.stdout())
+
+
+
+test.subdir('sub dir')
+
+test.write(['sub dir', 'SConstruct'], """\
+env=Environment(MSVS_VERSION = '%(msvs_version)s')
+
+env.MSVSProject(target = 'foo.vcxproj',
+                srcs = ['foo.c'],
+                buildtarget = 'foo.exe',
+                variant = 'Release',
+                DebugSettings = {'LocalDebuggerCommandArguments':'echo "<foo.c>" > output.txt'})
+env.Program('foo.c')
+""" % locals())
+
+test.write(['sub dir', 'foo.c'], r"""
+int
+main(int argc, char *argv)
+{
+    printf("foo.c\n");
+    exit (0);
+}
+""")
+
+test.run(chdir='sub dir', arguments='.')
+
+test.vcproj_sys_path(test.workpath('sub dir', 'foo.vcxproj'))
+
+import SCons.Platform.win32
+system_dll_path = os.path.join( SCons.Platform.win32.get_system_root(), 'System32' )
+os.environ['PATH'] = os.environ['PATH'] + os.pathsep + system_dll_path
+
+test.run(chdir='sub dir',
+         program=[test.get_msvs_executable(msvs_version)],
+         arguments=['foo.sln', '/build', 'Release'])
+
+test.run(program=test.workpath('sub dir', 'foo'), stdout="foo.c\n")
+test.validate_msvs_file(test.workpath('sub dir', 'foo.vcxproj.user'))
+
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Setting env var `SCONS_CACHE_MSVC_CONFIG` enables a filesystem cache of vcvars results, making them persistent across scons runs. On test runs (notably our CI system) this helps a lot; in normal usage where you run one scons invocation at a time instead of many hundreds in a test run it will make things a little more responsive (esp on vs2019) but the impact will be much smaller.

Marked WIP because the precise version of tools should probably be included in the cache key, but this value isn't readily available at the spot it would be needed - will take some refactoring.  There are existing bugs about being able to specify precise version for builds anyway.  Also there should probably be a unit test - still thinking about a test.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
