### PR TITLE
Remove deprecated Builder keywords

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -4960,7 +4960,8 @@ the same target file(s). The default is 0, which means the builder
 can not be called multiple times for the same target file(s). Calling a
 builder multiple times for the same target simply adds additional source
 files to the target; it is not allowed to change the environment associated
-with the target, specify addition environment overrides, or associate a different
+with the target, specify additional environment overrides,
+or associate a different
 builder with the target.</para>
 
   </listitem>

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -25,6 +25,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       On vs2019 saves 5+ seconds per SCons invocation, which really
       helps test suite runs.
     - Remove deprecated SourceSignatures, TargetSignatures
+    - Remove deprecated Builder keywords: overrides and scanner
 
   From Jacek Kuczera:
     - Fix CheckFunc detection code for Visual 2019. Some functions
@@ -35,6 +36,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     
   From Edoardo Bezzeccheri
     - Added debug option "action_timestamps" which outputs to stdout the absolute start and end time for each target.
+
 
 RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
 

--- a/src/engine/SCons/Builder.py
+++ b/src/engine/SCons/Builder.py
@@ -396,16 +396,13 @@ class BuilderBase(object):
         self.env = env
         self.single_source = single_source
         if 'overrides' in overrides:
-            SCons.Warnings.warn(SCons.Warnings.DeprecatedBuilderKeywordsWarning,
-                "The \"overrides\" keyword to Builder() creation has been deprecated;\n" +\
-                "\tspecify the items as keyword arguments to the Builder() call instead.")
-            overrides.update(overrides['overrides'])
-            del overrides['overrides']
+            msg =  "The \"overrides\" keyword to Builder() creation has been removed;\n" +\
+                "\tspecify the items as keyword arguments to the Builder() call instead."
+            raise TypeError(msg)
         if 'scanner' in overrides:
-            SCons.Warnings.warn(SCons.Warnings.DeprecatedBuilderKeywordsWarning,
-                                "The \"scanner\" keyword to Builder() creation has been deprecated;\n"
-                                "\tuse: source_scanner or target_scanner as appropriate.")
-            del overrides['scanner']
+            msg = "The \"scanner\" keyword to Builder() creation has been removed;\n" +\
+                "\tuse: source_scanner or target_scanner as appropriate."
+            raise TypeError(msg)
         self.overrides = overrides
 
         self.set_suffix(suffix)


### PR DESCRIPTION
`overrides=` and `scanner=` have been deprecated for over a decade.  They were not even mentioned in documentation or tests.  Flip the action if seen to raise an error from emitting a warning.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
