### PR TITLE
More manpage fiddling

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -54,10 +54,10 @@
 
     <corpauthor>Steven Knight and the SCons Development Team</corpauthor>
 
-    <pubdate>2004 - 2019</pubdate>
+    <pubdate>2004 - 2020</pubdate>
 
     <copyright>
-      <year>2004 - 2019</year>
+      <year>2004 - 2020</year>
       <holder>The SCons Foundation</holder>
     </copyright>
 
@@ -488,67 +488,61 @@ supports the same command-line options as GNU
 and many of those supported by
 <emphasis role="bold">cons</emphasis>.</para>
 
+<!-- Note: commented-out options are retained as they may be a model -->
+<!-- for future development directions. Do not remove. -->
+
 <variablelist>
   <varlistentry>
   <term>-b</term>
   <listitem>
-<para>Ignored for compatibility with non-GNU versions of
-<emphasis role="bold">make.</emphasis></para>
-
+<para>Ignored for compatibility with non-GNU versions of &Make;</para>
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-c, --clean, --remove</term>
   <listitem>
 <para>Clean up by removing all target files for which a construction
 command is specified.
 Also remove any files or directories associated to the construction command
-using the
-<emphasis role="bold">Clean</emphasis>()
-function.
-Will not remove any targets specified by the
-<emphasis role="bold">NoClean</emphasis>()
-function.</para>
-
+using the &Clean; function.
+Will not remove any targets specified by the &NoClean; function.</para>
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--cache-debug=<emphasis>file</emphasis></term>
   <listitem>
-<para>Print debug information about the
-<emphasis role="bold">CacheDir</emphasis>()
-derived-file caching
-to the specified
+<para>Print debug information about the &CacheDir;
+derived-file caching to the specified
 <emphasis>file</emphasis>.
 If
 <emphasis>file</emphasis>
 is
 <emphasis role="bold">-</emphasis>
 (a hyphen),
-the debug information are printed to the standard output.
-The printed messages describe what signature file names are
-being looked for in, retrieved from, or written to the
-<emphasis role="bold">CacheDir</emphasis>()
-directory tree.</para>
-
+the debug information is printed to the standard output.
+The printed messages describe what signature-file names
+are being looked for in, retrieved from, or written to the
+&CacheDir; directory tree.</para>
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--cache-disable, --no-cache</term>
   <listitem>
 <para>Disable the derived-file caching specified by
-<emphasis role="bold">CacheDir</emphasis>().
+&CacheDir;.
 <command>scons</command>
 will neither retrieve files from the cache
 nor copy files to the cache.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--cache-force, --cache-populate</term>
   <listitem>
-<para>When using
-<emphasis role="bold">CacheDir</emphasis>(),
+<para>When using &CacheDir;,
 populate a cache by copying any already-existing, up-to-date
 derived files to the cache,
 in addition to files built by this invocation.
@@ -558,23 +552,22 @@ or to add to the cache any derived files
 recently built with caching disabled via the
 <option>--cache-disable</option>
 option.</para>
-
   </listitem>
   </varlistentry>
-<varlistentry>
+
+  <varlistentry>
   <term>--cache-readonly</term>
   <listitem>
 <para>Use the cache (if enabled) for reading, but do not not update the
 cache with changed files.
 </para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--cache-show</term>
   <listitem>
-<para>When using
-<emphasis role="bold">CacheDir</emphasis>()
+<para>When using &CacheDir;
 and retrieving a derived file from the cache,
 show the command
 that would have been executed to build the file,
@@ -583,21 +576,20 @@ instead of the usual report,
 This will produce consistent output for build logs,
 regardless of whether a target
 file was rebuilt or retrieved from the cache.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--config=<emphasis>mode</emphasis></term>
   <listitem>
-<para>This specifies how the
-<emphasis role="bold">Configure</emphasis>
+<para>This specifies how the &Configure;
 call should use or generate the
 results of configuration tests.
 The option should be specified from
-among the following choices:</para>
-
+among the following choices.</para>
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--config=auto</term>
   <listitem>
@@ -609,9 +601,9 @@ but will overlook changes in system header files
 or external commands (such as compilers)
 if you don't specify those dependecies explicitly.
 This is the default behavior.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--config=force</term>
   <listitem>
@@ -623,9 +615,9 @@ This can be used to explicitly
 force the configuration tests to be updated
 in response to an otherwise unconfigured change
 in a system header file or compiler.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--config=cache</term>
   <listitem>
@@ -636,9 +628,9 @@ Note that scons will still consider it an error
 if --config=cache is specified
 and a necessary test does not
 yet have any results in the cache.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-C <replaceable>directory</replaceable>, --directory=<replaceable>directory</replaceable></term>
   <listitem>
@@ -653,7 +645,7 @@ That is, change directory before searching for the
 &Sconstruct.py;
 or
 &sconstruct.py;
-file, or doing anything else.
+file or doing anything else.
 When multiple
 <option>-C</option>
 options are given, each subsequent non-absolute
@@ -730,18 +722,18 @@ have been compiled with optimization
 (that is, when executing from
 <emphasis role="bold">*.pyo</emphasis>
 files).</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=duplicate</term>
   <listitem>
 <para>Print a line for each unlink/relink (or copy) of a variant file from
 its source file.  Includes debugging info for unlinking stale variant
 files, as well as unlinking old targets before building them.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=explain</term>
   <listitem>
