### PR TITLE
Add option to use box-draw chars with --tree

### DIFF
--- a/doc/generated/examples/troubleshoot_tree1_2.xml
+++ b/doc/generated/examples/troubleshoot_tree1_2.xml
@@ -1,7 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=all f2.o</userinput>
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=all,linedraw</userinput>
+cc -o f1.o -c -I. f1.c
 cc -o f2.o -c -I. f2.c
-+-f2.o
-  +-f2.c
-  +-inc.h
+cc -o f3.o -c -I. f3.c
+cc -o prog f1.o f2.o f3.o
+└─┬.
+  ├─SConstruct
+  ├─f1.c
+  ├─┬f1.o
+  │ ├─f1.c
+  │ └─inc.h
+  ├─f2.c
+  ├─┬f2.o
+  │ ├─f2.c
+  │ └─inc.h
+  ├─f3.c
+  ├─┬f3.o
+  │ ├─f3.c
+  │ └─inc.h
+  ├─inc.h
+  └─┬prog
+    ├─┬f1.o
+    │ ├─f1.c
+    │ └─inc.h
+    ├─┬f2.o
+    │ ├─f2.c
+    │ └─inc.h
+    └─┬f3.o
+      ├─f3.c
+      └─inc.h
 </screen>

--- a/doc/generated/examples/troubleshoot_tree1_3.xml
+++ b/doc/generated/examples/troubleshoot_tree1_3.xml
@@ -1,11 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=all f1.o f3.o</userinput>
-cc -o f1.o -c -I. f1.c
-+-f1.o
-  +-f1.c
-  +-inc.h
-cc -o f3.o -c -I. f3.c
-+-f3.o
-  +-f3.c
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=all f2.o</userinput>
+cc -o f2.o -c -I. f2.c
++-f2.o
+  +-f2.c
   +-inc.h
 </screen>

--- a/doc/generated/examples/troubleshoot_tree1_4.xml
+++ b/doc/generated/examples/troubleshoot_tree1_4.xml
@@ -1,43 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=status</userinput>
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=all f1.o f3.o</userinput>
 cc -o f1.o -c -I. f1.c
-cc -o f2.o -c -I. f2.c
++-f1.o
+  +-f1.c
+  +-inc.h
 cc -o f3.o -c -I. f3.c
-cc -o prog f1.o f2.o f3.o
- E         = exists
-  R        = exists in repository only
-   b       = implicit builder
-   B       = explicit builder
-    S      = side effect
-     P     = precious
-      A    = always build
-       C   = current
-        N  = no clean
-         H = no cache
-
-[E b      ]+-.
-[E     C  ]  +-SConstruct
-[E     C  ]  +-f1.c
-[E B   C  ]  +-f1.o
-[E     C  ]  | +-f1.c
-[E     C  ]  | +-inc.h
-[E     C  ]  +-f2.c
-[E B   C  ]  +-f2.o
-[E     C  ]  | +-f2.c
-[E     C  ]  | +-inc.h
-[E     C  ]  +-f3.c
-[E B   C  ]  +-f3.o
-[E     C  ]  | +-f3.c
-[E     C  ]  | +-inc.h
-[E     C  ]  +-inc.h
-[E B   C  ]  +-prog
-[E B   C  ]    +-f1.o
-[E     C  ]    | +-f1.c
-[E     C  ]    | +-inc.h
-[E B   C  ]    +-f2.o
-[E     C  ]    | +-f2.c
-[E     C  ]    | +-inc.h
-[E B   C  ]    +-f3.o
-[E     C  ]      +-f3.c
-[E     C  ]      +-inc.h
++-f3.o
+  +-f3.c
+  +-inc.h
 </screen>

--- a/doc/generated/examples/troubleshoot_tree1_5.xml
+++ b/doc/generated/examples/troubleshoot_tree1_5.xml
@@ -1,15 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=derived</userinput>
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=status</userinput>
 cc -o f1.o -c -I. f1.c
 cc -o f2.o -c -I. f2.c
 cc -o f3.o -c -I. f3.c
 cc -o prog f1.o f2.o f3.o
