### PR TITLE
Stop converting to list where not needed

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -35,6 +35,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - a bunch of linter/checker syntax fixups
     - Convert remaining uses of insecure/deprecated mktemp method.
     - Clean up some duplications in manpage.  Clarify portion of manpage on Dir and File nodes.
+    - Reduce needless list conversions.
 
   From Jeremy Elson:
     - Updated design doc to use the correct syntax for Depends()

--- a/src/engine/SCons/Builder.py
+++ b/src/engine/SCons/Builder.py
@@ -230,7 +230,7 @@ class OverrideWarner(collections.UserDict):
     def warn(self):
         if self.already_warned:
             return
-        for k in list(self.keys()):
+        for k in self.keys():
             if k in misleading_keywords:
                 alt = misleading_keywords[k]
                 msg = "Did you mean to use `%s' instead of `%s'?" % (alt, k)

--- a/src/engine/SCons/Environment.py
+++ b/src/engine/SCons/Environment.py
@@ -1854,7 +1854,7 @@ class Base(SubstitutionEnvironment):
         uniq = {}
         for executor in [n.get_executor() for n in nodes]:
             uniq[executor] = 1
-        for executor in list(uniq.keys()):
+        for executor in uniq.keys():
             executor.add_pre_action(action)
         return nodes
 
@@ -1864,7 +1864,7 @@ class Base(SubstitutionEnvironment):
         uniq = {}
         for executor in [n.get_executor() for n in nodes]:
             uniq[executor] = 1
-        for executor in list(uniq.keys()):
+        for executor in uniq.keys():
             executor.add_post_action(action)
         return nodes
 

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -1612,7 +1612,7 @@ class Dir(Base):
         This clears any cached information that is invalidated by changing
         the repository."""
 
-        for node in list(self.entries.values()):
+        for node in self.entries.values():
             if node != self.dir:
                 if node != self and isinstance(node, Dir):
                     node.__clearRepositoryCache(duplicate)
@@ -1623,7 +1623,7 @@ class Dir(Base):
                     except AttributeError:
                         pass
                     if duplicate is not None:
-                        node.duplicate=duplicate
+                        node.duplicate = duplicate
 
     def __resetDuplicate(self, node):
         if node != self:

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -132,8 +132,8 @@ def CreateConfigHBuilder(env):
                                  _stringConfigH)
     sconfigHBld = SCons.Builder.Builder(action=action)
     env.Append( BUILDERS={'SConfigHBuilder':sconfigHBld} )
-    for k in list(_ac_config_hs.keys()):
-        env.SConfigHBuilder(k, env.Value(_ac_config_hs[k]))
+    for k, v in _ac_config_hs.items():
+        env.SConfigHBuilder(k, env.Value(v))
 
 
 class SConfWarning(SCons.Warnings.Warning):
@@ -703,7 +703,7 @@ class SConfBase(object):
         """Adds all the tests given in the tests dictionary to this SConf
         instance
         """
-        for name in list(tests.keys()):
+        for name in tests.keys():
             self.AddTest(name, tests[name])
 
     def _createDir( self, node ):

--- a/src/engine/SCons/Script/Interactive.py
+++ b/src/engine/SCons/Script/Interactive.py
@@ -247,7 +247,7 @@ version                 Prints SCons version information.
             while n:
                 n = walker.get_next()
 
-        for node in list(seen_nodes.keys()):
+        for node in seen_nodes.keys():
             # Call node.clear() to clear most of the state
             node.clear()
             # node.clear() doesn't reset node.state, so call

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -743,9 +743,9 @@ def _load_site_scons_dir(topdir, site_dir_name=None):
                     modname = os.path.basename(pathname)[:-len(sfx)]
                     site_m = {"__file__": pathname, "__name__": modname, "__doc__": None}
                     re_special = re.compile("__[^_]+__")
-                    for k in list(m.__dict__.keys()):
+                    for k, v in m.__dict__.items():
                         if not re_special.match(k):
-                            site_m[k] = m.__dict__[k]
+                            site_m[k] = v
 
                     # This is the magic.
                     exec(compile(fp.read(), fp.name, 'exec'), site_m)

--- a/src/engine/SCons/Tool/MSCommon/common.py
+++ b/src/engine/SCons/Tool/MSCommon/common.py
@@ -152,8 +152,8 @@ def normalize_env(env, keys, force=False):
     Note: the environment is copied."""
     normenv = {}
     if env:
-        for k in list(env.keys()):
-            normenv[k] = copy.deepcopy(env[k])
+        for k, v in env.items():
+            normenv[k] = copy.deepcopy(v)
 
         for k in keys:
             if k in os.environ and (force or k not in normenv):

--- a/src/engine/SCons/Tool/__init__.py
+++ b/src/engine/SCons/Tool/__init__.py
@@ -1130,7 +1130,7 @@ class ToolInitializer(object):
         so we no longer copy and re-bind them when the construction
         environment gets cloned.
         """
-        for method in list(self.methods.values()):
+        for method in self.methods.values():
             env.RemoveMethod(method)
 
     def apply_tools(self, env):

--- a/src/engine/SCons/Tool/intelc.py
+++ b/src/engine/SCons/Tool/intelc.py
@@ -495,15 +495,15 @@ def generate(env, version=None, abi=None, topdir=None, verbose=0):
                    'LIB'             : libdir,
                    'PATH'            : bindir,
                    'LD_LIBRARY_PATH' : libdir}
-            for p in list(paths.keys()):
-                env.PrependENVPath(p, os.path.join(topdir, paths[p]))
+            for p, v in paths.items():
+                env.PrependENVPath(p, os.path.join(topdir, v))
         if is_mac:
             paths={'INCLUDE'         : 'include',
                    'LIB'             : libdir,
                    'PATH'            : bindir,
                    'LD_LIBRARY_PATH' : libdir}
-            for p in list(paths.keys()):
-                env.PrependENVPath(p, os.path.join(topdir, paths[p]))
+            for p, v in paths.items():
+                env.PrependENVPath(p, os.path.join(topdir, v))
         if is_windows:
             #       env key    reg valname   default subdir of top
             paths=(('INCLUDE', 'IncludeDir', 'Include'),

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -578,7 +578,9 @@ class _DSPGenerator(object):
         for i in range(len(variants)):
             AddConfig(self, variants[i], buildtarget[i], outdir[i], runfile[i], cmdargs[i], cppdefines[i], cpppaths[i])
 
-        self.platforms = {p.platform for p in self.configs.values()}
+        seen = set()
+        self.platforms = [p.platform for p in self.configs.values()
+                          if not (p.platform in seen or seen.add(p.platform))]
 
 
     def Build(self):
@@ -1502,7 +1504,9 @@ class _GenerateV7DSW(_DSWGenerator):
             for variant in env['variant']:
                 AddConfig(self, variant)
 
-        self.platforms = {p.platform for p in self.configs.values()}
+        seen = set()
+        self.platforms = [p.platform for p in self.configs.values()
+                          if not (p.platform in seen or seen.add(p.platform))]
 
         def GenerateProjectFilesInfo(self):
             for dspfile in self.dspfiles:

--- a/src/engine/SCons/Tool/msvs.py
+++ b/src/engine/SCons/Tool/msvs.py
@@ -220,7 +220,7 @@ class _UserGenerator(object):
             for var, src in dbg_settings.items():
                 # Update only expected keys
                 trg = {}
-                for key in [k for k in list(self.usrdebg.keys()) if k in src]:
+                for key in [k for k in self.usrdebg.keys() if k in src]:
                     trg[key] = str(src[key])
                 self.configs[var].debug = trg
 
@@ -578,11 +578,8 @@ class _DSPGenerator(object):
         for i in range(len(variants)):
             AddConfig(self, variants[i], buildtarget[i], outdir[i], runfile[i], cmdargs[i], cppdefines[i], cpppaths[i])
 
-        self.platforms = []
-        for key in list(self.configs.keys()):
-            platform = self.configs[key].platform
-            if platform not in self.platforms:
-                self.platforms.append(platform)
+        self.platforms = {p.platform for p in self.configs.values()}
+
 
     def Build(self):
         pass
@@ -702,7 +699,7 @@ class _GenerateV6DSP(_DSPGenerator):
                       'Resource Files': 'r|rc|ico|cur|bmp|dlg|rc2|rct|bin|cnt|rtf|gif|jpg|jpeg|jpe',
                       'Other Files': ''}
 
-        for kind in sorted(list(categories.keys()), key=lambda a: a.lower()):
+        for kind in sorted(categories.keys(), key=lambda a: a.lower()):
             if not self.sources[kind]:
                 continue # skip empty groups
 
@@ -1003,7 +1000,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
 
         self.file.write('\t<Files>\n')
 
-        cats = sorted([k for k in list(categories.keys()) if self.sources[k]],
+        cats = sorted([k for k in categories.keys() if self.sources[k]],
                       key=lambda a: a.lower())
         for kind in cats:
             if len(cats) > 1:
@@ -1348,7 +1345,7 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
                       'Resource Files': 'r;rc;ico;cur;bmp;dlg;rc2;rct;bin;cnt;rtf;gif;jpg;jpeg;jpe',
                       'Other Files': ''}
 
-        cats = sorted([k for k in list(categories.keys()) if self.sources[k]],
+        cats = sorted([k for k in categories.keys() if self.sources[k]],
                       key = lambda a: a.lower())
 
         # print vcxproj.filters file first
@@ -1505,11 +1502,7 @@ class _GenerateV7DSW(_DSWGenerator):
             for variant in env['variant']:
                 AddConfig(self, variant)
 
-        self.platforms = []
-        for key in list(self.configs.keys()):
-            platform = self.configs[key].platform
-            if platform not in self.platforms:
-                self.platforms.append(platform)
+        self.platforms = {p.platform for p in self.configs.values()}
 
         def GenerateProjectFilesInfo(self):
             for dspfile in self.dspfiles:

--- a/src/engine/SCons/Tool/msvsTests.py
+++ b/src/engine/SCons/Tool/msvsTests.py
@@ -771,8 +771,8 @@ class msvsTestCase(unittest.TestCase):
         
             # Check expected result
             self.assertListEqual(list(genDSP.configs.keys()), list(expected_configs.keys()))
-            for key in list(genDSP.configs.keys()):
-                self.assertDictEqual(genDSP.configs[key].__dict__, expected_configs[key])
+            for key, v in genDSP.configs.items():
+                self.assertDictEqual(v.__dict__, expected_configs[key])
 
             genDSP.Build()
 

--- a/src/engine/SCons/Tool/packaging/ipk.py
+++ b/src/engine/SCons/Tool/packaging/ipk.py
@@ -173,7 +173,7 @@ Description: $X_IPK_DESCRIPTION
 
     #
     # close all opened files
-    for f in list(opened_files.values()):
+    for f in opened_files.values():
         f.close()
 
     # call a user specified function

--- a/src/engine/SCons/Tool/packaging/rpm.py
+++ b/src/engine/SCons/Tool/packaging/rpm.py
@@ -284,7 +284,7 @@ def build_specfile_filesection(spec, files):
     for file in files:
         # build the tagset
         tags = {}
-        for k in list(supported_tags.keys()):
+        for k in supported_tags.keys():
             try:
                 v = file.GetTag(k)
                 if v:

--- a/src/engine/SCons/cpp.py
+++ b/src/engine/SCons/cpp.py
@@ -89,7 +89,7 @@ del op_list
 override = {
     'if'                        : 'if(?!n?def)',
 }
-l = [override.get(x, x) for x in list(Table.keys())]
+l = [override.get(x, x) for x in Table.keys()]
 
 
 # Turn the list of expressions into one big honkin' regular expression
@@ -268,7 +268,7 @@ class PreProcessor(object):
         d = {
             'scons_current_file'    : self.scons_current_file
         }
-        for op in list(Table.keys()):
+        for op in Table.keys():
             d[op] = getattr(self, 'do_' + op)
         self.default_table = d
 

--- a/src/test_interrupts.py
+++ b/src/test_interrupts.py
@@ -105,7 +105,7 @@ for f in files:
         indent_list.append( (line_num, match.group('try_or_except') ) )
         try_except_lines[match.group('indent')] = indent_list
     uncaught_this_file = []
-    for indent in list(try_except_lines.keys()):
+    for indent in try_except_lines.keys():
         exc_keyboardint_seen = 0
         exc_all_seen = 0
         for (l,statement) in try_except_lines[indent] + [(-1,indent + 'try')]:


### PR DESCRIPTION
Python 3 returns a special object, which is iterable, rather than a list when you ask for dictionary `keys()`, `values()`, `items()`. if you then proceed to iterate over it it's being used as expected and doesn't have to be forced to a list first.  This occurs a number of places in this form:
```
  for k in list(something.keys()):
```
Also there are several places where the code loops over the result of _dict_`.keys()` and then uses the key to index into the dictionary, this can be replaced by:
```
  for k, v in something.items():
```
Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
