### PR TITLE
Align way TeX and related tool names reported by tests

### DIFF
--- a/test/DVIPDF/makeindex.py
+++ b/test/DVIPDF/makeindex.py
@@ -32,15 +32,15 @@ test = TestSCons.TestSCons()
 
 dvipdf = test.where_is('dvipdf')
 if not dvipdf:
-    test.skip_test('Could not find dvipdf; skipping test(s).\n')
+    test.skip_test("Could not find 'dvipdf'; skipping test(s).\n")
 
 tex = test.where_is('tex')
 if not tex:
-    test.skip_test('Could not find tex; skipping test(s).\n')
+    test.skip_test("Could not find 'tex'; skipping test(s).\n")
  
 latex = test.where_is('latex')
 if not latex:
-    test.skip_test('Could not find latex; skipping test(s).\n')
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 
 

--- a/test/DVIPS/DVIPS.py
+++ b/test/DVIPS/DVIPS.py
@@ -116,13 +116,13 @@ test.must_match('test4.ps', "This is a .latex test.\n", mode='r')
 
 have_latex = test.where_is('latex')
 if not have_latex:
-    test.skip_test('Could not find latex; skipping test(s).\n')
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 dvips = test.where_is('dvips')
+if not dvips:
+    test.skip_test("Could not find 'dvips'; skipping test(s).\n")
 
