### PR TITLE
docs: refer *COM* and SH*COM* to each other  [ci skip]

### DIFF
--- a/doc/generated/variables.mod
+++ b/doc/generated/variables.mod
@@ -65,6 +65,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-CXXVERSION "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$CXXVERSION</envar>">
 <!ENTITY cv-DC "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DC</envar>">
 <!ENTITY cv-DCOM "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DCOM</envar>">
+<!ENTITY cv-DCOMSTR "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DCOMSTR</envar>">
 <!ENTITY cv-DDEBUG "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DDEBUG</envar>">
 <!ENTITY cv-DDEBUGPREFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DDEBUGPREFIX</envar>">
 <!ENTITY cv-DDEBUGSUFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DDEBUGSUFFIX</envar>">
@@ -457,6 +458,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-SHCXXFLAGS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHCXXFLAGS</envar>">
 <!ENTITY cv-SHDC "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHDC</envar>">
 <!ENTITY cv-SHDCOM "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHDCOM</envar>">
+<!ENTITY cv-SHDCOMSTR "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHDCOMSTR</envar>">
 <!ENTITY cv-SHDLIBVERSION "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHDLIBVERSION</envar>">
 <!ENTITY cv-SHDLIBVERSIONFLAGS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHDLIBVERSIONFLAGS</envar>">
 <!ENTITY cv-SHDLINK "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$SHDLINK</envar>">
@@ -706,6 +708,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-link-CXXVERSION "<link linkend='cv-CXXVERSION' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$CXXVERSION</envar></link>">
 <!ENTITY cv-link-DC "<link linkend='cv-DC' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DC</envar></link>">
 <!ENTITY cv-link-DCOM "<link linkend='cv-DCOM' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DCOM</envar></link>">
+<!ENTITY cv-link-DCOMSTR "<link linkend='cv-DCOMSTR' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DCOMSTR</envar></link>">
 <!ENTITY cv-link-DDEBUG "<link linkend='cv-DDEBUG' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DDEBUG</envar></link>">
 <!ENTITY cv-link-DDEBUGPREFIX "<link linkend='cv-DDEBUGPREFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DDEBUGPREFIX</envar></link>">
 <!ENTITY cv-link-DDEBUGSUFFIX "<link linkend='cv-DDEBUGSUFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DDEBUGSUFFIX</envar></link>">
@@ -1098,6 +1101,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-link-SHCXXFLAGS "<link linkend='cv-SHCXXFLAGS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHCXXFLAGS</envar></link>">
 <!ENTITY cv-link-SHDC "<link linkend='cv-SHDC' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHDC</envar></link>">
 <!ENTITY cv-link-SHDCOM "<link linkend='cv-SHDCOM' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHDCOM</envar></link>">
+<!ENTITY cv-link-SHDCOMSTR "<link linkend='cv-SHDCOMSTR' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHDCOMSTR</envar></link>">
 <!ENTITY cv-link-SHDLIBVERSION "<link linkend='cv-SHDLIBVERSION' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHDLIBVERSION</envar></link>">
 <!ENTITY cv-link-SHDLIBVERSIONFLAGS "<link linkend='cv-SHDLIBVERSIONFLAGS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHDLIBVERSIONFLAGS</envar></link>">
 <!ENTITY cv-link-SHDLINK "<link linkend='cv-SHDLINK' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$SHDLINK</envar></link>">

--- a/doc/user/output.xml
+++ b/doc/user/output.xml
@@ -47,7 +47,7 @@
   <para>
 
   A key aspect of creating a usable build configuration
-  is providing good output from the build
+  is providing useful output from the build
   so its users can readily understand
   what the build is doing
   and get information about how to control the build.
@@ -354,6 +354,17 @@ Removed foo
 cc -o foo.o -c foo.c
 cc -o foo foo.o
     </screen>
+
+    <para>
+
+    A gentle reminder here: many of the commands for building come in
+    pairs, depending on whether the intent is to build an object for
+    use in a shared library or not.  The command strings mirror this,
+    so it may be necessary to set, for example, both
+    <envar>CCCOMSTR</envar> and <envar>SHCCCOMSTR</envar>
+    to get the desired results.
+
+    </para>
 
   </section>
 

--- a/src/engine/SCons/Tool/DCommon.xml
+++ b/src/engine/SCons/Tool/DCommon.xml
@@ -27,7 +27,7 @@ See its __doc__ string for a discussion of the format.
 <summary>
 <para>
 The D compiler to use.
-See also &cv-link-SHDC;.
+See also &cv-link-SHDC; for compiling to shared objects.
 </para>
 </summary>
 </cvar>
