### PR TITLE
Optimize for most common case in Entry.disambiguate()

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -46,6 +46,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improved threading performance by ensuring NodeInfo is shared
       across threads. Results in ~13% improvement for parallel builds
       (-j# > 1) with many shared nodes.
+    - Improve performance of Entry.disambiguate() by making check for
+      most common case first, preventing unnecessary IO.
 
   From Mats Wichmann
     - Replace instances of string find method with "in" checks where

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -963,14 +963,14 @@ class Entry(Base):
 
     def disambiguate(self, must_exist=None):
         """
-        """
-        if self.isdir():
-            self.__class__ = Dir
-            self._morph()
-        elif self.isfile():
+        """ 
+        if self.isfile():
             self.__class__ = File
             self._morph()
             self.clear()
+        elif self.isdir():
+            self.__class__ = Dir
+            self._morph()
         else:
             # There was nothing on-disk at this location, so look in
             # the src directory.


### PR DESCRIPTION
This removes many unnecessary os.stat and related FS IO calls. Saves about 2 seconds on MongoDB's no-op rebuild time.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