-+-.
-  +-f1.o
-  +-f2.o
-  +-f3.o
-  +-prog
-    +-f1.o
-    +-f2.o
-    +-f3.o
+ E         = exists
+  R        = exists in repository only
+   b       = implicit builder
+   B       = explicit builder
+    S      = side effect
+     P     = precious
+      A    = always build
+       C   = current
+        N  = no clean
+         H = no cache
+
+[E b      ]+-.
+[E     C  ]  +-SConstruct
+[E     C  ]  +-f1.c
+[E B   C  ]  +-f1.o
+[E     C  ]  | +-f1.c
+[E     C  ]  | +-inc.h
+[E     C  ]  +-f2.c
+[E B   C  ]  +-f2.o
+[E     C  ]  | +-f2.c
+[E     C  ]  | +-inc.h
+[E     C  ]  +-f3.c
+[E B   C  ]  +-f3.o
+[E     C  ]  | +-f3.c
+[E     C  ]  | +-inc.h
+[E     C  ]  +-inc.h
+[E B   C  ]  +-prog
+[E B   C  ]    +-f1.o
+[E     C  ]    | +-f1.c
+[E     C  ]    | +-inc.h
+[E B   C  ]    +-f2.o
+[E     C  ]    | +-f2.c
+[E     C  ]    | +-inc.h
+[E B   C  ]    +-f3.o
+[E     C  ]      +-f3.c
+[E     C  ]      +-inc.h
 </screen>

--- a/doc/generated/examples/troubleshoot_tree1_6.xml
+++ b/doc/generated/examples/troubleshoot_tree1_6.xml
@@ -1,26 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=derived,status</userinput>
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=derived</userinput>
 cc -o f1.o -c -I. f1.c
 cc -o f2.o -c -I. f2.c
 cc -o f3.o -c -I. f3.c
 cc -o prog f1.o f2.o f3.o
- E         = exists
-  R        = exists in repository only
-   b       = implicit builder
-   B       = explicit builder
-    S      = side effect
-     P     = precious
-      A    = always build
-       C   = current
-        N  = no clean
-         H = no cache
-
-[E b      ]+-.
-[E B   C  ]  +-f1.o
-[E B   C  ]  +-f2.o
-[E B   C  ]  +-f3.o
-[E B   C  ]  +-prog
-[E B   C  ]    +-f1.o
-[E B   C  ]    +-f2.o
-[E B   C  ]    +-f3.o
++-.
+  +-f1.o
+  +-f2.o
+  +-f3.o
+  +-prog
+    +-f1.o
+    +-f2.o
+    +-f3.o
 </screen>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1709,6 +1709,19 @@ not source files.</para>
   </varlistentry>
 
   <varlistentry>
+  <term><emphasis role="bold">linedraw</emphasis></term>
+  <listitem>
+<para>Draw the tree output using Unicode line-drawing characters
+instead of plain ASCII text. This option acts as a modifier
+to the selected <replaceable>type</replaceable>(s). If
+specified alone, without any <replaceable>type</replaceable>,
+it behaves as if <emphasis role="bold">all</emphasis>
+had been specified.
+</para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><emphasis role="bold">status</emphasis></term>
   <listitem>
 <para>Prints status information for each displayed node.</para>
@@ -6844,7 +6857,7 @@ env.PDFBuilder(target = 'bar', source = 'bar')
 <para>Note also that the above initialization
 overwrites the default Builder objects,
 so the Environment created above
-can not be used call Builders like 
+can not be used call Builders like
 <methodname>env.Program</methodname>,
 <methodname>env.Object</methodname>,
 <methodname>env.StaticLibrary</methodname> etc.</para>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1718,6 +1718,7 @@ specified alone, without any <replaceable>type</replaceable>,
 it behaves as if <emphasis role="bold">all</emphasis>
 had been specified.
 </para>
+<para>Since &scons; 4.0.</para>
   </listitem>
   </varlistentry>
 

--- a/doc/user/troubleshoot.xml
+++ b/doc/user/troubleshoot.xml
@@ -442,6 +442,19 @@ inc.h
 
     <para>
 