@@ -38,7 +38,7 @@ See also &cv-link-SHDC;.
 The command line used to compile a D file to an object file.
 Any options specified in the &cv-link-DFLAGS; construction variable
 is included on this command line.
-See also &cv-link-SHDCOM;.
+See also &cv-link-SHDCOM; for compiling to shared objects.
 </para>
 </summary>
 </cvar>
@@ -49,7 +49,7 @@ See also &cv-link-SHDCOM;.
 If set, the string displayed when a D source file
 is compiled to a (static) object file.
 If not set, then &cv-link-DCOM; (the command line) is displayed.
-See also &cv-link-SHDCOMSTR;.
+See also &cv-link-SHDCOMSTR; for compiling to shared objects.
 </para>
 </summary>
 </cvar>
@@ -194,6 +194,7 @@ DLIBLINKSUFFIX.
 <summary>
 <para>
 Name of the linker to use for linking systems including D sources.
+See also &cv-link-SHDLINK; for linking shared objects.
 </para>
 </summary>
 </cvar>
@@ -202,6 +203,7 @@ Name of the linker to use for linking systems including D sources.
 <summary>
 <para>
 The command line to use when linking systems including D sources.
+See also &cv-link-SHDLINKCOM; for linking shared objects.
 </para>
 </summary>
 </cvar>
@@ -210,6 +212,7 @@ The command line to use when linking systems including D sources.
 <summary>
 <para>
 List of linker flags.
+See also &cv-link-SHDLINKFLAGS; for linking shared objects.
 </para>
 </summary>
 </cvar>
@@ -291,7 +294,7 @@ DVERSUFFIX.
 <para>
 The name of the compiler to use when compiling D source
 destined to be in a shared objects.
-See also &cv-link-DC;.
+See also &cv-link-DC; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -300,7 +303,7 @@ See also &cv-link-DC;.
 <summary>
 <para>
 The command line to use when compiling code to be part of shared objects.
-See also &cv-link-DCOM;.
+See also &cv-link-DCOM; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -311,7 +314,7 @@ See also &cv-link-DCOM;.
 If set, the string displayed when a D source file
 is compiled to a (shared) object file.
 If not set, then &cv-link-SHDCOM; (the command line) is displayed.
-See also &cv-link-DCOMSTR;.
+See also &cv-link-DCOMSTR; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -337,6 +340,7 @@ SHDLIBVERSIONFLAGS.
 <para>
 The linker to use when creating shared objects for code bases
 include D sources.
+See also &cv-link-DLINK; for linking static objects.
 </para>
 </summary>
 </cvar>
@@ -345,6 +349,7 @@ include D sources.
 <summary>
 <para>
 The command line to use when generating shared objects.
+See also &cv-link-DLINKCOM; for linking static objects.
 </para>
 </summary>
 </cvar>
@@ -353,6 +358,7 @@ The command line to use when generating shared objects.
 <summary>
 <para>
 The list of flags to use when generating a shared object.
+See also &cv-link-DLINKFLAGS; for linking static objects.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/DCommon.xml
+++ b/src/engine/SCons/Tool/DCommon.xml
@@ -291,6 +291,7 @@ DVERSUFFIX.
 <para>
 The name of the compiler to use when compiling D source
 destined to be in a shared objects.
+See also &cv-link-DC;.
 </para>
 </summary>
 </cvar>
@@ -299,6 +300,7 @@ destined to be in a shared objects.
 <summary>
 <para>
 The command line to use when compiling code to be part of shared objects.
+See also &cv-link-DCOM;.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/DCommon.xml
+++ b/src/engine/SCons/Tool/DCommon.xml
@@ -27,6 +27,7 @@ See its __doc__ string for a discussion of the format.
 <summary>
 <para>
 The D compiler to use.
+See also &cv-link-SHDC;.
 </para>
 </summary>
 </cvar>
@@ -37,6 +38,18 @@ The D compiler to use.
 The command line used to compile a D file to an object file.
 Any options specified in the &cv-link-DFLAGS; construction variable
 is included on this command line.
+See also &cv-link-SHDCOM;.
+</para>
+</summary>
+</cvar>
+
+<cvar name="DCOMSTR">
+<summary>
+<para>
+If set, the string displayed when a D source file
+is compiled to a (static) object file.
+If not set, then &cv-link-DCOM; (the command line) is displayed.
+See also &cv-link-SHDCOMSTR;.
 </para>
 </summary>
 </cvar>
@@ -286,6 +299,17 @@ destined to be in a shared objects.
 <summary>
 <para>
 The command line to use when compiling code to be part of shared objects.
