### PR TITLE
Drop Python 2.7 support on the road to SCons 4.0.0 release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,12 +49,6 @@ install:
 # split builds into sets of four jobs due to appveyor per-job time limit
 environment:
   matrix:
-    - WINPYTHON: "Python27"
-      PYTHON: "2.7"
-      PYVER: 27
-      BUILD_JOB_NUM: 1
-      COVERAGE: 0
-
     - WINPYTHON: "Python35"
       PYTHON: "3.5"
       PYVER: 35
@@ -78,12 +72,6 @@ environment:
       PYVER: 38
       BUILD_JOB_NUM: 1
       COVERAGE: 0
-
-    # - WINPYTHON: "Python27"
-    #   PYTHON: "2.7"
-    #   PYVER: 27
-    #   BUILD_JOB_NUM: 2
-    #   COVERAGE: 0
 
     # - WINPYTHON: "Python35"
     #   PYTHON: "3.5"
@@ -116,15 +104,13 @@ matrix:
   exclude:
     # test python 3.5 on Visual Studio 2015 image
     - image: Visual Studio 2015
-      WINPYTHON: "Python27"
-    - image: Visual Studio 2015
       WINPYTHON: "Python36"
     - image: Visual Studio 2015
       WINPYTHON: "Python37"
     - image: Visual Studio 2015
       WINPYTHON: "Python38"
 
-    # test python 2.7, 3.8 on Visual Studio 2017 image
+    # test python 3.8 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python35"
     - image: Visual Studio 2017
@@ -134,15 +120,11 @@ matrix:
 
     # test python 3.7 on Visual Studio 2019 image
     - image: Visual Studio 2019
-      WINPYTHON: "Python27"
-    - image: Visual Studio 2019
       WINPYTHON: "Python35"
     - image: Visual Studio 2019
       WINPYTHON: "Python36"
 
     # skip on Ubuntu
-    - image: Ubuntu
-      WINPYTHON: "Python27"
     - image: Ubuntu
       WINPYTHON: "Python35"
     - image: Ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
 # allow coverage to fail, so we can still do testing for all platforms
 matrix:
   allow_failures:
-    - python: pypy
     - python: pypy3
     - stage: Coverage
 
@@ -56,12 +55,6 @@ jobs:
         - PYTHON=pypy3
       sudo: required
 
-    - <<: *test_job
-      python: pypy
-      env:
-        - PYVER=pypy
-        - PYTHON=pypy
-      sudo: required
 
     - <<: *test_job
       python: 3.5
@@ -100,7 +93,7 @@ jobs:
       python: 3.7
       before_script:
         # install our own python so we can modify usercustomize.py
-        - deactivate
+#        - deactivate
 #        - sudo add-apt-repository -y ppa:deadsnakes/ppa
 #        - sudo apt-get update || true
 #        - sudo apt-get -y install python$PYTHON

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ jobs:
         # attempt to get a location where we can store the usercustomize.py file
         - python -m site
 #        - export PYSITEDIR=$(python -m site --user-site)