+    By default &SCons; uses "ASCII art" to draw the tree. It is
+    possible to use line-drawing characters (Unicode calls these
+    Box Drawing) to make a nicer display. To do this, add the
+    <option>linedraw</option> qualifier:
+
+    </para>
+
+    <scons_output example="troubleshoot_tree1" suffix="2">
+      <scons_output_command>scons -Q --tree=all,linedraw</scons_output_command>
+    </scons_output>
+
+    <para>
+
     The <option>--tree</option> option only prints
     the dependency graph for the specified targets
     (or the default target(s) if none are specified on the command line).
@@ -452,7 +465,7 @@ inc.h
 
     </para>
 
-    <scons_output example="troubleshoot_tree1" suffix="2">
+    <scons_output example="troubleshoot_tree1" suffix="3">
       <scons_output_command>scons -Q --tree=all f2.o</scons_output_command>
     </scons_output>
 
@@ -468,7 +481,7 @@ inc.h
 
     </para>
 
-    <scons_output example="troubleshoot_tree1" suffix="3">
+    <scons_output example="troubleshoot_tree1" suffix="4">
       <scons_output_command>scons -Q --tree=all f1.o f3.o</scons_output_command>
     </scons_output>
 
@@ -480,7 +493,7 @@ inc.h
 
     </para>
 
-    <scons_output example="troubleshoot_tree1" suffix="4">
+    <scons_output example="troubleshoot_tree1" suffix="5">
       <scons_output_command>scons -Q --tree=status</scons_output_command>
     </scons_output>
 
@@ -498,7 +511,7 @@ inc.h
 
     </para>
 
-    <scons_output example="troubleshoot_tree1" suffix="5">
+    <scons_output example="troubleshoot_tree1" suffix="6">
       <scons_output_command>scons -Q --tree=derived</scons_output_command>
     </scons_output>
 
@@ -509,7 +522,7 @@ inc.h
 
     </para>
 
-    <scons_output example="troubleshoot_tree1" suffix="6">
+    <scons_output example="troubleshoot_tree1" suffix="7">
       <scons_output_command>scons -Q --tree=derived,status</scons_output_command>
     </scons_output>
 

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -14,11 +14,15 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Specify UTF-8 encoding when opening Java source file as text.  By default, encoding is the output
     of locale.getpreferredencoding(False), and varies by platform.
 
+  From Iosif Kurazs:
+    - Added a new flag called "linedraw" for the command line argument  "--tree"
+    that instructs scons to use single line drawing characters to draw the dependency tree.
+
   From William Deegan:
-    - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to 
+    - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to
       propagate'VCINSTALLDIR' and 'VCToolsInstallDir' which clang tools use to locate
       header files and libraries from MSVC install. (Fixes GH Issue #3480)
-    - Added C:\msys64\mingw64\bin to default mingw and clang windows PATH's.  This 
+    - Added C:\msys64\mingw64\bin to default mingw and clang windows PATH's.  This
       is a reasonable default and also aligns with changes in Appveyor's VS2019 image.
     - Drop support for Python 2.7. SCons will be Python 3.5+ going forward.
     - Change SCons.Node.ValueWithMemo to consider any name passed when memoizing Value() nodes
@@ -119,7 +123,7 @@ RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000
       (e.g. memmove) were incorrectly recognized as not available.
 
   From Jakub Kulik
-    - Fix stacktrace when using SCons with Python 3.5+ and SunOS/Solaris related tools.	
+    - Fix stacktrace when using SCons with Python 3.5+ and SunOS/Solaris related tools.
 
   From Philipp Maierhöfer:
     - Avoid crash with UnicodeDecodeError on Python 3 when a Latex log file in

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -14,10 +14,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Specify UTF-8 encoding when opening Java source file as text.  By default, encoding is the output
     of locale.getpreferredencoding(False), and varies by platform.
 
-  From Iosif Kurazs:
-    - Added a new flag called "linedraw" for the command line argument  "--tree"
-    that instructs scons to use single line drawing characters to draw the dependency tree.
-
   From William Deegan:
     - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to
       propagate'VCINSTALLDIR' and 'VCToolsInstallDir' which clang tools use to locate

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -50,6 +50,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added support for explicitly passing a name when creating Value() nodes. This may be useful
       when the value can't be converted to a string or if having a name is otherwise desirable.
 
+  From Iosif Kurazs:
+    - Added a new flag called "linedraw" for the command line argument  "--tree"
+      that instructs scons to use single line drawing characters to draw the dependency tree.
+
   From Andrew Morrow:
     - Fix Issue #3469 - Fixed improper reuse of temporary and compiled files by Configure when changing
       the order and/or number of tests.  This is done by using the hash of the generated temporary files

--- a/src/engine/SCons/Script/Main.py
+++ b/src/engine/SCons/Script/Main.py
@@ -430,10 +430,11 @@ class QuestionTask(SCons.Taskmaster.AlwaysTask):
 
 
 class TreePrinter(object):
-    def __init__(self, derived=False, prune=False, status=False):
+    def __init__(self, derived=False, prune=False, status=False, sLineDraw=False):
         self.derived = derived
         self.prune = prune
         self.status = status
+        self.sLineDraw = sLineDraw
     def get_all_children(self, node):
         return node.all_children()
     def get_derived_children(self, node):
@@ -445,7 +446,7 @@ class TreePrinter(object):
         else:
             func = self.get_all_children
         s = self.status and 2 or 0
-        SCons.Util.print_tree(t, func, prune=self.prune, showtags=s)
+        SCons.Util.print_tree(t, func, prune=self.prune, showtags=s, lastChild=True, singleLineDraw=self.sLineDraw)
 
 
 def python_version_string():

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -834,7 +834,7 @@ def Parser(version):
                   help="Trace Node evaluation to FILE.",
                   metavar="FILE")
 
-    tree_options = ["all", "derived", "prune", "status"]
+    tree_options = ["all", "derived", "prune", "status", "linedraw"]
 
     def opt_tree(option, opt, value, parser, tree_options=tree_options):
         from . import Main
@@ -848,6 +848,8 @@ def Parser(version):
                 tp.prune = True
             elif o == 'status':
                 tp.status = True
+            elif o == 'linedraw':
+                tp.sLineDraw = True
             else:
                 raise OptionValueError(opt_invalid('--tree', o, tree_options))
         parser.values.tree_printers.append(tp)

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -253,6 +253,16 @@ def render_tree(root, child_func, prune=0, margin=[0], visited=None):
 
 IDX = lambda N: N and 1 or 0
 
+# unicode line drawing chars:
+BOX_HORIZ = chr(0x2500)  # '─'
+BOX_VERT = chr(0x2502)  # '│'
+BOX_UP_RIGHT = chr(0x2514)  # '└'
+BOX_DOWN_RIGHT = chr(0x250c)  # '┌'
+BOX_DOWN_LEFT = chr(0x2510)   # '┐'
+BOX_UP_LEFT = chr(0x2518)  # '┘'
+BOX_VERT_RIGHT = chr(0x251c)  # '├'
+BOX_HORIZ_DOWN = chr(0x252c)  # '┬'
+
 
 def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, lastChild=False, singleLineDraw=False):
     """
@@ -315,9 +325,9 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
 
     def MMM(m):
         if singleLineDraw:
-            return ["  ","│ "][m]
+            return ["  ", BOX_VERT + " "][m]
         else:
-            return ["  ","| "][m]
+            return ["  ", "| "][m]
 
     margins = list(map(MMM, margin[:-1]))
 
@@ -326,29 +336,19 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
 
     cross = "+-"
     if singleLineDraw:
-        # unicode line drawing chars:
-        box_horiz = chr(0x2500) # '─'
-        box_vert = chr(0x2510) # '│'
-        box_up_right = chr(0x2514) # '└'
-        box_down_right = chr(0x250c) # '┌'
-        box_down_left = chr(0x2510)  # '┐'
-        box_up_left = chr(0x2518) # '┘'
-        box_vert_right = chr(0x251c) # '├'
-        box_horiz_down = chr(0x252c) # '┬'
-
-        cross = box_vert_right + box_horiz   # sign used to point to the leaf.
+        cross = BOX_VERT_RIGHT + BOX_HORIZ   # sign used to point to the leaf.
         # check if this is the last leaf of the branch
         if lastChild:
             #if this if the last leaf, then terminate:
-            cross = box_up_right + box_horiz  # sign for the last leaf
+            cross = BOX_UP_RIGHT + BOX_HORIZ  # sign for the last leaf
 
         # if this branch has children then split it
         if children:
             # if it's a leaf:
             if prune and rname in visited and children:
-                cross += box_horiz
+                cross += BOX_HORIZ
             else:
-                cross += box_horiz_down
+                cross += BOX_HORIZ_DOWN
 
     if prune and rname in visited and children:
         sys.stdout.write(''.join(tags + margins + [cross,'[', rname, ']']) + '\n')

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -267,6 +267,7 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
         - `showtags`   - print status information to the left of each node line
         - `margin`     - the format of the left margin to use for children of root. 1 results in a pipe, and 0 results in no pipe.
         - `visited`    - a dictionary of visited nodes in the current branch if not prune, or in the whole tree if prune.
+        - `singleLineDraw` - use line-drawing characters rather than ASCII.
     """
 
     rname = str(root)
