### PR TITLE
Parse "-imacros" option in ParseFlags

### DIFF
--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -2505,16 +2505,16 @@ This specifies help text to be printed if the
 <option>-h</option>
 argument is given to
 <filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>.
-If 
+If
 <function xmlns="http://www.scons.org/dbxsd/v1.0">Help</function>
-is called multiple times, the text is appended together in the order that 
+is called multiple times, the text is appended together in the order that
 <function xmlns="http://www.scons.org/dbxsd/v1.0">Help</function>
-is called. With append set to False, any 
+is called. With append set to False, any
 <function xmlns="http://www.scons.org/dbxsd/v1.0">Help</function>
-text generated with 
+text generated with
 <function xmlns="http://www.scons.org/dbxsd/v1.0">AddOption</function>
 is clobbered. If append is True, the AddOption help is prepended to the help
-string, thus preserving the 
+string, thus preserving the
 <option>-h</option>
 message.
 </para>
@@ -2955,6 +2955,7 @@ and added to the following construction variables:
 -fmerge-all-constants   CCFLAGS, LINKFLAGS
 -fopenmp                CCFLAGS, LINKFLAGS
 -include                CCFLAGS
+-imacros                CCFLAGS
 -isysroot               CCFLAGS, LINKFLAGS
 -isystem                CCFLAGS
 -iquote                 CCFLAGS

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -32,12 +32,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Jakub Kulik
     - Fix subprocess result bytes not being decoded in SunOS/Solaris related tools.
-    
+
   From Edoardo Bezzeccheri
     - Added debug option "action_timestamps" which outputs to stdout the absolute start and end time for each target.
-    
+
   From Ivan Kravets
-    - Parse "-imacros" option in ParseFlags
+    - Added support for "-imacros" to ParseFlags
 
 RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -35,6 +35,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     
   From Edoardo Bezzeccheri
     - Added debug option "action_timestamps" which outputs to stdout the absolute start and end time for each target.
+    
+  From Ivan Kravets
+    - Parse GCC "-imacros" option in ParseFlags
 
 RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -37,7 +37,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added debug option "action_timestamps" which outputs to stdout the absolute start and end time for each target.
     
   From Ivan Kravets
-    - Parse GCC "-imacros" option in ParseFlags
+    - Parse "-imacros" option in ParseFlags
 
 RELEASE 3.1.1 - Mon, 07 Aug 2019 20:09:12 -0500
 

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -707,6 +707,9 @@ class SubstitutionEnvironment(object):
                    elif append_next_arg_to == '-include':
                        t = ('-include', self.fs.File(arg))
                        dict['CCFLAGS'].append(t)
+                   elif append_next_arg_to == '-imacros':
+                       t = ('-imacros', self.fs.File(arg))
+                       dict['CCFLAGS'].append(t)                    
                    elif append_next_arg_to == '-isysroot':
                        t = ('-isysroot', arg)
                        dict['CCFLAGS'].append(t)
@@ -793,7 +796,7 @@ class SubstitutionEnvironment(object):
                 elif arg[0] == '+':
                     dict['CCFLAGS'].append(arg)
                     dict['LINKFLAGS'].append(arg)
-                elif arg in ['-include', '-isysroot', '-isystem', '-iquote', '-idirafter', '-arch']:
+                elif arg in ['-include', '-imacros', '-isysroot', '-isystem', '-iquote', '-idirafter', '-arch']:
                     append_next_arg_to = arg
                 else:
                     dict['CCFLAGS'].append(arg)

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -702,34 +702,34 @@ class SubstitutionEnvironment(object):
             append_next_arg_to = None   # for multi-word args
             for arg in params:
                 if append_next_arg_to:
-                   if append_next_arg_to == 'CPPDEFINES':
-                       append_define(arg)
-                   elif append_next_arg_to == '-include':
-                       t = ('-include', self.fs.File(arg))
-                       dict['CCFLAGS'].append(t)
-                   elif append_next_arg_to == '-imacros':
-                       t = ('-imacros', self.fs.File(arg))
-                       dict['CCFLAGS'].append(t)                    
-                   elif append_next_arg_to == '-isysroot':
-                       t = ('-isysroot', arg)
-                       dict['CCFLAGS'].append(t)
-                       dict['LINKFLAGS'].append(t)
-                   elif append_next_arg_to == '-isystem':
-                       t = ('-isystem', arg)
-                       dict['CCFLAGS'].append(t)
-                   elif append_next_arg_to == '-iquote':
-                       t = ('-iquote', arg)
-                       dict['CCFLAGS'].append(t)
-                   elif append_next_arg_to == '-idirafter':
-                       t = ('-idirafter', arg)
-                       dict['CCFLAGS'].append(t)
-                   elif append_next_arg_to == '-arch':
-                       t = ('-arch', arg)
-                       dict['CCFLAGS'].append(t)
-                       dict['LINKFLAGS'].append(t)
-                   else:
-                       dict[append_next_arg_to].append(arg)
-                   append_next_arg_to = None
+                    if append_next_arg_to == 'CPPDEFINES':
+                        append_define(arg)
+                    elif append_next_arg_to == '-include':
+                        t = ('-include', self.fs.File(arg))
+                        dict['CCFLAGS'].append(t)
+                    elif append_next_arg_to == '-imacros':
+                        t = ('-imacros', self.fs.File(arg))
+                        dict['CCFLAGS'].append(t)
+                    elif append_next_arg_to == '-isysroot':
+                        t = ('-isysroot', arg)
+                        dict['CCFLAGS'].append(t)
+                        dict['LINKFLAGS'].append(t)
+                    elif append_next_arg_to == '-isystem':
+                        t = ('-isystem', arg)
+                        dict['CCFLAGS'].append(t)
+                    elif append_next_arg_to == '-iquote':
+                        t = ('-iquote', arg)
+                        dict['CCFLAGS'].append(t)
+                    elif append_next_arg_to == '-idirafter':
+                        t = ('-idirafter', arg)
+                        dict['CCFLAGS'].append(t)
+                    elif append_next_arg_to == '-arch':
+                        t = ('-arch', arg)
+                        dict['CCFLAGS'].append(t)
+                        dict['LINKFLAGS'].append(t)
+                    else:
+                        dict[append_next_arg_to].append(arg)
+                    append_next_arg_to = None
                 elif not arg[0] in ['-', '+']:
                     dict['LIBS'].append(self.fs.File(arg))
                 elif arg == '-dylib_file':

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -2324,6 +2324,7 @@ and added to the following construction variables:
 -fmerge-all-constants   CCFLAGS, LINKFLAGS
 -fopenmp                CCFLAGS, LINKFLAGS
 -include                CCFLAGS
+-imacros                CCFLAGS
 -isysroot               CCFLAGS, LINKFLAGS
 -isystem                CCFLAGS
 -iquote                 CCFLAGS

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -804,6 +804,7 @@ sys.exit(0)
             "-iquote /usr/include/foo1 " + \
             "-isystem /usr/include/foo2 " + \
             "-idirafter /usr/include/foo3 " + \
+            "-imacros /usr/include/foo4 " + \
             "+DD64 " + \
             "-DFOO -DBAR=value -D BAZ "
 
@@ -818,6 +819,7 @@ sys.exit(0)
                                 ('-iquote', '/usr/include/foo1'),
                                 ('-isystem', '/usr/include/foo2'),
                                 ('-idirafter', '/usr/include/foo3'),
+                                ('-imacros', env.fs.File('/usr/include/foo4')),
                                 '+DD64'], repr(d['CCFLAGS'])
         assert d['CXXFLAGS'] == ['-std=c++0x'], repr(d['CXXFLAGS'])
         assert d['CPPDEFINES'] == ['FOO', ['BAR', 'value'], 'BAZ'], d['CPPDEFINES']


### PR DESCRIPTION
- https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html
- https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-imacros-file

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
