### PR TITLE
Restore test syntax after earlier change dropped it.

### DIFF
--- a/test/srcchange.py
+++ b/test/srcchange.py
@@ -62,7 +62,7 @@ SubRevision = Action(subrevision)
 
 env=Environment()
 content_env=env.Clone()
-content_env.Command('revision.in', [], '%(_python_)s getrevision > $TARGET')
+content_env.Command('revision.in', [], r'%(_python_)s getrevision > $TARGET')
 content_env.AlwaysBuild('revision.in')
 env.Precious('main.c')
 env.Command('main.c', 'revision.in', SubRevision)


### PR DESCRIPTION
An earlier syntax cleanup pass on tests accidentally dropped the 'r' character in front of what needed to be a rawstring. Restoring.

Signed-off-by: Mats Wichmann <mats@linux.com>

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
