### PR TITLE
[WIP] Adjust appveyor build and mingw tool paths  [travis skip]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
   - cmd: "C:\\%WINPYTHON%\\python.exe --version"
   - cmd: for /F "tokens=*" %%g in ('C:\\%WINPYTHON%\\python.exe -m site --user-site') do (set PYSITEDIR=%%g)
   # use mingw 32 bit until #3291 is resolved
-  - cmd: "set PATH=C:\\%WINPYTHON%;C:\\%WINPYTHON%\\Scripts;C:\\ProgramData\\chocolatey\\bin;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin;C:\\cygwin\\bin;%PATH%"
+  - cmd: "set PATH=C:\\%WINPYTHON%;C:\\%WINPYTHON%\\Scripts;C:\\ProgramData\\chocolatey\\bin;C:\\msys64\\bin;C:\\msys\\bin;C:\\cygwin64\\bin;C:\\cygwin\\bin;%PATH%"
   - cmd: "C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off pip setuptools wheel "
   - cmd: "C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off pypiwin32 coverage codecov"
   - cmd: set STATIC_DEPS=true & C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off lxml

--- a/src/engine/SCons/Tool/mingw.py
+++ b/src/engine/SCons/Tool/mingw.py
@@ -46,9 +46,9 @@ import SCons.Util
 mingw_paths = [
     r'c:\MinGW\bin',
     r'C:\cygwin64\bin',
-    r'C:\msys64',
+    r'C:\msys64\bin',
     r'C:\cygwin\bin',
-    r'C:\msys',
+    r'C:\msys\bin',
 ]
 
 


### PR DESCRIPTION
All of the AppVeyor images we test on have msys2 installed, the 2019 image doesn't have mingw any longer, so adjust PATH to look for the msys2 ones instead.  Also added cygwin64.

The mingw tool has the msys paths in it, but not in the correct form to find anything: it had \msys64 and \msys, with no \bin suffix.  Added \bin to those two (this is mentioned in bug or clean up the messy way in which paths are looked up, but at least the msys paths shouldn't be useless now.

Marked WIP for now as I'm mostly interested in getting a test run to see if this works as expected.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
