### PR TITLE
Fix a problem under Solaris when using Python 3

### DIFF
--- a/src/engine/SCons/Tool/suncxx.py
+++ b/src/engine/SCons/Tool/suncxx.py
@@ -73,7 +73,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
             popen_args = {'stdout': subprocess.PIPE,
                           'stderr': DEVNULL}
             if PY3:
-                popen_args['encoding'] = 'utf-8'
+                popen_args['universal_newlines'] = True
             p = subprocess.Popen([pkginfo, '-l', package_name],
                                  **popen_args)
         except EnvironmentError:
@@ -92,7 +92,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
                 popen_args = {'stdout': subprocess.PIPE,
                               'stderr': DEVNULL}
                 if PY3:
-                    popen_args['encoding'] = 'utf-8'
+                    popen_args['universal_newlines'] = True
                 p = subprocess.Popen([pkgchk, '-l', package_name],
                                      **popen_args)
             except EnvironmentError:

--- a/src/engine/SCons/Tool/suncxx.py
+++ b/src/engine/SCons/Tool/suncxx.py
@@ -39,11 +39,13 @@ import os
 import re
 import subprocess
 
+from SCons.Util import PY3
 import SCons.Tool.cxx
 cplusplus = SCons.Tool.cxx
-#cplusplus = __import__('c++', globals(), locals(), [])
+# cplusplus = __import__('c++', globals(), locals(), [])
 
 package_info = {}
+
 
 def get_package_info(package_name, pkginfo, pkgchk):
     try:
@@ -52,7 +54,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
         version = None
         pathname = None
         try:
-            from subprocess import DEVNULL # py3k
+            from subprocess import DEVNULL  # py3k
         except ImportError:
             DEVNULL = open(os.devnull, 'wb')
 
@@ -68,13 +70,18 @@ def get_package_info(package_name, pkginfo, pkgchk):
                 pathname = os.path.dirname(sadm_match.group(1))
 
         try:
+            popen_args = {'stdout': subprocess.PIPE,
+                          'stderr': DEVNULL}
+            if PY3:
+                popen_args['encoding'] = 'utf-8'
             p = subprocess.Popen([pkginfo, '-l', package_name],
-                                 stdout=subprocess.PIPE,
-                                 stderr=DEVNULL)
+                                 **popen_args)
         except EnvironmentError:
             pass
         else:
-            pkginfo_contents = p.communicate()[0].decode()
+            pkginfo_contents = p.communicate()[0]
+            if not PY3:
+                pkginfo_contents.decode()
             version_re = re.compile(r'^ *VERSION:\s*(.*)$', re.M)
             version_match = version_re.search(pkginfo_contents)
             if version_match:
@@ -82,13 +89,18 @@ def get_package_info(package_name, pkginfo, pkgchk):
 
         if pathname is None:
             try:
+                popen_args = {'stdout': subprocess.PIPE,
+                              'stderr': DEVNULL}
+                if PY3:
+                    popen_args['encoding'] = 'utf-8'
                 p = subprocess.Popen([pkgchk, '-l', package_name],
-                                     stdout=subprocess.PIPE,
-                                     stderr=DEVNULL)
+                                     **popen_args)
             except EnvironmentError:
                 pass
             else:
-                pkgchk_contents = p.communicate()[0].decode()
+                pkgchk_contents = p.communicate()[0]
+                if not PY3:
+                    pkgchk_contents.decode()
                 pathname_re = re.compile(r'^Pathname:\s*(.*/bin/CC)$', re.M)
                 pathname_match = pathname_re.search(pkgchk_contents)
                 if pathname_match:
@@ -97,7 +109,8 @@ def get_package_info(package_name, pkginfo, pkgchk):
         package_info[package_name] = (pathname, version)
         return package_info[package_name]
 
-# use the package installer tool lslpp to figure out where cppc and what
+
+# use the package installer tool "pkg" to figure out where cppc and what
 # version of it is installed
 def get_cppc(env):
     cxx = env.subst('$CXX')
@@ -119,6 +132,7 @@ def get_cppc(env):
 
     return (cppcPath, 'CC', 'CC', cppcVersion)
 
+
 def generate(env):
     """Add Builders and construction variables for SunPRO C++."""
     path, cxx, shcxx, version = get_cppc(env)
@@ -131,10 +145,11 @@ def generate(env):
     env['CXX'] = cxx
     env['SHCXX'] = shcxx
     env['CXXVERSION'] = version
-    env['SHCXXFLAGS']   = SCons.Util.CLVar('$CXXFLAGS -KPIC')
-    env['SHOBJPREFIX']  = 'so_'
-    env['SHOBJSUFFIX']  = '.o'
-    
+    env['SHCXXFLAGS'] = SCons.Util.CLVar('$CXXFLAGS -KPIC')
+    env['SHOBJPREFIX'] = 'so_'
+    env['SHOBJSUFFIX'] = '.o'
+
+
 def exists(env):
     path, cxx, shcxx, version = get_cppc(env)
     if path and cxx:


### PR DESCRIPTION
Fix a problem under Solaris when using Python 3, while maintaining support for Python 2.7.  subproces.Popen() produces bytes without the encoding argument in 3, which is not recognized by 2.7, and doesn't need to be decoded.

Also made a few changes to make "pycodestyle" happy for PEP8 compliance.

The issue is Solaris specific, and I don't believe it warrants a test without a Solaris test node.
Manually tested with Python 2.7 and 3.7 on Solaris/SPARC machines.