### PR TITLE
Remove verbose_set calls from tests

### DIFF
--- a/test/Configure/issue-2906-useful-duplicate-configure-message.py
+++ b/test/Configure/issue-2906-useful-duplicate-configure-message.py
@@ -34,7 +34,6 @@ https://github.com/SCons/scons/issues/2906
 import TestSCons
 
 test = TestSCons.TestSCons()
-test.verbose_set(1)
 
 test.file_fixture('./fixture/SConstruct.issue-2906', 'SConstruct')
 

--- a/test/Configure/issue-3469/issue-3469.py
+++ b/test/Configure/issue-3469/issue-3469.py
@@ -38,7 +38,6 @@ _obj = TestSCons._obj
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
-test.verbose_set(1)
 
 NCR = test.NCR  # non-cached rebuild
 CR  = test.CR   # cached rebuild (up to date)

--- a/test/Configure/option--config.py
+++ b/test/Configure/option--config.py
@@ -34,7 +34,6 @@ from TestSCons import TestSCons, ConfigCheckInfo, _obj
 from TestCmd import IS_WINDOWS
 
 test = TestSCons()
-# test.verbose_set(1)
 
 test.subdir('include')
 

--- a/test/Java/Java-1.6.py
+++ b/test/Java/Java-1.6.py
@@ -41,8 +41,6 @@ version = '1.6'
 where_javac, java_version = test.java_where_javac(version)
 javac_path=os.path.dirname(where_javac)
 
-# test.verbose_set(1)
-
 if ' ' in javac_path:
     javac_path ='"%s"'%javac_path
 java_arguments=["--javac_path=%s"%javac_path,"--java_version=%s"%version]

--- a/test/Java/Java-1.8.py
+++ b/test/Java/Java-1.8.py
@@ -41,8 +41,6 @@ version = '1.8'
 where_javac, java_version = test.java_where_javac(version)
 javac_path=os.path.dirname(where_javac)
 
-# test.verbose_set(1)
-
 if ' ' in javac_path:
     javac_path ='"%s"'%javac_path
 java_arguments=["--javac_path=%s"%javac_path,"--java_version=%s"%version]

--- a/test/Java/RMIC.py
+++ b/test/Java/RMIC.py
@@ -32,8 +32,6 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-# test.verbose_set(1)
-
 test.write('myrmic.py', r"""
 import os
 import sys

--- a/test/Java/multi-step.py
+++ b/test/Java/multi-step.py
@@ -33,7 +33,6 @@ import os
 import TestSCons
 
 test = TestSCons.TestSCons()
-# test.verbose_set(1)
 
 where_javac, java_version = test.java_where_javac()
 where_javah = test.java_where_javah()

--- a/test/LINK/applelink.py
+++ b/test/LINK/applelink.py
@@ -34,8 +34,6 @@ _exe = TestSCons._exe
 
 test = TestSCons.TestSCons()
 
-# test.verbose_set(1)
-
 #  Test issue # 2580
 test.dir_fixture('applelink_image')
 test.run(arguments='-f SConstruct_gh2580 -Q -n', stdout='gcc -o foo.o -c -Fframeworks foo.c\n')

--- a/test/Libs/SharedLibrary.py
+++ b/test/Libs/SharedLibrary.py
@@ -30,7 +30,6 @@ import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
-test.verbose_set(1)
 
 test.write('SConstruct', """
 import sys

--- a/test/MSVC/mssdk.py
+++ b/test/MSVC/mssdk.py
@@ -32,7 +32,6 @@ import time
 import TestSCons
 
 test = TestSCons.TestSCons()
-test.verbose_set(1)
 
 test.skip_if_not_msvc()
 

--- a/test/Repository/Program.py
+++ b/test/Repository/Program.py
@@ -35,7 +35,6 @@ else:
 for implicit_deps in ['0', '1', '"all"']:
     # First, test a single repository.
     test = TestSCons.TestSCons()
-    test.verbose_set(1)
     test.subdir('repository', 'work1')
     repository = test.workpath('repository')
     repository_foo_c = test.workpath('repository', 'foo.c')

--- a/test/TEX/subdir_variantdir_include.py
+++ b/test/TEX/subdir_variantdir_include.py
@@ -38,8 +38,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-#test.verbose_set(2)
-
 latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test.\n")

--- a/test/TEX/subdir_variantdir_include2.py
+++ b/test/TEX/subdir_variantdir_include2.py
@@ -39,8 +39,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-#test.verbose_set(2)
-
 latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test.\n")

--- a/test/TEX/subdir_variantdir_input.py
+++ b/test/TEX/subdir_variantdir_input.py
@@ -38,8 +38,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-#test.verbose_set(2)
-
 latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test.\n")

--- a/test/option/taskmastertrace.py
+++ b/test/option/taskmastertrace.py
@@ -31,7 +31,6 @@ Simple tests of the --taskmastertrace= option.
 import TestSCons
 
 test = TestSCons.TestSCons()
-# test.verbose_set(3)
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])

--- a/test/textfile/issue-3540.py
+++ b/test/textfile/issue-3540.py
@@ -34,8 +34,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-# test.verbose_set(1)
-
 test.file_fixture('fixture/substfile.in', 'substfile.in')
 test.file_fixture('fixture/SConstruct.issue-3540', 'SConstruct')
 

--- a/test/textfile/issue-3550.py
+++ b/test/textfile/issue-3550.py
@@ -34,8 +34,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-# test.verbose_set(1)
-
 match_mode = 'r'
 
 test.file_fixture('fixture/SConstruct.issue-3550', 'SConstruct')

--- a/test/update-release-info/update-release-info.py
+++ b/test/update-release-info/update-release-info.py
@@ -49,7 +49,6 @@ test = TestRuntest.TestRuntest(
     program=os.path.join('bin', 'update-release-info.py'),
     things_to_copy=['bin']
 )
-# test.verbose_set(1)
 if not os.path.exists(test.program):
     test.skip_test("update-release-info.py is not distributed in this package\n")
 


### PR DESCRIPTION
`test.verbose_set()` enables verbose mode, can be a useful debugging aid.  Shouldn't be left in in production tests, as it creates noise in the test log.

Basic test-only cleanup, should affect no functionality.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
