### PR TITLE
[3.9] change tests not to expect bare scriptname

### DIFF
--- a/test/GetBuildFailures/option-k.py
+++ b/test/GetBuildFailures/option-k.py
@@ -45,11 +45,11 @@ test = TestSCons.TestSCons()
 
 contents = r"""\
 import sys
-if sys.argv[0] == 'mypass.py':
+if 'mypass.py' in sys.argv[0]:
     with open(sys.argv[3], 'wb') as ofp, open(sys.argv[4], 'rb') as ifp:
         ofp.write(ifp.read())
     exit_value = 0
-elif sys.argv[0] == 'myfail.py':
+elif 'myfail.py' in sys.argv[0]:
     exit_value = 1
 sys.exit(exit_value)
 """

--- a/test/GetBuildFailures/parallel.py
+++ b/test/GetBuildFailures/parallel.py
@@ -59,11 +59,11 @@ write_marker = sys.argv[2] + '.marker'
 if wait_marker != '-.marker':
     while not os.path.exists(wait_marker):
         time.sleep(1)
-if sys.argv[0] == 'mypass.py':
+if 'mypass.py' in sys.argv[0]:
     with open(sys.argv[3], 'wb') as ofp, open(sys.argv[4], 'rb') as ifp:
         ofp.write(ifp.read())
     exit_value = 0
-elif sys.argv[0] == 'myfail.py':
+elif 'myfail.py' in sys.argv[0]:
     exit_value = 1
 if write_marker != '-.marker':
     os.mkdir(write_marker)

--- a/test/GetBuildFailures/serial.py
+++ b/test/GetBuildFailures/serial.py
@@ -48,11 +48,11 @@ test = TestSCons.TestSCons()
 
 contents = r"""\
 import sys
-if sys.argv[0] == 'mypass.py':
+if 'mypass.py' in sys.argv[0]:
     with open(sys.argv[3], 'wb') as ofp, open(sys.argv[4], 'rb') as ifp:
         ofp.write(ifp.read())
     exit_value = 0
-elif sys.argv[0] == 'myfail.py':
+elif 'myfail.py' in sys.argv[0]:
     exit_value = 1
 sys.exit(exit_value)
 """

--- a/test/Rpcgen/RPCGEN.py
+++ b/test/Rpcgen/RPCGEN.py
@@ -69,10 +69,10 @@ expect_h = output % ('-h', test.workpath('rpcif.h'))
 expect_svc = output % ('-m', test.workpath('rpcif_svc.c'))
 expect_xdr = output % ('-c', test.workpath('rpcif_xdr.c'))
 
-test.must_match('rpcif_clnt.c', expect_clnt, mode='r')
-test.must_match('rpcif.h', expect_h, mode='r')
-test.must_match('rpcif_svc.c', expect_svc, mode='r')
-test.must_match('rpcif_xdr.c', expect_xdr, mode='r')
+test.must_contain('rpcif_clnt.c', expect_clnt, mode='r')
+test.must_contain('rpcif.h', expect_h, mode='r')
+test.must_contain('rpcif_svc.c', expect_svc, mode='r')
+test.must_contain('rpcif_xdr.c', expect_xdr, mode='r')
 
 
 

--- a/test/Rpcgen/RPCGENCLIENTFLAGS.py
+++ b/test/Rpcgen/RPCGENCLIENTFLAGS.py
@@ -72,10 +72,10 @@ expect_h        = output      % ('-h', test.workpath('rpcif.h'))
 expect_svc      = output      % ('-m', test.workpath('rpcif_svc.c'))
 expect_xdr      = output      % ('-c', test.workpath('rpcif_xdr.c'))
 
-test.must_match('rpcif_clnt.c', expect_clnt, mode='r')
-test.must_match('rpcif.h',      expect_h, mode='r')
-test.must_match('rpcif_svc.c',  expect_svc, mode='r')
-test.must_match('rpcif_xdr.c',  expect_xdr, mode='r')
+test.must_contain('rpcif_clnt.c', expect_clnt, mode='r')
+test.must_contain('rpcif.h',      expect_h, mode='r')
+test.must_contain('rpcif_svc.c',  expect_svc, mode='r')
+test.must_contain('rpcif_xdr.c',  expect_xdr, mode='r')
 
 
 

--- a/test/Rpcgen/RPCGENFLAGS.py
+++ b/test/Rpcgen/RPCGENFLAGS.py
@@ -71,10 +71,10 @@ expect_h = output % ('-h', test.workpath('rpcif.h'))
 expect_svc = output % ('-m', test.workpath('rpcif_svc.c'))
 expect_xdr = output % ('-c', test.workpath('rpcif_xdr.c'))
 
-test.must_match('rpcif_clnt.c', expect_clnt, mode='r')
-test.must_match('rpcif.h', expect_h, mode='r')
-test.must_match('rpcif_svc.c', expect_svc, mode='r')
-test.must_match('rpcif_xdr.c', expect_xdr, mode='r')
+test.must_contain('rpcif_clnt.c', expect_clnt, mode='r')
+test.must_contain('rpcif.h', expect_h, mode='r')
+test.must_contain('rpcif_svc.c', expect_svc, mode='r')
+test.must_contain('rpcif_xdr.c', expect_xdr, mode='r')
 
 
 

--- a/test/Rpcgen/RPCGENHEADERFLAGS.py
+++ b/test/Rpcgen/RPCGENHEADERFLAGS.py
@@ -72,10 +72,10 @@ expect_h        = output_h % ('-h', test.workpath('rpcif.h'))
 expect_svc      = output   % ('-m', test.workpath('rpcif_svc.c'))
 expect_xdr      = output   % ('-c', test.workpath('rpcif_xdr.c'))
 