+</para>
+</summary>
+</cvar>
+
+<cvar name="SHDCOMSTR">
+<summary>
+<para>
+If set, the string displayed when a D source file
+is compiled to a (shared) object file.
+If not set, then &cv-link-SHDCOM; (the command line) is displayed.
+See also &cv-link-DCOMSTR;.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/c++.xml
+++ b/src/engine/SCons/Tool/c++.xml
@@ -47,6 +47,7 @@ Sets construction variables for generic POSIX C++ compilers.
 </sets>
 <uses>
 <item>CXXCOMSTR</item>
+<item>SHCXXCOMSTR</item>
 </uses>
 </tool>
 
@@ -54,6 +55,7 @@ Sets construction variables for generic POSIX C++ compilers.
 <summary>
 <para>
 The C++ compiler.
+See also &cv-link-SHCXX;.
 </para>
 </summary>
 </cvar>
@@ -65,6 +67,7 @@ The command line used to compile a C++ source file to an object file.
 Any options specified in the &cv-link-CXXFLAGS; and
 &cv-link-CPPFLAGS; construction variables
 are included on this command line.
+See also &cv-link-SHCXXCOM;.
 </para>
 </summary>
 </cvar>
@@ -72,9 +75,10 @@ are included on this command line.
 <cvar name="CXXCOMSTR">
 <summary>
 <para>
-The string displayed when a C++ source file
+If set, the string displayed when a C++ source file
 is compiled to a (static) object file.
-If this is not set, then &cv-link-CXXCOM; (the command line) is displayed.
+If not set, then &cv-link-CXXCOM; (the command line) is displayed.
+See also &cv-link-SHCXXCOMSTR;.
 </para>
 
 <example_commands>
@@ -91,6 +95,7 @@ By default, this includes the value of &cv-link-CCFLAGS;,
 so that setting &cv-CCFLAGS; affects both C and C++ compilation.
 If you want to add C++-specific flags,
 you must set or override the value of &cv-link-CXXFLAGS;.
+See also &cv-link-SHCXXFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -99,6 +104,7 @@ you must set or override the value of &cv-link-CXXFLAGS;.
 <summary>
 <para>
 The C++ compiler used for generating shared-library objects.
+See also &cv-link-CXX;.
 </para>
 </summary>
 </cvar>
@@ -111,6 +117,7 @@ to a shared-library object file.
 Any options specified in the &cv-link-SHCXXFLAGS; and
 &cv-link-CPPFLAGS; construction variables
 are included on this command line.
+See also &cv-link-CXXCOM;.
 </para>
 </summary>
 </cvar>
@@ -118,9 +125,10 @@ are included on this command line.
 <cvar name="SHCXXCOMSTR">
 <summary>
 <para>
-The string displayed when a C++ source file
+If set, the string displayed when a C++ source file
 is compiled to a shared object file.
-If this is not set, then &cv-link-SHCXXCOM; (the command line) is displayed.
+If not set, then &cv-link-SHCXXCOM; (the command line) is displayed.
+See also &cv-link-CXXCOMSTR;.
 </para>
 
 <example_commands>
@@ -134,6 +142,7 @@ env = Environment(SHCXXCOMSTR = "Compiling shared object $TARGET")
 <para>
 Options that are passed to the C++ compiler
 to generate shared-library objects.
+See also &cv-link-CXXFLAGS;.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/c++.xml
+++ b/src/engine/SCons/Tool/c++.xml
@@ -55,7 +55,7 @@ Sets construction variables for generic POSIX C++ compilers.
 <summary>
 <para>
 The C++ compiler.
-See also &cv-link-SHCXX;.
+See also &cv-link-SHCXX; for compiling to shared objects..
 </para>
 </summary>
 </cvar>
@@ -67,7 +67,7 @@ The command line used to compile a C++ source file to an object file.
 Any options specified in the &cv-link-CXXFLAGS; and
 &cv-link-CPPFLAGS; construction variables
 are included on this command line.
-See also &cv-link-SHCXXCOM;.
+See also &cv-link-SHCXXCOM; for compiling to shared objects..
 </para>
 </summary>
 </cvar>
@@ -78,7 +78,7 @@ See also &cv-link-SHCXXCOM;.
 If set, the string displayed when a C++ source file
 is compiled to a (static) object file.
 If not set, then &cv-link-CXXCOM; (the command line) is displayed.
-See also &cv-link-SHCXXCOMSTR;.
+See also &cv-link-SHCXXCOMSTR; for compiling to shared objects..
 </para>
 
 <example_commands>
@@ -95,7 +95,7 @@ By default, this includes the value of &cv-link-CCFLAGS;,
 so that setting &cv-CCFLAGS; affects both C and C++ compilation.
 If you want to add C++-specific flags,
 you must set or override the value of &cv-link-CXXFLAGS;.
