### PR TITLE
Prevent unnecessary recursion when value is already expanded

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -24,6 +24,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improve performance of Subst in some cases by preventing
       unnecessary calls to eval when a token is surrounded in braces
       but is not a function call.
+    - Improve performance of subst by removing unnecessary recursion.
 
   From Mats Wichmann:
     - Remove deprecated SourceCode

--- a/src/engine/SCons/Subst.py
+++ b/src/engine/SCons/Subst.py
@@ -499,6 +499,9 @@ class ListSubber(collections.UserList):
         self.in_strip = None
         self.next_line()
 
+    def expanded(self, s):
+        return is_String(s) and _separate_args.findall(s) is None
+
     def expand(self, s, lvars, within_list):
         """Expand a single "token" as necessary, appending the
         expansion to the current result.
@@ -553,6 +556,10 @@ class ListSubber(collections.UserList):
                      raise_exception(NameError(), lvars['TARGETS'], old_s)
                 elif s is None:
                      return
+
+                if self.expanded(s):
+                    self.append(s)
+                    return
 
                 # Before re-expanding the result, handle
                 # recursive expansion by copying the local

--- a/src/engine/SCons/Subst.py
+++ b/src/engine/SCons/Subst.py
@@ -500,7 +500,11 @@ class ListSubber(collections.UserList):
         self.next_line()
 
     def expanded(self, s):
-        return is_String(s) and _separate_args.findall(s) is None
+        if not is_String(s) or isinstance(s, CmdStringHolder):
+            return False
+
+        s = str(s)  # in case it's a UserString
+        return _separate_args.findall(s) is None
 
     def expand(self, s, lvars, within_list):
         """Expand a single "token" as necessary, appending the

--- a/src/engine/SCons/Subst.py
+++ b/src/engine/SCons/Subst.py
@@ -500,6 +500,14 @@ class ListSubber(collections.UserList):
         self.next_line()
 
     def expanded(self, s):
+        """Determines if the string s requires further expansion.
+
+        Due to the implementation of ListSubber expand will call
+        itself 2 additional times for an already expanded string. This
+        method is used to determine if a string is already fully
+        expanded and if so exit the loop early to prevent these
+        recursive calls.
+        """
         if not is_String(s) or isinstance(s, CmdStringHolder):
             return False
 
@@ -561,6 +569,8 @@ class ListSubber(collections.UserList):
                 elif s is None:
                      return
 
+                # If the string is already full expanded there's no
+                # need to continue recursion.
                 if self.expanded(s):
                     self.append(s)
                     return


### PR DESCRIPTION
I had a similar change for StringSubber but it provided little to no perf gain so I have neglected to add it. I can make that change again however if it's decided these should work as similarly as possible.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
