### PR TITLE
Document that AddOption has limitations

### DIFF
--- a/doc/generated/builders.gen
+++ b/doc/generated/builders.gen
@@ -48,11 +48,15 @@ env.CFile(target = 'bar', source = 'bar.y')
     </term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-The <function xmlns="http://www.scons.org/dbxsd/v1.0">Command</function> "Builder" is actually implemented
-as a function that looks like a Builder,
-but actually takes an additional argument of the action
-from which the Builder should be made.
-See the <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-Command"><function>Command</function></link> function description
+The <function xmlns="http://www.scons.org/dbxsd/v1.0">Command</function> "Builder" is actually
+a function that looks like a Builder,
+but takes a required third argument, which is the
+action to take to construct the target
+from the source, used for "one-off" builds
+where a full builder is not needed.
+Thus it does not follow the builder
+calling rules described at the start of this section.
+See instead the <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-Command"><function>Command</function></link> function description
 for the calling syntax and details.
 </para>
 </listitem>
@@ -465,6 +469,22 @@ a builder.
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">
 env.Install('/usr/local/bin', source = ['foo', 'bar'])
 </example_commands>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+If the <option>--install-sandbox</option> command line
+option is given, the target directory will be prefixed
+by the directory path specified.
+This is useful to test installs without installing to
+a "live" location in the system.
+</para>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+See also <function xmlns="http://www.scons.org/dbxsd/v1.0">FindInstalledFiles</function>.
+For more thoughts on installation, see the User Guide
+(particularly the section on Command-Line Targets
+and the chapters on Installing Files and on Alias Targets).
+</para>
+
 </listitem>
   </varlistentry>
   <varlistentry id="b-InstallAs">

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -25,8 +25,8 @@
 Creates an Action object for
 the specified
 <varname>action</varname>.
-See the section "Action Objects,"
-below, for a complete explanation of the arguments and behavior.
+See the manpage section "Action Objects"
+for a complete explanation of the arguments and behavior.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -221,6 +221,21 @@ AddOption('--prefix',
           help='installation prefix')
 env = Environment(PREFIX = GetOption('prefix'))
 </example_commands>
+
+<note xmlns="http://www.scons.org/dbxsd/v1.0">
+<para>
+While <function xmlns="http://www.scons.org/dbxsd/v1.0">AddOption</function> behaves like
+<function>optparse.add_option</function>,
+the behavior of options added by <function xmlns="http://www.scons.org/dbxsd/v1.0">AddOption</function>
+which take arguments is underfined in
+<command>scons</command> if whitespace
+(rather than <literal>=</literal> sign) is used as
+the separator on the command line when
+the option is invoked.
+Such usage should be avoided.
+</para>
+</note>
+
 </listitem>
   </varlistentry>
   <varlistentry id="f-AddPostAction">
@@ -241,7 +256,8 @@ has been built.
 The specified action(s) may be
 an Action object, or anything that
 can be converted into an Action object
-(see below).
+See the manpage section "Action Objects"
+for a complete explanation.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -270,7 +286,8 @@ is built.
 The specified action(s) may be
 an Action object, or anything that
 can be converted into an Action object
-(see below).
+See the manpage section "Action Objects"
+for a complete explanation.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -444,7 +461,7 @@ Otherwise, the construction variable
 and the value of the keyword argument
 are both coerced to lists,
 and the lists are added together.
-(See also the Prepend method, below.)
+(See also the <function xmlns="http://www.scons.org/dbxsd/v1.0">Prepend</function> method).
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -568,8 +585,8 @@ or
 Creates a Builder object for
 the specified
 <varname>action</varname>.
-See the section "Builder Objects,"
-below, for a complete explanation of the arguments and behavior.
+See the manpage section "Builder Objects"
+for a complete explanation of the arguments and behavior.
 </para>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -873,7 +890,7 @@ same-named existing construction variables.
 An action can be an external command,
 specified as a string,
 or a callable Python object;
-see "Action Objects," below,
+see the manpage section "Action Objects"
 for more complete information.
 Also note that a string specifying an external command
 may be preceded by an
@@ -897,7 +914,7 @@ env.Command('foo.out', 'foo.in',
 env.Command('bar.out', 'bar.in',
             ["rm -f $TARGET",
              "$BAR_BUILD &lt; $SOURCES &gt; $TARGET"],
-            ENV = {'PATH' : '/usr/local/bin/'})
+            ENV={'PATH': '/usr/local/bin/'})
 
 def rename(env, target, source):
     import os
@@ -905,7 +922,7 @@ def rename(env, target, source):
 
 env.Command('baz.out', 'baz.in',
             ["$BAZ_BUILD &lt; $SOURCES &gt; .tmp",
-	     rename ])
+	     rename])
 </example_commands>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -914,14 +931,14 @@ Note that the
 function will usually assume, by default,
 that the specified targets and/or sources are Files,
 if no other part of the configuration
-identifies what type of entry it is.
+identifies what type of entries they are.
 If necessary, you can explicitly specify
 that targets or source nodes should
-be treated as directoriese
+be treated as directories
 by using the
 <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-Dir"><function>Dir</function></link>
 or
-<function>env.Dir</function>()
+<function>env.Dir</function>
 functions.
 </para>
 