@@ -301,7 +302,7 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
                 [0, 2][IDX(root.has_builder())]
             ],
             ' S'[IDX(root.side_effect)],
-			' P'[IDX(root.precious)],
+            ' P'[IDX(root.precious)],
             ' A'[IDX(root.always_build)],
             ' C'[IDX(root.is_up_to_date())],
             ' N'[IDX(root.noclean)],
@@ -322,21 +323,32 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, 
 
     children = child_func(root)
 
+
     cross = "+-"
     if singleLineDraw:
-        cross = "├─"  # sign used to point to the leaf.
+        # unicode line drawing chars:
+        box_horiz = chr(0x2500) # '─'
+        box_vert = chr(0x2510) # '│'
+        box_up_right = chr(0x2514) # '└'
+        box_down_right = chr(0x250c) # '┌'
+        box_down_left = chr(0x2510)  # '┐'
+        box_up_left = chr(0x2518) # '┘'
+        box_vert_right = chr(0x251c) # '├'
+        box_horiz_down = chr(0x252c) # '┬'
+
+        cross = box_vert_right + box_horiz   # sign used to point to the leaf.
         # check if this is the last leaf of the branch
         if lastChild:
             #if this if the last leaf, then terminate:
-            cross = "└─" # sign for the last leaf
+            cross = box_up_right + box_horiz  # sign for the last leaf
 
         # if this branch has children then split it
-        if len(children)>0:
+        if children:
             # if it's a leaf:
             if prune and rname in visited and children:
-                cross += "─"
+                cross += box_horiz
             else:
-                cross += "┬"
+                cross += box_horiz_down
 
     if prune and rname in visited and children:
         sys.stdout.write(''.join(tags + margins + [cross,'[', rname, ']']) + '\n')

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -254,7 +254,7 @@ def render_tree(root, child_func, prune=0, margin=[0], visited=None):
 IDX = lambda N: N and 1 or 0
 
 