@@ -752,9 +744,9 @@ is deciding to (re-)build any targets.
 for targets that are
 <emphasis>not</emphasis>
 rebuilt.)</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=findlibs</term>
   <listitem>
@@ -762,9 +754,9 @@ rebuilt.)</para>
 to print a message about each potential library
 name it is searching for,
 and about the actual libraries it finds.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=includes</term>
   <listitem>
@@ -778,6 +770,7 @@ $ scons --debug=includes foo.o
 
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=memoizer</term>
   <listitem>
@@ -785,35 +778,35 @@ $ scons --debug=includes foo.o
 an internal subsystem that counts
 how often SCons uses cached values in memory
 instead of recomputing them each time they're needed.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=memory</term>
   <listitem>
 <para>Prints how much memory SCons uses
 before and after reading the SConscript files
 and before and after building targets.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=objects</term>
   <listitem>
 <para>Prints a list of the various objects
 of the various classes used internally by SCons.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=pdb</term>
   <listitem>
 <para>Re-run SCons under the control of the
-pdb
+<command>pdb</command>
 Python debugger.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=prepare</term>
   <listitem>
@@ -826,9 +819,9 @@ This can help debug problems with targets that aren't being
 built; it shows whether
 <command>scons</command>
 is at least considering them or not.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=presub</term>
   <listitem>
@@ -836,50 +829,51 @@ is at least considering them or not.</para>
 before the construction environment variables are substituted.
 Also shows which targets are being built by this command.
 Output looks something like this:</para>
+
 <literallayout class="monospaced">
 $ scons --debug=presub
 Building myprog.o with action(s):
   $SHCC $SHCFLAGS $SHCCFLAGS $CPPFLAGS $_CPPINCFLAGS -c -o $TARGET $SOURCES
 ...
 </literallayout>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=stacktrace</term>
   <listitem>
 <para>Prints an internal Python stack trace
 when encountering an otherwise unexplained error.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--debug=time</term>
   <listitem>
 <para>Prints various time profiling information:</para>
-  <itemizedlist>
-    <listitem>
+    <itemizedlist>
+      <listitem>
 <para>The time spent executing each individual build command</para>
-    </listitem>
-    <listitem>
+      </listitem>
+      <listitem>
 <para>The total build time (time SCons ran from beginning to end)</para>
-    </listitem>
-    <listitem>
+      </listitem>
+      <listitem>
 <para>The total time spent reading and executing SConscript files</para>
-    </listitem>
-    <listitem>
-<para>The total time spent SCons itself spend running
+      </listitem>
+      <listitem>
+<para>The total time SCons itself spent running
 (that is, not counting reading and executing SConscript files)</para>
-    </listitem>
-    <listitem>
+      </listitem>
+      <listitem>
 <para>The total time spent executing all build commands</para></listitem>
-<listitem>
+      <listitem>
 <para>The elapsed wall-clock time spent executing those build commands</para>
-    </listitem>
-    <listitem>
+      </listitem>
+      <listitem>
 <para>The time spent processing each file passed to the <emphasis>SConscript()</emphasis> function</para>
-    </listitem>
-  </itemizedlist>
+      </listitem>
+    </itemizedlist>
 <para>
 (When
 <command>scons</command>
@@ -950,9 +944,9 @@ or of not handling errors gracefully
 found in SCCS or RCS, for example,
 or if a file really does exist
 where the SCons configuration expects a directory).</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--duplicate=<emphasis>ORDER</emphasis></term>
   <listitem>
@@ -971,22 +965,23 @@ or
 <emphasis>copy</emphasis>.
 SCons will attempt to duplicate files using
 the mechanisms in the specified order.</para>
+  </listitem>
+  </varlistentry>
 
 <!--  .TP -->
 <!--  \-e, \-\-environment\-overrides -->
 <!--  Variables from the execution environment override construction -->
 <!--  variables from the SConscript files. -->
 
-  </listitem>
-  </varlistentry>
   <varlistentry>
   <term>--enable-virtualenv</term>
   <listitem>
 <para>Import virtualenv-related variables to SCons.</para>
   </listitem>
   </varlistentry>
+
   <varlistentry>
-  <term>-f<emphasis> file</emphasis>, --file=<emphasis>file</emphasis>, --makefile=<emphasis>file</emphasis>, --sconstruct=<emphasis>file</emphasis></term>
+  <term>-f <emphasis>file</emphasis>, --file=<emphasis>file</emphasis>, --makefile=<emphasis>file</emphasis>, --sconstruct=<emphasis>file</emphasis></term>
   <listitem>
 <para>Use
 <emphasis>file</emphasis>
@@ -997,29 +992,29 @@ options may be specified,
 in which case
 <command>scons</command>
 will read all of the specified files.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-h, --help</term>
   <listitem>
 <para>Print a local help message for this build, if one is defined in
-the SConscript file(s), plus a line that describes the
+the SConscript files, plus a line that describes the
 <option>-H</option>
 option for command-line option help.  If no local help message
 is defined, prints the standard help message about command-line
 options.  Exits after displaying the appropriate message.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-H, --help-options</term>
   <listitem>
 <para>Print the standard help message about command-line options and
 exit.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-i, --ignore-errors</term>
   <listitem>
@@ -1027,6 +1022,7 @@ exit.</para>
 
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-I<emphasis> directory</emphasis>, --include-dir=<emphasis>directory</emphasis></term>
   <listitem>