-See also &cv-link-SHCXXFLAGS;.
+See also &cv-link-SHCXXFLAGS; for compiling to shared objects..
 </para>
 </summary>
 </cvar>
@@ -104,7 +104,7 @@ See also &cv-link-SHCXXFLAGS;.
 <summary>
 <para>
 The C++ compiler used for generating shared-library objects.
-See also &cv-link-CXX;.
+See also &cv-link-CXX; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -117,7 +117,7 @@ to a shared-library object file.
 Any options specified in the &cv-link-SHCXXFLAGS; and
 &cv-link-CPPFLAGS; construction variables
 are included on this command line.
-See also &cv-link-CXXCOM;.
+See also &cv-link-CXXCOM; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -128,7 +128,7 @@ See also &cv-link-CXXCOM;.
 If set, the string displayed when a C++ source file
 is compiled to a shared object file.
 If not set, then &cv-link-SHCXXCOM; (the command line) is displayed.
-See also &cv-link-CXXCOMSTR;.
+See also &cv-link-CXXCOMSTR; for compiling to static objects.
 </para>
 
 <example_commands>
@@ -142,7 +142,7 @@ env = Environment(SHCXXCOMSTR = "Compiling shared object $TARGET")
 <para>
 Options that are passed to the C++ compiler
 to generate shared-library objects.
-See also &cv-link-CXXFLAGS;.
+See also &cv-link-CXXFLAGS; for compiling to static objects.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/cc.xml
+++ b/src/engine/SCons/Tool/cc.xml
@@ -51,6 +51,8 @@ Sets construction variables for generic POSIX C compilers.
 </sets>
 <uses>
 <item>PLATFORM</item>
+<item>CCCOMSTR</item>
+<item>SHCCCOMSTR</item>
 </uses>
 </tool>
 
@@ -67,8 +69,8 @@ The C compiler.
 <para>
 The command line used to compile a C source file to a (static) object
 file.  Any options specified in the &cv-link-CFLAGS;, &cv-link-CCFLAGS; and
-&cv-link-CPPFLAGS; construction variables are included on this command
-line.
+&cv-link-CPPFLAGS; construction variables are included on this command line.
+See also &cv-link-SHCCCOM;.
 </para>
 </summary>
 </cvar>
@@ -76,9 +78,10 @@ line.
 <cvar name="CCCOMSTR">
 <summary>
 <para>
-The string displayed when a C source file
+If set, the string displayed when a C source file
 is compiled to a (static) object file.
-If this is not set, then &cv-link-CCCOM; (the command line) is displayed.
+If not set, then &cv-link-CCCOM; (the command line) is displayed.
+See also &cv-link-SHCCCOMSTR;.
 </para>
 
 <example_commands>
@@ -91,6 +94,7 @@ env = Environment(CCCOMSTR = "Compiling static object $TARGET")
 <summary>
 <para>
 General options that are passed to the C and C++ compilers.
+See also &cv-link-SHCCFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -99,6 +103,7 @@ General options that are passed to the C and C++ compilers.
 <summary>
 <para>
 General options that are passed to the C compiler (C only; not C++).
+See also &cv-link-SHCFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -156,6 +161,7 @@ The default list is:
 <summary>
 <para>
 The C compiler used for generating shared-library objects.
+See also &cv-link-CC;.
 </para>
 </summary>
 </cvar>
@@ -169,6 +175,7 @@ Any options specified in the &cv-link-SHCFLAGS;,
 &cv-link-SHCCFLAGS; and
 &cv-link-CPPFLAGS; construction variables
 are included on this command line.
+See also &cv-link-CCCOM;.
 </para>
 </summary>
 </cvar>
@@ -176,9 +183,10 @@ are included on this command line.
 <cvar name="SHCCCOMSTR">
 <summary>
 <para>
-The string displayed when a C source file
+If set, the string displayed when a C source file
 is compiled to a shared object file.
-If this is not set, then &cv-link-SHCCCOM; (the command line) is displayed.
+If not set, then &cv-link-SHCCCOM; (the command line) is displayed.
+See also &cv-link-CCCOMSTR;.
 </para>
 
 <example_commands>
@@ -192,6 +200,7 @@ env = Environment(SHCCCOMSTR = "Compiling shared object $TARGET")
 <para>
 Options that are passed to the C and C++ compilers
 to generate shared-library objects.
+See also &cv-link-CCFLAGS;.
 </para>
 </summary>
 </cvar>
@@ -201,6 +210,7 @@ to generate shared-library objects.
 <para>
 Options that are passed to the C compiler (only; not C++)
 to generate shared-library objects.
