### PR TITLE
test cleanups: use harness python

### DIFF
--- a/test/SWIG/SWIG.py
+++ b/test/SWIG/SWIG.py
@@ -35,19 +35,19 @@ _obj = TestSCons._obj
 
 test = TestSCons.TestSCons()
 
-python = test.where_is('python')
-if not python:
-    test.skip_test('Can not find installed "python", skipping test.\n')
+_python_ = TestSCons._python_
 
-
-test.write('myswig.py', r"""
+test.write('myswig.py', """\
 import getopt
 import sys
-opts, args = getopt.getopt(sys.argv[1:], 'c:o:v:')
+
+opts, args = getopt.getopt(sys.argv[1:], "c:o:v:")
 for opt, arg in opts:
-    if opt == '-c': pass
-    elif opt == '-o': out = arg
-    elif opt == '-v' and arg == 'ersion':
+    if opt == "-c":
+        pass
+    elif opt == "-o":
+        out = arg
+    elif opt == "-v" and arg == "ersion":
         print("")
         print("SWIG Version 0.1.2")
         print("")
@@ -55,23 +55,23 @@ for opt, arg in opts:
         print("")
         print("Configured options: +pcre")
         print("")
-        print("Please see http://www.swig.org for reporting bugs and further information")
+        print("Please see http://www.swig.org for reporting bugs "
+              "and further information")
         sys.exit(0)
-infile = open(args[0], 'r')
-outfile = open(out, 'w')
-for l in infile.readlines():
-    if l[:4] != 'swig':
-        outfile.write(l)
+
+with open(args[0], "r") as ifp, open(out, "w") as ofp:
+    for line in ifp:
+        if not line.startswith("swig"):
+            ofp.write(line)
 sys.exit(0)
 """)
 
-test.write('SConstruct', """
-env = Environment(tools=['default', 'swig'],
-                  SWIG = [r'%(python)s', 'myswig.py'])
+test.write('SConstruct', """\
+env = Environment(tools=["default", "swig"], SWIG=[r"%(_python_)s", "myswig.py"])
 print(env.subst("Using SWIG $SWIGVERSION"))
-env.Program(target = 'test1', source = 'test1.i')
-env.CFile(target = 'test2', source = 'test2.i')
-env.Clone(SWIGFLAGS = '-c++').Program(target = 'test3', source = 'test3.i')
+env.Program(target="test1", source="test1.i")
+env.CFile(target="test2", source="test2.i")
+env.Clone(SWIGFLAGS="-c++").Program(target="test3", source="test3.i")
 """ % locals())
 
 test.write('test1.i', r"""

--- a/test/SWIG/SWIGPATH.py
+++ b/test/SWIG/SWIGPATH.py
@@ -37,10 +37,6 @@ if not swig:
     test.skip_test('Can not find installed "swig", skipping test.\n')
 swig = swig.replace('\\','/')
 
-_python_ = TestSCons._python_
-
-test.file_fixture('wrapper.py')
-
 test.subdir('inc1', 'inc2')
 
 test.write(['inc2', 'dependency.i'], """\
@@ -58,7 +54,6 @@ foo = Environment(SWIGFLAGS='-python',
                   SWIG='%(swig)s',
                   SWIGPATH=['inc1', 'inc2'])
 swig = foo.Dictionary('SWIG')
-bar = foo.Clone(SWIG = [r'%(_python_)s', 'wrapper.py', swig])
 foo.CFile(target = 'dependent', source = ['dependent.i'])
 """ % locals())
 

--- a/test/SWIG/SWIGPATH.py
+++ b/test/SWIG/SWIGPATH.py
@@ -35,13 +35,12 @@ test = TestSCons.TestSCons()
 swig = test.where_is('swig')
 if not swig:
     test.skip_test('Can not find installed "swig", skipping test.\n')
-
-python = test.where_is('python')
-if not python:
-    test,skip_test('Can not find installed "python", skipping test.\n')
-
 swig = swig.replace('\\','/')
-python = python.replace('\\','/')
+
+_python_ = TestSCons._python_
+
+test.file_fixture('wrapper.py')
+
 test.subdir('inc1', 'inc2')
 
 test.write(['inc2', 'dependency.i'], """\
@@ -59,7 +58,7 @@ foo = Environment(SWIGFLAGS='-python',
                   SWIG='%(swig)s',
                   SWIGPATH=['inc1', 'inc2'])
 swig = foo.Dictionary('SWIG')
-bar = foo.Clone(SWIG = [r'%(python)s', 'wrapper.py', swig])
+bar = foo.Clone(SWIG = [r'%(_python_)s', 'wrapper.py', swig])
 foo.CFile(target = 'dependent', source = ['dependent.i'])
 """ % locals())
 

--- a/test/SWIG/implicit-dependencies.py
+++ b/test/SWIG/implicit-dependencies.py
@@ -35,13 +35,12 @@ test = TestSCons.TestSCons()
 swig = test.where_is('swig')
 if not swig:
     test.skip_test('Can not find installed "swig", skipping test.\n')
-
-python = test.where_is('python')
-if not python:
-    test.skip_test('Can not find installed "python", skipping test.\n')
-
 swig = swig.replace('\\','/')
-python = python.replace('\\','/')
+
+_python_ = TestSCons._python_
+
+test.file_fixture('wrapper.py')
+
 test.write("dependency.i", """\
 %module dependency
 """)
@@ -55,7 +54,7 @@ test.write("dependent.i", """\
 test.write('SConstruct', """
 foo = Environment(SWIGFLAGS='-python', SWIG='%(swig)s')
 swig = foo.Dictionary('SWIG')
-bar = foo.Clone(SWIG = [r'%(python)s', r'wrapper.py', swig])
+bar = foo.Clone(SWIG = [r'%(_python_)s', 'wrapper.py', swig])
 foo.CFile(target = 'dependent', source = ['dependent.i'])
 """ % locals())
 

--- a/test/SWIG/implicit-dependencies.py
+++ b/test/SWIG/implicit-dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/asr/bin/env python
 #
 # __COPYRIGHT__
 #
@@ -37,10 +37,6 @@ if not swig:
     test.skip_test('Can not find installed "swig", skipping test.\n')
 swig = swig.replace('\\','/')
 
-_python_ = TestSCons._python_
-
-test.file_fixture('wrapper.py')
-
 test.write("dependency.i", """\
 %module dependency
 """)
@@ -54,7 +50,6 @@ test.write("dependent.i", """\
 test.write('SConstruct', """
 foo = Environment(SWIGFLAGS='-python', SWIG='%(swig)s')
 swig = foo.Dictionary('SWIG')
-bar = foo.Clone(SWIG = [r'%(_python_)s', 'wrapper.py', swig])
 foo.CFile(target = 'dependent', source = ['dependent.i'])
 """ % locals())
 

--- a/test/SWIG/noproxy.py
+++ b/test/SWIG/noproxy.py
@@ -52,6 +52,8 @@ python, python_include, python_libpath, python_lib = \
 # handle testing on other platforms:
 ldmodule_prefix = '_'
 
+test.file_fixture('wrapper.py')
+
 test.write("dependency.i", """\
 %module dependency
 """)

--- a/test/SWIG/noproxy.py
+++ b/test/SWIG/noproxy.py
@@ -52,8 +52,6 @@ python, python_include, python_libpath, python_lib = \
 # handle testing on other platforms:
 ldmodule_prefix = '_'
 
-test.file_fixture('wrapper.py')
-
 test.write("dependency.i", """\
 %module dependency
 """)
@@ -75,7 +73,6 @@ foo = Environment(SWIGFLAGS=['-python', '-noproxy'],
                   )
 
 swig = foo.Dictionary('SWIG')
-bar = foo.Clone(SWIG = [r'%(python)s', 'wrapper.py', swig])
 foo.CFile(target = 'dependent', source = ['dependent.i'])
 """ % locals())
 

--- a/test/fixture/mycompile.py
+++ b/test/fixture/mycompile.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     with open(sys.argv[2], 'wb') as ofp:
         for f in sys.argv[3:]:
             with open(f, 'rb') as ifp:
-                lines = [ln for ln in ifp.readlines() if ln != line]
+                lines = [ln for ln in ifp if ln != line]
                 for ln in lines:
                     ofp.write(ln)
     sys.exit(0)

--- a/test/fixture/mylink.py
+++ b/test/fixture/mylink.py
@@ -23,9 +23,9 @@ if __name__ == '__main__':
             args = args[1:]
             if a[:5].lower() == '/out:': out = a[5:]
         with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
-            for l in ifp.readlines():
-                if not l.startswith(b'#link'):
-                    ofp.write(l)
+            for line in ifp:
+                if not line.startswith(b'#link'):
+                    ofp.write(line)
         sys.exit(0)
     else:
         import getopt
@@ -33,7 +33,7 @@ if __name__ == '__main__':
         for opt, arg in opts:
             if opt == '-o': out = arg
         with open(args[0], 'rb') as ifp, open(out, 'wb') as ofp:
-            for l in ifp.readlines():
-                if not l.startswith(b'#link'):
-                    ofp.write(l)
+            for line in ifp:
+                if not line.startswith(b'#link'):
+                    ofp.write(line)
         sys.exit(0)

--- a/test/fixture/myrewrite.py
+++ b/test/fixture/myrewrite.py
@@ -10,7 +10,7 @@ import sys
 if __name__ == '__main__':
     line = ('/*' + sys.argv[1] + '*/\n').encode()
     with open(sys.argv[2], 'rb') as ifp:
-        lines = [ln for ln in ifp.readlines() if ln != line]
+        lines = [ln for ln in ifp if ln != line]
     with open(sys.argv[2], 'wb') as ofp:
         for ln in lines:
             ofp.write(ln)

--- a/test/fixture/wrapper.py
+++ b/test/fixture/wrapper.py
@@ -5,6 +5,6 @@ import subprocess
 if __name__ == '__main__':
     path = os.path.join(os.path.dirname(os.path.relpath(__file__)), 'wrapper.out')
     if '--version' not in sys.argv and '-dumpversion' not in sys.argv:
-        with open(path, 'w') as f:
-            f.write("wrapper.py\n")
+        with open(path, 'wb') as f:
+            f.write(b"wrapper.py\n")
     subprocess.run(sys.argv[1:])

--- a/test/fixture/wrapper.py
+++ b/test/fixture/wrapper.py
@@ -5,6 +5,6 @@ import subprocess
 if __name__ == '__main__':
     path = os.path.join(os.path.dirname(os.path.relpath(__file__)), 'wrapper.out')
     if '--version' not in sys.argv and '-dumpversion' not in sys.argv:
-        with open(path, 'wb') as f:
-            f.write(b"wrapper.py\n")
-    subprocess.call(sys.argv[1:])
+        with open(path, 'w') as f:
+            f.write("wrapper.py\n")
+    subprocess.run(sys.argv[1:])

--- a/test/fixture/wrapper_with_args.py
+++ b/test/fixture/wrapper_with_args.py
@@ -6,4 +6,4 @@ if __name__ == '__main__':
     path = os.path.join(os.path.dirname(os.path.relpath(__file__)), 'wrapper.out')
     with open(path, 'a') as f:
         f.write("wrapper_with_args.py %s\n" % " ".join(sys.argv[1:]))
-    subprocess.call(sys.argv[1:])
+    subprocess.run(sys.argv[1:])


### PR DESCRIPTION
In a few places, a command line was built to execute a wrapper script written in Python, but the Python used was not the one used to invoke the test run (which is made available by TestSCons), but
the result of running `test.where_is('python')`.  On a system which still has the thing named 'python' resolve to Python 2, this fails. We should be using "the same Python" anyway for tests.

The two fixture wrapper scripts used occasionally by the tests used `subprocess.call`; this is considered "old" though not marked as deprecated at this time. Switched to `subprocess.run`.  See:
https://docs.python.org/3/library/subprocess.html#older-high-level-api. 

Modernized the inline `myswig.py` script (in `test/SWIG/SWIG.py`). This script was reformatted using Black along the way.

This is a test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