@@ -1037,15 +1033,16 @@ imported Python modules.  If several
 <option>-I</option>
 options
 are used, the directories are searched in the order specified.</para>
-
   </listitem>
   </varlistentry>
-   <varlistentry>
-   <term>--ignore-virtualenv</term>
-   <listitem>
+
+  <varlistentry>
+  <term>--ignore-virtualenv</term>
+  <listitem>
 <para>Suppress importing virtualenv-related variables to SCons.</para>
-   </listitem>
-   </varlistentry>
+  </listitem>
+  </varlistentry>
+
   <varlistentry>
   <term>--implicit-cache</term>
   <listitem>
@@ -1057,9 +1054,6 @@ from the last time it was run
 instead of scanning the files for implicit dependencies.
 This can significantly speed up SCons,
 but with the following limitations:</para>
-  </listitem>
-  </varlistentry>
-</variablelist>
 
 <para><command>scons</command>
 will not detect changes to implicit dependency search paths
@@ -1075,17 +1069,18 @@ dependency is added earlier in the implicit dependency search path
 (e.g.
 <emphasis role="bold">CPPPATH</emphasis>, <emphasis role="bold">LIBPATH</emphasis>)
 than a current implicit dependency with the same name.</para>
+  </listitem>
+  </varlistentry>
 
-<variablelist>
   <varlistentry>
   <term>--implicit-deps-changed</term>
   <listitem>
 <para>Forces SCons to ignore the cached implicit dependencies. This causes the
 implicit dependencies to be rescanned and recached. This implies
 <option>--implicit-cache</option>.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--implicit-deps-unchanged</term>
   <listitem>
@@ -1093,7 +1088,6 @@ implicit dependencies to be rescanned and recached. This implies
 This causes cached implicit dependencies to always be used.
 This implies
 <option>--implicit-cache</option>.</para>
-
   </listitem>
   </varlistentry>
 
@@ -1157,7 +1151,6 @@ command:</para>
 --taskmastertrace=FILE
 --tree=OPTIONS
 </literallayout>
-
       </listitem>
       </varlistentry>
     </variablelist>
@@ -1182,9 +1175,9 @@ with the specified options.
 is a synonym.
 This command is itself a synonym for
 <userinput>build --clean</userinput></para>
-
       </listitem>
       </varlistentry>
+
       <varlistentry>
       <term><emphasis role="bold">exit</emphasis></term>
       <listitem>
@@ -1192,9 +1185,9 @@ This command is itself a synonym for
 You can also exit by terminating input
 (CTRL+D on UNIX or Linux systems,
 CTRL+Z on Windows systems).</para>
-
       </listitem>
       </varlistentry>
+
       <varlistentry>
       <term><emphasis role="bold">help</emphasis><emphasis>[COMMAND]</emphasis></term>
       <listitem>
@@ -1207,9 +1200,9 @@ is specified,
 and
 <emphasis role="bold">?</emphasis>
 are synonyms.</para>
-
       </listitem>
       </varlistentry>
+
       <varlistentry>
       <term><emphasis role="bold">shell</emphasis><emphasis>[COMMANDLINE]</emphasis></term>
       <listitem>
@@ -1232,9 +1225,9 @@ environment variable
 and
 <emphasis role="bold">!</emphasis>
 are synonyms.</para>
-
       </listitem>
       </varlistentry>
+
       <varlistentry>
       <term><emphasis role="bold">version</emphasis></term>
       <listitem>
@@ -1276,15 +1269,17 @@ option, the last one is effective.</para>
 <!--  .B scons -->
 <!--  will not limit the number of -->
 <!--  simultaneous jobs. -->
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-k, --keep-going</term>
   <listitem>
 <para>Continue as much as possible after an error.  The target that
 failed and those that depend on it will not be remade, but other
 targets specified on the command line will still be processed.</para>
+  </listitem>
+  </varlistentry>
 
 <!--  .TP -->
 <!--  .RI  \-l " N" ", \-\-load\-average=" N ", \-\-max\-load=" N -->
@@ -1293,7 +1288,6 @@ targets specified on the command line will still be processed.</para>
 <!--  average is at least -->
 <!--  .I N -->
 <!--  (a floating\-point number). -->
-
 
 <!--  .TP -->
 <!--  \-\-list\-derived -->
@@ -1316,16 +1310,13 @@ targets specified on the command line will still be processed.</para>
 <!--  [XXX This can probably go away with the right -->
 <!--  combination of other options.  Revisit this issue.] -->
 
-  </listitem>
-  </varlistentry>
   <varlistentry>
   <term>-m</term>
   <listitem>
-<para>Ignored for compatibility with non-GNU versions of
-<emphasis role="bold">make</emphasis>.</para>
-
+<para>Ignored for compatibility with non-GNU versions of &Make;.</para>
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--max-drift=<emphasis>SECONDS</emphasis></term>
   <listitem>
@@ -1343,9 +1334,9 @@ A negative value means to never cache the content
 signature and to ignore the cached value if there already is one. A value
 of 0 means to always use the cached signature,
 no matter how old the file is.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--md5-chunksize=<emphasis>KILOBYTES</emphasis></term>
   <listitem>
@@ -1359,29 +1350,31 @@ small block-size slows down the build considerably.</para>
 
 <para>The default value is to use a chunk size of 64 kilobytes, which should
 be appropriate for most uses.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-n, --just-print, --dry-run, --recon</term>
   <listitem>
 <para>No execute.  Print the commands that would be executed to build
 any out-of-date target files, but do not execute the commands.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--no-site-dir</term>
   <listitem>
 <para>Prevents the automatic addition of the standard
 <emphasis>site_scons</emphasis>
 dirs to
