### PR TITLE
checker fixes: None, trailing ws, list init

### DIFF
--- a/doc/SConscript
+++ b/doc/SConscript
@@ -525,7 +525,7 @@ if not epydoc_cli:
             # first arg is a list where can be names of python package dirs,
             # python files, object names or objects itself
             docindex = build_doc_index([str(src) for src in source])
-            if docindex == None:
+            if docindex is None:
                 return -1
 
             if env['EPYDOCFLAGS'] == '--html':

--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -2508,8 +2508,8 @@ class FileTestCase(_tempdirTestCase):
         build_f1, src_f1)
 
     def test_changed(self):
-        """ 
-        Verify that changes between BuildInfo's list of souces, depends, and implicit 
+        """
+        Verify that changes between BuildInfo's list of souces, depends, and implicit
         dependencies do not corrupt content signature values written to .SConsign
         when using CacheDir and Timestamp-MD5 decider.
         This is for issue #2980
@@ -3374,10 +3374,11 @@ class find_fileTestCase(unittest.TestCase):
         node_pseudo.set_src_builder(1)  # Any non-zero value.
 
         paths = tuple(map(fs.Dir, ['.', 'same', './bar']))
-        nodes = [SCons.Node.FS.find_file('foo', paths)]
-        nodes.append(SCons.Node.FS.find_file('baz', paths))
-        nodes.append(SCons.Node.FS.find_file('pseudo', paths))
-        nodes.append(SCons.Node.FS.find_file('same', paths))
+        nodes = [SCons.Node.FS.find_file('foo', paths),
+                 SCons.Node.FS.find_file('baz', paths),
+                 SCons.Node.FS.find_file('pseudo', paths),
+                 SCons.Node.FS.find_file('same', paths)
+        ]
 
         file_names = list(map(str, nodes))
         file_names = list(map(os.path.normpath, file_names))

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -1067,7 +1067,7 @@ def CheckLibWithHeader(context, libs, header, language,
     """
     prog_prefix, dummy = \
                  createIncludesFromHeaders(header, 0)
-    if libs == []:
+    if not libs:
         libs = [None]
 
     if not SCons.Util.is_List(libs):

--- a/src/engine/SCons/Scanner/ScannerTests.py
+++ b/src/engine/SCons/Scanner/ScannerTests.py
@@ -236,7 +236,7 @@ class BaseTestCase(unittest.TestCase):
     def test___cmp__(self):
         """Test the Scanner.Base class __cmp__() method"""
         s = SCons.Scanner.Base(self.func, "Cmp")
-        assert s != None
+        assert s is not None
 
     def test_hash(self):
         """Test the Scanner.Base class __hash__() method"""
@@ -577,8 +577,6 @@ class ClassicTestCase(unittest.TestCase):
         self.assertTrue(n == [1, 3],
                         "recursive = 1 didn't return all nodes: %s" % n)
 
-
-        
 
 class ClassicCPPTestCase(unittest.TestCase):
     def test_find_include(self):

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -509,7 +509,7 @@ def _check_cl_exists_in_vc_dir(env, vc_dir, msvc_version):
             debug('_check_cl_exists_in_vc_dir(): found ' + _CL_EXE_NAME + '!')
             return True
 
-    elif ver_num <= 14 and ver_num >= 8:
+    elif 14 >= ver_num >= 8:
 
         # Set default value to be -1 as "" which is the value for x86/x86 yields true when tested
         # if not host_trgt_dir
@@ -541,7 +541,7 @@ def _check_cl_exists_in_vc_dir(env, vc_dir, msvc_version):
             debug('_check_cl_exists_in_vc_dir(): found ' + _CL_EXE_NAME + '!')
             return True
 
-    elif ver_num < 8 and ver_num >= 6:
+    elif 8 > ver_num >= 6:
         # not sure about these versions so if a walk the VC dir (could be slow)
         for root, _, files in os.walk(vc_dir):
             if _CL_EXE_NAME in files:

--- a/src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
+++ b/src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
@@ -33,7 +33,7 @@ def adjustColumnWidths(ctx, nodeset):
 
     # Get the nominal table width
     varString = lookupVariable(tctxt, "nominal.table.width", None)
-    if varString == None:
+    if varString is None:
         nominalWidth = 6 * pixelsPerInch;
     else:
         nominalWidth = convertLength(varString);
@@ -58,13 +58,13 @@ def adjustColumnWidths(ctx, nodeset):
         colChildren = colgroup.children
 
     col = colChildren
-    while col != None:
+    while col is not None:
         if foStylesheet:
             width = col.prop("column-width")
         else:
             width = col.prop("width")
 
-        if width == None:
+        if width is None:
             width = "1*"
 
         relPart = 0.0
@@ -145,7 +145,7 @@ def adjustColumnWidths(ctx, nodeset):
     # Side-effect free? We don' need no steenkin' side-effect free!
     count = 0
     col = colChildren
-    while col != None:
+    while col is not None:
         if foStylesheet:
             col.setProp("column-width", widths[count])
         else:
@@ -162,7 +162,7 @@ def convertLength(length):
     global unitHash
 
     m = re.search('([+-]?[\d\.]+)(\S+)', length)
-    if m != None and m.lastindex > 1:
+    if m is not None and m.lastindex > 1:
         unit = pixelsPerInch
         if m.group(2) in unitHash:
             unit = unitHash[m.group(2)]
@@ -204,7 +204,7 @@ def correctRoundingError(floatWidths):
 
 def lookupVariable(tctxt, varName, default):
     varString = tctxt.variableLookup(varName, None)
-    if varString == None:
+    if varString is None:
         return default
 
     # If it's a list, get the first element

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -312,18 +312,21 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None):
                       '\n')
             sys.stdout.write(legend)
 
-        tags = ['[']
-        tags.append(' E'[IDX(root.exists())])
-        tags.append(' R'[IDX(root.rexists() and not root.exists())])
-        tags.append(' BbB'[[0,1][IDX(root.has_explicit_builder())] +
-                           [0,2][IDX(root.has_builder())]])
-        tags.append(' S'[IDX(root.side_effect)])
-        tags.append(' P'[IDX(root.precious)])
-        tags.append(' A'[IDX(root.always_build)])
-        tags.append(' C'[IDX(root.is_up_to_date())])
-        tags.append(' N'[IDX(root.noclean)])
-        tags.append(' H'[IDX(root.nocache)])
-        tags.append(']')
+        tags = [
+            '[',
+            ' E'[IDX(root.exists())],
+            ' R'[IDX(root.rexists() and not root.exists())],
+            ' BbB'[
+                [0, 1][IDX(root.has_explicit_builder())] +
+                [0, 2][IDX(root.has_builder())]
+            ],
+            ' S'[IDX(root.side_effect)], ' P'[IDX(root.precious)],
+            ' A'[IDX(root.always_build)],
+            ' C'[IDX(root.is_up_to_date())],
+            ' N'[IDX(root.noclean)],
+            ' H'[IDX(root.nocache)],
+            ']'
+        ]
 
     else:
         tags = []
@@ -350,7 +353,6 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None):
         margin[-1] = 0
         print_tree(children[-1], child_func, prune, idx, margin, visited)
         margin.pop()
-
 
 
 # Functions for deciding if things are like various types, mainly to

--- a/src/engine/SCons/UtilTests.py
+++ b/src/engine/SCons/UtilTests.py
@@ -451,11 +451,11 @@ class UtilTestCase(unittest.TestCase):
         assert get_environment_var("${BAR}") == "BAR", get_environment_var("${BAR}")
         assert get_environment_var("$FOO_BAR1234") == "FOO_BAR1234", get_environment_var("$FOO_BAR1234")
         assert get_environment_var("${BAR_FOO1234}") == "BAR_FOO1234", get_environment_var("${BAR_FOO1234}")
-        assert get_environment_var("${BAR}FOO") == None, get_environment_var("${BAR}FOO")
-        assert get_environment_var("$BAR ") == None, get_environment_var("$BAR ")
-        assert get_environment_var("FOO$BAR") == None, get_environment_var("FOO$BAR")
-        assert get_environment_var("$FOO[0]") == None, get_environment_var("$FOO[0]")
-        assert get_environment_var("${some('complex expression')}") == None, get_environment_var(
+        assert get_environment_var("${BAR}FOO") is None, get_environment_var("${BAR}FOO")
+        assert get_environment_var("$BAR ") is None, get_environment_var("$BAR ")
+        assert get_environment_var("FOO$BAR") is None, get_environment_var("FOO$BAR")
+        assert get_environment_var("$FOO[0]") is None, get_environment_var("$FOO[0]")
+        assert get_environment_var("${some('complex expression')}") is None, get_environment_var(
             "${some('complex expression')}")
 
     def test_Proxy(self):

--- a/test/Value.py
+++ b/test/Value.py
@@ -102,7 +102,7 @@ for source_signature in ['MD5', 'timestamp-newer']:
 
     test.must_contain_all_lines(test.stdout(), [out1, out2, out7, out8])
     #print test.stdout()
-    test.fail_test(re.search(out3, test.stdout()) == None)
+    test.fail_test(re.search(out3, test.stdout()) is None)
 
     test.must_match('f1.out', "/usr/local")
     test.must_match('f2.out', "10")
@@ -118,7 +118,7 @@ for source_signature in ['MD5', 'timestamp-newer']:
     out6 = """create\\(\\["f3.out"\\], \\[<.*.Custom (instance|object) at """
     #" <- unconfuses emacs syntax highlighting
     test.must_contain_all_lines(test.stdout(), [out4, out5])
-    test.fail_test(re.search(out6, test.stdout()) == None)
+    test.fail_test(re.search(out6, test.stdout()) is None)
 
     test.must_match('f1.out', "/usr")
     test.must_match('f2.out', "4")
@@ -134,7 +134,7 @@ for source_signature in ['MD5', 'timestamp-newer']:
 
     test.must_contain_all_lines(test.stdout(), [out4, out7, out8])
     test.must_not_contain_any_line(test.stdout(), [out5])
-    test.fail_test(re.search(out6, test.stdout()) == None)
+    test.fail_test(re.search(out6, test.stdout()) is None)
 
     test.up_to_date(options='prefix=/var', arguments='.')
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1805,7 +1805,7 @@ class TestCmd(object):
         path name.  If the path is a null string (''), a unique
         directory name is created.
         """
-        if (path != None):
+        if path is not None:
             if path == '':
                 path = None
             path = self.tempdir(path)

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -1737,7 +1737,7 @@ class run_TestCase(TestCmdTestCase):
                 pass
 
             test.run(program = 'no_script', interpreter = 'python')
-            assert test.status != None, test.status
+            assert test.status is not None, test.status
 
             try:
                 test.run(program = 'no_script', interpreter = 'no_interpreter')
@@ -1750,7 +1750,7 @@ class run_TestCase(TestCmdTestCase):
                 # Python versions that use os.popen3() or the Popen3
                 # class run things through the shell, which just returns
                 # a non-zero exit status.
-                assert test.status != None, test.status
+                assert test.status is not None, test.status
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
@@ -1816,7 +1816,7 @@ class run_TestCase(TestCmdTestCase):
                 # Python versions that use os.popen3() or the Popen3
                 # class run things through the shell, which just returns
                 # a non-zero exit status.
-                assert test.status != None
+                assert test.status is not None
 
             test1 = TestCmd.TestCmd(program = t.script1,
                                     interpreter = ['python', '-x'],
@@ -2388,7 +2388,7 @@ with open(r'%s', 'wb') as logfp:
 
             p = test.start(program='no_script', interpreter='python')
             status = p.wait()
-            assert status != None, status
+            assert status is not None, status
 
             try:
                 p = test.start(program='no_script', interpreter='no_interpreter')
@@ -2402,7 +2402,7 @@ with open(r'%s', 'wb') as logfp:
                 # Python versions that use os.popen3() or the Popen3
                 # class run things through the shell, which just returns
                 # a non-zero exit status.
-                assert status != None, status
+                assert status is not None, status
 
             testx = TestCmd.TestCmd(program = t.scriptx,
                                     workdir = '',
@@ -3054,11 +3054,11 @@ class workdir_TestCase(TestCmdTestCase):
         assert test.workdir is None
 
         test = TestCmd.TestCmd(workdir = '')
-        assert test.workdir != None
+        assert test.workdir is not None
         assert os.path.isdir(test.workdir)
 
         test = TestCmd.TestCmd(workdir = 'dir')
-        assert test.workdir != None
+        assert test.workdir is not None
         assert os.path.isdir(test.workdir)
 
         no_such_subdir = os.path.join('no', 'such', 'subdir')
@@ -3071,11 +3071,11 @@ class workdir_TestCase(TestCmdTestCase):
 
         test = TestCmd.TestCmd(workdir = 'foo')
         workdir_foo = test.workdir
-        assert workdir_foo != None
+        assert workdir_foo is not None
 
         test.workdir_set('bar')
         workdir_bar = test.workdir
-        assert workdir_bar != None
+        assert workdir_bar is not None
 
         try:
             test.workdir_set(no_such_subdir)


### PR DESCRIPTION
checker-suggested fixes:

- Mostly, fix remaining instances of comparing none without "is"
- Some trailing whitespace on lines
- A couple of instances of list init followed immediately by several appends, turned into a single list init
- Some double comparisons turned into a single expression

Functionally, these should be a no-op, so no doc impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
