### PR TITLE
fix more Python escape complaints

### DIFF
--- a/src/engine/SCons/Tool/intelc.py
+++ b/src/engine/SCons/Tool/intelc.py
@@ -387,7 +387,7 @@ def get_intel_compiler_top(version, abi):
 
 
 def generate(env, version=None, abi=None, topdir=None, verbose=0):
-    """Add Builders and construction variables for Intel C/C++ compiler
+    r"""Add Builders and construction variables for Intel C/C++ compiler
     to an Environment.
     args:
       version: (string) compiler version to use, like "80"
@@ -551,7 +551,7 @@ def generate(env, version=None, abi=None, topdir=None, verbose=0):
         # Look for license file dir
         # in system environment, registry, and default location.
         envlicdir = os.environ.get("INTEL_LICENSE_FILE", '')
-        K = ('SOFTWARE\Intel\Licenses')
+        K = r'SOFTWARE\Intel\Licenses'
         try:
             k = SCons.Util.RegOpenKeyEx(SCons.Util.HKEY_LOCAL_MACHINE, K)
             reglicdir = SCons.Util.RegQueryValueEx(k, "w_cpp")[0]

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -224,7 +224,7 @@ def build_wxsfile(target, source, env):
 # setup function
 #
 def create_default_directory_layout(root, NAME, VERSION, VENDOR, filename_set):
-    """ Create the wix default target directory layout and return the innermost
+    r""" Create the wix default target directory layout and return the innermost
     directory.
 
     We assume that the XML tree delivered in the root argument already contains


### PR DESCRIPTION
Write as raw strings:
Two are docstrings that contain a backslash;
the third is an odd expression parenthesized for no good reason and containing backslashes.

Although these are changes to code files, since two are docstrings and the other is trivial, doesn't seem worth updating CHANGES.txt. No test or doc impact.  Will let the CI run, just in case.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
