### PR TITLE
Do not reuse tempfiles

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -10,6 +10,9 @@ NOTE: Please include a reference to any Issues resolved by your changes in the b
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Simon Tegelid
+    - Fix using TEMPFILE in multiple actions in an action list.
+
   From William Deegan:
     - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to 
       propagate'VCINSTALLDIR' and 'VCToolsInstallDir' which clang tools use to locate

--- a/src/engine/SCons/Platform/PlatformTests.py
+++ b/src/engine/SCons/Platform/PlatformTests.py
@@ -194,38 +194,8 @@ class TempFileMungeTestCase(unittest.TestCase):
         assert file_content != env['TEMPFILEARGJOINBYTE'].join(['test','command','line'])
 
 
-    def test_tempfilecreation_once(self):
-        # Init class with cmd, such that the fully expanded
-        # string reads "a test command line".
-        # Note, how we're using a command string here that is
-        # actually longer than the substituted one. This is to ensure
-        # that the TempFileMunge class internally really takes the
-        # length of the expanded string into account.
-        defined_cmd = "a $VERY $OVERSIMPLIFIED line"
-        t = SCons.Platform.TempFileMunge(defined_cmd)
-        env = SCons.Environment.SubstitutionEnvironment(tools=[])
-        # Setting the line length high enough...
-        env['VERY'] = 'test'
-        env['OVERSIMPLIFIED'] = 'command'
-        expanded_cmd = env.subst(defined_cmd)
-        env['MAXLINELENGTH'] = len(expanded_cmd)-1
-        # Disable printing of actions...
-        old_actions = SCons.Action.print_actions
-        SCons.Action.print_actions = 0
-        # Create an instance of object derived class to allow setattrb
 
-        class Node(object):
-            class Attrs(object):
-                pass
 
-            def __init__(self):
-                self.attributes = self.Attrs()
-        target = [Node()]
-        cmd = t(target, None, env, 0)
-        # ...and restoring its setting.
-        SCons.Action.print_actions = old_actions
-        assert cmd != defined_cmd, cmd
-        assert cmd == getattr(target[0].attributes, 'tempfile_cmdlist', None)
 
 
 class PlatformEscapeTestCase(unittest.TestCase):

--- a/src/engine/SCons/Platform/__init__.py
+++ b/src/engine/SCons/Platform/__init__.py
@@ -184,14 +184,6 @@ class TempFileMunge(object):
         if length <= maxline:
             return self.cmd
 
-        # Check if we already created the temporary file for this target
-        # It should have been previously done by Action.strfunction() call
-        node = target[0] if SCons.Util.is_List(target) else target
-        cmdlist = getattr(node.attributes, 'tempfile_cmdlist', None) \
-                    if node is not None else None
-        if cmdlist is not None:
-            return cmdlist
-
         # Default to the .lnk suffix for the benefit of the Phar Lap
         # linkloc linker, which likes to append an .lnk suffix if
         # none is given.
@@ -249,14 +241,7 @@ class TempFileMunge(object):
                     str(cmd[0]) + " " + " ".join(args))
                 self._print_cmd_str(target, source, env, cmdstr)
 
-        # Store the temporary file command list into the target Node.attributes
-        # to avoid creating two temporary files one for print and one for execute.
         cmdlist = [ cmd[0], prefix + native_tmp + '\n' + rm, native_tmp ]
-        if node is not None:
-            try :
-                setattr(node.attributes, 'tempfile_cmdlist', cmdlist)
-            except AttributeError:
-                pass
         return cmdlist
 
     def _print_cmd_str(self, target, source, env, cmdstr):

--- a/test/TEMPFILE-actionlist.py
+++ b/test/TEMPFILE-actionlist.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify that using $TEMPFILE in multiple actions in a
+list invokes each command in the list.
+"""
+
+import os
+import stat
+
+import TestSCons
+
+test = TestSCons.TestSCons(match=TestSCons.match_re)
+
+test.write('SConstruct', """
+env = Environment(BUILDCOM=['${TEMPFILE("xxx.py -otempfile $SOURCE")}',
+                            '${TEMPFILE("yyy.py -o$TARGET tempfile")}'],
+                  MAXLINELENGTH=1)
+env.Command('file.output', 'file.input', '$BUILDCOM')
+""")
+
+test.write('file.input', "file.input\n")
+
+test.run(arguments='-n -Q .',
+         stdout="""\
+Using tempfile \\S+ for command line:
+xxx.py -otempfile file.input
+xxx.py @\\S+
+Using tempfile \\S+ for command line:
+yyy.py -ofile.output tempfile
+yyy.py @\\S+
+""")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Actions lists with more than one action using `${TEMPFILE("TEMP FILE CONTENT")}` should not use the same tempfile for different "TEMP FILE CONTENT".  Therefore, we cannot store the cmd_list in neither the target nor the source attributes, since those are common for all actions.

Reusing the same tempfile causes the same command to be invoked for all actions in the list. However, not resusing tempfiles will create unneeded tempfiles on `strfunction` invocation. This is better than producing incorrect results, but leaves the tempfile in a bad state.

Accidentally closed PR https://github.com/SCons/scons/pull/3140, but there is some relevant discussion in there.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