-test.must_match('rpcif_clnt.c', expect_clnt, mode='r')
-test.must_match('rpcif.h',      expect_h, mode='r')
-test.must_match('rpcif_svc.c',  expect_svc, mode='r')
-test.must_match('rpcif_xdr.c',  expect_xdr, mode='r')
+test.must_contain('rpcif_clnt.c', expect_clnt, mode='r')
+test.must_contain('rpcif.h',      expect_h, mode='r')
+test.must_contain('rpcif_svc.c',  expect_svc, mode='r')
+test.must_contain('rpcif_xdr.c',  expect_xdr, mode='r')
 
 
 

--- a/test/Rpcgen/RPCGENSERVICEFLAGS.py
+++ b/test/Rpcgen/RPCGENSERVICEFLAGS.py
@@ -72,10 +72,10 @@ expect_h        = output     % ('-h', test.workpath('rpcif.h'))
 expect_svc      = output_svc % ('-m', test.workpath('rpcif_svc.c'))
 expect_xdr      = output     % ('-c', test.workpath('rpcif_xdr.c'))
 
-test.must_match('rpcif_clnt.c', expect_clnt, mode='r')
-test.must_match('rpcif.h',      expect_h, mode='r')
-test.must_match('rpcif_svc.c',  expect_svc, mode='r')
-test.must_match('rpcif_xdr.c',  expect_xdr, mode='r')
+test.must_contain('rpcif_clnt.c', expect_clnt, mode='r')
+test.must_contain('rpcif.h',      expect_h, mode='r')
+test.must_contain('rpcif_svc.c',  expect_svc, mode='r')
+test.must_contain('rpcif_xdr.c',  expect_xdr, mode='r')
 
 
 

--- a/test/Rpcgen/RPCGENXDRFLAGS.py
+++ b/test/Rpcgen/RPCGENXDRFLAGS.py
@@ -72,10 +72,10 @@ expect_h        = output     % ('-h', test.workpath('rpcif.h'))
 expect_svc      = output     % ('-m', test.workpath('rpcif_svc.c'))
 expect_xdr      = output_xdr % ('-c', test.workpath('rpcif_xdr.c'))
 
-test.must_match('rpcif_clnt.c', expect_clnt, mode='r')
-test.must_match('rpcif.h',      expect_h, mode='r')
-test.must_match('rpcif_svc.c',  expect_svc, mode='r')
-test.must_match('rpcif_xdr.c',  expect_xdr, mode='r')
+test.must_contain('rpcif_clnt.c', expect_clnt, mode='r')
+test.must_contain('rpcif.h',      expect_h, mode='r')
+test.must_contain('rpcif_svc.c',  expect_svc, mode='r')
+test.must_contain('rpcif_xdr.c',  expect_xdr, mode='r')
 
 
 

--- a/test/YACC/YACCHFILESUFFIX.py
+++ b/test/YACC/YACCHFILESUFFIX.py
@@ -71,9 +71,9 @@ test.write('bbb.yacc', "bbb.yacc\n/*yacc*/\n")
 test.run(arguments = '.')
 
 test.must_match('aaa.c', "aaa.y\n")
-test.must_match('aaa.hsuffix', "myyacc.py -d -o aaa.c aaa.y\n")
+test.must_contain('aaa.hsuffix', "myyacc.py -d -o aaa.c aaa.y\n")
 test.must_match('bbb.c', "bbb.yacc\n")
-test.must_match('bbb.hsuffix', "myyacc.py -d -o bbb.c bbb.yacc\n")
+test.must_contain('bbb.hsuffix', "myyacc.py -d -o bbb.c bbb.yacc\n")
 
 test.up_to_date(arguments = '.')
 

--- a/test/YACC/YACCHXXFILESUFFIX.py
+++ b/test/YACC/YACCHXXFILESUFFIX.py
@@ -69,7 +69,7 @@ test.write('aaa.yy', "aaa.yy\n/*yacc*/\n")
 test.run(arguments = '.')
 
 test.must_match('aaa.cc', "aaa.yy\n")
-test.must_match('aaa.hxxsuffix', "myyacc.py -d -o aaa.cc aaa.yy\n")
+test.must_contain('aaa.hxxsuffix', "myyacc.py -d -o aaa.cc aaa.yy\n")
 
 test.up_to_date(arguments = '.')
 

--- a/test/YACC/YACCVCGFILESUFFIX.py
+++ b/test/YACC/YACCVCGFILESUFFIX.py
@@ -78,7 +78,7 @@ test.must_not_exist('aaa.vcgsuffix')
 
 test.must_match('bbb.cc', "bbb.yy\n")
 test.must_not_exist('bbb.vcg')
-test.must_match('bbb.vcgsuffix', "myyacc.py -g -o bbb.cc bbb.yy\n")
+test.must_contain('bbb.vcgsuffix', "myyacc.py -g -o bbb.cc bbb.yy\n")
 
 test.up_to_date(arguments = '.')
 


### PR DESCRIPTION
Python 3.9 changes to give an absolute path in `sys.argv[0]`. Some tests expected to see just a simple path (`myyacc.py`); these now either do a `test.must_contain` instead of `test.must_match`,
or change to do `if 'mypass.py' in sys.argv[0]` instead of the former `if sys.argv[0] == 'mypass.py'`.

The Python change is described in https://bugs.python.org/issue20443. It looks possible the change to `sys.argv[0]` will not survive, BUT, the docs say whether or not this is a full path is OS-dependent (https://docs.python.org/dev/library/sys.html#sys.argv) so avoiding the expectation it is relative is more portable anyway.

This is a test-only change, no doc or source.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
