### PR TITLE
Fix issue 3550 substfile crashing with some backslashes in replacement strings

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -18,6 +18,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       is a reasonable default and also aligns with changes in Appveyor's VS2019 image.
     - Drop support for Python 2.7. SCons will be Python 3.5+ going forward.
     - Change SCons.Node.ValueWithMemo to consider any name passed when memoizing Value() nodes
+    - Fix Github Issue #3550 - When using Substfile() with a value like Z:\mongo\build\install\bin
+      the implementation using re.sub() would end up interpreting the string and finding regex escape
+      characters where it should have been simply replacing existing text. Switched to use string.replace().
     
   From Jeremy Elson:
     - Updated design doc to use the correct syntax for Depends()

--- a/src/engine/SCons/Tool/textfile.py
+++ b/src/engine/SCons/Tool/textfile.py
@@ -71,6 +71,7 @@ def _do_subst(node, subs):
     contents = node.get_text_contents()
     if subs:
         for (k, val) in subs:
+            # contents = contents.replace(k, val)
             contents = re.sub(k, val, contents)
 
     if 'b' in TEXTFILE_FILE_WRITE_MODE:

--- a/src/engine/SCons/Tool/textfile.py
+++ b/src/engine/SCons/Tool/textfile.py
@@ -71,8 +71,7 @@ def _do_subst(node, subs):
     contents = node.get_text_contents()
     if subs:
         for (k, val) in subs:
-            # contents = contents.replace(k, val)
-            contents = re.sub(k, val, contents)
+            contents = contents.replace(k, val)
 
     if 'b' in TEXTFILE_FILE_WRITE_MODE:
         try:

--- a/test/textfile/fixture/SConstruct
+++ b/test/textfile/fixture/SConstruct
@@ -1,7 +1,9 @@
+DefaultEnvironment(tools=[])
+
 
 env = Environment(tools=['textfile'])
 data0 = ['Goethe', 'Schiller']
-data  = ['lalala', 42, data0, 'tanteratei']
+data = ['lalala', 42, data0, 'tanteratei']
 
 env.Textfile('foo1', data)
 env.Textfile('foo2', data, LINESEPARATOR='|*')

--- a/test/textfile/fixture/SConstruct
+++ b/test/textfile/fixture/SConstruct
@@ -1,0 +1,20 @@
+
+env = Environment(tools=['textfile'])
+data0 = ['Goethe', 'Schiller']
+data  = ['lalala', 42, data0, 'tanteratei']
+
+env.Textfile('foo1', data)
+env.Textfile('foo2', data, LINESEPARATOR='|*')
+env.Textfile('foo1a.txt', data + [''])
+env.Textfile('foo2a.txt', data + [''], LINESEPARATOR='|*')
+
+# recreate the list with the data wrapped in Value()
+data0 = list(map(Value, data0))
+data = list(map(Value, data))
+data[2] = data0
+
+env.Substfile('bar1', data)
+env.Substfile('bar2', data, LINESEPARATOR='|*')
+data.append(Value(''))
+env.Substfile('bar1a.txt', data)
+env.Substfile('bar2a.txt', data, LINESEPARATOR='|*')

--- a/test/textfile/fixture/SConstruct.2
+++ b/test/textfile/fixture/SConstruct.2
@@ -1,24 +1,25 @@
+DefaultEnvironment(tools=[])
 
 textlist = ['This line has no substitutions',
             'This line has @subst@ substitutions',
             'This line has %subst% substitutions',
-           ]
+            ]
 
-sub1 = { '@subst@' : 'most' }
-sub2 = { '%subst%' : 'many' }
-sub3 = { '@subst@' : 'most' , '%subst%' : 'many' }
+sub1 = {'@subst@': 'most'}
+sub2 = {'%subst%': 'many'}
+sub3 = {'@subst@': 'most', '%subst%': 'many'}
 
-env = Environment()
+env = Environment(tools=['textfile'])
 
 t = env.Textfile('text', textlist)
 # no substitutions
 s = env.Substfile('sub1', t)
 # one substitution
-s = env.Substfile('sub2', s, SUBST_DICT = sub1)
+s = env.Substfile('sub2', s, SUBST_DICT=sub1)
 # the other substution
-s = env.Substfile('sub3', s, SUBST_DICT = sub2)
+s = env.Substfile('sub3', s, SUBST_DICT=sub2)
 # the reverse direction
-s = env.Substfile('sub4', t, SUBST_DICT = sub2)
-s = env.Substfile('sub5', s, SUBST_DICT = sub1)
+s = env.Substfile('sub4', t, SUBST_DICT=sub2)
+s = env.Substfile('sub5', s, SUBST_DICT=sub1)
 # both
-s = env.Substfile('sub6', t, SUBST_DICT = sub3)
+s = env.Substfile('sub6', t, SUBST_DICT=sub3)