+See also &cv-link-CFLAGS;.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/cc.xml
+++ b/src/engine/SCons/Tool/cc.xml
@@ -70,7 +70,7 @@ The C compiler.
 The command line used to compile a C source file to a (static) object
 file.  Any options specified in the &cv-link-CFLAGS;, &cv-link-CCFLAGS; and
 &cv-link-CPPFLAGS; construction variables are included on this command line.
-See also &cv-link-SHCCCOM;.
+See also &cv-link-SHCCCOM; for compiling to shared objects.
 </para>
 </summary>
 </cvar>
@@ -81,7 +81,7 @@ See also &cv-link-SHCCCOM;.
 If set, the string displayed when a C source file
 is compiled to a (static) object file.
 If not set, then &cv-link-CCCOM; (the command line) is displayed.
-See also &cv-link-SHCCCOMSTR;.
+See also &cv-link-SHCCCOMSTR; for compiling to shared objects.
 </para>
 
 <example_commands>
@@ -94,7 +94,7 @@ env = Environment(CCCOMSTR = "Compiling static object $TARGET")
 <summary>
 <para>
 General options that are passed to the C and C++ compilers.
-See also &cv-link-SHCCFLAGS;.
+See also &cv-link-SHCCFLAGS; for compiling to shared objects.
 </para>
 </summary>
 </cvar>
@@ -103,7 +103,7 @@ See also &cv-link-SHCCFLAGS;.
 <summary>
 <para>
 General options that are passed to the C compiler (C only; not C++).
-See also &cv-link-SHCFLAGS;.
+See also &cv-link-SHCFLAGS; for compiling to shared objects.
 </para>
 </summary>
 </cvar>
@@ -161,7 +161,7 @@ The default list is:
 <summary>
 <para>
 The C compiler used for generating shared-library objects.
-See also &cv-link-CC;.
+See also &cv-link-CC; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -175,7 +175,7 @@ Any options specified in the &cv-link-SHCFLAGS;,
 &cv-link-SHCCFLAGS; and
 &cv-link-CPPFLAGS; construction variables
 are included on this command line.
-See also &cv-link-CCCOM;.
+See also &cv-link-CCCOM; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -186,7 +186,7 @@ See also &cv-link-CCCOM;.
 If set, the string displayed when a C source file
 is compiled to a shared object file.
 If not set, then &cv-link-SHCCCOM; (the command line) is displayed.
-See also &cv-link-CCCOMSTR;.
+See also &cv-link-CCCOMSTR; for compiling to static objects.
 </para>
 
 <example_commands>
@@ -200,7 +200,7 @@ env = Environment(SHCCCOMSTR = "Compiling shared object $TARGET")
 <para>
 Options that are passed to the C and C++ compilers
 to generate shared-library objects.
-See also &cv-link-CCFLAGS;.
+See also &cv-link-CCFLAGS; for compiling to static objects.
 </para>
 </summary>
 </cvar>
@@ -210,7 +210,7 @@ See also &cv-link-CCFLAGS;.
 <para>
 Options that are passed to the C compiler (only; not C++)
 to generate shared-library objects.
-See also &cv-link-CFLAGS;.
+See also &cv-link-CFLAGS; for compiling to static objects.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/f03.xml
+++ b/src/engine/SCons/Tool/f03.xml
@@ -77,9 +77,9 @@ for all Fortran versions.
 <cvar name="F03COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 03 source file
+If set, the string displayed when a Fortran 03 source file
 is compiled to an object file.
-If this is not set, then &cv-link-F03COM; or &cv-link-FORTRANCOM;
+If not set, then &cv-link-F03COM; or &cv-link-FORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -217,10 +217,10 @@ for all Fortran versions.
 <cvar name="F03PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 03 source file
+If set, the string displayed when a Fortran 03 source file
 is compiled to an object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-F03PPCOM; or &cv-link-FORTRANPPCOM;
+If not set, then &cv-link-F03PPCOM; or &cv-link-FORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -256,9 +256,9 @@ for all Fortran versions.
 <cvar name="SHF03COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 03 source file
+If set, the string displayed when a Fortran 03 source file
 is compiled to a shared-library object file.
-If this is not set, then &cv-link-SHF03COM; or &cv-link-SHFORTRANCOM;
+If not set, then &cv-link-SHF03COM; or &cv-link-SHFORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -299,10 +299,10 @@ for all Fortran versions.
 <cvar name="SHF03PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 03 source file
+If set, the string displayed when a Fortran 03 source file
 is compiled to a shared-library object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-SHF03PPCOM; or &cv-link-SHFORTRANPPCOM;
