### PR TITLE
Fix runtest no-exec mode

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -368,14 +368,17 @@ class RuntestBase(object):
     def __init__(self, path, num, spe=None):
         self.path = path
         self.num = num
+        self.stdout = self.stderr = self.status = None
         self.abspath = os.path.abspath(path)
+        self.command_args = []
+        self.command_str = ""
+        self.test_time = self.total_time = 0
         if spe:
             for dir in spe:
                 f = os.path.join(dir, path)
                 if os.path.isfile(f):
                     self.abspath = f
                     break
-        self.status = None
 
 
 class SystemExecutor(RuntestBase):


### PR DESCRIPTION
Failure to default some values in class initializer caused a downstream problem if running no-exec mode, as one field was added only if running in execute mode. Affects only runtest - no changes to docs, engine or actual tests.

Signed-off-by: Mats Wichmann <mats@linux.com>

### Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
