### PR TITLE
Add a warning if msvc config cache may be outdated.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -62,6 +62,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Accommodate VS 2017 Express - it's got a more liberal license then VS
       Community, so some people prefer it (from 2019, no more Express)
     - vswhere call should also now work even if programs aren't on the C: drive.
+    - Add a specific warning msg if msvc config cache may be out of date.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -62,7 +62,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Accommodate VS 2017 Express - it's got a more liberal license then VS
       Community, so some people prefer it (from 2019, no more Express)
     - vswhere call should also now work even if programs aren't on the C: drive.
-    - Add a specific warning msg if msvc config cache may be out of date.
+    - Add an alternate warning message cl.exe is not found and msvc config
+      cache is in use (SCONS_CACHE_MSVC_CONFIG was given) - config cache
+      may be out of date.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000


### PR DESCRIPTION
If we didn't find `cl.exe` in the final check in `msvc_setup_env()`, issue a different warning if config caching is enabled. If it is, there's a decent chance we've found `cl.exe` in the past, meaning
the cache is probably out of date - entries are indexed by path to the bat file+arg, whereas an msvc update may bump a version number in the path and the old path won't be valid: a cached path entry could look like this:
```
"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.24.28314\\bin\\HostX64\\x64",
```
and the .28314 could be changed in an update.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