+If not set, then &cv-link-SHF03PPCOM; or &cv-link-SHFORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>

--- a/src/engine/SCons/Tool/f08.xml
+++ b/src/engine/SCons/Tool/f08.xml
@@ -77,9 +77,9 @@ for all Fortran versions.
 <cvar name="F08COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 08 source file
+If set, the string displayed when a Fortran 08 source file
 is compiled to an object file.
-If this is not set, then &cv-link-F08COM; or &cv-link-FORTRANCOM;
+If not set, then &cv-link-F08COM; or &cv-link-FORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -217,10 +217,10 @@ for all Fortran versions.
 <cvar name="F08PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 08 source file
+If set, the string displayed when a Fortran 08 source file
 is compiled to an object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-F08PPCOM; or &cv-link-FORTRANPPCOM;
+If not set, then &cv-link-F08PPCOM; or &cv-link-FORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -256,9 +256,9 @@ for all Fortran versions.
 <cvar name="SHF08COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 08 source file
+If set, the string displayed when a Fortran 08 source file
 is compiled to a shared-library object file.
-If this is not set, then &cv-link-SHF08COM; or &cv-link-SHFORTRANCOM;
+If not set, then &cv-link-SHF08COM; or &cv-link-SHFORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -299,10 +299,10 @@ for all Fortran versions.
 <cvar name="SHF08PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 08 source file
+If set, the string displayed when a Fortran 08 source file
 is compiled to a shared-library object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-SHF08PPCOM; or &cv-link-SHFORTRANPPCOM;
+If not set, then &cv-link-SHF08PPCOM; or &cv-link-SHFORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>

--- a/src/engine/SCons/Tool/f77.xml
+++ b/src/engine/SCons/Tool/f77.xml
@@ -108,9 +108,9 @@ F77 dialect will be used. By default, this is empty
 <cvar name="F77COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 77 source file
+If set, the string displayed when a Fortran 77 source file
 is compiled to an object file.
-If this is not set, then &cv-link-F77COM; or &cv-link-FORTRANCOM;
+If not set, then &cv-link-F77COM; or &cv-link-FORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -230,10 +230,10 @@ for all Fortran versions.
 <cvar name="F77PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 77 source file
+If set, the string displayed when a Fortran 77 source file
 is compiled to an object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-F77PPCOM; or &cv-link-FORTRANPPCOM;
+If not set, then &cv-link-F77PPCOM; or &cv-link-FORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -269,9 +269,9 @@ for all Fortran versions.
 <cvar name="SHF77COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 77 source file
+If set, the string displayed when a Fortran 77 source file
 is compiled to a shared-library object file.
-If this is not set, then &cv-link-SHF77COM; or &cv-link-SHFORTRANCOM;
+If not set, then &cv-link-SHF77COM; or &cv-link-SHFORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -312,10 +312,10 @@ for all Fortran versions.
 <cvar name="SHF77PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 77 source file
+If set, the string displayed when a Fortran 77 source file
 is compiled to a shared-library object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-SHF77PPCOM; or &cv-link-SHFORTRANPPCOM;
+If not set, then &cv-link-SHF77PPCOM; or &cv-link-SHFORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>

--- a/src/engine/SCons/Tool/f90.xml
+++ b/src/engine/SCons/Tool/f90.xml
@@ -77,9 +77,9 @@ for all Fortran versions.
 <cvar name="F90COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 90 source file
+If set, the string displayed when a Fortran 90 source file
 is compiled to an object file.
-If this is not set, then &cv-link-F90COM; or &cv-link-FORTRANCOM;
+If not set, then &cv-link-F90COM; or &cv-link-FORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -217,9 +217,9 @@ for all Fortran versions.
 <cvar name="F90PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 90 source file
+If set, the string displayed when a Fortran 90 source file
 is compiled after first running the file through the C preprocessor.
-If this is not set, then &cv-link-F90PPCOM; or &cv-link-FORTRANPPCOM;
+If not set, then &cv-link-F90PPCOM; or &cv-link-FORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -255,9 +255,9 @@ for all Fortran versions.
 <cvar name="SHF90COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 90 source file
+If set, the string displayed when a Fortran 90 source file
 is compiled to a shared-library object file.
-If this is not set, then &cv-link-SHF90COM; or &cv-link-SHFORTRANCOM;
+If not set, then &cv-link-SHF90COM; or &cv-link-SHFORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -298,10 +298,10 @@ for all Fortran versions.
 <cvar name="SHF90PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 90 source file
+If set, the string displayed when a Fortran 90 source file
 is compiled to a shared-library object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-SHF90PPCOM; or &cv-link-SHFORTRANPPCOM;