--- a/test/textfile/fixture/SConstruct.2
+++ b/test/textfile/fixture/SConstruct.2
@@ -1,0 +1,24 @@
+
+textlist = ['This line has no substitutions',
+            'This line has @subst@ substitutions',
+            'This line has %subst% substitutions',
+           ]
+
+sub1 = { '@subst@' : 'most' }
+sub2 = { '%subst%' : 'many' }
+sub3 = { '@subst@' : 'most' , '%subst%' : 'many' }
+
+env = Environment()
+
+t = env.Textfile('text', textlist)
+# no substitutions
+s = env.Substfile('sub1', t)
+# one substitution
+s = env.Substfile('sub2', s, SUBST_DICT = sub1)
+# the other substution
+s = env.Substfile('sub3', s, SUBST_DICT = sub2)
+# the reverse direction
+s = env.Substfile('sub4', t, SUBST_DICT = sub2)
+s = env.Substfile('sub5', s, SUBST_DICT = sub1)
+# both
+s = env.Substfile('sub6', t, SUBST_DICT = sub3)

--- a/test/textfile/fixture/SConstruct.issue-3550
+++ b/test/textfile/fixture/SConstruct.issue-3550
@@ -1,0 +1,12 @@
+DefaultEnvironment(tools=[])
+env = Environment(tools=['textfile'])
+
+env['FOO_PATH'] = r'Z:\mongo\build\install\bin'
+
+foo = env.Substfile(
+    target="foo",
+    source="foo-3550.in",
+    SUBST_DICT={
+        "@foo_path@": "$FOO_PATH",
+    }
+)

--- a/test/textfile/fixture/foo-3550.in
+++ b/test/textfile/fixture/foo-3550.in
@@ -1,0 +1,1 @@
+foo_path: @foo_path@

--- a/test/textfile/issue-3550.py
+++ b/test/textfile/issue-3550.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+import TestSCons
+
+import os
+
+test = TestSCons.TestSCons()
+
+test.verbose_set(1)
+
+match_mode = 'r'
+
+test.file_fixture('fixture/SConstruct.issue-3550', 'SConstruct')
+test.file_fixture('fixture/foo-3550.in', 'foo-3550.in')
+
+test.run(arguments='.')
+
+test.must_match('foo',
+                r'''foo_path: Z:\mongo\build\install\bin
+''', mode=match_mode)
+
+test.pass_test()

--- a/test/textfile/issue-3550.py
+++ b/test/textfile/issue-3550.py
@@ -26,8 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
-import os
-
 test = TestSCons.TestSCons()
 
 test.verbose_set(1)

--- a/test/textfile/textfile.py
+++ b/test/textfile/textfile.py
@@ -30,6 +30,8 @@ import os
 
 test = TestSCons.TestSCons()
 
+test.verbose_set(1)
+
 foo1 = test.workpath('foo1.txt')
 #foo2  = test.workpath('foo2.txt')
 #foo1a = test.workpath('foo1a.txt')
@@ -37,27 +39,7 @@ foo1 = test.workpath('foo1.txt')
 
 match_mode = 'r'
 
-test.write('SConstruct', """
-env = Environment(tools=['textfile'])
-data0 = ['Goethe', 'Schiller']
-data  = ['lalala', 42, data0, 'tanteratei']
-
-env.Textfile('foo1', data)
-env.Textfile('foo2', data, LINESEPARATOR='|*')
-env.Textfile('foo1a.txt', data + [''])
-env.Textfile('foo2a.txt', data + [''], LINESEPARATOR='|*')
-
-# recreate the list with the data wrapped in Value()
-data0 = list(map(Value, data0))
-data = list(map(Value, data))
-data[2] = data0
-
-env.Substfile('bar1', data)
-env.Substfile('bar2', data, LINESEPARATOR='|*')
-data.append(Value(''))
-env.Substfile('bar1a.txt', data)
-env.Substfile('bar2a.txt', data, LINESEPARATOR='|*')
-""", mode='w')
+test.file_fixture('fixture/SConstruct','SConstruct')
 
 test.run(arguments='.')
 
@@ -117,33 +99,10 @@ check_times()
 
 # now that textfile is part of default tool list, run one testcase
 # without adding it explicitly as a tool to make sure.