-def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None):
+def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None, lastChild=False, singleLineDraw=False):
     """
     Print a tree of nodes.  This is like render_tree, except it prints
     lines directly instead of creating a string representation in memory,
@@ -300,7 +300,8 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None):
                 [0, 1][IDX(root.has_explicit_builder())] +
                 [0, 2][IDX(root.has_builder())]
             ],
-            ' S'[IDX(root.side_effect)], ' P'[IDX(root.precious)],
+            ' S'[IDX(root.side_effect)],
+			' P'[IDX(root.precious)],
             ' A'[IDX(root.always_build)],
             ' C'[IDX(root.is_up_to_date())],
             ' N'[IDX(root.noclean)],
@@ -312,27 +313,50 @@ def print_tree(root, child_func, prune=0, showtags=0, margin=[0], visited=None):
         tags = []
 
     def MMM(m):
-        return ["  ","| "][m]
+        if singleLineDraw:
+            return ["  ","│ "][m]
+        else:
+            return ["  ","| "][m]
+
     margins = list(map(MMM, margin[:-1]))
 
     children = child_func(root)
 
+    cross = "+-"
+    if singleLineDraw:
+        cross = "├─"  # sign used to point to the leaf.
+        # check if this is the last leaf of the branch
+        if lastChild:
+            #if this if the last leaf, then terminate:
+            cross = "└─" # sign for the last leaf
+
+        # if this branch has children then split it
+        if len(children)>0:
+            # if it's a leaf:
+            if prune and rname in visited and children:
+                cross += "─"
+            else:
+                cross += "┬"
+
     if prune and rname in visited and children:
-        sys.stdout.write(''.join(tags + margins + ['+-[', rname, ']']) + '\n')
+        sys.stdout.write(''.join(tags + margins + [cross,'[', rname, ']']) + '\n')
         return
 
-    sys.stdout.write(''.join(tags + margins + ['+-', rname]) + '\n')
+    sys.stdout.write(''.join(tags + margins + [cross, rname]) + '\n')
 
     visited[rname] = 1
 
+    # if this item has children:
     if children:
-        margin.append(1)
+        margin.append(1) # Initialize margin with 1 for vertical bar.
         idx = IDX(showtags)
+        _child = 0 # Initialize this for the first child.
         for C in children[:-1]:
-            print_tree(C, child_func, prune, idx, margin, visited)
-        margin[-1] = 0
-        print_tree(children[-1], child_func, prune, idx, margin, visited)
-        margin.pop()
+            _child = _child + 1 # number the children
+            print_tree(C, child_func, prune, idx, margin, visited, (len(children) - _child) <= 0 ,singleLineDraw)
+        margin[-1] = 0  # margins are with space (index 0) because we arrived to the last child.
+        print_tree(children[-1], child_func, prune, idx, margin, visited, True ,singleLineDraw) # for this call child and nr of children needs to be set 0, to signal the second phase.
+        margin.pop() # destroy the last margin added
 
 
 # Functions for deciding if things are like various types, mainly to

--- a/test/option--tree.py
+++ b/test/option--tree.py
@@ -61,10 +61,7 @@ except NameError:
 env.Textfile("Foo", write)
 """)
 
-if sys.version_info.major < 3:
-    py23_char = unichr(0xe7).encode('utf-8')
-else:
-    py23_char = chr(0xe7)
+py23_char = chr(0xe7)
 
 expected = """Creating 'Foo.txt'
 +-.

--- a/test/option--tree.py
+++ b/test/option--tree.py
@@ -47,60 +47,42 @@ SCons Error: `foofoo' is not a valid --tree option type, try:
 
 
 # Test that unicode characters can be printed (escaped) with the --tree option
-test.write('SConstruct',
-           """
+test.write('SConstruct', """\
 env = Environment()
 env.Tool("textfile")
-try:
-    # Python 2
-    write = unichr(0xe7).encode('utf-8')
-except NameError:
-    # Python 3
-    # str is utf-8 by default
-    write = chr(0xe7)
-env.Textfile("Foo", write)
+name = "français"
+env.Textfile("Foo", name)
 """)
 
-if sys.version_info.major < 3:
-    py23_char = unichr(0xe7).encode('utf-8')
-else:
-    py23_char = chr(0xe7)
+uchar = chr(0xe7)
 
 expected = """Creating 'Foo.txt'
 +-.
   +-Foo.txt
-  | +-""" + py23_char + """
+  | +-fran%sais
   +-SConstruct
-"""
+""" % uchar
 
-test.run(arguments='-Q --tree=all',
-         stdout=expected,
-         status=0)
+test.run(arguments='-Q --tree=all', stdout=expected, status=0)
 
-#Tests the new command line option "linedraw"
-test.write('SConstruct',
-           """
+# Test the "linedraw" option: same basic test as previous.
+# With "--tree=linedraw" must default to "all", and use line-drawing chars.
+test.write('SConstruct', """\
 env = Environment()
 env.Tool("textfile")
-# Python 3
-# str is utf-8 by default
-write = chr(0xe7)
-env.Textfile("LineDraw", write)
+name = "français"
+env.Textfile("LineDraw", name)
 """)
