### PR TITLE
Add support for VS2017 Express

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -46,7 +46,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed regex in Python scanner.
     - Accommodate VS 2017 Express - it's got a more liberal license then VS
       Community, so some people prefer it (from 2019, no more Express)
-      vswhere call should also now work even if programs aren't on the C: drive.
+    - vswhere call should also now work even if programs aren't on the C: drive.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -44,6 +44,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Clean up some duplications in manpage.  Clarify portion of manpage on Dir and File nodes.
     - Reduce needless list conversions.
     - Fixed regex in Python scanner.
+    - Accomodate VS 2017 Express - it's got a more liberal license then VS
+      Community, so some people prefer it (from 2019, no more Express)
+      vswhere call should also now work even if programs aren't on the C: drive.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -44,7 +44,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Clean up some duplications in manpage.  Clarify portion of manpage on Dir and File nodes.
     - Reduce needless list conversions.
     - Fixed regex in Python scanner.
-    - Accomodate VS 2017 Express - it's got a more liberal license then VS
+    - Accommodate VS 2017 Express - it's got a more liberal license then VS
       Community, so some people prefer it (from 2019, no more Express)
       vswhere call should also now work even if programs aren't on the C: drive.
 

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -346,16 +346,15 @@ def find_vc_pdir_vswhere(msvc_version):
     # For bug 3542: also accommodate not being on C: drive.
     # NB: this gets called from testsuite on non-Windows platforms.
     # Whether that makes sense or not, don't break it for those.
-    pfpaths = []
-    with suppress(KeyError):
-        # 64-bit Windows only, try it first
-        pfpaths.append(os.environ["ProgramFiles(x86)"])
-    with suppress(KeyError):
-        pfpaths.append(os.environ["ProgramFiles"])
+    # TODO: requested to add a user-specified path to vswhere
+    #       and have this routine set the same var if it finds it.
+    pfpaths = [
+        os.path.expandvars(r"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"),
+        os.path.expandvars(r"%ProgramFiles%\Microsoft Visual Studio\Installer"),
+        os.path.expandvars(r"%ChocolateyInstall%\bin"),
+    ]
     for pf in pfpaths:
-        vswhere_path = os.path.join(
-            pf, "Microsoft Visual Studio", "Installer", "vswhere.exe"
-        )
+        vswhere_path = os.path.join(pf, "vswhere.exe")
         if os.path.exists(vswhere_path):
             break
     else:

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -43,6 +43,7 @@ import platform
 import sys
 from contextlib import suppress
 from string import digits as string_digits
+from subprocess import PIPE
 #TODO: Python 2 cleanup
 if sys.version_info[0] == 2:
     import collections
@@ -368,7 +369,9 @@ def find_vc_pdir_vswhere(msvc_version):
         "-property", "installationPath",
     ]
 
-    cp = subprocess.run(vswhere_cmd, capture_output=True)
+    #cp = subprocess.run(vswhere_cmd, capture_output=True)  # 3.7+ only
+    cp = subprocess.run(vswhere_cmd, stdout=PIPE, stderr=PIPE)
+
     if cp.stdout:
         # vswhere could return multiple lines, e.g. if Build Tools
         # and {Community,Professional,Enterprise} are both installed.

--- a/src/engine/SCons/Tool/MSCommon/vc.py
+++ b/src/engine/SCons/Tool/MSCommon/vc.py
@@ -365,7 +365,7 @@ def find_vc_pdir_vswhere(msvc_version):
     vswhere_cmd = [
         vswhere_path,
         "-products", "*",
-        "-version", '[15.0, 16.0)',  # vswhere_version,
+        "-version", vswhere_version,
         "-property", "installationPath",
     ]
 

--- a/src/engine/SCons/Tool/MSCommon/vs.py
+++ b/src/engine/SCons/Tool/MSCommon/vs.py
@@ -205,7 +205,8 @@ SupportedVSList = [
                  hkeys=[],
                  common_tools_var='VS160COMNTOOLS',
                  executable_path=r'Common7\IDE\devenv.com',
-                 batch_file_path=r'VC\Auxiliary\Build\vsvars32.bat',
+                 # should be a fallback, prefer use vswhere installationPath
+                 batch_file_path=r'Common7\Tools\VsDevCmd.bat',
                  supported_arch=['x86', 'amd64', "arm"],
                  ),
 
@@ -216,9 +217,22 @@ SupportedVSList = [
                  hkeys=[],
                  common_tools_var='VS150COMNTOOLS',
                  executable_path=r'Common7\IDE\devenv.com',
-                 batch_file_path=r'VC\Auxiliary\Build\vsvars32.bat',
+                 # should be a fallback, prefer use vswhere installationPath
+                 batch_file_path=r'Common7\Tools\VsDevCmd.bat',
                  supported_arch=['x86', 'amd64', "arm"],
                  ),