@@ -937,9 +954,9 @@ env.Command(env.Dir('$DISTDIR')), None, make_distdir)
 </example_commands>
 
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-(Also note that SCons will usually
+Also note that SCons will usually
 automatically create any directory necessary to hold a target file,
-so you normally don't need to create directories by hand.)
+so you normally don't need to create directories by hand.
 </para>
 </listitem>
   </varlistentry>
@@ -954,8 +971,8 @@ so you normally don't need to create directories by hand.)
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 Creates a Configure object for integrated
 functionality similar to GNU autoconf.
-See the section "Configure Contexts,"
-below, for a complete explanation of the arguments and behavior.
+See the manpage section "Configure Contexts"
+for a complete explanation of the arguments and behavior.
 </para>
 </listitem>
   </varlistentry>
@@ -1385,7 +1402,8 @@ would supply a string as a directory name
 to a Builder method or function.
 Directory Nodes have attributes and methods
 that are useful in many situations;
-see "File and Directory Nodes," below.
+see manpage section "File and Directory Nodes"
+for more information.
 </para>
 </listitem>
   </varlistentry>
@@ -1528,8 +1546,8 @@ Executes an Action object.
 The specified
 <varname>action</varname>
 may be an Action object
-(see the section "Action Objects,"
-below, for a complete explanation of the arguments and behavior),
+(see manpage section "Action Objects"
+for a complete explanation of the arguments and behavior),
 or it may be a command-line string,
 list of commands,
 or executable Python function,
@@ -1686,7 +1704,8 @@ would supply a string as a file name
 to a Builder method or function.
 File Nodes have attributes and methods
 that are useful in many situations;
-see "File and Directory Nodes," below.
+see manpage section "File and Directory Nodes"
+for more information.
 </para>
 </listitem>
   </varlistentry>
@@ -2836,7 +2855,7 @@ and the construction variables they affect
 are as specified for the
 <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-ParseFlags"><function>env.ParseFlags</function></link>
 method (which this method calls).
-See that method's description, below,
+See that method's description
 for a table of options and construction variables.
 </para>
 </listitem>
@@ -3539,8 +3558,8 @@ Return('val1 val2')
 Creates a Scanner object for
 the specified
 <varname>function</varname>.
-See the section "Scanner Objects,"
-below, for a complete explanation of the arguments and behavior.
+See manpage section "Scanner Objects"
+for a complete explanation of the arguments and behavior.
 </para>
 </listitem>
   </varlistentry>
@@ -4229,107 +4248,6 @@ env.SourceCode('no_source.c', None)
 </para>
 </listitem>
   </varlistentry>
-  <varlistentry id="f-SourceSignatures">
-    <term>
-      <literal>SourceSignatures(type)</literal>
-    </term>
-    <term>
-      <literal>env.SourceSignatures(type)</literal>
-    </term>
-    <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Note:  Although it is not yet officially deprecated,
-use of this function is discouraged.
-See the
-<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-Decider"><function>Decider</function></link>
-function for a more flexible and straightforward way
-to configure SCons' decision-making.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-The
-<function xmlns="http://www.scons.org/dbxsd/v1.0">SourceSignatures</function>
-function tells
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-how to decide if a source file
-(a file that is not built from any other files)
-has changed since the last time it
-was used to build a particular target file.
-Legal values are
-<literal>MD5</literal>
-or
-<literal>timestamp</literal>.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-If the environment method is used,
-the specified type of source signature
-is only used when deciding whether targets
-built with that environment are up-to-date or must be rebuilt.
-If the global function is used,
-the specified type of source signature becomes the default
-used for all decisions
-about whether targets are up-to-date.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>MD5</literal>
-means
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-decides that a source file has changed
-if the MD5 checksum of its contents has changed since
-the last time it was used to rebuild a particular target file.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>timestamp</literal>
-means
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-decides that a source file has changed
-if its timestamp (modification time) has changed since
-the last time it was used to rebuild a particular target file.
-(Note that although this is similar to the behavior of Make,
-by default it will also rebuild if the dependency is
-<emphasis>older</emphasis>
-than the last time it was used to rebuild the target file.)
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-There is no different between the two behaviors
-for Python
-<function xmlns="http://www.scons.org/dbxsd/v1.0">Value</function>
-node objects.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>MD5</literal>
-signatures take longer to compute,
-but are more accurate than
-<literal>timestamp</literal>
-signatures.
-The default value is
-<literal>MD5</literal>.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Note that the default
-<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-TargetSignatures"><function>TargetSignatures</function></link>
-setting (see below)
-is to use this
-<function xmlns="http://www.scons.org/dbxsd/v1.0">SourceSignatures</function>
-setting for any target files that are used
-to build other target files.
-Consequently, changing the value of
-<function xmlns="http://www.scons.org/dbxsd/v1.0">SourceSignatures</function>
-will, by default,
-affect the up-to-date decision for all files in the build
-(or all files built with a specific construction environment
-when
-<function xmlns="http://www.scons.org/dbxsd/v1.0">env.SourceSignatures</function>
-is used).
-</para>
-</listitem>
-  </varlistentry>
   <varlistentry id="f-Split">
     <term>
       <literal>Split(arg)</literal>
@@ -4499,161 +4417,6 @@ Tag( Library( 'lib.c' ), UNIX_ATTR="0644" )
 # marks file2.txt to be a documentation file
 Tag( 'file2.txt', DOC )
 </example_commands>
-</listitem>
-  </varlistentry>
-  <varlistentry id="f-TargetSignatures">
-    <term>
-      <literal>TargetSignatures(type)</literal>
-    </term>
-    <term>
-      <literal>env.TargetSignatures(type)</literal>
-    </term>
-    <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Note:  Although it is not yet officially deprecated,
-use of this function is discouraged.
-See the
-<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="f-Decider"><function>Decider</function></link>
-function for a more flexible and straightforward way
-to configure SCons' decision-making.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-The
-<function xmlns="http://www.scons.org/dbxsd/v1.0">TargetSignatures</function>
-function tells
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-how to decide if a target file
-(a file that
-<emphasis>is</emphasis>
-built from any other files)
-has changed since the last time it
-was used to build some other target file.
-Legal values are
-<literal>"build"</literal>;
-<literal>"content"</literal>
-(or its synonym
-<literal>"MD5"</literal>);
-<literal>"timestamp"</literal>;
-or
-<literal>"source"</literal>.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-If the environment method is used,
-the specified type of target signature is only used
-for targets built with that environment.
-If the global function is used,
-the specified type of signature becomes the default
-used for all target files that
-don't have an explicit target signature type
-specified for their environments.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>"content"</literal>
-(or its synonym
-<literal>"MD5"</literal>)
-means
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-decides that a target file has changed
-if the MD5 checksum of its contents has changed since
-the last time it was used to rebuild some other target file.
-This means
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-will open up
-MD5 sum the contents
-of target files after they're built,
-and may decide that it does not need to rebuild
-"downstream" target files if a file was
-rebuilt with exactly the same contents as the last time.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>"timestamp"</literal>
-means
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-decides that a target file has changed
-if its timestamp (modification time) has changed since
-the last time it was used to rebuild some other target file.
-(Note that although this is similar to the behavior of Make,
-by default it will also rebuild if the dependency is
-<emphasis>older</emphasis>
-than the last time it was used to rebuild the target file.)
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>"source"</literal>
-means
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-decides that a target file has changed
-as specified by the corresponding
-<function xmlns="http://www.scons.org/dbxsd/v1.0">SourceSignatures</function>
-setting
-(<literal>"MD5"</literal>
-or
-<literal>"timestamp"</literal>).
-This means that
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-will treat all input files to a target the same way,
-regardless of whether they are source files
-or have been built from other files.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>"build"</literal>
-means
-<filename xmlns="http://www.scons.org/dbxsd/v1.0">scons</filename>
-decides that a target file has changed
-if it has been rebuilt in this invocation
-or if its content or timestamp have changed
-as specified by the corresponding
-<function xmlns="http://www.scons.org/dbxsd/v1.0">SourceSignatures</function>
-setting.
-This "propagates" the status of a rebuilt file
-so that other "downstream" target files
-will always be rebuilt,
-even if the contents or the timestamp
-have not changed.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-<literal>"build"</literal>
-signatures are fastest because
-<literal>"content"</literal>
-(or
-<literal>"MD5"</literal>)
-signatures take longer to compute,
-but are more accurate than
-<literal>"timestamp"</literal>
-signatures,
-and can prevent unnecessary "downstream" rebuilds
-when a target file is rebuilt to the exact same contents
-as the previous build.
-The
-<literal>"source"</literal>
-setting provides the most consistent behavior
-when other target files may be rebuilt from
-both source and target input files.
-The default value is
-<literal>"source"</literal>.
-</para>
-
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Because the default setting is
-<literal>"source"</literal>,
-using
-<function xmlns="http://www.scons.org/dbxsd/v1.0">SourceSignatures</function>
-is generally preferable to
-<function xmlns="http://www.scons.org/dbxsd/v1.0">TargetSignatures</function>,
-so that the up-to-date decision
-will be consistent for all files
-(or all files built with a specific construction environment).
-Use of
-<function xmlns="http://www.scons.org/dbxsd/v1.0">TargetSignatures</function>
-provides specific control for how built target files
-affect their "downstream" dependencies.
-</para>
 </listitem>
   </varlistentry>
   <varlistentry id="f-Tool">
@@ -4949,30 +4712,51 @@ SConscript(dirs='doc', variant_dir='build/doc', duplicate=0)
 Searches for the specified executable
 <varname>program</varname>,
 returning the full path name to the program
-if it is found,
-and returning None if not.
-Searches the specified
-<varname>path</varname>,
-the value of the calling environment's PATH
-(<literal>env['ENV']['PATH']</literal>),
-or the user's current external PATH
-(<literal>os.environ['PATH']</literal>)
-by default.
+if it is found, else <literal>None</literal>.
+Searches the value of the
+<varname>path</varname> keyword argument,
+or if <literal>None</literal> (the default)
+the value of the calling environment's <envar>PATH</envar>
+(<literal>env['ENV']['PATH']</literal>).
+If <varname>path</varname> is <literal>None</literal> and
+the <literal>env['ENV']['PATH']</literal> key does not exist,
+the user's current external <envar>PATH</envar>
+(<literal>os.environ['PATH']</literal>) is used as fallback.
+</para>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
 On Windows systems, searches for executable
-programs with any of the file extensions
-listed in the specified
-<varname>pathext</varname>,
-the calling environment's PATHEXT
-(<literal>env['ENV']['PATHEXT']</literal>)
-or the user's current PATHEXT
+programs with any of the file extensions listed in the
+<varname>pathext</varname> keyword argument,
+or if <literal>None</literal> (the default)
+the calling environment's <envar>PATHEXT</envar>
+(<literal>env['ENV']['PATHEXT']</literal>).
+The user's current external <envar>PATHEXT</envar>
 (<literal>os.environ['PATHEXT']</literal>)
-by default.
+is used as a fallback if <varname>pathext</varname> is
+<literal>None</literal>
+and the key <literal>env['ENV']['PATHEXT']</literal>
+does not exist.
+</para>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
 Will not select any
 path name or names
 in the specified
 <varname>reject</varname>
 list, if any.
 </para>
+<note xmlns="http://www.scons.org/dbxsd/v1.0">
+<para>
+If you would prefer to search
+the user's current external <envar>PATH</envar>
+(<literal>os.environ['PATH']</literal>)
+by default,
+consider using the function <literal>SCons.Util.WhereIs</literal> instead.
+Note that <literal>SCons.Util.WhereIs</literal>
+does not expand environment variables automatically
+(no implicit <literal>env.subst</literal> for its arguments).
+</para>
+</note>
+
 </listitem>
   </varlistentry>
 </variablelist>

--- a/doc/generated/functions.mod
+++ b/doc/generated/functions.mod
@@ -82,11 +82,9 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-SetOption "<function xmlns='http://www.scons.org/dbxsd/v1.0'>SetOption</function>">
 <!ENTITY f-SideEffect "<function xmlns='http://www.scons.org/dbxsd/v1.0'>SideEffect</function>">
 <!ENTITY f-SourceCode "<function xmlns='http://www.scons.org/dbxsd/v1.0'>SourceCode</function>">
-<!ENTITY f-SourceSignatures "<function xmlns='http://www.scons.org/dbxsd/v1.0'>SourceSignatures</function>">
 <!ENTITY f-Split "<function xmlns='http://www.scons.org/dbxsd/v1.0'>Split</function>">
 <!ENTITY f-subst "<function xmlns='http://www.scons.org/dbxsd/v1.0'>subst</function>">
 <!ENTITY f-Tag "<function xmlns='http://www.scons.org/dbxsd/v1.0'>Tag</function>">
-<!ENTITY f-TargetSignatures "<function xmlns='http://www.scons.org/dbxsd/v1.0'>TargetSignatures</function>">
 <!ENTITY f-Tool "<function xmlns='http://www.scons.org/dbxsd/v1.0'>Tool</function>">
 <!ENTITY f-Value "<function xmlns='http://www.scons.org/dbxsd/v1.0'>Value</function>">
 <!ENTITY f-VariantDir "<function xmlns='http://www.scons.org/dbxsd/v1.0'>VariantDir</function>">
@@ -166,11 +164,9 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-env-SetOption "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.SetOption</function>">
 <!ENTITY f-env-SideEffect "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.SideEffect</function>">
 <!ENTITY f-env-SourceCode "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.SourceCode</function>">
-<!ENTITY f-env-SourceSignatures "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.SourceSignatures</function>">
 <!ENTITY f-env-Split "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.Split</function>">
 <!ENTITY f-env-subst "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.subst</function>">
 <!ENTITY f-env-Tag "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.Tag</function>">
-<!ENTITY f-env-TargetSignatures "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.TargetSignatures</function>">
 <!ENTITY f-env-Tool "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.Tool</function>">
 <!ENTITY f-env-Value "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.Value</function>">
 <!ENTITY f-env-VariantDir "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.VariantDir</function>">
@@ -260,11 +256,9 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-link-SetOption "<link linkend='f-SetOption' xmlns='http://www.scons.org/dbxsd/v1.0'><function>SetOption</function></link>">
 <!ENTITY f-link-SideEffect "<link linkend='f-SideEffect' xmlns='http://www.scons.org/dbxsd/v1.0'><function>SideEffect</function></link>">
 <!ENTITY f-link-SourceCode "<link linkend='f-SourceCode' xmlns='http://www.scons.org/dbxsd/v1.0'><function>SourceCode</function></link>">
-<!ENTITY f-link-SourceSignatures "<link linkend='f-SourceSignatures' xmlns='http://www.scons.org/dbxsd/v1.0'><function>SourceSignatures</function></link>">
 <!ENTITY f-link-Split "<link linkend='f-Split' xmlns='http://www.scons.org/dbxsd/v1.0'><function>Split</function></link>">
 <!ENTITY f-link-subst "<link linkend='f-subst' xmlns='http://www.scons.org/dbxsd/v1.0'><function>subst</function></link>">
 <!ENTITY f-link-Tag "<link linkend='f-Tag' xmlns='http://www.scons.org/dbxsd/v1.0'><function>Tag</function></link>">
-<!ENTITY f-link-TargetSignatures "<link linkend='f-TargetSignatures' xmlns='http://www.scons.org/dbxsd/v1.0'><function>TargetSignatures</function></link>">
 <!ENTITY f-link-Tool "<link linkend='f-Tool' xmlns='http://www.scons.org/dbxsd/v1.0'><function>Tool</function></link>">
 <!ENTITY f-link-Value "<link linkend='f-Value' xmlns='http://www.scons.org/dbxsd/v1.0'><function>Value</function></link>">
 <!ENTITY f-link-VariantDir "<link linkend='f-VariantDir' xmlns='http://www.scons.org/dbxsd/v1.0'><function>VariantDir</function></link>">
@@ -344,11 +338,9 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-link-env-SetOption "<link linkend='f-SetOption' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.SetOption</function></link>">
 <!ENTITY f-link-env-SideEffect "<link linkend='f-SideEffect' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.SideEffect</function></link>">
 <!ENTITY f-link-env-SourceCode "<link linkend='f-SourceCode' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.SourceCode</function></link>">
-<!ENTITY f-link-env-SourceSignatures "<link linkend='f-SourceSignatures' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.SourceSignatures</function></link>">
 <!ENTITY f-link-env-Split "<link linkend='f-Split' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.Split</function></link>">
 <!ENTITY f-link-env-subst "<link linkend='f-subst' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.subst</function></link>">
 <!ENTITY f-link-env-Tag "<link linkend='f-Tag' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.Tag</function></link>">
-<!ENTITY f-link-env-TargetSignatures "<link linkend='f-TargetSignatures' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.TargetSignatures</function></link>">
 <!ENTITY f-link-env-Tool "<link linkend='f-Tool' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.Tool</function></link>">
 <!ENTITY f-link-env-Value "<link linkend='f-Value' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.Value</function></link>">
 <!ENTITY f-link-env-VariantDir "<link linkend='f-VariantDir' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.VariantDir</function></link>">

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -488,7 +488,8 @@ after the SCons template for the file has been written.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>
@@ -498,7 +499,8 @@ that may not be set or used in a construction environment.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>
@@ -2804,15 +2806,6 @@ is <quote><literal>-dNOPAUSE -dBATCH -sDEVICE=pdfwrite</literal></quote>
     <term>HOST_ARCH</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-        The name of the host hardware architecture used to create the Environment.
-        If a platform is specified when creating the Environment, then
-        that Platform's logic will handle setting this value.
-        This value is immutable, and should not be changed by the user after
-        the Environment is initialized.
-        Currently only set for Win32.
-</para>
-    
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
 Sets the host architecture for Visual Studio compiler. If not set,
 default to the detected host architecture: note that this may depend
 on the python you are using.
@@ -2828,7 +2821,16 @@ Valid values are the same as for <envar xmlns="http://www.scons.org/dbxsd/v1.0">
 This is currently only used on Windows, but in the future it will be
 used on other OSes as well.
 </para>
-</listitem>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+        The name of the host hardware architecture used to create the Environment.
+        If a platform is specified when creating the Environment, then
+        that Platform's logic will handle setting this value.
+        This value is immutable, and should not be changed by the user after
+        the Environment is initialized.
+        Currently only set for Win32.
+</para>
+    </listitem>
   </varlistentry>
   <varlistentry id="cv-HOST_OS">
     <term>HOST_OS</term>
@@ -2900,7 +2902,7 @@ to <literal>'.dll'</literal>.
 Used to override <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link>/<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-LDMODULEVERSION"><envar>$LDMODULEVERSION</envar></link> when
 generating versioned import library for a shared library/loadable module. If
 undefined, the <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link>/<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-LDMODULEVERSION"><envar>$LDMODULEVERSION</envar></link> is used to
-determine the version of versioned import library. 
+determine the version of versioned import library.
 </para>
 </listitem>
   </varlistentry>
@@ -3070,7 +3072,7 @@ The command line used to call the Java archive tool.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 The string displayed when the Java archive tool
 is called
-If this is not set, then <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-JARCOM"><envar>$JARCOM</envar></link> (the command line) is displayed.
+If this is not set, then <envar xmlns="http://www.scons.org/dbxsd/v1.0">$JARCOM</envar> (the command line) is displayed.
 </para>
 
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -3080,7 +3082,7 @@ env = Environment(JARCOMSTR = "JARchiving $SOURCES into $TARGET")
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 The string displayed when the Java archive tool
 is called
-If this is not set, then <envar xmlns="http://www.scons.org/dbxsd/v1.0">$JARCOM</envar> (the command line) is displayed.
+If this is not set, then <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-JARCOM"><envar>$JARCOM</envar></link> (the command line) is displayed.
 </para>
 
 <example_commands xmlns="http://www.scons.org/dbxsd/v1.0">
@@ -3446,6 +3448,17 @@ If this is not set, then <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="
 </para>
 </listitem>
   </varlistentry>
+  <varlistentry id="cv-LDMODULEEMITTER">
+    <term>LDMODULEEMITTER</term>
+    <listitem>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+Contains the emitter specification for the
+<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-LoadableModule"><function>LoadableModule</function></link> builder.
+The manpage section "Builder Objects" contains
+general information on specifying emitters.
+</para>
+</listitem>
+  </varlistentry>
   <varlistentry id="cv-LDMODULEFLAGS">
     <term>LDMODULEFLAGS</term>
     <listitem>
@@ -3618,7 +3631,10 @@ when the <envar xmlns="http://www.scons.org/dbxsd/v1.0">$_LIBDIRFLAGS</envar> va
     <term>LIBEMITTER</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-TODO
+Contains the emitter specification for the
+<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-StaticLibrary"><function>StaticLibrary</function></link> builder.
+The manpage section "Builder Objects" contains
+general information on specifying emitters.
 </para>
 </listitem>
   </varlistentry>
@@ -5108,7 +5124,10 @@ for example.
     <term>PROGEMITTER</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-TODO
+Contains the emitter specification for the
+<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-Program"><function>Program</function></link> builder.
+The manpage section "Builder Objects" contains
+general information on specifying emitters.
 </para>
 </listitem>
   </varlistentry>
@@ -5803,9 +5822,9 @@ appending to this list,
 although the more flexible approach
 is to associate scanners
 with a specific Builder.
-See the sections "Builder Objects"
-and "Scanner Objects,"
-below, for more information.
+See the manpage sections "Builder Objects"
+and "Scanner Objects"
+for more information.
 </para>
 </listitem>
   </varlistentry>
@@ -6465,7 +6484,10 @@ If this is not set, then <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="
     <term>SHLIBEMITTER</term>
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
-TODO
+Contains the emitter specification for the
+<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link> builder.
+The manpage section "Builder Objects" contains
+general information on specifying emitters.
 </para>
 </listitem>
   </varlistentry>
@@ -6509,12 +6531,22 @@ The suffix used for shared library file names.
     <listitem>
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 When this construction variable is defined, a versioned shared library
-is created by <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link> builder. This activates the
+is created by the <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link> builder. This activates the
 <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-_SHLIBVERSIONFLAGS"><envar>$_SHLIBVERSIONFLAGS</envar></link> and thus modifies the <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLINKCOM"><envar>$SHLINKCOM</envar></link> as
 required, adds the version number to the library name, and creates the symlinks
 that are needed.  <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> versions should exist as alpha-numeric,
 decimal-delimited values as defined by the regular expression "\w+[\.\w+]*".
 Example <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> values include '1', '1.2.3', and '1.2.gitaa412c8b'.
+</para>
+</listitem>
+  </varlistentry>
+  <varlistentry id="cv-SHLIBVERSIONFLAGS">
+    <term>SHLIBVERSIONFLAGS</term>
+    <listitem>
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+Extra flags added to <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLINKCOM"><envar>$SHLINKCOM</envar></link> when building versioned
+<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link>. These flags are only used when <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> is
+set.
 </para>
 </listitem>
   </varlistentry>
@@ -6528,16 +6560,6 @@ is set). <literal>_SHLIBVERSIONFLAGS</literal> usually adds <link xmlns="http://
 and some extra dynamically generated options (such as
 <literal>-Wl,-soname=$_SHLIBSONAME</literal>. It is unused by "plain"
 (unversioned) shared libraries.
-</para>
-</listitem>
-  </varlistentry>
-  <varlistentry id="cv-SHLIBVERSIONFLAGS">
-    <term>SHLIBVERSIONFLAGS</term>
-    <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-Extra flags added to <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLINKCOM"><envar>$SHLINKCOM</envar></link> when building versioned
-<link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="b-SharedLibrary"><function>SharedLibrary</function></link>. These flags are only used when <link xmlns="http://www.scons.org/dbxsd/v1.0" linkend="cv-SHLIBVERSION"><envar>$SHLIBVERSION</envar></link> is
-set.
 </para>
 </listitem>
   </varlistentry>
@@ -6629,7 +6651,8 @@ The variable is used, for example, by <link xmlns="http://www.scons.org/dbxsd/v1
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>
@@ -6652,7 +6675,8 @@ field in the controlling information for Ipkg and RPM packages.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>
@@ -6996,20 +7020,14 @@ General options passed to the tar archiver.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>
   <varlistentry id="cv-TARGET_ARCH">
     <term>TARGET_ARCH</term>
     <listitem>
-<para xmlns="http://www.scons.org/dbxsd/v1.0">
-        The name of the target hardware architecture for the compiled objects
-        created by this Environment.
-        This defaults to the value of HOST_ARCH, and the user can override it.
-        Currently only set for Win32.
-</para>
-    
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 Sets the target architecture for Visual Studio compiler (i.e. the arch
 of the binaries generated by the compiler). If not set, default to
@@ -7041,7 +7059,14 @@ and <literal>ia64</literal> (Itanium).
 For example, if you want to compile 64-bit binaries, you would set
 <literal>TARGET_ARCH='x86_64'</literal> in your SCons environment.
 </para>
-</listitem>
+
+<para xmlns="http://www.scons.org/dbxsd/v1.0">
+        The name of the target hardware architecture for the compiled objects
+        created by this Environment.
+        This defaults to the value of HOST_ARCH, and the user can override it.
+        Currently only set for Win32.
+</para>
+    </listitem>
   </varlistentry>
   <varlistentry id="cv-TARGET_OS">
     <term>TARGET_OS</term>
@@ -7060,7 +7085,8 @@ For example, if you want to compile 64-bit binaries, you would set
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>
@@ -7193,7 +7219,8 @@ that are part of this construction environment.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>
@@ -7203,7 +7230,8 @@ that may not be set or used in a construction environment.
 <para xmlns="http://www.scons.org/dbxsd/v1.0">
 A reserved variable name
 that may not be set or used in a construction environment.
-(See "Variable Substitution," below.)
+(See the manpage section "Variable Substitution"
+for more information).
 </para>
 </listitem>
   </varlistentry>

--- a/doc/generated/variables.mod
+++ b/doc/generated/variables.mod
@@ -251,6 +251,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-LDMODULE "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$LDMODULE</envar>">
 <!ENTITY cv-LDMODULECOM "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$LDMODULECOM</envar>">
 <!ENTITY cv-LDMODULECOMSTR "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$LDMODULECOMSTR</envar>">
+<!ENTITY cv-LDMODULEEMITTER "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$LDMODULEEMITTER</envar>">
 <!ENTITY cv-LDMODULEFLAGS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$LDMODULEFLAGS</envar>">
 <!ENTITY cv-LDMODULENOVERSIONSYMLINKS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$LDMODULENOVERSIONSYMLINKS</envar>">
 <!ENTITY cv-LDMODULEPREFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$LDMODULEPREFIX</envar>">
@@ -891,6 +892,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-link-LDMODULE "<link linkend='cv-LDMODULE' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$LDMODULE</envar></link>">
 <!ENTITY cv-link-LDMODULECOM "<link linkend='cv-LDMODULECOM' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$LDMODULECOM</envar></link>">
 <!ENTITY cv-link-LDMODULECOMSTR "<link linkend='cv-LDMODULECOMSTR' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$LDMODULECOMSTR</envar></link>">
+<!ENTITY cv-link-LDMODULEEMITTER "<link linkend='cv-LDMODULEEMITTER' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$LDMODULEEMITTER</envar></link>">
 <!ENTITY cv-link-LDMODULEFLAGS "<link linkend='cv-LDMODULEFLAGS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$LDMODULEFLAGS</envar></link>">
 <!ENTITY cv-link-LDMODULENOVERSIONSYMLINKS "<link linkend='cv-LDMODULENOVERSIONSYMLINKS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$LDMODULENOVERSIONSYMLINKS</envar></link>">
 <!ENTITY cv-link-LDMODULEPREFIX "<link linkend='cv-LDMODULEPREFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$LDMODULEPREFIX</envar></link>">

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2278,10 +2278,10 @@ env.SomeTool(targets, sources)
 
 <refsect2 id='builder_methods'><title>Builder Methods</title>
 
-<para>You tell <program>scons</program> what to build
+<para>You tell <command>scons</command> what to build
 by calling Builders, functions which know to take a
 particular action when given files of a particular type
-to produce a particular result type. <program>scons</program>
+to produce a particular result type. <command>scons</command>
 defines a number of builders, and you can also write your own.
 Builders are attached to a &consenv; as methods,
 and the available builder methods are listed as

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sconsdoc [
     <!ENTITY % scons SYSTEM "../scons.mod">
     %scons;
-    
+
     <!ENTITY % builders-mod SYSTEM "../generated/builders.mod">
     %builders-mod;
     <!ENTITY % functions-mod SYSTEM "../generated/functions.mod">
@@ -89,7 +89,7 @@
     all of the command-line variable settings,
     the ability to apply command-line variable settings
     to construction environments,
-    and functions for configuring 
+    and functions for configuring
     specific types of variables
     (Boolean values, path names, etc.)
     with automatic validation of the user's specified values.
@@ -681,36 +681,43 @@ foo.in
 
       <note>
       <para>
-      Long options and option-arguments separated by a space, rather than
+      Long options and option-arguments separated by space, rather than
       by <literal>=</literal>, are ambiguous.
       While <literal>--input=ARG</literal>
       has a clear meaning, for <literal>--input ARG</literal> it is not
       possible to tell without instructions whether
       <parameter>ARG</parameter> is an argument belonging to the
-      <parameter>input</parameter> option or a positional argument
-      (that is, an argument that does not start with a single or double dash).
-      In <command>scons</command>, positional arguments are treated as either 
+      <parameter>input</parameter> option or a positional argument.
+      <command>scons</command> treats positional arguments as either
       command-line build options or command-line targets
       (see the immediately following sections for details),
       which are made available for use in the &SConscript;.
-      This means they have to be collected before &SConscript; processing
+      Thus, they must be collected before &SConscript; processing
       takes place. Since &AddOption; calls, which provide
-      the necessary processing instructions, happen in the &SConscript;,
-      <command>scons</command> cannot resolve the ambiguity in time
-      for options added this way, and unexpected things will happen.
+      the processing instructions to resolve the ambiguity,
+      happen in the &SConscript;,
+      <command>scons</command> does not know in time
+      for options added this way, and unexpected things will happen,
+      such as option-arguments assigned as targets and/or exceptions
+      due to missing option-arguments.
+      </para>
+      <para>
       As a result, this usage style should be avoided when invoking
       <command>scons</command>.  For single-argument
-      options, use the <literal>--input=ARG</literal> style on the
-      command line. For multiple-argument options 
+      options, use the <literal>--input=ARG</literal> form on the
+      command line. For multiple-argument options
       (<parameter>nargs</parameter> greater than one),
       set <parameter>nargs</parameter> to one in
-      &AddOption; and combine the option-arguments into one word
-      with a separator, and parse the result in your own code. 
-      See the built-in <parameter>--debug</parameter> option, which
+      &AddOption; calls and either: combine the option-arguments into one word
+      with a separator, and parse the result in your own code
+      (see the built-in <parameter>--debug</parameter> option, which
       allows specifying multiple arguments as a single comma-separated
-      word, for an example of such usage.
+      word, for an example of such usage); or allow the option to
+      be specified multiple times by setting
+      <literal>action='append'</literal>. Both methods can be
+      supported at the same time.
       </para>
-      </footnote>
+      </note>
 
     </section>
 
@@ -1166,12 +1173,12 @@ vars = Variables('custom.py', ARGUMENTS)
       </screen>
 
       <para>
-      
+
       where values in the option file &custom_py; get overwritten
       by the ones specified on the command line.
 
       </para>
-      
+
     </section>
 
     <section>

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -681,8 +681,8 @@ foo.in
 
       <note>
       <para>
-      Long options and option-arguments separated by space, rather than
-      by <literal>=</literal>, are ambiguous.
+      Long options and option-arguments separated by whitespace,
+      rather than by <literal>=</literal>, are ambiguous.
       While <literal>--input=ARG</literal>
       has a clear meaning, for <literal>--input ARG</literal> it is not
       possible to tell without instructions whether

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -608,6 +608,7 @@ foo.in
       of the <classname>optparse.OptionParser</classname>.
       </para>
       </footnote>
+
       Once you have added a custom command-line option
       with the &AddOption; function,
       the value of the option (if any) is immediately available
@@ -677,6 +678,39 @@ foo.in
       <scons_output example="commandline_AddOption" suffix="2">
         <scons_output_command>scons -Q -n --prefix=/tmp/install</scons_output_command>
       </scons_output>
+
+      <note>
+      <para>
+      Long options and option-arguments separated by a space, rather than
+      by <literal>=</literal>, are ambiguous.
+      While <literal>--input=ARG</literal>
+      has a clear meaning, for <literal>--input ARG</literal> it is not
+      possible to tell without instructions whether
+      <parameter>ARG</parameter> is an argument belonging to the
+      <parameter>input</parameter> option or a positional argument
+      (that is, an argument that does not start with a single or double dash).
+      In <command>scons</command>, positional arguments are treated as either 
+      command-line build options or command-line targets
+      (see the immediately following sections for details),
+      which are made available for use in the &SConscript;.
+      This means they have to be collected before &SConscript; processing
+      takes place. Since &AddOption; calls, which provide
+      the necessary processing instructions, happen in the &SConscript;,
+      <command>scons</command> cannot resolve the ambiguity in time
+      for options added this way, and unexpected things will happen.
+      As a result, this usage style should be avoided when invoking
+      <command>scons</command>.  For single-argument
+      options, use the <literal>--input=ARG</literal> style on the
+      command line. For multiple-argument options 
+      (<parameter>nargs</parameter> greater than one),
+      set <parameter>nargs</parameter> to one in
+      &AddOption; and combine the option-arguments into one word
+      with a separator, and parse the result in your own code. 
+      See the built-in <parameter>--debug</parameter> option, which
+      allows specifying multiple arguments as a single comma-separated
+      word, for an example of such usage.
+      </para>
+      </footnote>
 
     </section>
 

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -599,25 +599,30 @@ foo.in
       &SCons; also allows you to define your own
       command-line options with the &AddOption; function.
       The &AddOption; function takes the same arguments
-      as the <function>optparse.add_option</function> function
-      from the standard Python library.
+      as the <function>add_option</function> method
+      from the standard Python library module <emphasis>optparse</emphasis>.
       <footnote>
       <para>
       The &AddOption; function is,
       in fact, implemented using a subclass
-      of the <classname>optparse.OptionParser</classname>.
+      of <classname>optparse.OptionParser</classname>.
       </para>
       </footnote>
+      </para>
 
+      <para>
       Once you have added a custom command-line option
       with the &AddOption; function,
       the value of the option (if any) is immediately available
       using the standard &GetOption; function.
+      <!--
       (The value can also be set using &SetOption;,
       although that's not very useful in practice
       because a default value can be specified in
       directly in the &AddOption; call.)
-
+      -->
+      &SetOption; is not currently supported for
+      options added with &AddOption;.
       </para>
 
       <para>
@@ -681,21 +686,22 @@ foo.in
 
       <note>
       <para>
-      Long options and option-arguments separated by whitespace,
-      rather than by <literal>=</literal>, are ambiguous.
+      Option-arguments separated from long options by whitespace,
+      rather than by an <literal>=</literal>, cannot be correctly
+      resolved by <command>scons</command>.
       While <literal>--input=ARG</literal>
-      has a clear meaning, for <literal>--input ARG</literal> it is not
-      possible to tell without instructions whether
+      is clearly opt followed by arg, for <literal>--input ARG</literal>
+      it is not possible to tell without instructions whether
       <parameter>ARG</parameter> is an argument belonging to the
       <parameter>input</parameter> option or a positional argument.
       <command>scons</command> treats positional arguments as either
       command-line build options or command-line targets
-      (see the immediately following sections for details),
-      which are made available for use in the &SConscript;.
+      which are made available for use in an &SConscript;
+      (see the immediately following sections for details).
       Thus, they must be collected before &SConscript; processing
       takes place. Since &AddOption; calls, which provide
-      the processing instructions to resolve the ambiguity,
-      happen in the &SConscript;,
+      the processing instructions to resolve any ambiguity,
+      happen in an &SConscript;,
       <command>scons</command> does not know in time
       for options added this way, and unexpected things will happen,
       such as option-arguments assigned as targets and/or exceptions

--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -764,6 +764,7 @@ int main() { printf("Hello, world!\n"); }
     encounter them in older &SConscript; files.
 
     </para>
+  </section>
   
   <section>
   <title>Implicit Dependencies:  The &cv-CPPPATH; Construction Variable</title>

--- a/src/engine/SCons/Script/Main.xml
+++ b/src/engine/SCons/Script/Main.xml
@@ -33,11 +33,11 @@ See its __doc__ string for a discussion of the format.
 This function adds a new command-line option to be recognized.
 The specified
 <varname>arguments</varname>
-are the same as supported by the standard Python
-<function>optparse.add_option</function>()
-method (with a few additional capabilities noted below);
+are the same as supported by the <function>add_option</function>
+method in the standard Python library module <emphasis>optparse</emphasis>,
+with a few additional capabilities noted below;
 see the documentation for
-<literal>optparse</literal>
+<emphasis>optparse</emphasis>
 for a thorough discussion of its option-processing capabities.
 </para>
 
@@ -78,12 +78,22 @@ the option will have a default value of
 </para>
 
 <para>
+Unlike regular <emphasis>optparse</emphasis>, option names
+added via <function>AddOption</function> must be matched
+exactly, the automatic matching of abbreviations on the
+command line for long options is not supported.
+To allow specific abbreviations,
+include them in the &f-AddOption; call.
+</para>
+
+<para>
 Once a new command-line option has been added with
 &f-AddOption;,
 the option value may be accessed using
 &f-GetOption;
 or
 <function>env.GetOption</function>().
+<!--
 The value may also be set, using
 &f-SetOption;
 or
@@ -95,6 +105,9 @@ Note, however, that a
 value specified on the command line will
 <emphasis>always</emphasis>
 override a value set by any SConscript file.
+-->
+&f-SetOption; is not currently supported for
+options added with &f-AddOption;.
 </para>
 
 <para>
@@ -137,11 +150,12 @@ env = Environment(PREFIX = GetOption('prefix'))
 <note>
 <para>
 While &AddOption; behaves like
-<function>optparse.add_option</function>,
+<function>add_option</function>,
+from the <emphasis>optparse</emphasis> module,
 the behavior of options added by &AddOption;
 which take arguments is underfined in
 <command>scons</command> if whitespace
-(rather than <literal>=</literal> sign) is used as
+(rather than an <literal>=</literal> sign) is used as
 the separator on the command line when
 the option is invoked.
 Such usage should be avoided.

--- a/src/engine/SCons/Script/Main.xml
+++ b/src/engine/SCons/Script/Main.xml
@@ -138,9 +138,9 @@ env = Environment(PREFIX = GetOption('prefix'))
 <para>
 While &AddOption; behaves like
 <function>optparse.add_option</function>,
-the behavior of options added by &AddOption; 
+the behavior of options added by &AddOption;
 which take arguments is underfined in
-<command>scons</command> if a space
+<command>scons</command> if whitespace
 (rather than <literal>=</literal> sign) is used as
 the separator on the command line when
 the option is invoked.

--- a/src/engine/SCons/Script/Main.xml
+++ b/src/engine/SCons/Script/Main.xml
@@ -133,6 +133,21 @@ AddOption('--prefix',
           help='installation prefix')
 env = Environment(PREFIX = GetOption('prefix'))
 </example_commands>
+
+<note>
+<para>
+While &AddOption; behaves like
+<function>optparse.add_option</function>,
+the behavior of options added by &AddOption; 
+which take arguments is underfined in
+<command>scons</command> if a space
+(rather than <literal>=</literal> sign) is used as
+the separator on the command line when
+the option is invoked.
+Such usage should be avoided.
+</para>
+</note>
+
 </summary>
 </scons_function>
 


### PR DESCRIPTION
Manpage describes that using spaces between `AddOption`'d option and its argument is undefined.

User Guide goes into more detail, including workarounds.

:: these are not a solution, but do at least reduce the  surprise factor.

Multiple github issues touch on this topic, at least #2748, #2805, #2977

Fix tag mismatch in depends.xml introduced by a previous deletion, which was preventing doc builds.

This is a doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
