### PR TITLE
Fix crash when Latin-1 encoded Latex log file is read with Python 3

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -6,6 +6,10 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Philipp Maierhöfer:
+    - Avoid crash with UnicodeDecodeError on Python 3 when a Latex log file in
+      non-UTF-8 encoding (e.g. containing umlauts in Latin-1 encoding) is read.
+
   From Mathew Robinson:
 
     - Improved threading performance by ensuring NodeInfo is shared

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,7 +8,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Philipp Maierhöfer:
     - Avoid crash with UnicodeDecodeError on Python 3 when a Latex log file in
-      non-UTF-8 encoding (e.g. containing umlauts in Latin-1 encoding) is read.
+      non-UTF-8 encoding (e.g. containing umlauts in Latin-1 encoding when
+      the fontenc package is included with \usepackage[T1]{fontenc}) is read.
 
   From Mathew Robinson:
 

--- a/src/engine/SCons/Tool/tex.py
+++ b/src/engine/SCons/Tool/tex.py
@@ -297,8 +297,8 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
         logfilename = targetbase + '.log'
         logContent = ''
         if os.path.isfile(logfilename):
-            with open(logfilename, "r") as f:
-                logContent = f.read()
+            with open(logfilename, "rb") as f:
+                logContent = f.read().decode(errors='replace')
 
 
         # Read the fls file to find all .aux files

--- a/test/TEX/LATEX.py
+++ b/test/TEX/LATEX.py
@@ -193,6 +193,22 @@ This is the include file. mod %s
     test.must_not_exist('latexi.ilg')
 
 
+    test.write('SConstruct', """
+env = Environment()
+env.PostScript('latin1log.tex')
+""")
+
+    test.write('latin1log.tex', r"""
+\documentclass[12pt,a4paper]{article}
+\usepackage[T1]{fontenc}
+\begin{document}
+\"oxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+\end{document}
+""")
+
+    test.run(arguments = 'latin1log.dvi', stderr = None)
+    test.must_exist('latin1log.dvi')
+
 test.pass_test()
 
 # Local Variables:

--- a/test/TEX/LATEX.py
+++ b/test/TEX/LATEX.py
@@ -28,6 +28,8 @@ r"""
 Validate that we can set the LATEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.
+Check that a log file with a warning encoded in non-UTF-8 (here: Latin-1)
+is read without throwing an error.
 """
 
 import TestSCons
@@ -195,9 +197,11 @@ This is the include file. mod %s
 
     test.write('SConstruct', """
 env = Environment()
-env.PostScript('latin1log.tex')
+env.DVI('latin1log.tex')
 """)
 
+    # This will trigger an overfull hbox warning in the log file,
+    # containing the umlaut "o in Latin-1 ("T1 fontenc") encoding.
     test.write('latin1log.tex', r"""
 \documentclass[12pt,a4paper]{article}
 \usepackage[T1]{fontenc}

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1528,7 +1528,7 @@ class TestCmd(object):
         # TODO: Run full tests on both platforms and see if this fixes failures
         # It seems that py3.6 still sets text mode if you set encoding.
         elif sys.version_info[0] == 3:  # TODO and sys.version_info[1] < 6:
-            stream = stream.decode('utf-8')
+            stream = stream.decode('utf-8', errors='replace')
             stream = stream.replace('\r\n', '\n')
         elif sys.version_info[0] == 2:
             stream = stream.replace('\r\n', '\n')


### PR DESCRIPTION
When T1 fontenc is used in Latex, the log file is written in Latin-1 encoding. Python 3 expects UTF-8 per default and throws a UnicodeDecodeError when the file is read and contains e.g. umlauts. With the patch, the log file is read in binary mode and then decoded with the option errors='replace' so that invalid characters are replaced by the � replacement character.

In order for the test case to work, I had to apply a similar fix to the testing framework where the stream with the log file content is decoded.

Note that similar issues might exist in other places, whenever a file of unknown encoding is read.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