-<emphasis>sys.path</emphasis>.
+<varname>sys.path</varname>.
 Also prevents loading the
-<emphasis>site_scons/site_init.py</emphasis>
+<filename>site_scons/site_init.py</filename>
 modules if they exist, and prevents adding their
-<emphasis>site_scons/site_tools</emphasis>
+<filename>site_scons/site_tools</filename>
 dirs to the toolpath.</para>
+  </listitem>
+  </varlistentry>
 
 <!--  .TP -->
 <!--  .RI \-o " file" ", \-\-old\-file=" file ", \-\-assume\-old=" file -->
@@ -1395,6 +1388,7 @@ dirs to the toolpath.</para>
 <!--  Read values to override specific build environment variables -->
 <!--  from the specified -->
 <!--  .IR file . -->
+
 <!--  .TP -->
 <!--  \-p -->
 <!--  Print the data base (construction environments, -->
@@ -1413,8 +1407,6 @@ dirs to the toolpath.</para>
 <!--  scons \-p \-q -->
 <!--  .EE -->
 
-  </listitem>
-  </varlistentry>
   <varlistentry>
   <term>--profile=<emphasis>file</emphasis></term>
   <listitem>
@@ -1423,9 +1415,9 @@ and save the results in the specified
 <emphasis>file</emphasis>.
 The results may be analyzed using the Python
 pstats module.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-q, --question</term>
   <listitem>
@@ -1434,6 +1426,7 @@ status that is zero if the specified targets are already up to
 date, non-zero otherwise.</para>
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-Q</term>
   <listitem>
@@ -1443,14 +1436,14 @@ building targets
 and entering directories.
 Commands that are executed
 to rebuild target files are still printed.</para>
+  </listitem>
+  </varlistentry>
 
 <!--  .TP -->
 <!--  \-r, \-R, \-\-no\-builtin\-rules, \-\-no\-builtin\-variables -->
 <!--  Clear the default construction variables.  Construction -->
 <!--  environments that are created will be completely empty. -->
 
-  </listitem>
-  </varlistentry>
   <varlistentry>
   <term>--random</term>
   <listitem>
@@ -1458,37 +1451,37 @@ to rebuild target files are still printed.</para>
 building multiple trees simultaneously with caching enabled,
 to prevent multiple builds from simultaneously trying to build
 or retrieve the same target files.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-s, --silent, --quiet</term>
   <listitem>
 <para>Silent.  Do not print commands that are executed to rebuild
 target files.
 Also suppresses SCons status messages.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-S, --no-keep-going, --stop</term>
   <listitem>
 <para>Ignored for compatibility with GNU
 <emphasis role="bold">make</emphasis>.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
-  <term>--site-dir=<emphasis>dir</emphasis></term>
+  <term>--site-dir=<replaceable>dir</replaceable></term>
   <listitem>
-<para>Uses the named dir as the site dir rather than the default
+<para>Uses the named <replaceable>dir</replaceable> as the site dir rather than the default
 <emphasis>site_scons</emphasis>
 dirs.  This dir will get prepended to
-<emphasis>sys.path</emphasis>,
+<varname>sys.path</varname>,
 the module
-<emphasis>dir</emphasis>/site_init.py
+<filename><replaceable>dir</replaceable>/site_init.py</filename>
 will get loaded if it exists, and
-<emphasis>dir</emphasis>/site_tools
+<filename><replaceable>dir</replaceable>/site_tools</filename>
 will get added to the default toolpath.</para>
 
 <para>The default set of
@@ -1497,18 +1490,15 @@ dirs used when
 <option>--site-dir</option>
 is not specified depends on the system platform, as follows.  Note
 that the directories are examined in the order given, from most
-generic to most specific, so the last-executed site_init.py file is
+generic to most specific, so the last-executed <filename>site_init.py</filename> file is
 the most specific one (which gives it the chance to override
 everything else), and the dirs are prepended to the paths, again so
 the last dir examined comes first in the resulting path.</para>
 
-  </listitem>
-  </varlistentry>
-</variablelist>
-<variablelist>
-  <varlistentry>
-  <term>Windows:</term>
-  <listitem>
+    <variablelist>
+      <varlistentry>
+      <term>Windows:</term>
+      <listitem>
 <literallayout class="monospaced">
 %ALLUSERSPROFILE/Application Data/scons/site_scons
 %USERPROFILE%/Local Settings/Application Data/scons/site_scons
@@ -1516,11 +1506,12 @@ the last dir examined comes first in the resulting path.</para>
 %HOME%/.scons/site_scons
 ./site_scons
 </literallayout>
-  </listitem>
-  </varlistentry>
-  <varlistentry>
-  <term>Mac OS X:</term>
-  <listitem>
+      </listitem>
+      </varlistentry>
+
+      <varlistentry>
+      <term>Mac OS X:</term>
+      <listitem>
 <literallayout class="monospaced">
 /Library/Application Support/SCons/site_scons
 /opt/local/share/scons/site_scons (for MacPorts)
@@ -1529,32 +1520,36 @@ $HOME/Library/Application Support/SCons/site_scons
 $HOME/.scons/site_scons
 ./site_scons
 </literallayout>
-  </listitem>
-  </varlistentry>
-  <varlistentry>
-  <term>Solaris:</term>
-  <listitem>
+      </listitem>
+      </varlistentry>
+
+      <varlistentry>
+      <term>Solaris:</term>
+      <listitem>
 <literallayout class="monospaced">
 /opt/sfw/scons/site_scons
 /usr/share/scons/site_scons
 $HOME/.scons/site_scons
 ./site_scons
 </literallayout>
-  </listitem>
-  </varlistentry>
-  <varlistentry>
-  <term>Linux, HPUX, and other Posix-like systems:</term>
-  <listitem>
+      </listitem>
+      </varlistentry>
+
+      <varlistentry>
+      <term>Linux, HPUX, and other Posix-like systems:</term>
+      <listitem>
 <literallayout class="monospaced">
 /usr/share/scons/site_scons
 $HOME/.scons/site_scons
 ./site_scons
 </literallayout>
+      </listitem>
+      </varlistentry>
+    </variablelist>
 
   </listitem>
   </varlistentry>
-</variablelist>
-<variablelist>
+
   <varlistentry>
   <term>--stack-size=<emphasis>KILOBYTES</emphasis></term>
   <listitem>
@@ -1575,9 +1570,9 @@ build process.</para>
 <para>The default value is to use a stack size of 256 kilobytes, which should
 be appropriate for most uses.  You should not need to increase this value
 unless you encounter stack overflow errors.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-t, --touch</term>
   <listitem>
@@ -1586,9 +1581,9 @@ unless you encounter stack overflow errors.</para>
 (Touching a file to make it
 appear up-to-date is unnecessary when using
 <command>scons</command>.)</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--taskmastertrace=<emphasis>file</emphasis></term>
   <listitem>
@@ -1599,9 +1594,9 @@ evaluates and controls the order in which Nodes are built.
 A file name of
 <emphasis role="bold">-</emphasis>
 may be used to specify the standard output.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-tree=<emphasis>options</emphasis></term>
   <listitem>
@@ -1612,9 +1607,9 @@ in various formats,
 depending on the
 <emphasis>options</emphasis>
 specified:</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--tree=all</term>
   <listitem>
@@ -1622,24 +1617,24 @@ specified:</para>
 after each top-level target is built.
 This prints out the complete dependency tree,
 including implicit dependencies and ignored dependencies.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--tree=derived</term>
   <listitem>
 <para>Restricts the tree output to only derived (target) files,
 not source files.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--tree=status</term>
   <listitem>
 <para>Prints status information for each displayed node.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--tree=prune</term>
   <listitem>
@@ -1651,7 +1646,6 @@ will have its name printed in
 as an indication that the dependencies
 for that node can be found by searching
 for the relevant output higher up in the tree.</para>
-
   </listitem>
   </varlistentry>
 </variablelist>
@@ -1673,21 +1667,16 @@ scons --tree=all,prune,status target
   <term>-u, --up, --search-up</term>
   <listitem>
 <para>Walks up the directory structure until an
-<emphasis>SConstruct ,</emphasis>
-<emphasis>Sconstruct ,</emphasis>
-<emphasis>sconstruct ,</emphasis>
-<emphasis>SConstruct.py</emphasis>
-<emphasis>Sconstruct.py</emphasis>
-or
-<emphasis>sconstruct.py</emphasis>
+&SConstruct;, &Sconstruct;, &sconstruct;, &SConstruct.py;,
+&Sconstruct.py; or &sconstruct.py;
 file is found, and uses that
 as the top of the directory tree.
 If no targets are specified on the command line,
 only targets at or below the
 current directory will be built.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-U</term>
   <listitem>
@@ -1698,9 +1687,9 @@ When this option is used and no targets are specified on the command line,
 all default targets that are defined in the SConscript(s) in the current
 directory are built, regardless of what directory the resultant targets end
 up in.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-v, --version</term>
   <listitem>
@@ -1709,40 +1698,40 @@ up in.</para>
 version, copyright information,
 list of authors, and any other relevant information.
 Then exit.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>-w, --print-directory</term>
   <listitem>
 <para>Print a message containing the working directory before and
 after other processing.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--no-print-directory</term>
   <listitem>
 <para>Turn off -w, even if it was turned on implicitly.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=<emphasis>type</emphasis>, --warn=no-<emphasis>type</emphasis></term>
   <listitem>
 <para>Enable or disable warnings.
 <emphasis>type</emphasis>
 specifies the type of warnings to be enabled or disabled:</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=all, --warn=no-all</term>
   <listitem>
 <para>Enables or disables all warnings.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=cache-version, --warn=no-cache-version</term>
   <listitem>
@@ -1750,9 +1739,9 @@ specifies the type of warnings to be enabled or disabled:</para>
 the latest configuration information
 <emphasis role="bold">CacheDir</emphasis>().
 These warnings are enabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=cache-write-error, --warn=no-cache-write-error</term>
   <listitem>
@@ -1760,9 +1749,9 @@ These warnings are enabled by default.</para>
 write a copy of a built file to a specified
 <emphasis role="bold">CacheDir</emphasis>().
 These warnings are disabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=corrupt-sconsign, --warn=no-corrupt-sconsign</term>
   <listitem>
@@ -1770,17 +1759,17 @@ These warnings are disabled by default.</para>
 <markup>.sconsign</markup>
 files.
 These warnings are enabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=dependency, --warn=no-dependency</term>
   <listitem>
 <para>Enables or disables warnings about dependencies.
 These warnings are disabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=deprecated, --warn=no-deprecated</term>
   <listitem>
@@ -1797,9 +1786,9 @@ before they are officially no longer supported by SCons.
 Warnings for some specific deprecated features
 may be enabled or disabled individually;
 see below.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=duplicate-environment, --warn=no-duplicate-environment</term>
   <listitem>
@@ -1807,18 +1796,18 @@ see below.</para>
 of a target with two different construction environments
 that use the same action.
 These warnings are enabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=fortran-cxx-mix, --warn=no-fortran-cxx-mix</term>
   <listitem>
 <para>Enables or disables the specific warning about linking
 Fortran and C++ object files in a single executable,
 which can yield unpredictable behavior with some compilers.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=future-deprecated, --warn=no-future-deprecated</term>
   <listitem>
@@ -1831,16 +1820,16 @@ SCons configurations for other users to build,
 so that the project can be warned as soon as possible
 about to-be-deprecated features
 that may require changes to the configuration.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=link, --warn=no-link</term>
   <listitem>
 <para>Enables or disables warnings about link steps.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=misleading-keywords, --warn=no-misleading-keywords</term>
   <listitem>
@@ -1856,17 +1845,17 @@ characters, the correct spellings are
 and
 <emphasis role="bold">source.)</emphasis>
 These warnings are enabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=missing-sconscript, --warn=no-missing-sconscript</term>
   <listitem>
 <para>Enables or disables warnings about missing SConscript files.
 These warnings are enabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=no-object-count, --warn=no-no-object-count</term>
   <listitem>