+If not set, then &cv-link-SHF90PPCOM; or &cv-link-SHFORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>

--- a/src/engine/SCons/Tool/f95.xml
+++ b/src/engine/SCons/Tool/f95.xml
@@ -77,9 +77,9 @@ for all Fortran versions.
 <cvar name="F95COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 95 source file
+If set, the string displayed when a Fortran 95 source file
 is compiled to an object file.
-If this is not set, then &cv-link-F95COM; or &cv-link-FORTRANCOM;
+If not set, then &cv-link-F95COM; or &cv-link-FORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -217,10 +217,10 @@ for all Fortran versions.
 <cvar name="F95PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 95 source file
+If set, the string displayed when a Fortran 95 source file
 is compiled to an object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-F95PPCOM; or &cv-link-FORTRANPPCOM;
+If not set, then &cv-link-F95PPCOM; or &cv-link-FORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -256,9 +256,9 @@ for all Fortran versions.
 <cvar name="SHF95COMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 95 source file
+If set, the string displayed when a Fortran 95 source file
 is compiled to a shared-library object file.
-If this is not set, then &cv-link-SHF95COM; or &cv-link-SHFORTRANCOM;
+If not set, then &cv-link-SHF95COM; or &cv-link-SHFORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -299,10 +299,10 @@ for all Fortran versions.
 <cvar name="SHF95PPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran 95 source file
+If set, the string displayed when a Fortran 95 source file
 is compiled to a shared-library object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-SHF95PPCOM; or &cv-link-SHFORTRANPPCOM;
+If not set, then &cv-link-SHF95PPCOM; or &cv-link-SHFORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>

--- a/src/engine/SCons/Tool/fortran.xml
+++ b/src/engine/SCons/Tool/fortran.xml
@@ -73,9 +73,9 @@ are included on this command line.
 <cvar name="FORTRANCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran source file
+If set, the string displayed when a Fortran source file
 is compiled to an object file.
-If this is not set, then &cv-link-FORTRANCOM;
+If not set, then &cv-link-FORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -285,10 +285,10 @@ construction variables are included on this command line.
 <cvar name="FORTRANPPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran source file
+If set, the string displayed when a Fortran source file
 is compiled to an object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-FORTRANPPCOM;
+If not set, then &cv-link-FORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -330,9 +330,9 @@ to a shared-library object file.
 <cvar name="SHFORTRANCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran source file
+If set, the string displayed when a Fortran source file
 is compiled to a shared-library object file.
-If this is not set, then &cv-link-SHFORTRANCOM;
+If not set, then &cv-link-SHFORTRANCOM;
 (the command line) is displayed.
 </para>
 </summary>
@@ -364,10 +364,10 @@ are included on this command line.
 <cvar name="SHFORTRANPPCOMSTR">
 <summary>
 <para>
-The string displayed when a Fortran source file
+If set, the string displayed when a Fortran source file
 is compiled to a shared-library object file
 after first running the file through the C preprocessor.
-If this is not set, then &cv-link-SHFORTRANPPCOM;
+If not set, then &cv-link-SHFORTRANPPCOM;
 (the command line) is displayed.
 </para>
 </summary>

--- a/src/engine/SCons/Tool/link.xml
+++ b/src/engine/SCons/Tool/link.xml
@@ -32,9 +32,6 @@ based on the types of source files.
 </para>
 </summary>
 <sets>
-<item>SHLINK</item>
-<item>SHLINKFLAGS</item>
-<item>SHLINKCOM</item>
 <item>LINK</item>
 <item>LINKFLAGS</item>
 <item>LINKCOM</item>
@@ -42,6 +39,9 @@ based on the types of source files.
 <item>LIBDIRSUFFIX</item>
 <item>LIBLINKPREFIX</item>
 <item>LIBLINKSUFFIX</item>
+<item>SHLINK</item>
+<item>SHLINKFLAGS</item>
+<item>SHLINKCOM</item>
 <item>SHLIBSUFFIX</item>
 <item>__SHLIBVERSIONFLAGS</item>
 <item>LDMODULE</item>
@@ -243,6 +243,7 @@ set.
 <summary>
 <para>
 The linker.
+See also &cv-link-SHLINK; for linking shared objects.
 </para>
 </summary>
 </cvar>
@@ -251,6 +252,7 @@ The linker.
 <summary>
 <para>
 The command line used to link object files into an executable.
+See also &cv-link-SHLINKCOM; for linking shared objects.
 </para>
 </summary>
 </cvar>