-
-py23_char = chr(0xe7)
 
 expected = """Creating 'LineDraw.txt'
 └─┬.
   ├─┬LineDraw.txt
-  │ └─""" + py23_char + """
+  │ └─fran%sais
   └─SConstruct
-"""
+""" % uchar
 
 
-test.run(arguments='-Q --tree=linedraw',
-        stdout=expected,
-        status=0)
+test.run(arguments='-Q --tree=linedraw', stdout=expected, status=0)
 
 test.pass_test()
 

--- a/test/option--tree.py
+++ b/test/option--tree.py
@@ -82,20 +82,13 @@ test.write('SConstruct',
            """
 env = Environment()
 env.Tool("textfile")
-try:
-    # Python 2
-    write = unichr(0xe7).encode('utf-8')
-except NameError:
-    # Python 3
-    # str is utf-8 by default
-    write = chr(0xe7)
+# Python 3
+# str is utf-8 by default
+write = chr(0xe7)
 env.Textfile("LineDraw", write)
 """)
 
-if sys.version_info.major < 3:
-    py23_char = unichr(0xe7).encode('utf-8')
-else:
-    py23_char = chr(0xe7)
+py23_char = chr(0xe7)
 
 expected = """Creating 'LineDraw.txt'
 └─┬.

--- a/test/option--tree.py
+++ b/test/option--tree.py
@@ -61,7 +61,10 @@ except NameError:
 env.Textfile("Foo", write)
 """)
 
-py23_char = chr(0xe7)
+if sys.version_info.major < 3:
+    py23_char = unichr(0xe7).encode('utf-8')
+else:
+    py23_char = chr(0xe7)
 
 expected = """Creating 'Foo.txt'
 +-.

--- a/test/option--tree.py
+++ b/test/option--tree.py
@@ -41,7 +41,7 @@ test.run(arguments='-Q --tree=foofoo',
          stderr="""usage: scons [OPTION] [TARGET] ...
 
 SCons Error: `foofoo' is not a valid --tree option type, try:
-    all, derived, prune, status
+    all, derived, prune, status, linedraw
 """,
          status=2)
 
@@ -76,6 +76,39 @@ expected = """Creating 'Foo.txt'
 test.run(arguments='-Q --tree=all',
          stdout=expected,
          status=0)
+
+#Tests the new command line option "linedraw"
+test.write('SConstruct',
+           """
+env = Environment()
+env.Tool("textfile")
+try:
+    # Python 2
+    write = unichr(0xe7).encode('utf-8')
+except NameError:
+    # Python 3
+    # str is utf-8 by default
+    write = chr(0xe7)
+env.Textfile("LineDraw", write)
+""")
+
+if sys.version_info.major < 3:
+    py23_char = unichr(0xe7).encode('utf-8')
+else:
+    py23_char = chr(0xe7)
+
+expected = """Creating 'LineDraw.txt'
+└─┬.
+  ├─┬LineDraw.txt
+  │ └─""" + py23_char + """
+  └─SConstruct
+"""
+
+
+test.run(arguments='-Q --tree=linedraw',
+        stdout=expected,
+        status=0)
+
 test.pass_test()
 
 # Local Variables:


### PR DESCRIPTION
This picks up and hopefully completes PR #3560.

Add documentation for new `--tree` "linedraw" option to manpage.

There is a new example output in userguide, which renumbers several of the existing `troubleshoot_tree` example outputs due to the insertion - these did not otherwise change.

Test is cleaned up a bit (not just the added part). 

The actual implementation in `Util.py` is made a little more general - it uses unicode chr() values (with comments) instead of literally pasting in the line drawing characters.

The rest of the PR is as described in #3560 

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
