### PR TITLE
syntax fixups suggested by PyCharm

### DIFF
--- a/bin/SConsExamples.py
+++ b/bin/SConsExamples.py
@@ -830,7 +830,7 @@ def create_scons_output(e):
         # regardless of reported addresses or Python version.
 
         # Massage addresses in object repr strings to a constant.
-        address_re = re.compile(r' at 0x[0-9a-fA-F]*\>')
+        address_re = re.compile(r' at 0x[0-9a-fA-F]*>')
 
         # Massage file names in stack traces (sometimes reported as absolute
         # paths) to a consistent relative path.

--- a/bin/scons-diff.py
+++ b/bin/scons-diff.py
@@ -54,16 +54,16 @@ for o, a in opts:
     elif o in ('-h', '--help'):
         print(Usage)
         sys.exit(0)
-    elif o in ('-n',):
+    elif o == '-n':
         diff_options.append(o)
         edit_type = o
-    elif o in ('-q',):
+    elif o == '-q':
         diff_type = o
         diff_line = lambda l, r: None
     elif o in ('-r', '--recursive'):
         recursive = True
         diff_options.append(o)
-    elif o in ('-s',):
+    elif o '-s':
         report_same = True
 
 try:

--- a/bin/scons-diff.py
+++ b/bin/scons-diff.py
@@ -30,7 +30,7 @@ Options:
 
 opts, args = getopt.getopt(sys.argv[1:],
                            'c:dhnqrsu:',
-		           ['context=', 'help', 'recursive', 'unified='])
+                           ['context=', 'help', 'recursive', 'unified='])
 
 diff_type = None
 edit_type = None
@@ -53,17 +53,17 @@ for o, a in opts:
         diff_options.append(o)
     elif o in ('-h', '--help'):
         print(Usage)
-	sys.exit(0)
-    elif o in ('-n'):
+        sys.exit(0)
+    elif o in ('-n',):
         diff_options.append(o)
         edit_type = o
-    elif o in ('-q'):
+    elif o in ('-q',):
         diff_type = o
         diff_line = lambda l, r: None
     elif o in ('-r', '--recursive'):
         recursive = True
         diff_options.append(o)
-    elif o in ('-s'):
+    elif o in ('-s',):
         report_same = True
 
 try:

--- a/bin/scons-diff.py
+++ b/bin/scons-diff.py
@@ -63,7 +63,7 @@ for o, a in opts:
     elif o in ('-r', '--recursive'):
         recursive = True
         diff_options.append(o)
-    elif o '-s':
+    elif o == '-s':
         report_same = True
 
 try:

--- a/bin/scons_dev_master.py
+++ b/bin/scons_dev_master.py
@@ -152,11 +152,11 @@ Usage:  scons_dev_master.py [-hnqy] [--password PASSWORD] [--username USER]
                 sys.exit(0)
             elif o in ('-n', '--no-exec'):
                 CommandRunner.execute = CommandRunner.do_not_execute
-            elif o in '--password':
+            elif o == '--password':
                 password = a
             elif o in ('-q', '--quiet'):
                 CommandRunner.display = CommandRunner.do_not_display
-            elif o in '--username':
+            elif o == '--username':
                 username = a
             elif o in ('-y', '--yes', '--assume-yes'):
                 yesflag = o

--- a/bin/scons_dev_master.py
+++ b/bin/scons_dev_master.py
@@ -152,11 +152,11 @@ Usage:  scons_dev_master.py [-hnqy] [--password PASSWORD] [--username USER]
                 sys.exit(0)
             elif o in ('-n', '--no-exec'):
                 CommandRunner.execute = CommandRunner.do_not_execute
-            elif o in ('--password'):
+            elif o in '--password':
                 password = a
             elif o in ('-q', '--quiet'):
                 CommandRunner.display = CommandRunner.do_not_display
-            elif o in ('--username'):
+            elif o in '--username':
                 username = a
             elif o in ('-y', '--yes', '--assume-yes'):
                 yesflag = o

--- a/bin/svn-bisect.py
+++ b/bin/svn-bisect.py
@@ -33,7 +33,7 @@ def error(s):
 
 # update to the specified version and run test
 def testfail(revision):
-    "Return true if test fails"
+    """Return true if test fails"""
     print("Updating to revision", revision)
     if subprocess.call(["svn","up","-qr",str(revision)]) != 0:
         m = "SVN did not update properly to revision %d"

--- a/bin/update-release-info.py
+++ b/bin/update-release-info.py
@@ -146,13 +146,9 @@ except KeyError:
 if DEBUG: print('copyright years', copyright_years)
 
 class UpdateFile(object):
-    """
-    XXX
-    """
+    """ XXX """
 
     def __init__(self, file, orig = None):
-        '''
-        '''
         if orig is None: orig = file
         try:
             with open(orig, 'r') as f:
@@ -171,15 +167,11 @@ class UpdateFile(object):
                 self.orig = ''
 
     def sub(self, pattern, replacement, count = 1):
-        '''
-        XXX
-        '''
+        """ XXX """
         self.content = re.sub(pattern, replacement, self.content, count)
 
     def replace_assign(self, name, replacement, count = 1):
-        '''
-        XXX
-        '''
+        """ XXX """
         self.sub('\n' + name + ' = .*', '\n' + name + ' = ' + replacement)
 
     # Determine the pattern to match a version
@@ -189,9 +181,7 @@ class UpdateFile(object):
     match_rel = re.compile(match_pat)
 
     def replace_version(self, replacement = version_string, count = 1):
-        '''
-        XXX
-        '''
+        """ XXX """
         self.content = self.match_rel.sub(replacement, self.content, count)
 
     # Determine the release date and the pattern to match a date
@@ -213,15 +203,11 @@ class UpdateFile(object):
     match_date = re.compile(match_date)
 
     def replace_date(self, replacement = new_date, count = 1):
-        '''
-        XXX
-        '''
+        """ XXX """
         self.content = self.match_date.sub(replacement, self.content, count)
 
     def __del__(self):
-        '''
-        XXX
-        '''
+        """ XXX """
         if self.file is not None and self.content != self.orig:
             print('Updating ' + self.file + '...')
             with open(self.file, 'w') as f:

--- a/site_scons/Utilities.py
+++ b/site_scons/Utilities.py
@@ -7,7 +7,7 @@ import distutils.util
 platform = distutils.util.get_platform()
 
 def is_windows():
-    " Check if we're on a Windows platform"
+    """ Check if we're on a Windows platform"""
     if platform.startswith('win'):
         return True
     else:

--- a/site_scons/soe_utils.py
+++ b/site_scons/soe_utils.py
@@ -28,7 +28,7 @@ def soelim(target, source, env):
 
 def soscan(node, env, path):
     c = node.get_text_contents()
-    return re.compile(r"^[\.']so\s+(\S+)", re.M).findall(c)
+    return re.compile(r"^[.']so\s+(\S+)", re.M).findall(c)
 
 soelimbuilder = Builder(action = Action(soelim),
                         source_scanner = Scanner(soscan))

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -16,6 +16,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Remove deprecated SourceCode
     - str.format syntax errors fixed
+    - a bunch of linter/checker syntax fixups
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/engine/SCons/BuilderTests.py
+++ b/src/engine/SCons/BuilderTests.py
@@ -581,7 +581,7 @@ class BuilderTestCase(unittest.TestCase):
         assert b5.src_suffixes(env) == ['.y'], b5.src_suffixes(env)
 
     def test_srcsuffix_nonext(self):