@@ -1877,9 +1866,9 @@ feature not working when
 is run with the Python
 <option>-O</option>
 option or from optimized Python (.pyo) modules.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=no-parallel-support, --warn=no-no-parallel-support</term>
   <listitem>
@@ -1888,18 +1877,18 @@ not being able to support parallel builds when the
 <option>-j</option>
 option is used.
 These warnings are enabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=python-version, --warn=no-python-version</term>
   <listitem>
 <para>Enables or disables the warning about running
 SCons with a deprecated version of Python.
 These warnings are enabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=reserved-variable, --warn=no-reserved-variable</term>
   <listitem>
@@ -1915,15 +1904,29 @@ reserved construction variable names
 or
 <emphasis role="bold">UNCHANGED_TARGETS</emphasis>.
 These warnings are disabled by default.</para>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>--warn=stack-size, --warn=no-stack-size</term>
   <listitem>
 <para>Enables or disables warnings about requests to set the stack size
 that could not be honored.
 These warnings are enabled by default.</para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
+  <term>--warn=target_not_build, --warn=no-target_not_built</term>
+  <listitem>
+<para>Enables or disables warnings about a build rule not building the
+ expected targets. These warnings are not currently enabled by default.</para>
+  </listitem>
+  </varlistentry>
+
+<!--  .TP -->
+<!--  \-\-warn\-undefined\-variables -->
+<!--  Warn when an undefined variable is referenced. -->
 
 <!--  .TP -->
 <!--  .RI \-\-write\-filenames= file -->
