### PR TITLE
Fixup some doc inconsistencies.

### DIFF
--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -747,25 +747,6 @@ int main() { printf("Hello, world!\n"); }
   </section>
 
   <section>
-  <title>Obsolete Functions for Deciding When an Input File Has Changed</title>
-
-    <para>
-
-    In the past, &SCons; supported two functions
-    (<function>SourceSignatures</function> and
-    <function>TargetSignatures</function>)
-    that once were the primary methods for configuring the
-    decision about whether or not an input file had changed.
-    These functions were deprecated since &SCons; version 2.0,
-    and removed in &SCons; version 3.1 and
-    are mentioned here solely for identification purposes,
-    as there are a number of very old examples that may turn up
-    in web searches and in the SCons Wiki that may reference them.
-
-    </para>
-  </section>
-
-  <section>
   <title>Implicit Dependencies:  The &cv-CPPPATH; Construction Variable</title>
 
     <para>

--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sconsdoc [
     <!ENTITY % scons SYSTEM "../scons.mod">
     %scons;
-    
+
     <!ENTITY % builders-mod SYSTEM "../generated/builders.mod">
     %builders-mod;
     <!ENTITY % functions-mod SYSTEM "../generated/functions.mod">
@@ -372,7 +372,7 @@ int main() { printf("Hello, world!\n"); }
       instead of
       <literal>timestamp-match</literal>,
       would be if you have some specific reason
-      to require this &Make;-like behavior of 
+      to require this &Make;-like behavior of
       not rebuilding a target when an otherwise-modified
       source file is older.
 
@@ -747,25 +747,24 @@ int main() { printf("Hello, world!\n"); }
   </section>
 
   <section>
-  <title>Older Functions for Deciding When an Input File Has Changed</title>
+  <title>Obsolete Functions for Deciding When an Input File Has Changed</title>
 
     <para>
 
-    &SCons; still supports two functions that used to be the
-    primary methods for configuring the
-    decision about whether or not an input file has changed.
-    These functions have been officially deprecated
-    as &SCons; version 2.0,
-    and their use is discouraged,
-    mainly because they rely on a somewhat
-    confusing distinction between how
-    source files and target files are handled.
-    These functions are documented here mainly in case you
-    encounter them in older &SConscript; files.
+    In the past, &SCons; supported two functions
+    (<function>SourceSignatures</function> and
+    <function>TargetSignatures</function>)
+    that once were the primary methods for configuring the
+    decision about whether or not an input file had changed.
+    These functions were deprecated since &SCons; version 2.0,
+    and removed in &SCons; version 3.1 and
+    are mentioned here solely for identification purposes,
+    as there are a number of very old examples that may turn up
+    in web searches and in the SCons Wiki that may reference them.
 
     </para>
   </section>
-  
+
   <section>
   <title>Implicit Dependencies:  The &cv-CPPPATH; Construction Variable</title>
 
@@ -1426,11 +1425,11 @@ Ignore(hello, '/usr/include/stdio.h')
     </programlisting>
 
     <para>
-    &Ignore; can also be used to prevent a generated file from being built 
-    by default. This is due to the fact that directories depend on 
-    their contents.  So to ignore a generated file from the default build, 
+    &Ignore; can also be used to prevent a generated file from being built
+    by default. This is due to the fact that directories depend on
+    their contents.  So to ignore a generated file from the default build,
     you specify that the directory should ignore the generated file.
-    Note that the file will still be built if the user specifically 
+    Note that the file will still be built if the user specifically
     requests the target on scons command line, or if the file is
     a dependency of another file which is requested and/or is built
     by default.

--- a/src/engine/SCons/Environment.xml
+++ b/src/engine/SCons/Environment.xml
@@ -2879,6 +2879,38 @@ function.
 </summary>
 </scons_function>
 
+<scons_function name="Split">
+<arguments>(arg)</arguments>
+<summary>
+<para>
+Returns a list of file names or other objects.
+If <varname>arg</varname> is a string,
+it will be split on strings of white-space characters
+within the string,
+making it easier to write long lists of file names.
+If <varname>arg</varname> is already a list,
+the list will be returned untouched.
+If <varname>arg</varname> is any other type of object,
+it will be returned as a list
+containing just the object.
+</para>
+
+<para>
+Example:
+</para>
+
+<example_commands>
+files = Split("f1.c f2.c f3.c")
+files = env.Split("f4.c f5.c f6.c")
+files = Split("""
+       f7.c
+       f8.c
+       f9.c
+""")
+</example_commands>
+</summary>
+</scons_function>
+
 <scons_function name="subst">
 <arguments signature="env">
 (input, [raw, target, source, conv])

--- a/src/engine/SCons/Script/SConscript.xml
+++ b/src/engine/SCons/Script/SConscript.xml
@@ -252,16 +252,16 @@ This specifies help text to be printed if the
 <option>-h</option>
 argument is given to
 &scons;.
-If 
+If
 &f-Help;
-is called multiple times, the text is appended together in the order that 
+is called multiple times, the text is appended together in the order that
 &f-Help;
-is called. With append set to False, any 
+is called. With append set to False, any
 &f-Help;
-text generated with 
+text generated with
 &f-AddOption;
 is clobbered. If append is True, the AddOption help is prepended to the help
-string, thus preserving the 
+string, thus preserving the
 <option>-h</option>
 message.
 </para>
@@ -393,7 +393,7 @@ A single script may be specified as a string;
 multiple scripts must be specified as a list
 (either explicitly or as created by
 a function like
-&f-Split;).
+&f-link-Split;).
 Examples:
 </para>
 <example_commands>


### PR DESCRIPTION
PR #3464 removed `SourceSignatures`, `TargetSignatures` but left a dangling reference in the User Guide (referred to the existence of the functions but did not give their names, which is how they were missed). [Fixes #3519]

PR #3506 removed `SourceCode`, and accidentally removed the documentation of the `Split` function as well. In the PR history is a note that it was discovered and restored, but somehow it is still missing from master so restoring (again) with small markup changes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

https://scons.org/guidelines.html


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
