### PR TITLE
Issue #2906 useful error on duplicate configure

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -21,6 +21,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix Github Issue #3550 - When using Substfile() with a value like Z:\mongo\build\install\bin
       the implementation using re.sub() would end up interpreting the string and finding regex escape
       characters where it should have been simply replacing existing text. Switched to use string.replace().
+    - Fix Github Issue #2904 - Provide useful error message when more than one Configure Contexts are opened.
+      Only one open is allowed. You must call conf.Finish() to complete the currently open one before creating another
     
   From Jeremy Elson:
     - Updated design doc to use the correct syntax for Depends()

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -430,7 +430,8 @@ class SConfBase(object):
             SConfFS = SCons.Node.FS.default_fs or \
                       SCons.Node.FS.FS(env.fs.pathTop)
         if sconf_global is not None:
-            raise SCons.Errors.UserError
+            raise SCons.Errors.UserError("""User Called Configure() when another Configure() exists.
+            Please call .Finish() before creating and second Configure() context""")
 
         if log_file is not None:
             log_file = SConfFS.File(env.subst(log_file))

--- a/src/engine/SCons/SConf.py
+++ b/src/engine/SCons/SConf.py
@@ -430,7 +430,7 @@ class SConfBase(object):
             SConfFS = SCons.Node.FS.default_fs or \
                       SCons.Node.FS.FS(env.fs.pathTop)
         if sconf_global is not None:
-            raise SCons.Errors.UserError("""User Called Configure() when another Configure() exists.
+            raise SCons.Errors.UserError("""Configure() called while another Configure() exists.
             Please call .Finish() before creating and second Configure() context""")
 
         if log_file is not None:

--- a/test/Configure/fixture/SConstruct.issue-2906
+++ b/test/Configure/fixture/SConstruct.issue-2906
@@ -1,0 +1,5 @@
+env = Environment()
+conf1 = Configure(env)
+env2 = Environment()
+# Error right here. You can't have two configure contexts in flight at the same time.
+conf2 = Configure(env2)

--- a/test/Configure/issue-2906-useful-duplicate-configure-message.py
+++ b/test/Configure/issue-2906-useful-duplicate-configure-message.py
@@ -43,7 +43,7 @@ test_SConstruct_path = test.workpath('SConstruct')
 expected_stdout = "scons: Reading SConscript files ...\n"
 
 expected_stderr = """
-scons: *** User Called Configure() when another Configure() exists.
+scons: *** Configure() called while another Configure() exists.
             Please call .Finish() before creating and second Configure() context
 File "%s", line 5, in <module>\n"""%test_SConstruct_path
 test.run(stderr=expected_stderr, stdout=expected_stdout, status=2)

--- a/test/Configure/issue-2906-useful-duplicate-configure-message.py
+++ b/test/Configure/issue-2906-useful-duplicate-configure-message.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify useful error message when you create a second Configure context without
+finalizing the previous one via conf.Finish()
+This addresses Issue 2906: 
+https://github.com/SCons/scons/issues/2906
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+test.verbose_set(1)
+
+test.file_fixture('./fixture/SConstruct.issue-2906', 'SConstruct')
+
+test_SConstruct_path = test.workpath('SConstruct')
+
+expected_stdout = "scons: Reading SConscript files ...\n"
+
+expected_stderr = """
+scons: *** User Called Configure() when another Configure() exists.
+            Please call .Finish() before creating and second Configure() context
+File "%s", line 5, in <module>\n"""%test_SConstruct_path
+test.run(stderr=expected_stderr, stdout=expected_stdout, status=2)
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Fix issue #2906 

When presented with more than one open Configure contexts like this:

```
env = Environment()
conf1 = Configure(env)
env2 = Environment()
# Error right here. You can't have two configure contexts in flight at the same time.
conf2 = Configure(env2)
```

Users were presented with an unhelpful error:
```
scons: ***
File "C:\TSconsDir\scbug\SConstruct", line 4, in 
```

Now the message will be:
```
scons: *** User Called Configure() when another Configure() exists.
            Please call .Finish() before creating and second Configure() context
```

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