@@ -1943,20 +1946,6 @@ These warnings are enabled by default.</para>
 <!--  .B \-n -->
 <!--  ... what? XXX -->
 
-<!--  .TP -->
-<!--  \-\-warn\-undefined\-variables -->
-<!--  Warn when an undefined variable is referenced. -->
-
-  </listitem>
-  </varlistentry>
-  <varlistentry>
-  <term>--warn=target_not_build, --warn=no-target_not_built</term>
-  <listitem>
-<para>Enables or disables warnings about a build rule not building the
- expected targets. These warnings are not currently enabled by default.</para>
-
-  </listitem>
-  </varlistentry>
   <varlistentry>
   <term>-Y<emphasis> repository</emphasis>, --repository=<emphasis>repository</emphasis>, --srcdir=<emphasis>repository</emphasis></term>
   <listitem>
@@ -1965,9 +1954,9 @@ files not found in the local directory hierarchy.  Multiple
 <option>-Y</option>
 options may be specified, in which case the
 repositories are searched in the order specified.</para>
-
   </listitem>
   </varlistentry>
+
 </variablelist>
 </refsect1>
 
@@ -1976,10 +1965,10 @@ repositories are searched in the order specified.</para>
 <!--  XXX Adding this in the future would be a help. -->
 
 <refsect2 id='construction_environments'><title>Construction Environments</title>
-<para>A construction environment is the basic means by which the SConscript
+<para>A <firstterm>&ConsEnv;</firstterm> is the basic means by which the SConscript
 files communicate build information to
 <command>scons</command>.
-A new construction environment is created using the
+A new &consenv; is created using the
 <emphasis role="bold">Environment</emphasis>
 function:</para>
 
@@ -1988,27 +1977,26 @@ env = Environment()
 </literallayout>
 
 <para>Variables, called
-<emphasis>construction</emphasis>
-<emphasis>variables</emphasis>,
-may be set in a construction environment
+<firstterm>&ConsVars;</firstterm>
+may be set in a &consenv;
 either by specifying them as keywords when the object is created
 or by assigning them a value after the object is created:</para>
 
 <literallayout class="monospaced">
-env = Environment(FOO = 'foo')
+env = Environment(FOO='foo')
 env['BAR'] = 'bar'
 </literallayout>
 
 <para>As a convenience,
