### PR TITLE
Fix syntax problem in Action doc  [ci skip]

### DIFF
--- a/src/engine/SCons/Action.xml
+++ b/src/engine/SCons/Action.xml
@@ -65,9 +65,9 @@ is set to <literal>2</literal> or higher,
 then that number of entries in the command
 string will be scanned for relative or absolute
 paths. The count will reset after any
-<literal>&&</literal> entries are found.
+<literal>&amp;&amp;</literal> entries are found.
 The first command in the action string and
-the first after any <literal>&&</literal>
+the first after any <literal>&amp;&amp;</literal>
 entries will be found by searching the
 <varname>PATH</varname> variable in the
 <varname>ENV</varname> environment used to
@@ -88,7 +88,7 @@ with that construction environment.
 not be added to the targets built with that
 construction environment. The first command
 in the action string and the first after any
-<literal>&&</literal> entries will be found
+<literal>&amp;&amp;</literal> entries will be found
 by searching the <varname>PATH</varname>
 variable in the <varname>ENV</varname>
 environment used to execute the command.


### PR DESCRIPTION
Recent change introduced an xml problem which prevents the docs from validating or building - transforming so it builds now.

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
