### PR TITLE
Typo in testing document

### DIFF
--- a/testing/framework/test-framework.rst
+++ b/testing/framework/test-framework.rst
@@ -29,7 +29,7 @@ There are three types of SCons tests:
   ``src/engine/`` subdirectory and are the same base name as the module
   to be tests, with ``Tests`` appended before the ``.py``. For example,
   the unit tests for the ``Builder.py`` module are in the
- ``BuilderTests.py`` script.  Unit tests tend to be based on assertions.
+  ``BuilderTests.py`` script.  Unit tests tend to be based on assertions.
 
 *External Tests*
   For the support of external Tools (in the form of packages, preferably),


### PR DESCRIPTION
lack of a consistent indent confused ReST readers:

System Message: WARNING/2 (/home/mats/github/scons/testing/framework/test-framework.rst, line 32)

Block quote ends without a blank line; unexpected unindent.

This file appears, in converted form, in the wiki; the wiki can support rst format so perhaps we should switch to that?  In any case, an update there is needed to stay in sync.

Signed-off-by: Mats Wichmann <mats@linux.com>

None of the checklist items really appear - although this is doc, it's not part of the normal scons documentation set.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
