### PR TITLE
Fix two small syntax errors in string formatting

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -15,6 +15,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Mats Wichmann:
     - Remove deprecated SourceCode
+    - str.format syntax errors fixed
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/engine/SCons/Tool/install.py
+++ b/src/engine/SCons/Tool/install.py
@@ -168,7 +168,7 @@ def installShlibLinks(dest, source, env):
     Verbose = False
     symlinks = listShlibLinksToInstall(dest, source, env)
     if Verbose:
-        print('installShlibLinks: symlinks={:r}'.format(SCons.Tool.StringizeLibSymlinks(symlinks)))
+        print('installShlibLinks: symlinks={!r}'.format(SCons.Tool.StringizeLibSymlinks(symlinks)))
     if symlinks:
         SCons.Tool.CreateLibSymlinks(env, symlinks)
     return
@@ -244,7 +244,7 @@ def add_versioned_targets_to_INSTALLED_FILES(target, source, env):
     Verbose = False
     _INSTALLED_FILES.extend(target)
     if Verbose:
-        print("add_versioned_targets_to_INSTALLED_FILES: target={:r}".format(list(map(str, target))))
+        print("add_versioned_targets_to_INSTALLED_FILES: target={!r}".format(list(map(str, target))))
     symlinks = listShlibLinksToInstall(target[0], source, env)
     if symlinks:
         SCons.Tool.EmitLibSymlinks(env, symlinks, target[0])


### PR DESCRIPTION
The `:r` designation is unknown, should be `!r`

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