-        - export PYSITEDIR=$(python -c "import sys; print(sys.path[-1]))
+        - export PYSITEDIR=$(python -c "import sys; print(sys.path[-1])")
         - mkdir -p $PYSITEDIR
         - export COVERAGE_FILE=$PWD/.coverage
         # write the usercustomize.py file so all python processes use coverage and know where the config file is

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,10 +111,10 @@ jobs:
         - mkdir -p $PYSITEDIR
         - export COVERAGE_FILE=$PWD/.coverage
         # write the usercustomize.py file so all python processes use coverage and know where the config file is
-        - echo "import os" |  tee --append ${PYSITEDIR}/usercustomize.py
-        - echo "os.environ['COVERAGE_PROCESS_START'] = '$PWD/.coveragerc'" | tee --append ${PYSITEDIR}/usercustomize.py
-        - echo "import coverage" | tee --append ${PYSITEDIR}/usercustomize.py
-        - echo "coverage.process_startup()" | tee --append ${PYSITEDIR}/usercustomize.py
+        - echo "import os" |  tee --append ${PYSITEDIR}/sitecustomize.py
+        - echo "os.environ['COVERAGE_PROCESS_START'] = '$PWD/.coveragerc'" | tee --append ${PYSITEDIR}/sitecustomize.py
+        - echo "import coverage" | tee --append ${PYSITEDIR}/sitecustomize.py
+        - echo "coverage.process_startup()" | tee --append ${PYSITEDIR}/sitecustomize.py
 
       script:
         - export TOTAL_BUILD_JOBS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,13 +64,6 @@ jobs:
       sudo: required
 
     - <<: *test_job
-      python: 2.7
-      env:
-        - PYVER=27
-        - PYTHON=2.7
-      sudo: required
-
-    - <<: *test_job
       python: 3.5
       env:
         - PYVER=35
@@ -165,45 +158,3 @@ jobs:
         - PYVER=37
         - PYTHON=3.7
         - BUILD_JOB_NUM=1
-#
-#    - <<: *coverage_jobs
-#      env:
-#        - PYVER=27
-#        - PYTHON=2.7
-#        - BUILD_JOB_NUM=2
-#    - <<: *coverage_jobs
-#      env:
-#        - PYVER=27
-#        - PYTHON=2.7
-#        - BUILD_JOB_NUM=3
-#    - <<: *coverage_jobs
-#      env:
-#        - PYVER=27
-#        - PYTHON=2.7
-#        - BUILD_JOB_NUM=4
-
-#    - <<: *coverage_jobs
-#      python: 3.6
-#      env:
-#        - PYVER=36
-#        - PYTHON=3.6
-#        - BUILD_JOB_NUM=1
-#    - <<: *coverage_jobs
-#      python: 3.6
-#      env:
-#        - PYVER=36
-#        - PYTHON=3.6
-#        - BUILD_JOB_NUM=2
-#    - <<: *coverage_jobs
-#      python: 3.6
-#      env:
-#        - PYVER=36
-#        - PYTHON=3.6
-#        - BUILD_JOB_NUM=3
-#    - <<: *coverage_jobs
-#      python: 3.6
-#      env:
-#        - PYVER=36
-#        - PYTHON=3.6
-#        - BUILD_JOB_NUM=4
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
 #        - sudo -H python$PYTHON get-pip.py
         - which python
         - python --version
-        - python -m pip install --user -U coverage codecov
+        - python -m pip install -U coverage codecov
         # set this ensure user sites are available
         - export PYTHONNOUSERSITE=
         # attempt to get a location where we can store the usercustomize.py file

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,15 +106,15 @@ jobs:
         - export PYTHONNOUSERSITE=
         # attempt to get a location where we can store the usercustomize.py file
         - python -m site
-        - export PYSITEDIR=$(python -m site --user-site)
-        - sudo mkdir -p $PYSITEDIR
-        - sudo touch ${PYSITEDIR}/usercustomize.py
+#        - export PYSITEDIR=$(python -m site --user-site)
+        - export PYSITEDIR=$(python -c "import sys; print(sys.path[-1]))
+        - mkdir -p $PYSITEDIR
         - export COVERAGE_FILE=$PWD/.coverage
         # write the usercustomize.py file so all python processes use coverage and know where the config file is
-        - echo "import os" | sudo tee --append ${PYSITEDIR}/usercustomize.py
-        - echo "os.environ['COVERAGE_PROCESS_START'] = '$PWD/.coveragerc'" | sudo tee --append ${PYSITEDIR}/usercustomize.py
-        - echo "import coverage" | sudo tee --append ${PYSITEDIR}/usercustomize.py
-        - echo "coverage.process_startup()" | sudo tee --append ${PYSITEDIR}/usercustomize.py
+        - echo "import os" |  tee --append ${PYSITEDIR}/usercustomize.py
+        - echo "os.environ['COVERAGE_PROCESS_START'] = '$PWD/.coveragerc'" | tee --append ${PYSITEDIR}/usercustomize.py
+        - echo "import coverage" | tee --append ${PYSITEDIR}/usercustomize.py
+        - echo "coverage.process_startup()" | tee --append ${PYSITEDIR}/usercustomize.py
 
       script:
         - export TOTAL_BUILD_JOBS=1

--- a/.travis/.coveragerc
+++ b/.travis/.coveragerc
@@ -1,0 +1,8 @@
+echo "[run]" >> .coveragerc
+echo "source = $PWD/src" >> .coveragerc
+echo "parallel = True" >> .coveragerc
+printf "omit =\n\t*Tests.py\n\tsrc/test_*\n\tsrc/setup.py\n\n" >> .coveragerc
+echo "[path]" >> .coveragerc
+echo "source = $PWD" >> .coveragerc
+echo "[report]" >> .coveragerc
+printf "omit =\n\t*Tests.py\n\tsrc/test_*\n\tsrc/setup.py\n\n" >> .coveragerc

--- a/README-SF.rst
+++ b/README-SF.rst
@@ -48,7 +48,7 @@ version at the SCons download page:
 Execution Requirements
 ======================
 
-Running SCons requires either Python version 2.7.* or Python 3.5 or higher.
+Running SCons requires Python 3.5 or higher.
 There should be no other dependencies or requirements to run SCons.
 
 The default SCons configuration assumes use of the Microsoft Visual C++

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ version at the SCons download page:
 Execution Requirements
 ======================
 
-Running SCons requires either Python version 2.7.* or Python 3.5 or higher.
+Running SCons requires Python 3.5 or higher.
 There should be no other dependencies or requirements to run SCons.
 
 The default SCons configuration assumes use of the Microsoft Visual C++

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -16,6 +16,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       is a reasonable default and also aligns with changes in Appveyor's VS2019 image.
     - Drop support for Python 2.7. SCons will be Python 3.5+ going forward.
 
+
   From Mathew Robinson:
     - Improve performance of Subst by preventing unnecessary frame
       allocations by no longer defining the *Subber classes inside of their

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -14,6 +14,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       header files and libraries from MSVC install. (Fixes GH Issue #3480)
     - Added C:\msys64\mingw64\bin to default mingw and clang windows PATH's.  This 
       is a reasonable default and also aligns with changes in Appveyor's VS2019 image.
+    - Drop support for Python 2.7. SCons will be Python 3.5+ going forward.
 
   From Mathew Robinson:
     - Improve performance of Subst by preventing unnecessary frame

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -36,6 +36,8 @@ import pprint
 import hashlib
 
 PY3 = sys.version_info[0] == 3
+PYPY = hasattr(sys, 'pypy_translation_info')
+
 
 try:
     from collections import UserDict, UserList, UserString
@@ -612,6 +614,7 @@ class Proxy(object):
             return self._subject == other
         return self.__dict__ == other.__dict__
 
+
 class Delegate(object):
     """A Python Descriptor class that delegates attribute fetches
     to an underlying wrapped subject of a Proxy.  Typical use:
@@ -621,7 +624,9 @@ class Delegate(object):
     """
     def __init__(self, attribute):
         self.attribute = attribute
+
     def __get__(self, obj, cls):
+        print("IN GET")
         if isinstance(obj, cls):
             return getattr(obj._subject, self.attribute)
         else:

--- a/src/engine/SCons/compat/__init__.py
+++ b/src/engine/SCons/compat/__init__.py
@@ -78,66 +78,14 @@ def rename_module(new, old):
         return False
 
 
-# TODO: FIXME
-# In 3.x, 'pickle' automatically loads the fast version if available.
-rename_module('pickle', 'cPickle')
-
-# Default pickle protocol. Higher protocols are more efficient/featureful
-# but incompatible with older Python versions. On Python 2.7 this is 2.
+# Default pickle protocol. Higher protocols are more efficient/featured
+# but incompatible with older Python versions.
 # Negative numbers choose the highest available protocol.
 import pickle
 
 # Was pickle.HIGHEST_PROTOCOL
 # Changed to 2 so py3.5+'s pickle will be compatible with py2.7.
 PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
-
-# TODO: FIXME
-# In 3.x, 'profile' automatically loads the fast version if available.
-rename_module('profile', 'cProfile')
-
-# TODO: FIXME
-# Before Python 3.0, the 'queue' module was named 'Queue'.
-rename_module('queue', 'Queue')
-
-# TODO: FIXME
-# Before Python 3.0, the 'winreg' module was named '_winreg'
-rename_module('winreg', '_winreg')
-
-# Python 3 moved builtin intern() to sys package
-# To make porting easier, make intern always live
-# in sys package (for python 2.7.x)
-try:
-    sys.intern
-except AttributeError:
-    # We must be using python 2.7.x so monkey patch
-    # intern into the sys package
-    sys.intern = intern
-
-# UserDict, UserList, UserString are in # collections for 3.x,
-# but standalone in 2.7.x. Monkey-patch into collections for 2.7.
-import collections
-
-try:
-    collections.UserDict
-except AttributeError:
-    from UserDict import UserDict as _UserDict
-    collections.UserDict = _UserDict
-    del _UserDict
-
-try:
-    collections.UserList
-except AttributeError:
-    from UserList import UserList as _UserList
-    collections.UserList = _UserList
-    del _UserList
-
-try:
-    collections.UserString
-except AttributeError:
-    from UserString import UserString as _UserString
-    collections.UserString = _UserString
-    del _UserString
-
 
 import shutil
 try:

--- a/src/script/scons.py
+++ b/src/script/scons.py
@@ -59,9 +59,9 @@ import sys
 ##############################################################################
 
 # compatibility check
-if (3,0,0) < sys.version_info < (3,5,0) or sys.version_info < (2,7,0):
+if sys.version_info < (3,5,0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python 2.7 or >= 3.5 is required.\n"
+Python >= 3.5 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/src/script/sconsign.py
+++ b/src/script/sconsign.py
@@ -50,9 +50,9 @@ import sys
 ##############################################################################
 
 # compatibility check
-if (3,0,0) < sys.version_info < (3,5,0) or sys.version_info < (2,7,0):
+if sys.version_info < (3,5,0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python 2.7 or >= 3.5 is required.\n"
+Python >= 3.5 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/test/SConsignFile/use-dbm.py
+++ b/test/SConsignFile/use-dbm.py
@@ -27,20 +27,22 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 """
 Verify SConsignFile() when used with dbm.
 """
-
+import os.path
+import dbm
 import TestSCons
 
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-
 try:
     import dbm.ndbm
+
     use_db = 'dbm.ndbm'
 except ImportError:
     try:
         import dbm
+
         use_db = 'dbm'
     except ImportError:
         test.skip_test('No dbm.ndbm in this version of Python; skipping test.\n')
@@ -78,20 +80,21 @@ test.run()
 # We don't check for explicit .db or other file, because base "dbm"
 # can use different file extensions on different implementations.
 
-test.must_not_exist(test.workpath('.sconsign'))
+test.fail_test(os.path.exists('.sconsign') and 'dbm' not in dbm.whichdb('.sconsign'),
+               message=".sconsign existed an wasn't any type of dbm file")
 test.must_not_exist(test.workpath('.sconsign.dblite'))
 test.must_not_exist(test.workpath('subdir', '.sconsign'))
 test.must_not_exist(test.workpath('subdir', '.sconsign.dblite'))
-  
+
 test.must_match('f1.out', "f1.in\n")
 test.must_match('f2.out', "f2.in\n")
 test.must_match(['subdir', 'f3.out'], "subdir/f3.in\n")
 test.must_match(['subdir', 'f4.out'], "subdir/f4.in\n")
 
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
-
-test.must_not_exist(test.workpath('.sconsign'))
+test.fail_test(os.path.exists('.sconsign') and 'dbm' not in dbm.whichdb('.sconsign'),
+               message=".sconsign existed an wasn't any type of dbm file")
 test.must_not_exist(test.workpath('.sconsign.dblite'))
 test.must_not_exist(test.workpath('subdir', '.sconsign'))
 test.must_not_exist(test.workpath('subdir', '.sconsign.dblite'))

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -310,6 +310,7 @@ import types
 IS_PY3 = sys.version_info[0] == 3
 IS_WINDOWS = sys.platform == 'win32'
 IS_64_BIT = sys.maxsize > 2**32
+IS_PYPY = hasattr(sys, 'pypy_translation_info')
 
 class null(object):
     pass


### PR DESCRIPTION
Drop Python 2.7 support.


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
