### PR TITLE
A feature request for nicer dep. tree printing

### DIFF
--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -324,13 +324,20 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
 
     children = child_func(root)
     
-    if child < lenChildren:
-        if child<2:
-            cross = "└┬"
+    cross = "├─"  # sign used to point to the leaf.
+    
+    # check if this is the last leaf of the branch
+    if child == lenChildren:
+        #if this if the last leaf, then terminate:
+        cross = "└─" # sign for the last leaf
+
+    # if this is not a leaf after all, split it
+    if len(children)>0:
+        # If it is actually a reference to another branch:
+        if prune and rname in visited and children:
+            cross += "─"
         else:
-            cross = " ├─"
-    else:
-        cross = " └─"
+            cross += "┬"
         
     if prune and rname in visited and children:
         sys.stdout.write(''.join(tags + margins + [cross,'[', rname, ']']) + '\n')
@@ -345,10 +352,14 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
         idx = IDX(showtags)
         _child = 0
         for C in children[:-1]:
-            _child = _child + 1
+            # additional parameters:
+            #  - the nr of children of the current item
+            #  - the current child from the available            
             print_tree(C, child_func, prune, idx, margin, visited, _child, len(children))
+            _child = _child + 1
         margin[-1] = 0
-        print_tree(children[-1], child_func, prune, idx, margin, visited)
+        # for this call child and nr of children needs to be set to 0
+        print_tree(children[-1], child_func, prune, idx, margin, visited,0,0) 
         margin.pop()
 
 

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -325,7 +325,7 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
     children = child_func(root)
     
     if child < lenChildren:
-        if chield<2:
+        if child<2:
             cross = "└┬"
         else:
             cross = " ├─"

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -261,7 +261,7 @@ def render_tree(root, child_func, prune=0, margin=[0], visited=None):
 IDX = lambda N: N and 1 or 0
 
 
-def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None):
+def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, child=0, lenChildren=0):
     """
     Print a tree of nodes.  This is like render_tree, except it prints
     lines directly instead of creating a string representation in memory,
@@ -319,24 +319,34 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None):
         tags = []
 
     def MMM(m):
-        return ["  ","| "][m]
+        return ["  "," │ "][m]
     margins = list(map(MMM, margin[:-1]))
 
     children = child_func(root)
-
+    
+    if child < lenChildren:
+        if chield<2:
+            cross = "└┬"
+        else:
+            cross = " ├─"
+    else:
+        cross = " └─"
+        
     if prune and rname in visited and children:
-        sys.stdout.write(''.join(tags + margins + ['+-[', rname, ']']) + '\n')
+        sys.stdout.write(''.join(tags + margins + [cross,'[', rname, ']']) + '\n')
         return
 
-    sys.stdout.write(''.join(tags + margins + ['+-', rname]) + '\n')
+    sys.stdout.write(''.join(tags + margins + [cross, rname]) + '\n')
 
     visited[rname] = 1
 
     if children:
         margin.append(1)
         idx = IDX(showtags)
+        _child = 0
         for C in children[:-1]:
-            print_tree(C, child_func, prune, idx, margin, visited)
+            _child = _child + 1
+            print_tree(C, child_func, prune, idx, margin, visited, _child, len(children))
         margin[-1] = 0
         print_tree(children[-1], child_func, prune, idx, margin, visited)
         margin.pop()


### PR DESCRIPTION
Hello, 
Would it be possible to allow for a better rendering of the dependency tree ?
I implemented this change locally, and would really appreciate if i could generate this tree for documentation purposes.
Of course these have to be supported by the terminal that scons runs in. 
To combat this it would be possible to allow customization's from the project's via environmental variables.

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

https://scons.org/guidelines.html


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
