### PR TITLE
Change 'Dependency' to 'Depends' in documentation

### DIFF
--- a/doc/design/engine.xml
+++ b/doc/design/engine.xml
@@ -1104,13 +1104,13 @@ you set it up with another environment...
   </para>
 
 	<programlisting>
-	env.Dependency(target = 'output1', dependency = 'input_1 input_2')
-	env.Dependency(target = 'output2', dependency = ['input_1', 'input_2'])
-	env.Dependency(target = 'output3', dependency = ['white space input'])
+	env.Depends(target = 'output1', dependency = 'input_1 input_2')
+	env.Depends(target = 'output2', dependency = ['input_1', 'input_2'])
+	env.Depends(target = 'output3', dependency = ['white space input'])
 
-	env.Dependency(target = 'output_a output_b', dependency = 'input_3')
-	env.Dependency(target = ['output_c', 'output_d'], dependency = 'input_4')
-	env.Dependency(target = ['white space output'], dependency = 'input_5')
+	env.Depends(target = 'output_a output_b', dependency = 'input_3')
+	env.Depends(target = ['output_c', 'output_d'], dependency = 'input_4')
+	env.Depends(target = ['white space output'], dependency = 'input_5')
 	</programlisting>
 
   <para>
@@ -1129,7 +1129,7 @@ you set it up with another environment...
   </para>
 
 	<programlisting>
-	env.Dependency(target = 'archive.tar.gz', dependency = 'SConstruct')
+	env.Depends(target = 'archive.tar.gz', dependency = 'SConstruct')
 	</programlisting>
 
  </section>

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,7 +8,6 @@ NOTE: The 4.0.0 Release of SCons will drop Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-
   From William Deegan:
     - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to 
       propagate'VCINSTALLDIR' and 'VCToolsInstallDir' which clang tools use to locate
@@ -37,6 +36,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Convert remaining uses of insecure/deprecated mktemp method.
     - Clean up some duplications in manpage.  Clarify portion of manpage on Dir and File nodes.
 
+  From Jeremy Elson:
+    - Updated design doc to use the correct syntax for Depends()
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000
 


### PR DESCRIPTION
SconsEnvironment contains a function called 'Depends', not 'Dependency'. This simple PR changes
the documentation to match reality.

## Contributor Checklist:

* [n/a] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [n/a] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