-        "Test target generation from non-extension source suffixes"
+        """Test target generation from non-extension source suffixes"""
         env = Environment()
         b6 = SCons.Builder.Builder(action = '',
                                    src_suffix='_src.a',
@@ -679,7 +679,7 @@ class BuilderTestCase(unittest.TestCase):
             """create the file"""
             with open(str(target[0]), "w"):
                 pass
-            if (len(source) == 1 and len(target) == 1):
+            if len(source) == 1 and len(target) == 1:
                 env['CNT'][0] = env['CNT'][0] + 1
 
         env = Environment()

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -2247,7 +2247,7 @@ class Base(SubstitutionEnvironment):
         build_source(node.all_children())
 
         def final_source(node):
-            while (node != node.srcnode()):
+            while node != node.srcnode():
               node = node.srcnode()
             return node
         sources = list(map(final_source, sources))

--- a/src/engine/SCons/EnvironmentTests.py
+++ b/src/engine/SCons/EnvironmentTests.py
@@ -726,7 +726,7 @@ sys.exit(0)
         assert r == 'replace_func2', r
 
     def test_Override(self):
-        "Test overriding construction variables"
+        """Test overriding construction variables"""
         env = SubstitutionEnvironment(ONE=1, TWO=2, THREE=3, FOUR=4)
         assert env['ONE'] == 1, env['ONE']
         assert env['TWO'] == 2, env['TWO']
@@ -1408,7 +1408,7 @@ def exists(env):
         assert env['XYZ'] == 'ddd', env
 
     def test_concat(self):
-        "Test _concat()"
+        """Test _concat()"""
         e1 = self.TestEnvironment(PRE='pre', SUF='suf', STR='a b', LIST=['a', 'b'])
         s = e1.subst
         x = s("${_concat('', '', '', __env__)}")
@@ -1423,7 +1423,7 @@ def exists(env):
         assert x == 'preasuf prebsuf', x
 
     def test_concat_nested(self):
-        "Test _concat() on a nested substitution strings."
+        """Test _concat() on a nested substitution strings."""
         e = self.TestEnvironment(PRE='pre', SUF='suf',
                                  L1=['a', 'b'],
                                  L2=['c', 'd'],
@@ -1956,7 +1956,7 @@ def generate(env):
         assert 'XXX' not in env.Dictionary()
 
     def test_FindIxes(self):
-        "Test FindIxes()"
+        """Test FindIxes()"""
         env = self.TestEnvironment(LIBPREFIX='lib',
                           LIBSUFFIX='.a',
                           SHLIBPREFIX='lib',
@@ -2398,7 +2398,7 @@ f5: \
         assert hasattr(env3, 'b2'), "b2 was not set"
 
     def test_ReplaceIxes(self):
-        "Test ReplaceIxes()"
+        """Test ReplaceIxes()"""
         env = self.TestEnvironment(LIBPREFIX='lib',
                           LIBSUFFIX='.a',
                           SHLIBPREFIX='lib',
@@ -3431,7 +3431,7 @@ def generate(env):
             assert x in over, bad_msg % x
 
     def test_parse_flags(self):
-        '''Test the Base class parse_flags argument'''
+        """Test the Base class parse_flags argument"""
         # all we have to show is that it gets to MergeFlags internally
         env = Environment(tools=[], parse_flags = '-X')
         assert env['CCFLAGS'] == ['-X'], env['CCFLAGS']
@@ -3445,7 +3445,7 @@ def generate(env):
         assert env['CPPDEFINES'] == ['FOO', 'BAR'], env['CPPDEFINES']
 
     def test_clone_parse_flags(self):
-        '''Test the env.Clone() parse_flags argument'''
+        """Test the env.Clone() parse_flags argument"""
         # all we have to show is that it gets to MergeFlags internally
         env = Environment(tools = [])
         env2 = env.Clone(parse_flags = '-X')
@@ -3714,7 +3714,7 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
         assert x == ['x3', 'y3', 'z3'], x
 
     def test_parse_flags(self):
-        '''Test the OverrideEnvironment parse_flags argument'''
+        """Test the OverrideEnvironment parse_flags argument"""
         # all we have to show is that it gets to MergeFlags internally
         env = SubstitutionEnvironment()
         env2 = env.Override({'parse_flags' : '-X'})

--- a/src/engine/SCons/EnvironmentValues.py
+++ b/src/engine/SCons/EnvironmentValues.py
@@ -3,7 +3,7 @@ import re
 _is_valid_var = re.compile(r'[_a-zA-Z]\w*$')
 
 _rm = re.compile(r'\$[()]')
-_remove = re.compile(r'\$\([^\$]*(\$[^\)][^\$]*)*\$\)')
+_remove = re.compile(r'\$\([^$]*(\$[^)][^$]*)*\$\)')
 
 # Regular expressions for splitting strings and handling substitutions,
 # for use by the scons_subst() and scons_subst_list() functions:
@@ -28,7 +28,7 @@ _remove = re.compile(r'\$\([^\$]*(\$[^\)][^\$]*)*\$\)')
 #
 _dollar_exps_str = r'\$[\$\(\)]|\$[_a-zA-Z][\.\w]*|\${[^}]*}'
 _dollar_exps = re.compile(r'(%s)' % _dollar_exps_str)
-_separate_args = re.compile(r'(%s|\s+|[^\s\$]+|\$)' % _dollar_exps_str)
+_separate_args = re.compile(r'(%s|\s+|[^\s$]+|\$)' % _dollar_exps_str)
 
 # This regular expression is used to replace strings of multiple white
 # space characters in the string result from the scons_subst() function.

--- a/src/engine/SCons/JobTests.py
+++ b/src/engine/SCons/JobTests.py
@@ -46,7 +46,7 @@ def get_cpu_nums():
             return int( os.popen2( "sysctl -n hw.ncpu")[1].read() )
     # Windows:
     if "NUMBER_OF_PROCESSORS" in os.environ:
-        ncpus = int( os.environ[ "NUMBER_OF_PROCESSORS" ] );
+        ncpus = int(os.environ["NUMBER_OF_PROCESSORS"])
     if ncpus > 0:
         return ncpus
     return 1 # Default
@@ -59,14 +59,14 @@ num_jobs = get_cpu_nums()*2
 
 # in case we werent able to detect num cpus for this test
 # just make a hardcoded suffcient large number, though not future proof
-if(num_jobs == 2):
+if num_jobs == 2:
     num_jobs = 33
 
 # how many tasks to perform for the test
 num_tasks = num_jobs*5
 
 class DummyLock(object):
-    "fake lock class to use if threads are not supported"
+    """fake lock class to use if threads are not supported"""
     def acquire(self):
         pass
 
@@ -74,7 +74,7 @@ class DummyLock(object):
         pass
 
 class NoThreadsException(Exception):
-    "raised by the ParallelTestCase if threads are not supported"
+    """raised by the ParallelTestCase if threads are not supported"""
 
     def __str__(self):
         return "the interpreter doesn't support threads"
@@ -113,7 +113,7 @@ class Task(object):
 
         # check if task was executing while another was also executing
         for j in range(1, self.taskmaster.num_tasks):
-            if(self.taskmaster.parallel_list[j+1] == 1):
+            if self.taskmaster.parallel_list[j + 1] == 1:
                 self.taskmaster.found_parallel = True
                 break
 
@@ -237,7 +237,7 @@ class Taskmaster(object):
         return self.num_postprocessed == self.num_tasks
 
     def tasks_were_serial(self):
-        "analyze the task order to see if they were serial"
+        """analyze the task order to see if they were serial"""
         return not self.found_parallel
 
     def exception_set(self):
@@ -251,7 +251,7 @@ ThreadPoolCallList = []
 
 class ParallelTestCase(unittest.TestCase):
     def runTest(self):
-        "test parallel jobs"
+        """test parallel jobs"""
 
         try:
             import threading
@@ -319,7 +319,7 @@ class ParallelTestCase(unittest.TestCase):
 
 class SerialTestCase(unittest.TestCase):
     def runTest(self):
-        "test a serial job"
+        """test a serial job"""
 
         taskmaster = Taskmaster(num_tasks, self, RandomTask)
         jobs = SCons.Job.Jobs(1, taskmaster)
@@ -338,7 +338,7 @@ class SerialTestCase(unittest.TestCase):
 
 class NoParallelTestCase(unittest.TestCase):
     def runTest(self):
-        "test handling lack of parallel support"
+        """test handling lack of parallel support"""
         def NoParallel(tm, num, stack_size):
             raise NameError
         save_Parallel = SCons.Job.Parallel
@@ -365,7 +365,7 @@ class NoParallelTestCase(unittest.TestCase):
 
 class SerialExceptionTestCase(unittest.TestCase):
     def runTest(self):
-        "test a serial job with tasks that raise exceptions"
+        """test a serial job with tasks that raise exceptions"""
 
         taskmaster = Taskmaster(num_tasks, self, ExceptionTask)
         jobs = SCons.Job.Jobs(1, taskmaster)
@@ -382,7 +382,7 @@ class SerialExceptionTestCase(unittest.TestCase):
 
 class ParallelExceptionTestCase(unittest.TestCase):
     def runTest(self):
-        "test parallel jobs with tasks that raise exceptions"
+        """test parallel jobs with tasks that raise exceptions"""
 
         taskmaster = Taskmaster(num_tasks, self, ExceptionTask)
         jobs = SCons.Job.Jobs(num_jobs, taskmaster)
@@ -534,13 +534,13 @@ class _SConsTaskTest(unittest.TestCase):
 
 class SerialTaskTest(_SConsTaskTest):
     def runTest(self):
-        "test serial jobs with actual Taskmaster and Task"
+        """test serial jobs with actual Taskmaster and Task"""
         self._test_seq(1)
 
 
 class ParallelTaskTest(_SConsTaskTest):
     def runTest(self):
-        "test parallel jobs with actual Taskmaster and Task"
+        """test parallel jobs with actual Taskmaster and Task"""
         self._test_seq(num_jobs)
 
 

--- a/src/engine/SCons/Node/Alias.py
+++ b/src/engine/SCons/Node/Alias.py
@@ -37,6 +37,7 @@ import collections
 import SCons.Errors
 import SCons.Node
 import SCons.Util
+from SCons.Util import MD5signature
 
 class AliasNameSpace(collections.UserDict):
     def Alias(self, name, **kw):
@@ -166,7 +167,7 @@ class Alias(SCons.Node.Node):
             pass
 
         contents = self.get_contents()
-        csig = SCons.Util.MD5signature(contents)
+        csig = MD5signature(contents)
         self.get_ninfo().csig = csig
         return csig
 

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -54,6 +54,7 @@ import SCons.Node
 import SCons.Node.Alias
 import SCons.Subst
 import SCons.Util
+from SCons.Util import MD5signature, MD5filesignature, MD5collect
 import SCons.Warnings
 
 from SCons.Debug import Trace
@@ -1862,7 +1863,7 @@ class Dir(Base):
         node is called which has a child directory, the child
         directory should return the hash of its contents."""
         contents = self.get_contents()
-        return SCons.Util.MD5signature(contents)
+        return MD5signature(contents)
 
     def do_duplicate(self, src):
         pass
@@ -2501,14 +2502,14 @@ class FileBuildInfo(SCons.Node.BuildInfoBase):
 
     Attributes unique to FileBuildInfo:
         dependency_map : Caches file->csig mapping
-                    for all dependencies.  Currently this is only used when using
-                    MD5-timestamp decider.
-                    It's used to ensure that we copy the correct
-                    csig from previous build to be written to .sconsign when current build
-                    is done. Previously the matching of csig to file was strictly by order
-                    they appeared in bdepends, bsources, or bimplicit, and so a change in order
-                    or count of any of these could yield writing wrong csig, and then false positive
-                    rebuilds
+            for all dependencies.  Currently this is only used when using
+            MD5-timestamp decider.
+            It's used to ensure that we copy the correct csig from the
+            previous build to be written to .sconsign when current build
+            is done. Previously the matching of csig to file was strictly
+            by order they appeared in bdepends, bsources, or bimplicit,
+            and so a change in order or count of any of these could
+            yield writing wrong csig, and then false positive rebuilds
     """
     __slots__ = ['dependency_map', ]
     current_version_id = 2
@@ -2723,11 +2724,10 @@ class File(Base):
         Compute and return the MD5 hash for this file.
         """
         if not self.rexists():
-            return SCons.Util.MD5signature('')
+            return MD5signature('')
         fname = self.rfile().get_abspath()
         try:
-            cs = SCons.Util.MD5filesignature(fname,
-                chunksize=SCons.Node.FS.File.md5_chunksize*1024)
+            cs = MD5filesignature(fname, chunksize=File.md5_chunksize * 1024)
         except EnvironmentError as e:
             if not e.filename:
                 e.filename = fname
@@ -3028,7 +3028,7 @@ class File(Base):
 
          @see: built() and Node.release_target_info()
          """
-        if (self.released_target_info or SCons.Node.interactive):
+        if self.released_target_info or SCons.Node.interactive:
             return
 
         if not hasattr(self.attributes, 'keep_targetinfo'):
@@ -3210,7 +3210,7 @@ class File(Base):
         if csig is None:
 
             try:
-                if self.get_size() < SCons.Node.FS.File.md5_chunksize:
+                if self.get_size() < File.md5_chunksize:
                     contents = self.get_contents()
                 else:
                     csig = self.get_content_hash()
@@ -3312,7 +3312,7 @@ class File(Base):
 
         # For an "empty" binfo properties like bsources
         # do not exist: check this to avoid exception.
-        if (len(binfo.bsourcesigs) + len(binfo.bdependsigs) + \
+        if (len(binfo.bsourcesigs) + len(binfo.bdependsigs) +
             len(binfo.bimplicitsigs)) == 0:
             return {}
 
@@ -3580,7 +3580,7 @@ class File(Base):
                 node = repo_dir.file_on_disk(self.name)
 
             if node and node.exists() and \
-                    (isinstance(node, File) or isinstance(node, Entry) \
+                    (isinstance(node, File) or isinstance(node, Entry)
                      or not node.is_derived()):
                 retvals.append(node)
 
@@ -3611,8 +3611,7 @@ class File(Base):
 
         cachedir, cachefile = self.get_build_env().get_CacheDir().cachepath(self)
         if not self.exists() and cachefile and os.path.exists(cachefile):
-            self.cachedir_csig = SCons.Util.MD5filesignature(cachefile, \
-                SCons.Node.FS.File.md5_chunksize * 1024)
+            self.cachedir_csig = MD5filesignature(cachefile, File.md5_chunksize * 1024)
         else:
             self.cachedir_csig = self.get_csig()
         return self.cachedir_csig
@@ -3632,7 +3631,7 @@ class File(Base):
 
         executor = self.get_executor()
 
-        result = self.contentsig = SCons.Util.MD5signature(executor.get_contents())
+        result = self.contentsig = MD5signature(executor.get_contents())
         return result
 
     def get_cachedir_bsig(self):
@@ -3663,7 +3662,7 @@ class File(Base):
         sigs.append(self.get_internal_path())
 
         # Merge this all into a single signature
-        result = self.cachesig = SCons.Util.MD5collect(sigs)
+        result = self.cachesig = MD5collect(sigs)
         return result
 
 default_fs = None

--- a/src/engine/SCons/Node/NodeTests.py
+++ b/src/engine/SCons/Node/NodeTests.py
@@ -1304,7 +1304,7 @@ class NodeTestCase(unittest.TestCase):
     def test_postprocess(self):
         """Test calling the base Node postprocess() method"""
         n = SCons.Node.Node()
-        n.waiting_parents = set( ['foo','bar'] )
+        n.waiting_parents = {'foo', 'bar'}
 
         n.postprocess()
         assert n.waiting_parents == set(), n.waiting_parents
@@ -1316,7 +1316,7 @@ class NodeTestCase(unittest.TestCase):
         assert n1.waiting_parents == set(), n1.waiting_parents
         r = n1.add_to_waiting_parents(n2)
         assert r == 1, r
-        assert n1.waiting_parents == set((n2,)), n1.waiting_parents
+        assert n1.waiting_parents == {n2}, n1.waiting_parents
         r = n1.add_to_waiting_parents(n2)
         assert r == 0, r
 

--- a/src/engine/SCons/Node/__init__.py
+++ b/src/engine/SCons/Node/__init__.py
@@ -60,6 +60,7 @@ from SCons.Debug import logInstanceCreation
 import SCons.Executor
 import SCons.Memoize
 import SCons.Util
+from SCons.Util import MD5signature
 
 from SCons.Debug import Trace
 
@@ -1167,7 +1168,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
 
         if self.has_builder():
             binfo.bact = str(executor)
-            binfo.bactsig = SCons.Util.MD5signature(executor.get_contents())
+            binfo.bactsig = MD5signature(executor.get_contents())
 
         if self._specific_sources:
             sources = [s for s in self.sources if s not in ignore_set]
@@ -1205,7 +1206,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
             return self.ninfo.csig
         except AttributeError:
             ninfo = self.get_ninfo()
-            ninfo.csig = SCons.Util.MD5signature(self.get_contents())
+            ninfo.csig = MD5signature(self.get_contents())
             return self.ninfo.csig
 
     def get_cachedir_csig(self):
@@ -1496,7 +1497,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
 
         if self.has_builder():
             contents = self.get_executor().get_contents()
-            newsig = SCons.Util.MD5signature(contents)
+            newsig = MD5signature(contents)
             if bi.bactsig != newsig:
                 if t: Trace(': bactsig %s != newsig %s' % (bi.bactsig, newsig))
                 result = True

--- a/src/engine/SCons/PathListTests.py
+++ b/src/engine/SCons/PathListTests.py
@@ -108,7 +108,7 @@ class subst_pathTestCase(unittest.TestCase):
 
         self.env.subst = lambda s, target, source, conv: 'NOT THIS STRING'
 
-        pl = SCons.PathList.PathList(('x'))
+        pl = SCons.PathList.PathList(('x',))
 
         result = pl.subst_path(self.env, 'y', 'z')
 

--- a/src/engine/SCons/Platform/virtualenv.py
+++ b/src/engine/SCons/Platform/virtualenv.py
@@ -61,7 +61,7 @@ def _is_path_in(path, base):
     if not path or not base: # empty path may happen, base too
         return False
     rp = os.path.relpath(path, base)
-    return ((not rp.startswith(os.path.pardir)) and (not rp == os.path.curdir))
+    return (not rp.startswith(os.path.pardir)) and (not rp == os.path.curdir)
 
 
 def _inject_venv_variables(env):

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -270,7 +270,7 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
         cached_error = False
         cachable = True
         for t in self.targets:
-            if T: Trace('%s' % (t))
+            if T: Trace('%s' % t)
             bi = t.get_stored_info().binfo
             if isinstance(bi, SConfBuildInfo):
                 if T: Trace(': SConfBuildInfo')
@@ -280,7 +280,7 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
                 else:
                     if T: Trace(': get_state() %s' % t.get_state())
                     if T: Trace(': changed() %s' % t.changed())
-                    if (t.get_state() != SCons.Node.up_to_date and t.changed()):
+                    if t.get_state() != SCons.Node.up_to_date and t.changed():
                         changed = True
                     if T: Trace(': changed %s' % changed)
                 cached_error = cached_error or bi.result
@@ -668,7 +668,7 @@ class SConfBase(object):
         is saved in self.lastTarget (for further processing).
         """
         ok = self.TryLink(text, extension)
-        if( ok ):
+        if ok:
             prog = self.lastTarget
             pname = prog.get_internal_path()
             output = self.confdir.File(os.path.basename(pname)+'.out')
@@ -866,9 +866,9 @@ class CheckContext(object):
         return self.sconf.TryRun(*args, **kw)
 
     def __getattr__( self, attr ):
-        if( attr == 'env' ):
+        if attr == 'env':
             return self.sconf.env
-        elif( attr == 'lastTarget' ):
+        elif attr == 'lastTarget':
             return self.sconf.lastTarget
         else:
             raise AttributeError("CheckContext instance has no attribute '%s'" % attr)

--- a/src/engine/SCons/SConfTests.py
+++ b/src/engine/SCons/SConfTests.py
@@ -151,7 +151,7 @@ class SConfTestCase(unittest.TestCase):
                                  log_file=self.test.workpath('config.log'))
         no_std_header_h = self.test.workpath('config.tests', 'no_std_header.h')
         test_h = self.test.write( no_std_header_h,
-                                  "/* we are changing a dependency now */\n" );
+                                  "/* we are changing a dependency now */\n" )
         try:
             res = checks( self, sconf, TryFunc )
             log = self.test.read( self.test.workpath('config.log') )

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -355,7 +355,7 @@ class CleanTask(SCons.Taskmaster.AlwaysTask):
                     display("Removed directory " + pathstr)
                 else:
                     errstr = "Path '%s' exists but isn't a file or directory."
-                    raise SCons.Errors.UserError(errstr % (pathstr))
+                    raise SCons.Errors.UserError(errstr % pathstr)
         except SCons.Errors.UserError as e:
             print(e)
         except (IOError, OSError) as e:

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -28,7 +28,7 @@ import re
 import sys
 import textwrap
 
-no_hyphen_re = re.compile(r'(\s+|(?<=[\w\!\"\'\&\.\,\?])-{2,}(?=\w))')
+no_hyphen_re = re.compile(r'(\s+|(?<=[\w!\"\'&.,?])-{2,}(?=\w))')
 
 try:
     from gettext import gettext

--- a/src/engine/SCons/Subst.py
+++ b/src/engine/SCons/Subst.py
@@ -754,7 +754,7 @@ _list_remove = [ _rm_list, None, _remove_list ]
 #
 _dollar_exps_str = r'\$[\$\(\)]|\$[_a-zA-Z][\.\w]*|\${[^}]*}'
 _dollar_exps = re.compile(r'(%s)' % _dollar_exps_str)
-_separate_args = re.compile(r'(%s|\s+|[^\s\$]+|\$)' % _dollar_exps_str)
+_separate_args = re.compile(r'(%s|\s+|[^\s$]+|\$)' % _dollar_exps_str)
 
 # This regular expression is used to replace strings of multiple white
 # space characters in the string result from the scons_subst() function.

--- a/src/engine/SCons/SubstTests.py
+++ b/src/engine/SCons/SubstTests.py
@@ -133,8 +133,8 @@ class SubstTestCase(unittest.TestCase):
             return self.value
 
     # only use of this is currently commented out below
-    def function_foo(arg):
-        pass
+    #def function_foo(arg):
+    #    pass
 
     target = [ MyNode("./foo/bar.exe"),
                MyNode("/bar/baz with spaces.obj"),
@@ -207,7 +207,7 @@ class SubstTestCase(unittest.TestCase):
         'S'         : 'x y',
         'LS'        : ['x y'],
         'L'         : ['x', 'y'],
-        'TS'        : ('x y'),
+        'TS'        : ('x y',),
         'T'         : ('x', 'y'),
         'CS'        : cs,
         'CL'        : cl,

--- a/src/engine/SCons/Tool/JavaCommon.py
+++ b/src/engine/SCons/Tool/JavaCommon.py
@@ -40,7 +40,7 @@ default_java_version = '1.4'
 
 # a switch for which jdk versions to use the Scope state for smarter
 # anonymous inner class parsing.
-scopeStateVersions = ('1.8')
+scopeStateVersions = ('1.8',)
 
 # Glob patterns for use in finding where the JDK is.
 # These are pairs, *dir_glob used in the general case,
@@ -87,8 +87,8 @@ if java_parsing:
     #     any alphanumeric token surrounded by angle brackets (generics);
     #     the multi-line comment begin and end tokens /* and */;
     #     array declarations "[]".
-    _reToken = re.compile(r'(\n|\\\\|//|\\[\'"]|[\'"\{\}\;\.\(\)]|' +
-                          r'\d*\.\d*|[A-Za-z_][\w\$\.]*|<[A-Za-z_]\w+>|' +
+    _reToken = re.compile(r'(\n|\\\\|//|\\[\'"]|[\'"{\};.()]|' +
+                          r'\d*\.\d*|[A-Za-z_][\w$.]*|<[A-Za-z_]\w+>|' +
                           r'/\*|\*/|\[\])')
 
 

--- a/src/engine/SCons/Tool/MSCommon/sdk.py
+++ b/src/engine/SCons/Tool/MSCommon/sdk.py
@@ -110,12 +110,12 @@ class SDKDefinition(object):
         """ Return the script to initialize the VC compiler installed by SDK
         """
 
-        if (host_arch == 'amd64' and target_arch == 'x86'):
+        if host_arch == 'amd64' and target_arch == 'x86':
             # No cross tools needed compiling 32 bits on 64 bit machine
             host_arch=target_arch
 
         arch_string=target_arch
-        if (host_arch != target_arch):
+        if host_arch != target_arch:
             arch_string='%s_%s'%(host_arch,target_arch)
 
         debug("get_sdk_vc_script():arch_string:%s host_arch:%s target_arch:%s"%(arch_string,

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -766,12 +766,12 @@ def msvc_find_valid_batch_script(env, version):
                 vc_script=None
                 continue
         if not vc_script and sdk_script:
-            debug('msvc_find_valid_batch_script() use_script 4: trying sdk script: %s'%(sdk_script))
+            debug('msvc_find_valid_batch_script() use_script 4: trying sdk script: %s' % sdk_script)
             try:
                 d = script_env(sdk_script)
                 found = sdk_script
             except BatchFileExecutionError as e:
-                debug('msvc_find_valid_batch_script() use_script 5: failed running SDK script %s: Error:%s'%(repr(sdk_script),e))
+                debug('msvc_find_valid_batch_script() use_script 5: failed running SDK script %s: Error:%s'%(repr(sdk_script), e))
                 continue
         elif not vc_script and not sdk_script:
             debug('msvc_find_valid_batch_script() use_script 6: Neither VC script nor SDK script found')

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -774,11 +774,11 @@ def EmitLibSymlinks(env, symlinks, libnode, **kw):
 
     for link, linktgt in symlinks:
         env.SideEffect(link, linktgt)
-        if (Verbose):
+        if Verbose:
             print("EmitLibSymlinks: SideEffect(%r,%r)" % (link.get_path(), linktgt.get_path()))
         clean_list = [x for x in nodes if x != linktgt]
         env.Clean(list(set([linktgt] + clean_targets)), clean_list)
-        if (Verbose):
+        if Verbose:
             print("EmitLibSymlinks: Clean(%r,%r)" % (linktgt.get_path(), [x.get_path() for x in clean_list]))
 
 
@@ -792,18 +792,18 @@ def CreateLibSymlinks(env, symlinks):
     for link, linktgt in symlinks:
         linktgt = link.get_dir().rel_path(linktgt)
         link = link.get_path()
-        if (Verbose):
+        if Verbose:
             print("CreateLibSymlinks: preparing to add symlink %r -> %r" % (link, linktgt))
         # Delete the (previously created) symlink if exists. Let only symlinks
         # to be deleted to prevent accidental deletion of source files...
         if env.fs.islink(link):
             env.fs.unlink(link)
-            if (Verbose):
+            if Verbose:
                 print("CreateLibSymlinks: removed old symlink %r" % link)
         # If a file or directory exists with the same name as link, an OSError
         # will be thrown, which should be enough, I think.
         env.fs.symlink(linktgt, link)
-        if (Verbose):
+        if Verbose:
             print("CreateLibSymlinks: add symlink %r -> %r" % (link, linktgt))
     return 0
 

--- a/src/engine/SCons/Tool/docbook/__init__.py
+++ b/src/engine/SCons/Tool/docbook/__init__.py
@@ -135,7 +135,7 @@ def __get_xml_text(root):
     """ Return the text for the given root node (xml.dom.minidom). """
     txt = ""
     for e in root.childNodes:
-        if (e.nodeType == e.TEXT_NODE):
+        if e.nodeType == e.TEXT_NODE:
             txt += e.data
     return txt
 
@@ -207,7 +207,7 @@ def _detect(env):
     if env.get('DOCBOOK_PREFER_XSLTPROC',''):
         prefer_xsltproc = True
 
-    if ((not has_libxml2 and not has_lxml) or (prefer_xsltproc)):
+    if (not has_libxml2 and not has_lxml) or prefer_xsltproc:
         # Try to find the XSLT processors
         __detect_cl_tool(env, 'DOCBOOK_XSLTPROC', xsltproc_com, xsltproc_com_priority)
         __detect_cl_tool(env, 'DOCBOOK_XMLLINT', xmllint_com)

--- a/src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
+++ b/src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
@@ -34,9 +34,9 @@ def adjustColumnWidths(ctx, nodeset):
     # Get the nominal table width
     varString = lookupVariable(tctxt, "nominal.table.width", None)
     if varString is None:
-        nominalWidth = 6 * pixelsPerInch;
+        nominalWidth = 6 * pixelsPerInch
     else:
-        nominalWidth = convertLength(varString);
+        nominalWidth = convertLength(varString)
 
     # Get the requested table width
     tableWidth = lookupVariable(tctxt, "table.width", "100%")
@@ -161,7 +161,7 @@ def convertLength(length):
     global pixelsPerInch
     global unitHash
 
-    m = re.search('([+-]?[\d\.]+)(\S+)', length)
+    m = re.search('([+-]?[\d.]+)(\S+)', length)
     if m is not None and m.lastindex > 1:
         unit = pixelsPerInch
         if m.group(2) in unitHash:

--- a/src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/xslt.py
+++ b/src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/xslt.py
@@ -36,7 +36,7 @@ try:
         outfile = None
 
     count = 4
-    while (sys.argv[count]):
+    while sys.argv[count]:
         try:
             name, value = sys.argv[count].split("=", 2)
             if name in params:

--- a/src/engine/SCons/Tool/intelc.py
+++ b/src/engine/SCons/Tool/intelc.py
@@ -318,7 +318,7 @@ def get_intel_compiler_top(version, abi):
         if not os.path.exists(os.path.join(top, "Bin", "icl.exe")) \
               and not os.path.exists(os.path.join(top, "Bin", abi, "icl.exe")) \
               and not os.path.exists(os.path.join(top, "Bin", archdir, "icl.exe")):
-            raise MissingDirError("Can't find Intel compiler in %s"%(top))
+            raise MissingDirError("Can't find Intel compiler in %s" % top)
     elif is_mac or is_linux:
         def find_in_2008style_dir(version):
             # first dir is new (>=9.0) style, second is old (8.0) style.

--- a/src/engine/SCons/Tool/jar.py
+++ b/src/engine/SCons/Tool/jar.py
@@ -158,7 +158,7 @@ def Jar(env, target = None, source = [], *args, **kw):
     #       files.
     def dir_to_class(s):
         dir_targets = env.JavaClassDir(source = s, *args, **kw)
-        if(dir_targets == []):
+        if dir_targets == []:
             # no classes files could be built from the source dir
             # so pass the dir as is.
             return [env.fs.Dir(s)]

--- a/src/engine/SCons/Tool/javah.py
+++ b/src/engine/SCons/Tool/javah.py
@@ -115,7 +115,7 @@ def getJavaHClassPath(env,target, source, for_signature):
     path = "${SOURCE.attributes.java_classdir}"
     if 'JAVACLASSPATH' in env and env['JAVACLASSPATH']:
         path = SCons.Util.AppendPath(path, env['JAVACLASSPATH'])
-    return "-classpath %s" % (path)
+    return "-classpath %s" % path
 
 def generate(env):
     """Add Builders and construction variables for javah to an Environment."""

--- a/src/engine/SCons/Tool/mslink.py
+++ b/src/engine/SCons/Tool/mslink.py
@@ -220,7 +220,7 @@ def embedManifestDllCheck(target, source, env):
     if env.get('WINDOWS_EMBED_MANIFEST', 0):
         manifestSrc = target[0].get_abspath() + '.manifest'
         if os.path.exists(manifestSrc):
-            ret = (embedManifestDllAction) ([target[0]],None,env)
+            ret = embedManifestDllAction([target[0]], None, env)
             if ret:
                 raise SCons.Errors.UserError("Unable to embed manifest into %s" % (target[0]))
             return ret
@@ -234,7 +234,7 @@ def embedManifestExeCheck(target, source, env):
     if env.get('WINDOWS_EMBED_MANIFEST', 0):
         manifestSrc = target[0].get_abspath() + '.manifest'
         if os.path.exists(manifestSrc):
-            ret = (embedManifestExeAction) ([target[0]],None,env)
+            ret = embedManifestExeAction([target[0]], None, env)
             if ret:
                 raise SCons.Errors.UserError("Unable to embed manifest into %s" % (target[0]))
             return ret

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -172,9 +172,9 @@ def makeHierarchy(sources):
     return hierarchy
 
 class _UserGenerator(object):
-    '''
+    """
     Base class for .dsp.user file generator
-    '''
+    """
     # Default instance values.
     # Ok ... a bit defensive, but it does not seem reasonable to crash the
     # build for a workspace user file. :-)
@@ -980,7 +980,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
             if SCons.Util.is_Dict(value):
                 self.file.write('\t\t\t<Filter\n'
                                 '\t\t\t\tName="%s"\n'
-                                '\t\t\t\tFilter="">\n' % (key))
+                                '\t\t\t\tFilter="">\n' % key)
                 self.printSources(value, commonprefix)
                 self.file.write('\t\t\t</Filter>\n')
 
@@ -992,7 +992,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
                 file = os.path.normpath(file)
                 self.file.write('\t\t\t<File\n'
                                 '\t\t\t\tRelativePath="%s">\n'
-                                '\t\t\t</File>\n' % (file))
+                                '\t\t\t</File>\n' % file)
 
     def PrintSourceFiles(self):
         categories = {'Source Files': 'cpp;c;cxx;l;y;def;odl;idl;hpj;bat',
@@ -2047,17 +2047,17 @@ def generate(env):
         (version_num, suite) = (7.0, None) # guess at a default
     if 'MSVS' not in env:
         env['MSVS'] = {}
-    if (version_num < 7.0):
+    if version_num < 7.0:
         env['MSVS']['PROJECTSUFFIX']  = '.dsp'
         env['MSVS']['SOLUTIONSUFFIX'] = '.dsw'
-    elif (version_num < 10.0):
+    elif version_num < 10.0:
         env['MSVS']['PROJECTSUFFIX']  = '.vcproj'
         env['MSVS']['SOLUTIONSUFFIX'] = '.sln'
     else:
         env['MSVS']['PROJECTSUFFIX']  = '.vcxproj'
         env['MSVS']['SOLUTIONSUFFIX'] = '.sln'
 
-    if (version_num >= 10.0):
+    if version_num >= 10.0:
         env['MSVSENCODING'] = 'utf-8'
     else:
         env['MSVSENCODING'] = 'Windows-1252'

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -182,7 +182,7 @@ def generate_guids(root):
 
 
 def string_wxsfile(target, source, env):
-    return "building WiX file %s"%( target[0].path )
+    return "building WiX file %s" % target[0].path
 
 def build_wxsfile(target, source, env):
     """ Compiles a .wxs file from the keywords given in env['msi_spec'] and

--- a/src/engine/SCons/Tool/tex.py
+++ b/src/engine/SCons/Tool/tex.py
@@ -204,7 +204,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
     # with LaTeXAction and from the pdflatex.py with PDFLaTeXAction
     # set this up now for the case where the user requests a different extension
     # for the target filename
-    if (XXXLaTeXAction == LaTeXAction):
+    if XXXLaTeXAction == LaTeXAction:
        callerSuffix = ".dvi"
     else:
        callerSuffix = env['PDFSUFFIX']
@@ -283,7 +283,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
 
     count = 0
 
-    while (must_rerun_latex and count < int(env.subst('$LATEXRETRIES'))) :
+    while must_rerun_latex and count < int(env.subst('$LATEXRETRIES')):
         result = XXXLaTeXAction(target, source, env)
         if result != 0:
             return result
@@ -461,7 +461,7 @@ def InternalLaTeXAuxAction(XXXLaTeXAction, target = None, source= None, env=None
             if Verbose:
                 print("rerun Latex due to undefined references or citations")
 
-        if (count >= int(env.subst('$LATEXRETRIES')) and must_rerun_latex):
+        if count >= int(env.subst('$LATEXRETRIES')) and must_rerun_latex:
             print("reached max number of retries on Latex ,",int(env.subst('$LATEXRETRIES')))
 # end of while loop
 
@@ -861,7 +861,7 @@ def generate_darwin(env):
         environ = {}
         env['ENV'] = environ
 
-    if (platform.system() == 'Darwin'):
+    if platform.system() == 'Darwin':
         try:
             ospath = env['ENV']['PATHOSX']
         except:

--- a/src/engine/SCons/Tool/xgettext.py
+++ b/src/engine/SCons/Tool/xgettext.py
@@ -133,7 +133,7 @@ def _update_pot_file(target, source, env):
             re_cdate = re.compile(r'^"POT-Creation-Date: .*"$[\r\n]?', re.M)
             old_content_nocdate = re.sub(re_cdate, "", old_content)
             new_content_nocdate = re.sub(re_cdate, "", new_content)
-            if (old_content_nocdate == new_content_nocdate):
+            if old_content_nocdate == new_content_nocdate:
                 # Messages are up-to-date
                 needs_update = False
                 explain = "messages in file found to be up-to-date"

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -392,7 +392,7 @@ except NameError:
 try:
     BaseStringTypes = (str, unicode)
 except NameError:
-    BaseStringTypes = (str)
+    BaseStringTypes = str
 
 def is_Dict(obj, isinstance=isinstance, DictTypes=DictTypes):
     return isinstance(obj, DictTypes)

--- a/src/engine/SCons/dblite.py
+++ b/src/engine/SCons/dblite.py
@@ -131,9 +131,10 @@ class dblite(object):
                         # Note how we catch KeyErrors too here, which might happen
                         # when we don't have cPickle available (default pickle
                         # throws it).
-                        if (ignore_corrupt_dbfiles == 0): raise
-                        if (ignore_corrupt_dbfiles == 1):
+                        if ignore_corrupt_dbfiles:
                             corruption_warning(self._file_name)
+                        else:
+                            raise
 
     def close(self):
         if self._needs_sync:
@@ -166,13 +167,13 @@ class dblite(object):
             except OSError:
                 pass
         self._needs_sync = 00000
-        if (keep_all_files):
+        if keep_all_files:
             self._shutil_copyfile(
                 self._file_name,
                 self._file_name + "_" + str(int(self._time_time())))
 
     def _check_writable(self):
-        if (self._flag == "r"):
+        if self._flag == "r":
             raise IOError("Read-only database: %s" % self._file_name)
 
     def __getitem__(self, key):
@@ -180,9 +181,9 @@ class dblite(object):
 
     def __setitem__(self, key, value):
         self._check_writable()
-        if (not is_string(key)):
+        if not is_string(key):
             raise TypeError("key `%s' must be a string but is %s" % (key, type(key)))
-        if (not is_bytes(value)):
+        if not is_bytes(value):
             raise TypeError("value `%s' must be a bytes but is %s" % (value, type(value)))
         self._dict[key] = value
         self._needs_sync = 0o001
@@ -280,7 +281,7 @@ def _exercise():
         raise RuntimeError("IOError expected.")
 
 
-if (__name__ == "__main__"):
+if __name__ == "__main__":
     _exercise()
 
 # Local Variables:

--- a/src/script/scons-configure-cache.py
+++ b/src/script/scons-configure-cache.py
@@ -23,13 +23,13 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-'''Show or convert the configuration of an SCons cache directory.
+"""Show or convert the configuration of an SCons cache directory.
 
 A cache of derived files is stored by file signature.
 The files are split into directories named by the first few
 digits of the signature. The prefix length used for directory
 names can be changed by this script.
-'''
+"""
 
 from __future__ import print_function
 import argparse
@@ -51,11 +51,11 @@ __developer__ = "__DEVELOPER__"
 
 
 def rearrange_cache_entries(current_prefix_len, new_prefix_len):
-    '''Move cache files if prefix length changed.
+    """Move cache files if prefix length changed.
 
     Move the existing cache files to new directories of the
     appropriate name length and clean up the old directories.
-    '''
+    """
     print('Changing prefix length from', current_prefix_len,
           'to', new_prefix_len)
     dirs = set()

--- a/src/script/scons-time.py
+++ b/src/script/scons-time.py
@@ -625,7 +625,7 @@ class SConsTimer(object):
         if not contents:
             sys.stderr.write('file %s has no contents!\n' % repr(file))
             return None
-        result = re.findall(r'%s: ([\d\.]*)' % search_string, contents)[-4:]
+        result = re.findall(r'%s: ([\d.]*)' % search_string, contents)[-4:]
         result = [ float(r) for r in result ]
         if time_string is not None:
             try:

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -524,7 +524,7 @@ def Do_SConsignDir(name):
             except KeyboardInterrupt:
                 raise
             except pickle.UnpicklingError:
-                err = "sconsign: ignoring invalid .sconsign file `%s'\n" % (name)
+                err = "sconsign: ignoring invalid .sconsign file `%s'\n" % name
                 sys.stderr.write(err)
                 return
             except Exception as e:

--- a/test/CC/SHCCFLAGS.py
+++ b/test/CC/SHCCFLAGS.py
@@ -120,7 +120,7 @@ foomain_obj = barMain.Object(target='foomain', source='main.c')
 barmain_obj = barMain.Object(target='barmain', source='main.c')
 barMain.Program(target='barprog', source=foomain_obj)
 barMain.Program(target='fooprog', source=barmain_obj)
-""" % (barflags))
+""" % barflags)
 
 test.run(arguments = '.')
 

--- a/test/CC/SHCFLAGS.py
+++ b/test/CC/SHCFLAGS.py
@@ -120,7 +120,7 @@ foomain_obj = barMain.Object(target='foomain', source='main.c')
 barmain_obj = barMain.Object(target='barmain', source='main.c')
 barMain.Program(target='barprog', source=foomain_obj)
 barMain.Program(target='fooprog', source=barmain_obj)
-""" % (barflags))
+""" % barflags)
 
 test.run(arguments = '.')
 

--- a/test/CacheDir/readonly-cache.py
+++ b/test/CacheDir/readonly-cache.py
@@ -64,11 +64,11 @@ if time1 <= time0:
 
 test.unlink('file.out')
 
-for root, dirs, files in os.walk("cache",topdown=False):
-	for file in files:
-		os.chmod(os.path.join(root,file),0o444)
-	for dir in dirs:
-		os.chmod(os.path.join(root,dir),0o555)
+for root, dirs, files in os.walk("cache", topdown=False):
+    for file in files:
+        os.chmod(os.path.join(root,file), 0o444)
+    for dir in dirs:
+        os.chmod(os.path.join(root,dir), 0o555)
 
 test.run(arguments = '--debug=explain --cache-debug=- .')
 

--- a/test/Configure/ConfigureDryRunError.py
+++ b/test/Configure/ConfigureDryRunError.py
@@ -56,7 +56,7 @@ r2 = conf.CheckLib('hopefullynolib') # will fail
 env = conf.Finish()
 if not (r1 and not r2):
  Exit(1)
-""" % (lib))
+""" % lib)
 
 expect = """
 scons: *** Cannot create configure directory ".sconf_temp" within a dry-run.

--- a/test/D/Support/executablesSearch.py
+++ b/test/D/Support/executablesSearch.py
@@ -56,11 +56,11 @@ if __name__ == '__main__':
     import TestSCons
 
     class VariousTests(unittest.TestCase):
-        '''
+        """
         These tests are somewhat self referential in that
         isExecutableOfToolAvailable uses where_is to do most of it's
         work and we use the same function in the tests.
-        '''
+        """
         def setUp(self):
             self.test = TestSCons.TestSCons()
 

--- a/test/Exit.py
+++ b/test/Exit.py
@@ -121,7 +121,7 @@ exit_builder(["%s"], ["%s"])
 """ % (subdir_foo_out, subdir_foo_in), error=1),
          stderr = """\
 scons: *** [%s] Explicit exit, status 27
-""" % (subdir_foo_out))
+""" % subdir_foo_out)
 
 test.must_match(['subdir', 'foo.out'], "subdir/foo.in\n")
 

--- a/test/LINK/LINKCOMSTR.py
+++ b/test/LINK/LINKCOMSTR.py
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {}
 """)
 
 test.run()