+
+    # Visual C++ 2017 Express Edition (for Desktop)
+    VisualStudio('14.1Exp',
+                 vc_version='14.1',
+                 sdk_version='10.0A',
+                 hkeys=[],
+                 common_tools_var='VS150COMNTOOLS',
+                 executable_path=r'Common7\IDE\WDExpress.exe',
+                 # should be a fallback, prefer use vswhere installationPath
+                 batch_file_path=r'Common7\Tools\VsDevCmd.bat',
+                 supported_arch=['x86', 'amd64', "arm"],
+    ),
 
     # Visual Studio 2015
     VisualStudio('14.0',

--- a/src/engine/SCons/Tool/msvc.xml
+++ b/src/engine/SCons/Tool/msvc.xml
@@ -355,6 +355,7 @@ constructor; setting it later has no effect.
 Valid values for Windows are
 <literal>14.2</literal>,
 <literal>14.1</literal>,
+<literal>14.1Exp</literal>,
 <literal>14.0</literal>,
 <literal>14.0Exp</literal>,
 <literal>12.0</literal>,

--- a/test/MSVC/MSVC_UWP_APP.py
+++ b/test/MSVC/MSVC_UWP_APP.py
@@ -83,23 +83,23 @@ test = TestSCons.TestSCons()
 test.skip_if_not_msvc()
 
 installed_msvc_versions = msvc.cached_get_installed_vcs()
-# MSVC guaranteed to be at least one version on the system or else skip_if_not_msvc() function
-# would have skipped the test
+# MSVC guaranteed to be at least one version on the system or else
+# skip_if_not_msvc() function would have skipped the test
 
 msvc_140 = '14.0' in installed_msvc_versions
 msvc_141 = '14.1' in installed_msvc_versions
+msvc_142 = '14.2' in installed_msvc_versions
 
-if not (msvc_140 or msvc_141):
-    test.skip_test("Available MSVC doesn't support App store")
+if not any((msvc_140, msvc_141, msvc_142)):
+    test.skip_test("Available MSVC doesn't support App store\n")
 
 if msvc_140:
-
-    test.write('SConstruct', """
+    test.write('SConstruct', """\
 if ARGUMENTS.get('MSVC_UWP_APP'):
     help_vars = Variables()
     help_vars.Add(EnumVariable(
                 'MSVC_UWP_APP',
-                'Build for a Universal Windows Platform (UWP) Application',
+                'Build a Universal Windows Platform (UWP) Application',
                 '0',
                 allowed_values=('0', '1')))
 else:
@@ -128,14 +128,31 @@ print('env[MSVC_VERSION]=%s' % env.get('MSVC_VERSION'))
     test.fail_test((vclibstore_path_present is True) or (vclibstorerefs_path_present is True),
                 message='VC Store LIBPATHs present when MSVC_UWP_APP not set (msvc_version=%s)' % msvc_version)
 
-if msvc_141:
-
-    test.write('SConstruct', """
+if msvc_141 or msvc_142:
+    if msvc_142:
+        test.write('SConstruct', """\
 if ARGUMENTS.get('MSVC_UWP_APP'):
     help_vars = Variables()
     help_vars.Add(EnumVariable(
                 'MSVC_UWP_APP',
-                'Build for a Universal Windows Platform (UWP) Application',
+                'Build a Universal Windows Platform (UWP) Application',
+                '0',
+                allowed_values=('0', '1')))
+else:
+    help_vars = None
+env = Environment(tools=['default', 'msvc'], variables=help_vars, MSVC_VERSION='14.2')
+# Print the ENV LIBPATH to stdout
+print('env[ENV][LIBPATH]=%s' % env.get('ENV').get('LIBPATH'))
+print('env[MSVC_VERSION]=%s' % env.get('MSVC_VERSION'))
+print('env[ENV][VSCMD_ARG_app_plat]=%s' % env.get('ENV').get('VSCMD_ARG_app_plat'))
+""")
+    elif msvc_141:
+        test.write('SConstruct', """\
+if ARGUMENTS.get('MSVC_UWP_APP'):
+    help_vars = Variables()
+    help_vars.Add(EnumVariable(
+                'MSVC_UWP_APP',
+                'Build a Universal Windows Platform (UWP) Application',
                 '0',
                 allowed_values=('0', '1')))
 else:


### PR DESCRIPTION
Needed some new logic to accomodate that tools are not in the expected place (if real host is amd64, Express still uses Hostx86 as the tools dir, not Hostx64).

Also needed a hack to run vcvarsall.bat with the correct argument. We now derive the "argument" by finding the appropriate host_target vcvars script, which has the argument to vcvarsall embedded, which we then run instead of calling vcvarsall directly.  This allows us to deal with the pseudo target that Express has always used - we derive this part of the script name by using an existing lookup table. arm targets were also added (untested).

There is no doc impact; tests should work as is - but this isn't going to be directly tested by the CI runs, which will only test that this didn't break something else- we'll need some external feedback. I'm now able to build on a system with only 2017 Express installed.

Fixes #3530 
Update: should also fix #3542

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
