### PR TITLE
Fix regex from recent change

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -43,7 +43,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Convert remaining uses of insecure/deprecated mktemp method.
     - Clean up some duplications in manpage.  Clarify portion of manpage on Dir and File nodes.
     - Reduce needless list conversions.
-    - Another Python regex syntax fix.
+    - Fixed regex in Python scanner.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -43,7 +43,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Convert remaining uses of insecure/deprecated mktemp method.
     - Clean up some duplications in manpage.  Clarify portion of manpage on Dir and File nodes.
     - Reduce needless list conversions.
-
+    - Another Python regex syntax fix.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/engine/SCons/Scanner/Python.py
+++ b/src/engine/SCons/Scanner/Python.py
@@ -42,8 +42,8 @@ import re
 import SCons.Scanner
 
 # Capture python "from a import b" and "import a" statements.
-from_cre = re.compile('^\s*from\s+([^\s]+)\s+import\s+(.*)', re.M)
-import_cre = re.compile('^\s*import\s+([^\s]+)', re.M)
+from_cre = re.compile(r'^\s*from\s+([^\s]+)\s+import\s+(.*)', re.M)
+import_cre = re.compile(r'^\s*import\s+([^\s]+)', re.M)
 
 
 def path_function(env, dir=None, target=None, source=None, argument=None):


### PR DESCRIPTION
The new Python scanner had a couple of regexes not specified as raw strings. Python 3.9a3 complains about invalid escape as a result, causing the `option/debug-count` test to fail. Adding the 'r' fixes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