-if ("Linking" not in test.stdout()):
+if "Linking" not in test.stdout():
     test.fail_test()
 
 test.pass_test()

--- a/test/LINK/SHLINKCOMSTR.py
+++ b/test/LINK/SHLINKCOMSTR.py
@@ -87,7 +87,7 @@ int i;
 """)
 
         test.run()
-        if ("Shared-Linking" not in test.stdout()):
+        if "Shared-Linking" not in test.stdout():
             test.fail_test()
 
 test.pass_test()

--- a/test/LINK/applelink.py
+++ b/test/LINK/applelink.py
@@ -135,7 +135,7 @@ for SHLIBVERSION, \
         test.must_contain_all_lines(test.stdout(),
                                     ['-Wl,-compatibility_version,{APPLELINK_COMPATIBILITY_VERSION}'.format(**locals())])
 
-    if not (extra_flags):
+    if not extra_flags:
         # Now run otool -L to get the compat and current version info and verify it's correct in the library.
         # We expect output such as this
         # libfoo.1.2.3.dylib:

--- a/test/MSVS/vs-10.0-exec.py
+++ b/test/MSVS/vs-10.0-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-10.0Exp-exec.py
+++ b/test/MSVS/vs-10.0Exp-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-11.0-exec.py
+++ b/test/MSVS/vs-11.0-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-11.0Exp-exec.py
+++ b/test/MSVS/vs-11.0Exp-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
     

--- a/test/MSVS/vs-14.0-exec.py
+++ b/test/MSVS/vs-14.0-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-14.1-exec.py
+++ b/test/MSVS/vs-14.1-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-6.0-exec.py
+++ b/test/MSVS/vs-6.0-exec.py
@@ -58,7 +58,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-7.0-exec.py
+++ b/test/MSVS/vs-7.0-exec.py
@@ -58,7 +58,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-7.1-exec.py
+++ b/test/MSVS/vs-7.1-exec.py
@@ -58,7 +58,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-8.0-exec.py
+++ b/test/MSVS/vs-8.0-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-8.0Exp-exec.py
+++ b/test/MSVS/vs-8.0Exp-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-9.0-exec.py
+++ b/test/MSVS/vs-9.0-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/MSVS/vs-9.0Exp-exec.py
+++ b/test/MSVS/vs-9.0Exp-exec.py
@@ -59,7 +59,7 @@ if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 

--- a/test/NodeOps.py
+++ b/test/NodeOps.py
@@ -213,7 +213,7 @@ build_nodes = ['fooprog' + _exe,
                ] + builddir_srcnodes + sub_build_nodes
 
 def cleanup_test():
-    "cleanup after running a test"
+    """cleanup after running a test"""
     for F in builddir_srcnodes:
         test.unlink(F)  # will be repopulated during clean operation
     test.run(arguments = '-c')

--- a/test/QT/up-to-date.py
+++ b/test/QT/up-to-date.py
@@ -134,7 +134,7 @@ test.run(arguments = my_obj, stderr=None)
 
 expect = my_obj.replace( '/', os.sep )
 test.up_to_date(options = '--debug=explain',
-                arguments = (expect),
+                arguments =expect,
                 stderr=None)
 
 test.pass_test()

--- a/test/Repository/SharedLibrary.py
+++ b/test/Repository/SharedLibrary.py
@@ -56,7 +56,7 @@ if ARGUMENTS.get('PROGRAM'):
 """)
 
 for fx in ['1', '2', '3']:
-    test.write(['repository', 'f%s.c' % (fx)], r"""
+    test.write(['repository', 'f%s.c' % fx], r"""
 #include <stdio.h>
 
 void

--- a/test/SWIG/recursive-includes-cpp.py
+++ b/test/SWIG/recursive-includes-cpp.py
@@ -49,7 +49,7 @@ python, python_include, python_libpath, python_lib = \
 
 if sys.platform == 'win32':
     python_lib = os.path.dirname(sys.executable) + "/libs/" + ('python%d%d'%(sys.version_info[0],sys.version_info[1])) + '.lib'
-    if( not os.path.isfile(python_lib)):
+    if not os.path.isfile(python_lib):
         test.skip_test('Can not find python lib at "' + python_lib + '", skipping test.%s' % os.linesep)
 
 test.write("recursive.h", """\

--- a/test/TEX/LATEX.py
+++ b/test/TEX/LATEX.py
@@ -168,7 +168,7 @@ This is the include file. mod %s
     test.write('makeindex.idx',  '')
 
     test.subdir('subdir')
-    test.write('latexi.tex',  latex1 % 'latexi.tex');
+    test.write('latexi.tex',  latex1 % 'latexi.tex')
     test.write([ 'subdir', 'latexinputfile'], latex2)
     test.write([ 'subdir', 'latexincludefile.tex'], latex3 % '1')
 

--- a/test/TEX/LATEX2.py
+++ b/test/TEX/LATEX2.py
@@ -95,7 +95,7 @@ This is the include file. mod %s
     test.write('makeindex.idx',  '')
 
     test.subdir('subdir')
-    test.write('latexi.tex',  latex1 % 'latexi.tex');
+    test.write('latexi.tex',  latex1 % 'latexi.tex')
     test.write([ 'subdir', 'latexinputfile'], latex2)
     test.write([ 'subdir', 'latexincludefile.tex'], latex3 % '1')
 

--- a/test/Win32/bad-drive.py
+++ b/test/Win32/bad-drive.py
@@ -53,7 +53,7 @@ for d in reversed(ascii_uppercase):
 if bad_drive is None:
     print("All drive letters appear to be in use.")
     print("Cannot test SCons handling of invalid Windows drive letters.")
-    test.no_result(1);
+    test.no_result(1)
 
 test.write('SConstruct', """
 def cat(env, source, target):

--- a/test/implicit-cache/SetOption.py
+++ b/test/implicit-cache/SetOption.py
@@ -63,7 +63,7 @@ test.run(arguments = '.')
 
 test.write('i1/foo.h', """
 this line will cause a syntax error if it's included by a rebuild
-""");
+""")
 
 test.up_to_date(arguments = '.')
 

--- a/test/site_scons/sysdirs.py
+++ b/test/site_scons/sysdirs.py
@@ -50,7 +50,7 @@ import SCons.Platform
 platform = SCons.Platform.platform_default()
 if platform in ('win32', 'cygwin'):
     dir_to_check_for='Application Data'
-elif platform in ('darwin'):
+elif platform in 'darwin':
     dir_to_check_for='Library'
 else:
     dir_to_check_for='.scons'

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -667,7 +667,7 @@ def diff_re(a, b, fromfile='', tofile='',
 
 if os.name == 'posix':
     def escape(arg):
-        "escape shell special characters"
+        """escape shell special characters"""
         slash = '\\'
         special = '"$'
         arg = arg.replace(slash, slash + slash)

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -121,8 +121,8 @@ class TestCmdTestCase(unittest.TestCase):
         else:
             textx = '#! /usr/bin/env python\n' + textx + '\n'
         text1 = 'A first line to be ignored!\n' + fmt % (t.script1, t.script1)
-        textout = fmtout % (t.scriptout)
-        texterr = fmterr % (t.scripterr)
+        textout = fmtout % t.scriptout
+        texterr = fmterr % t.scripterr
 
         run_env = TestCmd.TestCmd(workdir = '')
         run_env.subdir('sub dir')
@@ -1974,7 +1974,7 @@ class run_verbose_TestCase(TestCmdTestCase):
                 assert expect == o, (expect, o)
 
                 e = sys.stderr.getvalue()
-                expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
+                expect = 'python "%s" "arg1 arg2"\n' % t.scriptout_path
                 assert e == expect, (e, expect)
 
             test = TestCmd.TestCmd(program = t.scriptout,
@@ -1993,7 +1993,7 @@ class run_verbose_TestCase(TestCmdTestCase):
                 assert expect == o, (expect, o)
 
                 e = sys.stderr.getvalue()
-                expect = 'python "%s" "arg1 arg2"\n' % (t.scriptout_path)
+                expect = 'python "%s" "arg1 arg2"\n' % t.scriptout_path
                 assert e == expect, (e, expect)
 
             # Test letting TestCmd() pick up verbose = 2 from the environment.

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -817,7 +817,7 @@ class TestSCons(TestCommon):
         sp = subprocess.Popen([where_java_bin, "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = sp.communicate()
         sp.wait()
-        if("No Java runtime" in str(stderr)):
+        if "No Java runtime" in str(stderr):
             self.skip_test("Could not find Java " + java_bin_name + ", skipping test(s).\n")
 
     def java_where_jar(self, version=None):

--- a/testing/framework/TestUnit/taprunner.py
+++ b/testing/framework/TestUnit/taprunner.py
@@ -62,7 +62,7 @@ class TAPTestResult(TextTestResult):
 
     def addExpectedFailure(self, test, err):
         super(TextTestResult, self).addExpectedFailure(test, err)
-        self._process(test, "not ok", directive=("  # TODO"))
+        self._process(test, "not ok", directive="  # TODO")
 
     def addUnexpectedSuccess(self, test):
         super(TextTestResult, self).addUnexpectedSuccess(test)


### PR DESCRIPTION
- Drop unneeded parens.
- Drop trailing semicolons.
- Triple double-quote docstrings.
- Regexes drop unneeded escapes.
- Spaces around parens, braces: remove/add.
- Some one-tuples get their missing closing comma.
- A couple of sets use set init syntax `{foo}` instead of `set([iter])` now.
- And a fiddle in Node to reduce lookup time on md5 signature functions  (came about because of a line-too-long issue, initially)

Signed-off-by: Mats Wichmann <mats@linux.com>

Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