-construction variables may also be set or modified by the
-<emphasis role="bold">parse_flags</emphasis>
+&consvars; may also be set or modified by the
+<parameter class="function">parse_flags</parameter>
 keyword argument, which applies the
 &f-link-env-MergeFlags;
 method (described below) to the argument value
 after all other processing is completed.
 This is useful either if the exact content of the flags is unknown
 (for example, read from a control file)
-or if the flags are distributed to a number of construction variables.</para>
+or if the flags are distributed to a number of &consvars;.</para>
 
 <literallayout class="monospaced">
 env = Environment(parse_flags='-Iinclude -DEBUG -lm')
@@ -2021,9 +2009,9 @@ env = Environment(parse_flags='-Iinclude -DEBUG -lm')
 and 'm' to
 <emphasis role="bold">LIBS</emphasis>.</para>
 
-<para>By default, a new construction environment is
+<para>By default, a new &consenv; is
 initialized with a set of builder methods
-and construction variables that are appropriate
+and &consvars; that are appropriate
 for the current platform.
 An optional platform keyword argument may be
 used to specify that an environment should
@@ -2037,7 +2025,7 @@ env = Environment(platform = 'win32')
 </literallayout>
 
 <para>Specifying a platform initializes the appropriate
-construction variables in the environment
+&consvars; in the environment
 to use and generate file names with prefixes
 and suffixes appropriate for the platform.</para>
 
@@ -2328,8 +2316,8 @@ path strings: if the string begins with
 the <emphasis role="bold">#</emphasis> character it is
 top-relative - it works like a relative path but the
 search follows down from the directory containing the top-level
-<emphasis role="bold">SConstruct</emphasis> rather than
-from the current directory (the # is allowed
+&SConstruct; rather than
+from the current directory (the <emphasis role="bold">#</emphasis> is allowed
 to be followed by a pathname separator, which is ignored if
 found in that position).
 Top-relative paths only work in places where &scons; will
@@ -2636,14 +2624,14 @@ construction variables like
 <emphasis role="bold">$TARGET</emphasis>
 and
 <emphasis role="bold">$SOURCE</emphasis>
-when using the chdir
+when using the <parameter>chdir</parameter>
 keyword argument--that is,
 the expanded file names
 will still be relative to
-the top-level SConstruct directory,
+the top-level directory where &SConstruct; was found,
 and consequently incorrect
 relative to the chdir directory.
-If you use the chdir keyword argument,
+If you use the <parameter>chdir</parameter> keyword argument,
 you will typically need to supply a different
 command line using
 expansions like
@@ -2654,7 +2642,7 @@ to use just the filename portion of the
 targets and source.</para>
 
 <para><command>scons</command>
-predefined the following builder methods.
+predefines the following builder methods.
 Depending on the setup of a particular
 &consenv; and on the type and software
 installation status of the underlying system,
@@ -2745,7 +2733,8 @@ object.</para>
 
 </refsect2>
 
-<refsect2 id='methods_and_functions_to_do_things'><title>Methods and Functions to Do Things</title>
+<refsect2 id='methods_and_functions_to_do_things'>
+<title>Methods and Functions To Do Things</title>
 <para>In addition to Builder methods,
 <command>scons</command>
 provides a number of other construction environment methods
@@ -2754,41 +2743,30 @@ manipulate the build configuration.</para>
 
 <para>Usually, a construction environment method
 and global function with the same name both exist
-so that you don't have to remember whether
-to a specific bit of functionality
-must be called with or without a construction environment.
-In the following list,
-if you call something as a global function
-it looks like:</para>
+for convenience.
+In the following list, the global function
+is documented like:</para>
 <literallayout class="monospaced">
 Function(<emphasis>arguments</emphasis>)
 </literallayout>
-<para>and if you call something through a construction
-environment it looks like:</para>
+<para>and the construction environment method looks like:</para>
 <literallayout class="monospaced">
 env.Function(<emphasis>arguments</emphasis>)
 </literallayout>
-<para>If you can call the functionality in both ways,
+<para>If you can call the function in both ways,
 then both forms are listed.</para>
 
-<para>Global functions may be called from custom Python modules that you
-import into an SConscript file by adding the following
-to the Python module:</para>
-
-<literallayout class="monospaced">
-from SCons.Script import *
-</literallayout>
-
-<para>Except where otherwise noted,
-the same-named
+<para>The global function and same-named
 construction environment method
-and global function
-provide the exact same functionality.
-The only difference is that,
-where appropriate,
+provide almost identical functionality, with a couple of exceptions.
+First, many of the construction environment methods affect only that
+construction environment, while the global function has a
+global effect. Second, where appropriate,
 calling the functionality through a construction environment will
 substitute construction variables into
-any supplied strings.
+any supplied strings, while the global function doesn't have the
+context of a construction environment to pick variables from,
+so it cannot perform the substitution.
 For example:</para>
 
 <literallayout class="monospaced">
@@ -2813,6 +2791,14 @@ to the list of default targets.
 For more on construction variable expansion,
 see the next section on
 construction variables.</para>
+
+<para>Global functions may be called from custom Python modules that you
+import into an SConscript file by adding the following import
+to the Python module:</para>
+
+<literallayout class="monospaced">
+from SCons.Script import *
+</literallayout>
 
 <para>Construction environment methods
 and global functions supported by
@@ -2937,9 +2923,10 @@ else:
 <command>scons</command>
 will actually try to build,
 regardless of whether they were specified on
-the command line or via the
-<emphasis role="bold">Default</emphasis>()
-function or method.
+the command line or via the &Default;
+function or method
+(but empty if neither
+command line targets or &Default; calls are present).
 The elements of this list may be strings
 <emphasis>or</emphasis>
 nodes, so you should run the list through the Python
@@ -2949,8 +2936,7 @@ are converted to strings.</para>
 
 <para>Because this list may be taken from the
 list of targets specified using the
-<emphasis role="bold">Default</emphasis>()
-function or method,
+&Default; function or method,
 the contents of the list may change
 on each successive call to
 <emphasis role="bold">Default</emphasis>().
@@ -2973,7 +2959,7 @@ if 'special/program' in BUILD_TARGETS:
 
 <para>Note that the
 <emphasis role="bold">BUILD_TARGETS</emphasis>
-list only contains targets expected listed
+list only contains targets listed
 on the command line or via calls to the
 <emphasis role="bold">Default</emphasis>()
 function or method.
@@ -3991,9 +3977,9 @@ opt.AddVariables(
         'notset', validator, None),
     )
 </literallayout>
