### PR TITLE
Stop calling os.system in tests.

### DIFF
--- a/test/AS/as-live.py
+++ b/test/AS/as-live.py
@@ -56,12 +56,12 @@ if sys.platform == "win32":
     testccc = ""
     
 test.write("wrapper.py", """\
-import os
+import subprocess
 import sys
 with open('%s', 'wb') as f:
     f.write(("wrapper.py: %%s\\n" %% sys.argv[-1]).encode())
 cmd = " ".join(sys.argv[1:])
-os.system(cmd)
+subprocess.run(cmd, shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
 test.write('SConstruct', """\

--- a/test/Actions/actions.py
+++ b/test/Actions/actions.py
@@ -65,12 +65,13 @@ test.must_match('foo.out', '2\nfoo.in\n')
 test.up_to_date(arguments = '.')
 
 test.write('SConstruct', """
-import os
+import subprocess
 def func(env, target, source):
     cmd = r'%(_python_)s build.py %%s 3 %%s' %% (' '.join(map(str, target)),
                                        ' '.join(map(str, source)))
     print(cmd)
-    return os.system(cmd)
+    cp = subprocess.run(cmd, shell=True)
+    return cp.returncode
 B = Builder(action = func)
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
@@ -83,7 +84,7 @@ test.must_match('foo.out', '3\nfoo.in\n')
 test.up_to_date(arguments = '.')
 
 test.write('SConstruct', """
-import os
+import subprocess
 assert 'string' not in globals()
 class bld(object):
     def __init__(self):
@@ -91,7 +92,8 @@ class bld(object):
     def __call__(self, env, target, source):
         cmd = self.get_contents(env, target, source)
         print(cmd)
-        return os.system(cmd)
+        cp = subprocess.run(cmd, shell=True)
+        return cp.returncode
     def get_contents(self, env, target, source):
         return self.cmd %% (' '.join(map(str, target)),
                             ' '.join(map(str, source)))

--- a/test/CC/CCVERSION-fixture/versioned.py
+++ b/test/CC/CCVERSION-fixture/versioned.py
@@ -1,4 +1,4 @@
-import os
+import subprocess
 import sys
 if '-dumpversion' in sys.argv:
     print('3.9.9')
@@ -9,4 +9,4 @@ if '--version' in sys.argv:
 if sys.argv[1] not in [ '2.9.9', '3.9.9' ]:
     print('wrong version', sys.argv[1], 'when wrapping', sys.argv[2])
     sys.exit(1)
-os.system(" ".join(sys.argv[2:]))
+subprocess.run(" ".join(sys.argv[2:]), shell=True)

--- a/test/CXX/CXXVERSION.py
+++ b/test/CXX/CXXVERSION.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 import TestSCons
 
@@ -37,9 +36,8 @@ if sys.platform == 'win32':
     test.skip_test('CXXVERSION not set with MSVC, skipping test.')
 
 
-test.write("versioned.py",
-"""from __future__ import print_function
-import os
+test.write("versioned.py", """\
+import subprocess
 import sys
 if '-dumpversion' in sys.argv:
     print('3.9.9')
@@ -50,7 +48,7 @@ if '--version' in sys.argv:
 if sys.argv[1] not in [ '2.9.9', '3.9.9' ]:
     print('wrong version', sys.argv[1], 'when wrapping', sys.argv[2])
     sys.exit(1)
-os.system(" ".join(sys.argv[2:]))
+subprocess.run(" ".join(sys.argv[2:]), shell=True)
 """)
 
 test.write('SConstruct', """

--- a/test/DVIPDF/DVIPDF.py
+++ b/test/DVIPDF/DVIPDF.py
@@ -107,11 +107,12 @@ tex = test.where_is('tex')
 
 if dvipdf and tex:
 
-    test.write("wrapper.py", """import os
+    test.write("wrapper.py", """\
+import subprocess
 import sys
 cmd = " ".join(sys.argv[1:])
 open('%s', 'a').write("%%s\\n" %% cmd)
-os.system(cmd)
+subprocess.run(cmd, shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
     test.write('SConstruct', """

--- a/test/DVIPDF/DVIPDFFLAGS.py
+++ b/test/DVIPDF/DVIPDFFLAGS.py
@@ -111,11 +111,12 @@ tex = test.where_is('tex')
 
 if dvipdf and tex:
 
-    test.write("wrapper.py", """import os
+    test.write("wrapper.py", """\
+import subprocess
 import sys
 cmd = " ".join(sys.argv[1:])
 open('%s', 'a').write("%%s\\n" %% cmd)
-os.system(cmd)
+subprocess.run(cmd, shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
     test.write('SConstruct', """

--- a/test/DVIPS/DVIPS.py
+++ b/test/DVIPS/DVIPS.py
@@ -123,11 +123,11 @@ if not dvips:
     test.skip_test("Could not find 'dvips'; skipping test(s).\n")
 
 test.write("wrapper.py", """
-import os
+import subprocess
 import sys
 cmd = " ".join(sys.argv[1:])
 open('%s', 'a').write("%%s\\n" %% cmd)
-os.system(cmd)
+subprocess.run(cmd, shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
 test.write('SConstruct', """

--- a/test/DVIPS/DVIPSFLAGS.py
+++ b/test/DVIPS/DVIPSFLAGS.py
@@ -126,11 +126,12 @@ dvips = test.where_is('dvips')
 if dvips:
 
     test.write("wrapper.py", """
-import os
+import subprocess
 import sys
 cmd = " ".join(sys.argv[1:])
-open('%s', 'a').write("%%s\\n" %% cmd)
-os.system(cmd)
+with open('%s', 'a') as f:
+    f.write("%%s\\n" %% cmd)
+subprocess.run(cmd, shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
     test.write('SConstruct', """

--- a/test/Ghostscript/GS.py
+++ b/test/Ghostscript/GS.py
@@ -74,13 +74,12 @@ else:
 gs = test.where_is(gs_executable)
 
 if gs:
-
     test.write("wrapper.py", """\
-import os
+import subprocess
 import sys
 cmd = " ".join(sys.argv[1:])
 open('%s', 'a').write("%%s\\n" %% cmd)
-os.system(cmd)
+subprocess.run(cmd, shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
     test.write('SConstruct', """\

--- a/test/LINK/LINKFLAGS.py
+++ b/test/LINK/LINKFLAGS.py
@@ -33,13 +33,13 @@ _exe = TestSCons._exe
 
 test = TestSCons.TestSCons()
 
-test.write("wrapper.py",
-"""import os
+test.write("wrapper.py", """\
+import subprocess
 import sys
 with open('%s', 'wb') as f:
     f.write(("wrapper.py\\n").encode())
 args = [s for s in sys.argv[1:] if s != 'fake_link_flag']
-os.system(" ".join(args))
+subprocess.run(" ".join(args), shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
 test.write('SConstruct', """

--- a/test/LINK/SHLINKFLAGS.py
+++ b/test/LINK/SHLINKFLAGS.py
@@ -34,13 +34,13 @@ _shlib = TestSCons._dll
 
 test = TestSCons.TestSCons()
 
-test.write("wrapper.py",
-"""import os
+test.write("wrapper.py", """
+import subprocess
 import sys
 with open('%s', 'wb') as f:
     f.write(("wrapper.py\\n").encode())
 args = [s for s in sys.argv[1:] if s != 'fake_shlink_flag']
-os.system(" ".join(args))
+subprocess.run(" ".join(args), shell=True)
 """ % test.workpath('wrapper.out').replace('\\', '\\\\'))
 
 test.write('SConstruct', """

--- a/test/SPAWN.py
+++ b/test/SPAWN.py
@@ -43,18 +43,20 @@ with open(sys.argv[1], 'wb') as ofp:
 """)
 
 test.write('SConstruct', """
-import os
+import subprocess
 import sys
 def my_spawn1(sh, escape, cmd, args, env):
     s = " ".join(args + ['extra1.txt'])
     if sys.platform in ['win32']:
         s = '"' + s + '"'
-    os.system(s)
+    cp = subprocess.run(s, shell=True)
+    return cp.returncode
 def my_spawn2(sh, escape, cmd, args, env):
     s = " ".join(args + ['extra2.txt'])
     if sys.platform in ['win32']:
         s = '"' + s + '"'
-    os.system(s)
+    cp = subprocess.run(s, shell=True)
+    return cp.returncode
 env = Environment(MY_SPAWN1 = my_spawn1,
                   MY_SPAWN2 = my_spawn2,
                   COMMAND = r'%(_python_)s cat.py $TARGET $SOURCES')

--- a/test/SPAWN.py
+++ b/test/SPAWN.py
@@ -45,18 +45,17 @@ with open(sys.argv[1], 'wb') as ofp:
 test.write('SConstruct', """
 import subprocess
 import sys
+
 def my_spawn1(sh, escape, cmd, args, env):
     s = " ".join(args + ['extra1.txt'])
-    if sys.platform in ['win32']:
-        s = '"' + s + '"'
     cp = subprocess.run(s, shell=True)
     return cp.returncode
+
 def my_spawn2(sh, escape, cmd, args, env):
     s = " ".join(args + ['extra2.txt'])
-    if sys.platform in ['win32']:
-        s = '"' + s + '"'
     cp = subprocess.run(s, shell=True)
     return cp.returncode
+
 env = Environment(MY_SPAWN1 = my_spawn1,
                   MY_SPAWN2 = my_spawn2,
                   COMMAND = r'%(_python_)s cat.py $TARGET $SOURCES')

--- a/test/TEX/biber_biblatex.py
+++ b/test/TEX/biber_biblatex.py
@@ -30,8 +30,9 @@ Test creation of a Tex document that uses the multibib oackage
 Test courtesy Rob Managan.
 """
 
+import subprocess
+
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 
@@ -43,8 +44,8 @@ biber = test.where_is('biber')
 if not biber:
     test.skip_test("Could not find 'biber'; skipping test.\n")
 
-gloss = os.system('kpsewhich biblatex.sty')
-if not gloss==0:
+cp = subprocess.run('kpsewhich biblatex.sty', shell=True)
+if cp.returncode:
     test.skip_test("biblatex.sty not installed; skipping test(s).\n")
 
 

--- a/test/TEX/biber_biblatex2.py
+++ b/test/TEX/biber_biblatex2.py
@@ -32,8 +32,9 @@ Require both be installed
 Test courtesy Rob Managan.
 """
 
+import subprocess
+
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 
@@ -49,8 +50,8 @@ bibtex = test.where_is('bibtex')
 if not bibtex:
     test.skip_test("Could not find 'bibtex'; skipping test.\n")
 
-biblatex = os.system('kpsewhich biblatex.sty')
-if not biblatex==0:
+cp = subprocess.run('kpsewhich biblatex.sty', shell=True)
+if cp.returncode:
     test.skip_test("biblatex.sty not installed; skipping test(s).\n")
 
 

--- a/test/TEX/biblatex.py
+++ b/test/TEX/biblatex.py
@@ -30,8 +30,9 @@ Test creation of a Tex document that uses the biblatex package
 Test courtesy Rob Managan.
 """
 
+import subprocess
+
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 
@@ -39,8 +40,8 @@ latex = test.where_is('pdflatex')
 if not latex:
     test.skip_test("Could not find 'pdflatex'; skipping test.\n")
 
-biblatex = os.system('kpsewhich biblatex.sty')
-if not biblatex==0:
+cp = subprocess.run('kpsewhich biblatex.sty', shell=True)
+if cp.returncode:
     test.skip_test("biblatex.sty not installed; skipping test(s).\n")
 
 

--- a/test/TEX/biblatex_plain.py
+++ b/test/TEX/biblatex_plain.py
@@ -30,8 +30,9 @@ Test creation of a Tex document that uses the biblatex package
 Test courtesy Rob Managan.
 """
 
+import subprocess
+
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 
@@ -39,8 +40,8 @@ latex = test.where_is('pdflatex')
 if not latex:
     test.skip_test("Could not find 'pdflatex'; skipping test.\n")
 
-biblatex = os.system('kpsewhich biblatex.sty')
-if not biblatex==0:
+cp = subprocess.run('kpsewhich biblatex.sty', shell=True)
+if cp.returncode:
     test.skip_test("biblatex.sty not installed; skipping test(s).\n")
 
 

--- a/test/TEX/clean.py
+++ b/test/TEX/clean.py
@@ -28,7 +28,8 @@ r"""
 Check that all auxilary files created by LaTeX are properly cleaned by scons -c.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -38,8 +39,8 @@ latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
-comment = os.system('kpsewhich comment.sty')
-if not comment==0:
+cp = subprocess.run('kpsewhich comment.sty', shell=True)
+if cp.returncode:
     test.skip_test("comment.sty not installed; skipping test(s).\n")
 
 # package hyperref generates foo.out

--- a/test/TEX/glossaries.py
+++ b/test/TEX/glossaries.py
@@ -31,7 +31,8 @@ be aware of the necessary created glossary files.
 Test configuration contributed by Robert Managan.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -41,8 +42,8 @@ latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
-gloss = os.system('kpsewhich glossaries.sty')
-if not gloss==0:
+cp = subprocess.run('kpsewhich glossaries.sty', shell=True)
+if cp.returncode:
     test.skip_test("glossaries.sty not installed; skipping test(s).\n")
 
 test.write('SConstruct', """\

--- a/test/TEX/glossary.py
+++ b/test/TEX/glossary.py
@@ -31,7 +31,8 @@ be aware of the necessary created glossary files.
 Test configuration contributed by Robert Managan.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -41,8 +42,8 @@ latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
-gloss = os.system('kpsewhich glossary.sty')
-if not gloss==0:
+cp = subprocess.run('kpsewhich glossary.sty', shell=True)
+if cp.returncode:
     test.skip_test("glossary.sty not installed; skipping test(s).\n")
 
 test.write('SConstruct', """\

--- a/test/TEX/lstinputlisting.py
+++ b/test/TEX/lstinputlisting.py
@@ -31,8 +31,9 @@ changes.
 Thanks to Stefan Hepp for the patch that fixed this.
 """
 
+import subprocess
+
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 
@@ -41,8 +42,8 @@ pdflatex = test.where_is('pdflatex')
 if not pdflatex:
     test.skip_test("Could not find 'pdflatex'; skipping test(s).\n")
 
-listings = os.system('kpsewhich listings.sty')
-if not listings==0:
+cp = subprocess.run('kpsewhich listings.sty', shell=True)
+if cp.returncode:
     test.skip_test("listings.sty not installed; skipping test(s).\n")
 
 test.write(['SConstruct'], """\

--- a/test/TEX/multibib.py
+++ b/test/TEX/multibib.py
@@ -30,8 +30,9 @@ Test creation of a Tex document that uses the multibib oackage
 Test courtesy Rob Managan.
 """
 
+import subprocess
+
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 
@@ -39,8 +40,8 @@ latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test.\n")
 
-multibib = os.system('kpsewhich multibib.sty')
-if not multibib==0:
+cp = subprocess.run('kpsewhich multibib.sty', shell=True)
+if cp.returncode:
     test.skip_test("multibib.sty not installed; skipping test(s).\n")
 
 test.subdir(['src'])

--- a/test/TEX/newglossary.py
+++ b/test/TEX/newglossary.py
@@ -31,7 +31,8 @@ be aware of the necessary created glossary files.
 Test configuration contributed by Robert Managan.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -41,8 +42,8 @@ latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
-gloss = os.system('kpsewhich glossaries.sty')
-if not gloss==0:
+cp = subprocess.run('kpsewhich glossaries.sty', shell=True)
+if cp.returncode:
     test.skip_test("glossaries.sty not installed; skipping test(s).\n")
 
 test.write('SConstruct', """\

--- a/test/TEX/nomencl.py
+++ b/test/TEX/nomencl.py
@@ -31,7 +31,8 @@ be aware of the necessary created glossary files.
 Test configuration contributed by Robert Managan.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -41,8 +42,8 @@ latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
-nomencl = os.system('kpsewhich nomencl.sty')
-if not nomencl==0:
+cp = subprocess.run('kpsewhich nomencl.sty', shell=True)
+if cp.returncode:
     test.skip_test("nomencl.sty not installed; skipping test(s).\n")
 
 test.write('SConstruct', """\

--- a/test/TEX/recursive_scanner_dependencies_import.py
+++ b/test/TEX/recursive_scanner_dependencies_import.py
@@ -34,7 +34,8 @@ recursive_scanner_dependencies_input.py test because \input and
 dependencies are found only by the scanner.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -44,8 +45,8 @@ pdflatex = test.where_is('pdflatex')
 if not pdflatex:
     test.skip_test("Could not find 'pdflatex'; skipping test(s).\n")
 
-latex_import = os.system('kpsewhich import.sty')
-if latex_import != 0:
+cp = subprocess.run('kpsewhich import.sty', shell=True)
+if cp.returncode:
     test.skip_test("import.sty not installed; skipping test(s).\n")
 
 test.subdir('subdir')

--- a/test/TEX/variant_dir_bibunit.py
+++ b/test/TEX/variant_dir_bibunit.py
@@ -34,8 +34,9 @@ Latex produces by default.
 Test courtesy Rob Managan.
 """
 
+import subprocess
+
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 
@@ -44,8 +45,8 @@ bibtex = test.where_is('bibtex')
 if not all((latex, bibtex)):
     test.skip_test("Could not find 'latex' and/or 'bibtex'; skipping test.\n")
 
-bibunits = os.system('kpsewhich bibunits.sty')
-if not bibunits==0:
+cp = subprocess.run('kpsewhich bibunits.sty', shell=True)
+if cp.returncode:
     test.skip_test("bibunits.sty not installed; skipping test(s).\n")
 
 test.subdir(['src'])

--- a/test/TEX/variant_dir_newglossary.py
+++ b/test/TEX/variant_dir_newglossary.py
@@ -31,7 +31,8 @@ with variant_dir.
 Test configuration contributed by Kendrick Boyd.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -41,8 +42,8 @@ latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
-gloss = os.system('kpsewhich glossaries.sty')
-if gloss!=0:
+cp = subprocess.run('kpsewhich glossaries.sty', shell=True)
+if cp.returncode:
     test.skip_test("glossaries.sty not installed; skipping test(s).\n")
 
 

--- a/test/packaging/use-builddir.py
+++ b/test/packaging/use-builddir.py
@@ -28,13 +28,13 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test the ability to use the archiver in combination with builddir.
 """
 
-import os
+import subprocess
+
 import TestSCons
 
 python = TestSCons.python
 
 test = TestSCons.TestSCons()
-test.verbose_set(3)
 tar = test.detect("TAR", "tar")
 
 if not tar:
@@ -48,9 +48,7 @@ test.subdir("build")
 
 test.write("src/main.c", "")
 
-test.write(
-    "SConstruct",
-    """
+test.write("SConstruct", """\
 VariantDir('build', 'src')
 DefaultEnvironment(tools=[])
 env=Environment(tools=['packaging', 'filesystem', 'zip'])
@@ -76,9 +74,7 @@ test.subdir("temp")
 
 test.write("src/main.c", "")
 
-test.write(
-    "SConstruct",
-    """
+test.write("SConstruct", """\
 DefaultEnvironment(tools=[])
 VariantDir('build', 'src')
 env=Environment(tools=['packaging', 'filesystem', 'tar'])
@@ -93,7 +89,8 @@ test.run(stderr=None)
 
 test.must_exist("libfoo-1.2.3.tar.gz")
 
-os.system('%s -C temp -xzf %s'%(tar, test.workpath('libfoo-1.2.3.tar.gz') ))
+testdir = test.workpath('libfoo-1.2.3.tar.gz')
+subprocess.run('%s -C temp -xzf %s' % (tar, testdir), shell=True)
 
 test.must_exist("temp/libfoo-1.2.3/src/main.c")
 test.must_exist("temp/libfoo-1.2.3/SConstruct")

--- a/test/update-release-info/update-release-info.py
+++ b/test/update-release-info/update-release-info.py
@@ -110,7 +110,7 @@ combo_fail(0, 2)
 combo_fail(1, 2)
 combo_fail(0, 1, 2, stdout =
 """ERROR: `bad' is not a valid release type in version tuple;
-\tit must be one of alpha, beta, candidate, or final
+\tit must be one of dev, beta, candidate, or final
 """)
 
 # We won't need this entry again, so put in a default


### PR DESCRIPTION
This converts the remaining tests that called `os.system` themselves to use `subprocess` instead. This aligns with current Python project recommendations.

This is a test-only change, and it is intended to be a no-op - the same strings are still built as were passed to `os.system`, even though an arg vector would work as well and avoid all of the joining and quoting and so forth that takes place.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
