### PR TITLE
Add msys2 installed mingw64 to PATH for mingw tool

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -27,6 +27,7 @@ From Rob Boehne
       characters where it should have been simply replacing existing text. Switched to use string.replace().
     - Fix Github Issue #2904 - Provide useful error message when more than one Configure Contexts are opened.
       Only one open is allowed. You must call conf.Finish() to complete the currently open one before creating another
+    - Add msys2 installed mingw to PATH for mingw tool.
     
   From Jeremy Elson:
     - Updated design doc to use the correct syntax for Depends()

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -27,7 +27,8 @@ From Rob Boehne
       characters where it should have been simply replacing existing text. Switched to use string.replace().
     - Fix Github Issue #2904 - Provide useful error message when more than one Configure Contexts are opened.
       Only one open is allowed. You must call conf.Finish() to complete the currently open one before creating another
-    - Add msys2 installed mingw to PATH for mingw tool.
+    - Add msys2 installed mingw default path to PATH for mingw tool.
+      - C:\msys64\mingw64\bin
     
   From Jeremy Elson:
     - Updated design doc to use the correct syntax for Depends()

--- a/src/engine/SCons/Tool/mingw.py
+++ b/src/engine/SCons/Tool/mingw.py
@@ -47,6 +47,7 @@ mingw_paths = [
     r'c:\MinGW\bin',
     r'C:\cygwin64\bin',
     r'C:\msys64',
+    r'C:\msys64\mingw64\bin',
     r'C:\cygwin\bin',
     r'C:\msys',
 ]


### PR DESCRIPTION
Adding the path msys2 installs mingw to the list of default search paths for mingw tool

This may help resolve https://github.com/msys2/MSYS2-packages/issues/1249

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