-
   </listitem>
   </varlistentry>
+
   <varlistentry>
   <term>Update(<emphasis>env</emphasis>, [<emphasis>args</emphasis>])</term>
   <listitem>
@@ -4015,13 +4001,12 @@ the Environment() function:</para>
 <literallayout class="monospaced">
 env = Environment(variables=vars)
 </literallayout>
-
   </listitem>
   </varlistentry>
 </variablelist>
 
 <para>The text file(s) that were specified
-when the Variables object was created
+when the &Variables; object was created
 are executed as Python scripts,
 and the values of (global) Python variables set in the file
 are added to the construction environment.</para>
@@ -4405,9 +4390,7 @@ in SConscript files:</para>
 of the given
 file or directory.
 This path is relative to the top-level directory
-(where the
-<emphasis role="bold">SConstruct</emphasis>
-file is found).
+(where the &SConstruct; file is found).
 The build path is the same as the source path if
 <emphasis>variant_dir</emphasis>
 is not being used.</para>
@@ -5095,14 +5078,14 @@ construction variables like
 <emphasis role="bold">$TARGET</emphasis>
 and
 <emphasis role="bold">$SOURCE</emphasis>
-when using the chdir
+when using the <parameter>chdir</parameter>
 keyword argument--that is,
 the expanded file names
 will still be relative to
-the top-level SConstruct directory,
+the top-level directory containing the &SConstruct; file,
 and consequently incorrect
 relative to the chdir directory.
-Builders created using chdir keyword argument,
+Builders created using <parameter>chdir</parameter> keyword argument,
 will need to use construction variable
 expansions like
 <emphasis role="bold">${TARGET.file}</emphasis>
@@ -5433,14 +5416,14 @@ construction variables like
 <emphasis role="bold">$TARGET</emphasis>
 and
 <emphasis role="bold">$SOURCE</emphasis>
-when using the chdir
+when using the <parameter>chdir</parameter>
 keyword argument--that is,
 the expanded file names
 will still be relative to
-the top-level SConstruct directory,
+the top-level directory containing the &SConstruct; file,
 and consequently incorrect
 relative to the chdir directory.
-Builders created using chdir keyword argument,
+Builders created using <parameter>chdir</parameter> keyword argument,
 will need to use construction variable
 expansions like
 <emphasis role="bold">${TARGET.file}</emphasis>
@@ -7052,7 +7035,7 @@ prefix and suffix for the current platform
 <refsect2 id='customizing_construction_variables_from_'><title>Customizing construction variables from the command line.</title>
 
 <para>The following would allow the C compiler to be specified on the command
-line or in the file custom.py.</para>
+line or in the file <filename>custom.py</filename>.</para>
 
 <literallayout class="monospaced">
 vars = Variables('custom.py')
@@ -7067,7 +7050,7 @@ Help(vars.GenerateHelpText(env))
 scons "CC=my_cc"
 </literallayout>
 
-<para>or in the custom.py file:</para>
+<para>or in the <filename>custom.py</filename> file:</para>
 
 <literallayout class="monospaced">
 CC = 'my_cc'
@@ -7171,7 +7154,10 @@ However the following variables are imported by
     <term>SCONS_LIB_DIR</term>
     <listitem>
 <para>Specifies the directory that contains the &scons;
-Python module directory (for example,
+Python module directory. Normally &scons; can deduce this,
+but in some circumstances, such as working with a source
+release, it may be necessary to specify
+(for example,
 <filename>/home/aroach/scons-src-0.01/src/engine</filename>).</para>
     </listitem>
   </varlistentry>
@@ -7211,7 +7197,7 @@ Remove the cache file in case of problems with this.
 &scons; will ignore failures reading or writing the file
 and will silently revert to non-cached behavior in such cases.</para>
 
-<para>Since &scons; 3.1.</para>
+<para>Since &scons; 3.1 (experimental).</para>
 
     </listitem>
   </varlistentry>


### PR DESCRIPTION
- Add 2020 year.
- Use entities in more places where such are already defined.
- Change more instances of option formatting so the line break is between `</listitem>` and `<listitem>`
- Commented out options (not implemented) are not inside a `<listitem>` block.
- A few other markup bits and indentations.

Most of this does not show in the built manpage.

Also amplified a few descriptions.

This is a doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