-test.write('SConstruct', """
-textlist = ['This line has no substitutions',
-            'This line has @subst@ substitutions',
-            'This line has %subst% substitutions',
-           ]
+test.file_fixture('fixture/SConstruct.2','SConstruct.2')
 
-sub1 = { '@subst@' : 'most' }
-sub2 = { '%subst%' : 'many' }
-sub3 = { '@subst@' : 'most' , '%subst%' : 'many' }
 
-env = Environment()
-
-t = env.Textfile('text', textlist)
-# no substitutions
-s = env.Substfile('sub1', t)
-# one substitution
-s = env.Substfile('sub2', s, SUBST_DICT = sub1)
-# the other substution
-s = env.Substfile('sub3', s, SUBST_DICT = sub2)
-# the reverse direction
-s = env.Substfile('sub4', t, SUBST_DICT = sub2)
-s = env.Substfile('sub5', s, SUBST_DICT = sub1)
-# both
-s = env.Substfile('sub6', t, SUBST_DICT = sub3)
-""", mode='w')
-
-test.run(arguments='.')
+test.run(options='-f SConstruct.2', arguments='.')
 
 line1 = 'This line has no substitutions'
 line2a = 'This line has @subst@ substitutions'
@@ -169,6 +128,6 @@ matchem('sub4', [line1, line2a, line3b])
 matchem('sub5', [line1, line2b, line3b])
 matchem('sub6', [line1, line2b, line3b])
 
-test.up_to_date(arguments='.')
+test.up_to_date(options='-f SConstruct.2', arguments='.')
 
 test.pass_test()

--- a/test/textfile/textfile.py
+++ b/test/textfile/textfile.py
@@ -30,16 +30,14 @@ import os
 
 test = TestSCons.TestSCons()
 
-test.verbose_set(1)
-
 foo1 = test.workpath('foo1.txt')
-#foo2  = test.workpath('foo2.txt')
-#foo1a = test.workpath('foo1a.txt')
-#foo2a = test.workpath('foo2a.txt')
+# foo2  = test.workpath('foo2.txt')
+# foo1a = test.workpath('foo1a.txt')
+# foo2a = test.workpath('foo2a.txt')
 
 match_mode = 'r'
 
-test.file_fixture('fixture/SConstruct','SConstruct')
+test.file_fixture('fixture/SConstruct', 'SConstruct')
 
 test.run(arguments='.')
 
@@ -57,7 +55,7 @@ test.up_to_date(arguments='.')
 
 files = list(map(test.workpath, (
     'foo1.txt', 'foo2.txt', 'foo1a.txt', 'foo2a.txt',
-    'bar1',     'bar2',     'bar1a.txt', 'bar2a.txt',
+    'bar1', 'bar2', 'bar1a.txt', 'bar2a.txt',
 )))
 
 
@@ -75,10 +73,10 @@ def check_times():
 
 
 # make sure that the file content is as expected
-test.must_match('foo1.txt',  foo1Text, mode=match_mode)
-test.must_match('bar1',      foo1Text, mode=match_mode)
-test.must_match('foo2.txt',  foo2Text, mode=match_mode)
-test.must_match('bar2',      foo2Text, mode=match_mode)
+test.must_match('foo1.txt', foo1Text, mode=match_mode)
+test.must_match('bar1', foo1Text, mode=match_mode)
+test.must_match('foo2.txt', foo2Text, mode=match_mode)
+test.must_match('bar2', foo2Text, mode=match_mode)
 test.must_match('foo1a.txt', foo1aText, mode=match_mode)
 test.must_match('bar1a.txt', foo1aText, mode=match_mode)
 test.must_match('foo2a.txt', foo2aText, mode=match_mode)
@@ -87,10 +85,10 @@ check_times()
 
 # write the contents and make sure the files
 # didn't get rewritten, because nothing changed:
-test.write('foo1.txt',  foo1Text)
-test.write('bar1',      foo1Text)
-test.write('foo2.txt',  foo2Text)
-test.write('bar2',      foo2Text)
+test.write('foo1.txt', foo1Text)
+test.write('bar1', foo1Text)
+test.write('foo2.txt', foo2Text)
+test.write('bar2', foo2Text)
 test.write('foo1a.txt', foo1aText)
 test.write('bar1a.txt', foo1aText)
 test.write('foo2a.txt', foo2aText)
@@ -99,8 +97,7 @@ check_times()
 
 # now that textfile is part of default tool list, run one testcase
 # without adding it explicitly as a tool to make sure.
-test.file_fixture('fixture/SConstruct.2','SConstruct.2')
-
+test.file_fixture('fixture/SConstruct.2', 'SConstruct.2')
 
 test.run(options='-f SConstruct.2', arguments='.')
 
@@ -117,7 +114,7 @@ def matchem(match_file, lines):
     then compare
     """
     lines = linesep.join(lines)
-    test.must_match(match_file, lines, mode=match_mode, message="Expected:\n%s\n"%lines)
+    test.must_match(match_file, lines, mode=match_mode, message="Expected:\n%s\n" % lines)
 
 
 matchem('text.txt', [line1, line2a, line3a])


### PR DESCRIPTION
Fix Github Issue #3550 - When using Substfile() with a value like ```Z:\mongo\build\install\bin```
the previous implementation using re.sub() would end up interpreting the string and finding regex escape characters where it should have been simply replacing existing text. Switched to use string.replace().


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