-if dvips:
-
-    test.write("wrapper.py", """
+test.write("wrapper.py", """
 import os
 import sys
 cmd = " ".join(sys.argv[1:])
@@ -130,7 +130,7 @@ open('%s', 'a').write("%%s\\n" %% cmd)
 os.system(cmd)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
-    test.write('SConstruct', """
+test.write('SConstruct', """
 import os
 ENV = { 'PATH' : os.environ['PATH'] }
 foo = Environment(ENV = ENV)
@@ -142,41 +142,41 @@ bar.PostScript(target = 'bar2', source = 'bar2.ltx')
 bar.PostScript(target = 'bar3', source = 'bar3.latex')
 """ % locals())
 
-    tex = r"""
+tex = r"""
 This is the %s TeX file.
 \end
 """
 
-    latex = r"""
+latex = r"""
 \documentclass{letter}
 \begin{document}
 This is the %s LaTeX file.
 \end{document}
 """
 
-    test.write('foo.tex', tex % 'foo.tex')
-    test.write('bar1.tex', tex % 'bar1.tex')
-    test.write('bar2.ltx', latex % 'bar2.ltx')
-    test.write('bar3.latex', latex % 'bar3.latex')
+test.write('foo.tex', tex % 'foo.tex')
+test.write('bar1.tex', tex % 'bar1.tex')
+test.write('bar2.ltx', latex % 'bar2.ltx')
+test.write('bar3.latex', latex % 'bar3.latex')
 
-    test.run(arguments = 'foo.dvi', stderr = None)
+test.run(arguments = 'foo.dvi', stderr = None)
 
-    test.must_not_exist(test.workpath('wrapper.out'))
+test.must_not_exist(test.workpath('wrapper.out'))
 
-    test.must_exist(test.workpath('foo.dvi'))
+test.must_exist(test.workpath('foo.dvi'))
 
-    test.run(arguments = 'bar1.ps bar2.ps bar3.ps', stderr = None)
+test.run(arguments = 'bar1.ps bar2.ps bar3.ps', stderr = None)
 
-    expect = """dvips -o bar1.ps bar1.dvi
+expect = """dvips -o bar1.ps bar1.dvi
 dvips -o bar2.ps bar2.dvi
 dvips -o bar3.ps bar3.dvi
 """
 
-    test.must_match('wrapper.out', expect, mode='r')
+test.must_match('wrapper.out', expect, mode='r')
 
-    test.must_exist(test.workpath('bar1.ps'))
-    test.must_exist(test.workpath('bar2.ps'))
-    test.must_exist(test.workpath('bar3.ps'))
+test.must_exist(test.workpath('bar1.ps'))
+test.must_exist(test.workpath('bar2.ps'))
+test.must_exist(test.workpath('bar3.ps'))
 
 test.pass_test()
 

--- a/test/TEX/TEX.py
+++ b/test/TEX/TEX.py
@@ -38,7 +38,7 @@ test = TestSCons.TestSCons()
 
 have_latex = test.where_is('latex')
 if not have_latex:
-    test.skip_test('Could not find latex; skipping test(s).\n')
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 
 test.write('mytex.py', r"""

--- a/test/TEX/auxiliaries.py
+++ b/test/TEX/auxiliaries.py
@@ -45,8 +45,8 @@ test = TestSCons.TestSCons()
 dvips = test.where_is('dvips')
 latex = test.where_is('latex')
 
-if not dvips or not latex:
-    test.skip_test("Could not find dvips or latex; skipping test(s).\n")
+if not all((dvips, latex)):
+    test.skip_test("Could not find 'dvips' and/or 'latex'; skipping test(s).\n")
 
 
 test.subdir(['docs'])

--- a/test/TEX/bibliography.py
+++ b/test/TEX/bibliography.py
@@ -38,15 +38,15 @@ test = TestSCons.TestSCons()
 dvips = test.where_is('dvips')
 
 if not dvips:
-    test.skip_test("Could not find dvips; skipping test(s).\n")
+    test.skip_test("Could not find 'dvips'; skipping test(s).\n")
 
 bibtex = test.where_is('bibtex')
 if not bibtex:
-    test.skip_test("Could not find bibtex; skipping test(s).\n")
+    test.skip_test("Could not find 'bibtex'; skipping test(s).\n")
 
 have_latex = test.where_is('latex')
 if not have_latex:
-    test.skip_test('Could not find latex; skipping test(s).\n')
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 
 test.write('SConstruct', """\

--- a/test/TEX/bibtex-latex-rerun.py
+++ b/test/TEX/bibtex-latex-rerun.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 pdflatex = test.where_is('pdflatex')
 
 if not pdflatex:
-    test.skip_test("Could not find pdflatex; skipping test(s).\n")
+    test.skip_test("Could not find 'pdflatex'; skipping test(s).\n")
 
 test.write(['SConstruct'], """\
 import os

--- a/test/TEX/clean.py
+++ b/test/TEX/clean.py
@@ -36,7 +36,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find tex or latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 comment = os.system('kpsewhich comment.sty')
 if not comment==0:

--- a/test/TEX/configure.py
+++ b/test/TEX/configure.py
@@ -40,8 +40,8 @@ test = TestSCons.TestSCons()
 dvips = test.where_is('dvips')
 latex = test.where_is('latex')
 
-if not dvips or not latex:
-    test.skip_test("Could not find dvips or latex; skipping test(s).\n")
+if not all((dvips, latex)):
+    test.skip_test("Could not find 'dvips' and/or 'latex'; skipping test(s).\n")
 
 NCR = test.NCR  # non-cached rebuild
 

--- a/test/TEX/dryrun.py
+++ b/test/TEX/dryrun.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test('could not find latex; skipping test\n')
+    test.skip_test("could not find 'latex'; skipping test\n")
 
 test.write('SConstruct', """
 import os

--- a/test/TEX/glossaries.py
+++ b/test/TEX/glossaries.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 gloss = os.system('kpsewhich glossaries.sty')
 if not gloss==0:

--- a/test/TEX/glossary.py
+++ b/test/TEX/glossary.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 gloss = os.system('kpsewhich glossary.sty')
 if not gloss==0:

--- a/test/TEX/lstinputlisting.py
+++ b/test/TEX/lstinputlisting.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 pdflatex = test.where_is('pdflatex')
 
 if not pdflatex:
-    test.skip_test("Could not find pdflatex; skipping test(s).\n")
+    test.skip_test("Could not find 'pdflatex'; skipping test(s).\n")
 
 listings = os.system('kpsewhich listings.sty')
 if not listings==0:

--- a/test/TEX/makeindex.py
+++ b/test/TEX/makeindex.py
@@ -38,8 +38,8 @@ test = TestSCons.TestSCons()
 pdflatex = test.where_is('pdflatex')
 makeindex = test.where_is('makeindex')
 
-if not pdflatex or not makeindex:
-    test.skip_test("Could not find pdflatex or makeindex; skipping test(s).\n")
+if not all((pdflatex, makeindex)):
+    test.skip_test("Could not find 'pdflatex' and/or 'makeindex'; skipping test(s).\n")
 
 test.write('SConstruct', """\
 import os

--- a/test/TEX/multi-line_include_options.py
+++ b/test/TEX/multi-line_include_options.py
@@ -44,7 +44,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 test.write('SConstruct', """\
 import os

--- a/test/TEX/multi-run.py
+++ b/test/TEX/multi-run.py
@@ -38,11 +38,8 @@ test = TestSCons.TestSCons()
 
 tex = test.where_is('tex')
 latex = test.where_is('latex')
-
-if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
-if not tex and not latex:
-    test.skip_test("Could not find tex or latex; skipping test(s).\n")
+if not all((tex, latex)):
+    test.skip_test("Could not find 'tex' and/or 'latex'; skipping test(s).\n")
 
 test.subdir('work1', 'work2', 'work3', 'work4')
 

--- a/test/TEX/newglossary.py
+++ b/test/TEX/newglossary.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 gloss = os.system('kpsewhich glossaries.sty')
 if not gloss==0:

--- a/test/TEX/nomencl.py
+++ b/test/TEX/nomencl.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 nomencl = os.system('kpsewhich nomencl.sty')
 if not nomencl==0:

--- a/test/TEX/recursive_scanner_dependencies_import.py
+++ b/test/TEX/recursive_scanner_dependencies_import.py
@@ -42,7 +42,7 @@ test = TestSCons.TestSCons()
 pdflatex = test.where_is('pdflatex')
 
 if not pdflatex:
-    test.skip_test("Could not find pdflatex; skipping test(s).\n")
+    test.skip_test("Could not find 'pdflatex'; skipping test(s).\n")
 
 latex_import = os.system('kpsewhich import.sty')
 if latex_import != 0:

--- a/test/TEX/recursive_scanner_dependencies_input.py
+++ b/test/TEX/recursive_scanner_dependencies_input.py
@@ -36,7 +36,7 @@ test = TestSCons.TestSCons()
 pdflatex = test.where_is('pdflatex')
 
 if not pdflatex:
-    test.skip_test("Could not find pdflatex; skipping test(s).\n")
+    test.skip_test("Could not find 'pdflatex'; skipping test(s).\n")
 
 test.write(['SConstruct'], """\
 env = Environment(tools=['pdftex', 'tex'])

--- a/test/TEX/rename_result.py
+++ b/test/TEX/rename_result.py
@@ -38,7 +38,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test('could not find latex; skipping test\n')
+    test.skip_test("could not find 'latex'; skipping test\n")
 
 test.write('SConstruct', """
 import os

--- a/test/TEX/synctex.py
+++ b/test/TEX/synctex.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 test.write('SConstruct', """\
 import os

--- a/test/TEX/usepackage.py
+++ b/test/TEX/usepackage.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test('could not find latex; skipping test\n')
+    test.skip_test("could not find 'latex'; skipping test\n")
 
 test.write('SConstruct', """
 import os

--- a/test/TEX/variant_dir.py
+++ b/test/TEX/variant_dir.py
@@ -36,8 +36,9 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 latex = test.where_is('latex')
-if not latex:
-    test.skip_test("Could not find 'latex'; skipping test.\n")
+dvipdf = test.where_is('dvipdf')
+if not all((latex, dvipdf)):
+    test.skip_test("Could not find 'latex' and/or 'dvipdf'; skipping test(s).\n")
 
 test.subdir(['docs'])
 

--- a/test/TEX/variant_dir_bibunit.py
+++ b/test/TEX/variant_dir_bibunit.py
@@ -41,8 +41,8 @@ test = TestSCons.TestSCons()
 
 latex = test.where_is('pdflatex')
 bibtex = test.where_is('bibtex')
-if not latex or not bibtex:
-    test.skip_test("Could not find 'latex' or 'bibtex'; skipping test.\n")
+if not all((latex, bibtex)):
+    test.skip_test("Could not find 'latex' and/or 'bibtex'; skipping test.\n")
 
 bibunits = os.system('kpsewhich bibunits.sty')
 if not bibunits==0:

--- a/test/TEX/variant_dir_dup0.py
+++ b/test/TEX/variant_dir_dup0.py
@@ -42,8 +42,8 @@ latex = test.where_is('latex')
 dvipdf = test.where_is('dvipdf')
 makeindex = test.where_is('makeindex')
 bibtex = test.where_is('bibtex')
-if not latex or not makeindex or not bibtex or not dvipdf:
-    test.skip_test("Could not find 'latex', 'makeindex', 'bibtex', or dvipdf; skipping test.\n")
+if not all((latex, makeindex, bibtex, dvipdf)):
+    test.skip_test("Could not find one or more of 'latex', 'makeindex', 'bibtex', or 'dvipdf'; skipping test.\n")
 
 test.subdir(['docs'])
 

--- a/test/TEX/variant_dir_newglossary.py
+++ b/test/TEX/variant_dir_newglossary.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 latex = test.where_is('latex')
 
 if not latex:
-    test.skip_test("Could not find latex; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 gloss = os.system('kpsewhich glossaries.sty')
 if gloss!=0:

--- a/test/TEX/variant_dir_style_dup0.py
+++ b/test/TEX/variant_dir_style_dup0.py
@@ -45,8 +45,8 @@ latex = test.where_is('latex')
 dvipdf = test.where_is('dvipdf')
 makeindex = test.where_is('makeindex')
 bibtex = test.where_is('bibtex')
-if not latex or not makeindex or not bibtex or not dvipdf:
-    test.skip_test("Could not find 'latex', 'makeindex', 'bibtex', or 'dvipdf'; skipping test.\n")
+if not all((latex, makeindex, bibtex, dvipdf)):
+    test.skip_test("Could not find one or more of 'latex', 'makeindex', 'bibtex', or 'dvipdf'; skipping test.\n")
 
 test.subdir(['docs'])
 


### PR DESCRIPTION
Two concrete changes:
- `DVIPS/DVIPS` test ran only if dvips tool is found, but did not leave any message if not. Print a skip message if tool not found, which also lets us dedent the rest of the test for the case where we continue due to having found it.
- `TEX/variant_dir` test did not check for dvipdf tool, but then calls the tool. Add a check so we get a skip message instead of a fail (the fail had lots of lines but it hard to see actual reason).

Fix one test which failed for me due to not checking for its tool.

For the rest, align "Could not find" messages to quote the tool name, which most of the tests do - so this is just stylistic, has no functional effect. Also stylistic: use any/all for checking multiple tools' existence.

A test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