@@ -261,7 +263,7 @@ The command line used to link object files into an executable.
 If set, the string displayed when object files
 are linked into an executable.
 If not set, then &cv-link-LINKCOM; (the command line) is displayed.
-See also &cv-link-SHLINKCOMSTR;.
+See also &cv-link-SHLINKCOMSTR;.  for linking shared objects.
 </para>
 
 <example_commands>
@@ -291,6 +293,7 @@ and
 &cv-link-_LIBDIRFLAGS;
 above,
 for the variable that expands to library search path options.
+See also &cv-link-SHLINKFLAGS;.  for linking shared objects.
 </para>
 </summary>
 </cvar>
@@ -318,6 +321,7 @@ set.
 <summary>
 <para>
 The linker for programs that use shared libraries.
+See also &cv-link-LINK; for linking static objects.
 </para>
 </summary>
 </cvar>
@@ -326,6 +330,7 @@ The linker for programs that use shared libraries.
 <summary>
 <para>
 The command line used to link programs using shared libraries.
+See also &cv-link-LINKCOM; for linking static objects.
 </para>
 </summary>
 </cvar>
@@ -335,7 +340,7 @@ The command line used to link programs using shared libraries.
 <para>
 The string displayed when programs using shared libraries are linked.
 If this is not set, then &cv-link-SHLINKCOM; (the command line) is displayed.
-See also &cv-link-LINKCOMSTR;.
+See also &cv-link-LINKCOMSTR;  for linking static objects.
 </para>
 
 <example_commands>
@@ -365,6 +370,7 @@ and
 &cv-link-_LIBDIRFLAGS;
 above,
 for the variable that expands to library search path options.
+See also &cv-link-LINKFLAGS;  for linking static objects.
 </para>
 </summary>
 </cvar>

--- a/src/engine/SCons/Tool/link.xml
+++ b/src/engine/SCons/Tool/link.xml
@@ -55,8 +55,8 @@ based on the types of source files.
 <item>__LDMODULEVERSIONFLAGS</item>
 </sets>
 <uses>
-<item>SHLINKCOMSTR</item>
 <item>LINKCOMSTR</item>
+<item>SHLINKCOMSTR</item>
 <item>LDMODULECOMSTR</item>
 </uses>
 </tool>
@@ -184,8 +184,8 @@ On other systems, this is the same as &cv-link-SHLINK;.
 <cvar name="LDMODULECOMSTR">
 <summary>
 <para>
-The string displayed when building loadable modules.
-If this is not set, then &cv-link-LDMODULECOM; (the command line) is displayed.
+If set, the string displayed when building loadable modules.
+If not set, then &cv-link-LDMODULECOM; (the command line) is displayed.
 </para>
 </summary>
 </cvar>
@@ -258,9 +258,10 @@ The command line used to link object files into an executable.
 <cvar name="LINKCOMSTR">
 <summary>
 <para>
-The string displayed when object files
+If set, the string displayed when object files
 are linked into an executable.
-If this is not set, then &cv-link-LINKCOM; (the command line) is displayed.
+If not set, then &cv-link-LINKCOM; (the command line) is displayed.
+See also &cv-link-SHLINKCOMSTR;.
 </para>
 
 <example_commands>
@@ -334,6 +335,7 @@ The command line used to link programs using shared libraries.
 <para>
 The string displayed when programs using shared libraries are linked.
 If this is not set, then &cv-link-SHLINKCOM; (the command line) is displayed.
+See also &cv-link-LINKCOMSTR;.
 </para>
 
 <example_commands>


### PR DESCRIPTION
[fixes #2565] Object code intended for use in a shared library may need different compilation options than object code not intended for such use. When SCons tools recognize this need they define parallel sets of variables, such that for `FOO` there is both `FOOCOM` and `SHFOOCOM`, `FOOCOMSTR` and `SHFOOCOMSTR`, etc.  Refer such pairs to each other. Issue 2565 described a case where a user did not realize they needed to use `SHCXXCOMSTR` to affect the output for certain C++-compiled objects. The discussion concluded this was just a doc fix.

Some examination turned up cases of this in docs for the C compiler, C++ compiler, D compiler, Fortran compiler and linker modules, seemed better to just hit all of those. (**_This PR does not contain the Fortran ones, since there are a whole bunch - 12 pairs. We can hold the PR for getting those added if desired_**).

I would have preferred to move the pairs together into a single entry but it seems the scons doc markup doesn't support this kind of usage - a `<cvar>` can take only a single name attribute, and uses it to generate tags, etc. so there would have been a ton of surgery needed to implement that way.

This is a doc-only change (including that `doc/generated/variables.mod` needed to be checked in, as it defines new link entities for the added `DCOMSTR` and `SHDCOMSTR` entries).

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
