### PR TITLE
Improve manpage treatment of Variables and Configure

### DIFF
--- a/doc/man/epub.xsl
+++ b/doc/man/epub.xsl
@@ -24,12 +24,12 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/epub/docbook.xsl"/> 
+	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/epub/docbook.xsl"/>
 
 <xsl:param name="html.stylesheet" select="'epub.css'"/>
 
-</xsl:stylesheet> 
+</xsl:stylesheet>

--- a/doc/man/html.xsl
+++ b/doc/man/html.xsl
@@ -24,15 +24,17 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/> 
+	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
 <xsl:param name="section.label.includes.component.label" select="1"/>
+<xsl:param name="variablelist.term.break.after" select="1"/>
+<xsl:param name="variablelist.term.separator"/>
 <xsl:param name="html.stylesheet" select="'scons.css'"/>
 <xsl:param name="generate.toc">
 /appendix toc,title
@@ -56,5 +58,5 @@ set       toc,title
 <xsl:template match="mediaobject[@role = 'cover']">
 </xsl:template>
 
-</xsl:stylesheet> 
+</xsl:stylesheet>
 

--- a/doc/man/pdf.xsl
+++ b/doc/man/pdf.xsl
@@ -25,19 +25,20 @@
 -->
 
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/fo/docbook.xsl"/> 
-	<xsl:include href="scons_title.xsl"/> 
+	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/fo/docbook.xsl"/>
+	<xsl:include href="scons_title.xsl"/>
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
-<xsl:param name="section.autolabel" select="1"></xsl:param>
+<xsl:param name="section.autolabel" select="1"/>
 <xsl:param name="section.label.includes.component.label" select="1"/>
-<xsl:param name="paper.type" select="'letter'"></xsl:param>
+<xsl:param name="paper.type" select="'letter'"/>
 <xsl:param name="body.start.indent">0pt</xsl:param>
-<xsl:param name="shade.verbatim" select="1"></xsl:param>
-<xsl:param name="variablelist.term.break.after" select="1"></xsl:param>
+<xsl:param name="shade.verbatim" select="1"/>
+<xsl:param name="variablelist.term.break.after" select="1"/>
+<xsl:param name="variablelist.term.separator"/>
 
 <xsl:param name="generate.toc">
 /appendix toc,title
@@ -72,4 +73,4 @@ set       toc,title
 <xsl:template match="mediaobject[@role = 'cover']">
 </xsl:template>
 
-</xsl:stylesheet> 
+</xsl:stylesheet>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2930,28 +2930,19 @@ include:</para>
 
 <para>In addition to the global functions and methods,
 &scons;
-supports a number of Python variables
+supports a number of variables
 that can be used in SConscript files
-to affect how you want the build to be performed.
-These variables may be accessed from custom Python modules that you
-import into an SConscript file by adding the following
-to the Python module:</para>
-
-<programlisting language="python">
-from SCons.Script import *
-</programlisting>
+to affect how you want the build to be performed.</para>
 
 <variablelist>
   <varlistentry>
   <term>ARGLIST</term>
   <listitem>
-<para>A list
+<para>A list of the
 <emphasis>keyword</emphasis>=<emphasis>value</emphasis>
 arguments specified on the command line.
 Each element in the list is a tuple
-containing the
-(<emphasis>keyword</emphasis>,<emphasis>value</emphasis>)
-of the argument.
+containing the argument.
 The separate
 <emphasis>keyword</emphasis>
 and
@@ -3048,9 +3039,7 @@ if 'special/program' in BUILD_TARGETS:
 </programlisting>
   </listitem>
   </varlistentry>
-</variablelist>
 
-<variablelist>
   <varlistentry>
   <term>COMMAND_LINE_TARGETS</term>
   <listitem>
@@ -3058,10 +3047,10 @@ if 'special/program' in BUILD_TARGETS:
 the command line. If there are command line targets,
 this list will have the same contents as &BUILD_TARGETS;.
 If there are no targets specified on the command line,
-the list is empty. The elemnts of this list are strings.
+the list is empty. The elements of this list are strings.
 This can be used, for example,
 to take specific actions only
-when certain targets is explicitly being built.</para>
+when certain targets are explicitly being built.</para>
 
 <para>Example:</para>
 
@@ -3084,10 +3073,10 @@ that have been specified using the
 function or method. If there are no command line
 targets, this list will have the same contents as
 &BUILD_TARGETS;.
-The elements of the list are nodes,
-so you need to run them through the Python
+Since the elements of the list are nodes,
+you need to call the Python
 <emphasis role="bold">str</emphasis>
-function to get at the path name for each Node.</para>
+function on them to get the path name for each Node.</para>
 
 <para>Example:</para>
 
@@ -3125,6 +3114,15 @@ default target before it's actually been added to the list.</para>
   </listitem>
   </varlistentry>
 </variablelist>
+
+<para>
+These variables may be accessed from custom Python modules that you
+import into an SConscript file by adding the following
+to the Python module:</para>
+
+<programlisting language="python">
+from SCons.Script import *
+</programlisting>
 
 </refsect2>
 
@@ -3221,10 +3219,10 @@ env2 = env.Clone(CC="cl.exe")
 supports
 <emphasis>configure contexts,</emphasis>
 an integrated mechanism similar to the
-various AC_CHECK macros in GNU autoconf
+various <constant>AC_CHECK</constant> macros in GNU &Autoconf;
 for testing for the existence of C header
 files, libraries, etc.
-In contrast to autoconf,
+In contrast to &Autoconf;,
 &scons;
 does not maintain an explicit cache of the tested values,
 but uses its normal dependency tracking to keep the checked values
@@ -3252,37 +3250,38 @@ specifies a directory where the test cases are built.
 Note that this directory is not used for building
 normal targets.
 The default value is the directory
-#/.sconf_temp.
+<filename>#/.sconf_temp.</filename>
 <emphasis>log_file</emphasis>
 specifies a file which collects the output from commands
 that are executed to check for the existence of header files, libraries, etc.
-The default is the file #/config.log.
+The default is the file <filename>#/config.log</filename>.
 If you are using the
-<emphasis role="bold">VariantDir</emphasis>()
-method,
+&VariantDir; function,
 you may want to specify a subdirectory under your variant directory.
 <emphasis>config_h</emphasis>
 specifies a C header file where the results of tests
-will be written, e.g. #define HAVE_STDIO_H, #define HAVE_LIBM, etc.
+will be written, e.g.
+<literal>#define HAVE_STDIO_H</literal>,
+<literal>#define HAVE_LIBM</literal>, etc.
 The default is to not write a
-<emphasis role="bold">config.h</emphasis>
+<filename>config.h</filename>
 file.
 You can specify the same
-<emphasis role="bold">config.h</emphasis>
-file in multiple calls to Configure,
+<filename>config.h</filename>
+file in multiple calls to &Configure;,
 in which case &SCons;
 will concatenate all results in the specified file.
 Note that &SCons;
 uses its normal dependency checking
 to decide if it's necessary to rebuild
 the specified
-<emphasis>config_h</emphasis>
+<filename>config_h</filename>
 file.
 This means that the file is not necessarily re-built each
 time scons is run,
 but is only rebuilt if its contents will have changed
 and some target that depends on the
-<emphasis>config_h</emphasis>
+<filename>config_h</filename>
 file is being built.</para>
 
 <para>The optional
@@ -3291,9 +3290,9 @@ and
 <emphasis role="bold">help</emphasis>
 arguments can be used to suppress execution of the configuration
 tests when the
-<option>-c/--clean</option>
+<option>-c</option>/<option>--clean</option>
 or
-<option>-H/-h/--help</option>
+<option>-H</option>/<option>-h</option>/<option>--help</option>
 options are used, respectively.
 The default behavior is always to execute
 configure context tests,
@@ -3329,7 +3328,7 @@ with this configuration context.
 However, you can create a new
 Configure
 context to perform additional checks.
-Only one context should be active at a time.</para>
+Only one context may be active at a time.</para>
 
 <para>The following Checks are predefined.
 (This list will likely grow larger as time
@@ -3943,8 +3942,7 @@ For example, libraries needed for the build may be in non-standard
 locations, or site-specific compiler options may need to be passed to the
 compiler.
 &scons;
-provides a
-<emphasis role="bold">Variables</emphasis>
+provides a <firstterm>&Variables;</firstterm>
 object to support overriding &consvars;
 on the command line:</para>
 
@@ -3952,23 +3950,31 @@ on the command line:</para>
 <userinput>scons VARIABLE=foo</userinput>
 </screen>
 
-<para>The variable values can also be specified in a text-based SConscript file.
-To create a Variables object, call the Variables() function:</para>
+<para>The variable values can also be specified in an SConscript file.
+To obtain the object for manipulating values,
+call the &Variables; function:</para>
 
 <variablelist>
   <varlistentry>
-  <term>Variables([<emphasis>files</emphasis>], [<emphasis>args</emphasis>])</term>
+  <term>Variables([<emphasis>files</emphasis>[, <emphasis>args</emphasis>]])</term>
   <listitem>
-<para>This creates a Variables object that will read &consvars; from
-the file or list of filenames specified in
-<emphasis>files</emphasis>.
+<para>If <emphasis>files</emphasis> is a file or
+list of files, those are executed as Python scripts,
+and the values of (global) Python variables set in
+those files are added as &consvars; in the
+default &consenv;.
 If no files are specified,
 or the
 <emphasis>files</emphasis>
 argument is
 <emphasis role="bold">None</emphasis>,
-then no files will be read.
-The optional argument
+then no files will be read. Example file content:</para>
+
+<programlisting language="python">
+CC = 'my_cc'
+</programlisting>
+
+<para>The optional argument
 <emphasis>args</emphasis>
 is a dictionary of
 values that will override anything read from the specified files;
@@ -3984,10 +3990,13 @@ vars = Variables('overrides.py', ARGUMENTS)
 vars = Variables(None, {FOO:'expansion', BAR:7})
 </programlisting>
 
-<para>Variables objects have the following methods:</para>
-
   </listitem>
   </varlistentry>
+  </variablelist>
+
+<para>Variables objects have the following methods:</para>
+
+  <variablelist>
   <varlistentry>
   <term>Add(<emphasis>key</emphasis>, [<emphasis>help</emphasis>, <emphasis>default</emphasis>, <emphasis>validator</emphasis>, <emphasis>converter</emphasis>])</term>
   <listitem>
@@ -4024,7 +4033,7 @@ and then added to the environment.</para>
 <para>Examples:</para>
 
 <programlisting language="python">
-vars.Add('CC', 'The C compiler')
+vars.Add('CC', help='The C compiler')
 
 def validate_color(key, val, env):
     if not val in ['red', 'blue', 'yellow']:
@@ -4035,7 +4044,7 @@ vars.Add('COLOR', validator=valid_color)
   </varlistentry>
 
   <varlistentry>
-  <term>AddVariables(<emphasis>list</emphasis>)</term>
+  <term>vars.AddVariables(<emphasis>list</emphasis>)</term>
   <listitem>
 <para>A wrapper script that adds
 multiple customizable &consvars;
@@ -4060,7 +4069,7 @@ opt.AddVariables(
   </varlistentry>
 
   <varlistentry>
-  <term>Update(<emphasis>env</emphasis>, [<emphasis>args</emphasis>])</term>
+  <term>vars.Update(<emphasis>env</emphasis>, [<emphasis>args</emphasis>])</term>
   <listitem>
 <para>This updates a &consenv;
 <emphasis>env</emphasis>
@@ -4083,23 +4092,9 @@ env = Environment(variables=vars)
 
   </listitem>
   </varlistentry>
-</variablelist>
 
-<para>The text file(s) that were specified
-when the &Variables; object was created
-are executed as Python scripts,
-and the values of (global) Python variables set in the file
-are added to the &consenv;.</para>
-
-<para>Example:</para>
-
-<programlisting language="python">
-CC = 'my_cc'
-</programlisting>
-
-<variablelist>
   <varlistentry>
-  <term>UnknownVariables(<emphasis>)</emphasis></term>
+  <term>vars.UnknownVariables(<emphasis>)</emphasis></term>
   <listitem>
 <para>Returns a dictionary containing any
 variables that were specified
@@ -4118,7 +4113,7 @@ for key, value in vars.UnknownVariables():
   </varlistentry>
 
   <varlistentry>
-  <term>Save(<emphasis>filename</emphasis>, <emphasis>env</emphasis>)</term>
+  <term>vars.Save(<emphasis>filename</emphasis>, <emphasis>env</emphasis>)</term>
   <listitem>
 <para>This saves the currently set variables into a script file named
 <emphasis>filename</emphasis>
@@ -4138,7 +4133,7 @@ vars.Save('variables.cache', env)
   </varlistentry>
 
   <varlistentry>
-  <term>GenerateHelpText(<emphasis>env</emphasis>, [<emphasis>sort</emphasis>])</term>
+  <term>vars.GenerateHelpText(<emphasis>env</emphasis>, [<emphasis>sort</emphasis>])</term>
   <listitem>
 <para>This generates help text documenting the customizable construction
 variables suitable to passing in to the Help() function.
@@ -4196,15 +4191,18 @@ def my_format(env, opt, help, default, actual):
     return fmt % (opt, default. actual, help)
 vars.FormatVariableHelpText = my_format
 </programlisting>
+  </listitem>
+  </varlistentry>
+  </variablelist>
+
 
 <para>To make it more convenient to work with customizable Variables,
 &scons;
 provides a number of functions
 that make it easy to set up
 various types of Variables:</para>
-  </listitem>
-  </varlistentry>
 
+  <variablelist>
   <varlistentry>
   <term>BoolVariable(<emphasis>key</emphasis>, <emphasis>help</emphasis>, <emphasis>default</emphasis>)</term>
   <listitem>
@@ -4390,27 +4388,54 @@ that will be called to
 verify that the specified path
 is acceptable.
 SCons supplies the
-following ready-made validators:
-<emphasis role="bold">PathVariable.PathExists</emphasis>
-(the default),
-which verifies that the specified path exists;
-<emphasis role="bold">PathVariable.PathIsFile</emphasis>,
-which verifies that the specified path is an existing file;
-<emphasis role="bold">PathVariable.PathIsDir</emphasis>,
-which verifies that the specified path is an existing directory;
-<emphasis role="bold">PathVariable.PathIsDirCreate</emphasis>,
-which verifies that the specified path is a directory
-and will create the specified directory if the path does not exist;
-and
-<emphasis role="bold">PathVariable.PathAccept</emphasis>,
-which simply accepts the specific path name argument without validation,
-and which is suitable if you want your users
+following ready-made validators:</para>
+
+  <variablelist>  <!-- nested list -->
+  <varlistentry>
+    <term>PathVariable.PathExists</term>
+    <listitem>
+<para>Verify that the specified path exists (the default).</para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term>PathVariable.PathIsFile</term>
+    <listitem>
+<para>Verify that the specified path is an existing file.</para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term>PathVariable.PathIsDir</term>
+    <listitem>
+<para>Verify that the specified path is an existing directory.</para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term>PathVariable.PathIsDirCreate</term>
+    <listitem>
+<para>Verify that the specified path is a directory
+and will create the specified directory if the path does not exist.</para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term>PathVariable.PathAccept</term>
+    <listitem>
+<para>Simply accept the specific path name argument without validation,
+suitable for when you want your users
 to be able to specify a directory path that will be
-created as part of the build process, for example.
+created as part of the build process, for example.</para>
+    </listitem>
+  </varlistentry>
+  </variablelist>  <!-- end nested list -->
+
+<para>
 You may supply your own
 <emphasis>validator</emphasis>
 function,
-which must take three arguments
+which must accept three arguments
 (<emphasis>key</emphasis>,
 the name of the variable to be set;
 <emphasis>val</emphasis>,
@@ -4426,28 +4451,44 @@ if the specified value is not acceptable.</para>
 <para>These functions make it
 convenient to create a number
 of variables with consistent behavior
-in a single call to the
-<emphasis role="bold">AddVariables</emphasis>
+in a single call to the &AddVariables;
 method:</para>
 
 <programlisting language="python">
 vars.AddVariables(
-    BoolVariable("warnings", "compilation with -Wall and similar", 1),
+    BoolVariable(
+        "warnings",
+        help="compilation with -Wall and similar",
+        default=1,
+    ),
     EnumVariable(
         "debug",
-        "debug output and symbols",
-        "no",
+        help="debug output and symbols",
+        default="no",
         allowed_values=("yes", "no", "full"),
         map={},
         ignorecase=0,  # case sensitive
     ),
     ListVariable(
-        "shared", "libraries to build as shared libraries", "all", names=list_of_libs
+        "shared",
+        help="libraries to build as shared libraries",
+        default="all",
+        names=list_of_libs,
     ),
-    PackageVariable("x11", "use X11 installed here (yes = search some places)", "yes"),
-    PathVariable("qtdir", "where the root of Qt is installed", qtdir),
+    PackageVariable(
+        "x11",
+        help="use X11 installed here (yes = search some places)",
+        default="yes",
+    ),
     PathVariable(
-        "foopath", "where the foo library is installed", foopath, PathVariable.PathIsDir
+        "qtdir",
+        help="where the root of Qt is installed",
+        default=qtdir),
+    PathVariable(
+        "foopath",
+        help="where the foo library is installed",
+        default=foopath,
+        validator=PathVariable.PathIsDir,
     ),
 )
 </programlisting>
@@ -4569,7 +4610,7 @@ directory as the one the Node represents:
 
 <variablelist>
   <varlistentry>
-  <term><replaceable>d</replaceable>.Dir(<replaceable>name</replaceable>)</term>
+  <term><replaceable>f</replaceable>.Dir(<replaceable>name</replaceable>)</term>
   <listitem>
 <para>Returns a directory named
 <replaceable>name</replaceable>
@@ -4579,7 +4620,7 @@ within the parent directory of
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>d</replaceable>.File(<replaceable>name</replaceable>)</term>
+  <term><replaceable>f</replaceable>.File(<replaceable>name</replaceable>)</term>
   <listitem>
 <para>Returns a file named
 <replaceable>name</replaceable>
@@ -4589,7 +4630,7 @@ within the parent directory of
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>d</replaceable>.Entry(<replaceable>name</replaceable>)</term>
+  <term><replaceable>f</replaceable>.Entry(<replaceable>name</replaceable>)</term>
   <listitem>
 <para>Returns an unresolved Node named
 <replaceable>name</replaceable>
@@ -5324,7 +5365,7 @@ Action([['cc', '-c', '-DWHITE SPACE', '-o', '$TARGET', '$SOURCES']])
   <listitem>
 <para>If the first argument is a Python function,
 a function Action is returned.
-The Python function must take three keyword arguments,
+The Python function must accept three keyword arguments,
 <emphasis role="bold">target</emphasis>
 (a Node object representing the target file),
 <emphasis role="bold">source</emphasis>
@@ -5387,7 +5428,7 @@ The function may also be specified by the
 <emphasis>strfunction</emphasis>=
 keyword argument.
 Like a function to build a file,
-this function must take three keyword arguments:
+this function must accept three keyword arguments:
 <emphasis role="bold">target</emphasis>
 (a Node object representing the target file),
 <emphasis role="bold">source</emphasis>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -3216,8 +3216,8 @@ env2 = env.Clone(CC="cl.exe")
 <title>Configure Contexts</title>
 
 <para>&scons;
-supports
-<emphasis>configure contexts,</emphasis>
+supports a
+<firstterm>configure context</firstterm>,
 an integrated mechanism similar to the
 various <constant>AC_CHECK</constant> macros in GNU &Autoconf;
 for testing for the existence of C header
@@ -3230,27 +3230,35 @@ up to date. However, users may override this behaviour with the
 <option>--config</option>
 command line option.</para>
 
-<para>The following methods can be used to perform checks:</para>
+<para>To create a configure context:</para>
 
 <variablelist>
   <varlistentry>
   <term>Configure(<emphasis>env</emphasis>, [<emphasis>custom_tests</emphasis>, <emphasis>conf_dir</emphasis>, <emphasis>log_file</emphasis>, <emphasis>config_h</emphasis>, <emphasis>clean</emphasis>, <emphasis>help])</emphasis></term>
-  <term>env.Configure([<emphasis>custom_tests</emphasis>, <emphasis>conf_dir</emphasis>, <emphasis>log_file</emphasis>, <emphasis>config_h</emphasis>, <emphasis>clean</emphasis>, <emphasis>help])</emphasis></term>
+  <term><replaceable>env</replaceable>.Configure([<emphasis>custom_tests</emphasis>, <emphasis>conf_dir</emphasis>, <emphasis>log_file</emphasis>, <emphasis>config_h</emphasis>, <emphasis>clean</emphasis>, <emphasis>help])</emphasis></term>
   <listitem>
-<para>This creates a configure context, which can be used to perform checks.
-<emphasis>env</emphasis>
+<para>Create a configure context, which tracks information
+discovered while running tests. The context includes a
+&consenv;, which is used when running the tests and
+which is updated with the check results.
+When the context is complete, the (possibly modified)
+environment is returned). Only one context may be active
+at a time (since 4.0, &scons; will raise an exception
+if this rule is not followed), but a new context can be created
+after the active one is completed.</para>
+<para>
+The required <emphasis>env</emphasis> argument
 specifies the environment for building the tests.
-This environment may be modified when performing checks.
 <emphasis>custom_tests</emphasis>
-is a dictionary containing custom tests.
-See also the section about custom tests below.
+is a dictionary containing custom tests
+(see the section on custom tests below).
 By default, no custom tests are added to the configure context.
 <emphasis>conf_dir</emphasis>
 specifies a directory where the test cases are built.
 Note that this directory is not used for building
 normal targets.
 The default value is the directory
-<filename>#/.sconf_temp.</filename>
+<filename>#/.sconf_temp</filename>.
 <emphasis>log_file</emphasis>
 specifies a file which collects the output from commands
 that are executed to check for the existence of header files, libraries, etc.
@@ -3309,36 +3317,48 @@ arguments
 to avoid unnecessary test execution.</para>
   </listitem>
   </varlistentry>
-</variablelist>
 
-<para>A created
-<emphasis role="bold">Configure</emphasis>
-instance has the following associated methods:</para>
-
-<variablelist>
   <varlistentry>
   <term>SConf.Finish(<emphasis>context</emphasis>)</term>
-  <term><emphasis>sconf</emphasis>.Finish()</term>
+  <term><replaceable>context</replaceable>.Finish()</term>
   <listitem>
-<para>This method should be called after configuration is done.
-It returns the environment as modified
-by the configuration checks performed.
+<para>This method must be called after configuration is done.
+Though required, this is not enforced except
+if &Configure; is called when there still an active context,
+in which case an exception is raised.
+&Finish; returns the environment as modified
+during the course of running the configuration checks.
 After this method is called, no further checks can be performed
 with this configuration context.
 However, you can create a new
-Configure
-context to perform additional checks.
-Only one context may be active at a time.</para>
-
-<para>The following Checks are predefined.
-(This list will likely grow larger as time
-goes by and developers contribute new useful tests.)</para>
+configure context to perform additional checks.
+</para>
   </listitem>
   </varlistentry>
+</variablelist>
 
+<para>Example of a typical Configure usage:</para>
+
+<programlisting language="python">
+env = Environment()
+conf = Configure(env)
+if not conf.CheckCHeader("math.h"):
+    print("We really need math.h!")
+    Exit(1)
+if conf.CheckLibWithHeader("qt", "qapp.h", "c++", "QApplication qapp(0,0);"):
+    # do stuff for qt - usage, e.g.
+    conf.env.Append(CPPFLAGS="-DWITH_QT")
+env = conf.Finish()
+</programlisting>
+
+<para>A configure context
+has the following predefined methods which
+can be used to perform checks:</para>
+
+<variablelist>
   <varlistentry>
   <term>SConf.CheckHeader(<emphasis>context</emphasis>, <emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>, <emphasis>language</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckHeader(<emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>, <emphasis>language</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckHeader(<emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>, <emphasis>language</emphasis>])</term>
   <listitem>
 <para>Checks if
 <emphasis>header</emphasis>
@@ -3349,7 +3369,7 @@ in which case the last item in the list
 is the header file to be checked,
 and the previous list items are
 header files whose
-<emphasis role="bold">#include</emphasis>
+<literal>#include</literal>
 lines should precede the
 header line being checked for.
 The optional argument
@@ -3371,10 +3391,10 @@ Returns 1 on success and 0 on failure.</para>
 
   <varlistentry>
   <term>SConf.CheckCHeader(<emphasis>context</emphasis>, <emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckCHeader(<emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckCHeader(<emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>])</term>
   <listitem>
 <para>This is a wrapper around
-<emphasis role="bold">SConf.CheckHeader</emphasis>
+<methodname>SConf.CheckHeader</methodname>
 which checks if
 <emphasis>header</emphasis>
 is usable in the C language.
@@ -3384,7 +3404,7 @@ in which case the last item in the list
 is the header file to be checked,
 and the previous list items are
 header files whose
-<emphasis role="bold">#include</emphasis>
+<literal>#include</literal>
 lines should precede the
 header line being checked for.
 The optional argument
@@ -3399,10 +3419,10 @@ Returns 1 on success and 0 on failure.</para>
 
   <varlistentry>
   <term>SConf.CheckCXXHeader(<emphasis>context</emphasis>, <emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckCXXHeader(<emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckCXXHeader(<emphasis>header</emphasis>, [<emphasis>include_quotes</emphasis>])</term>
   <listitem>
 <para>This is a wrapper around
-<emphasis role="bold">SConf.CheckHeader</emphasis>
+<methodname>SConf.CheckHeader</methodname>
 which checks if
 <emphasis>header</emphasis>
 is usable in the C++ language.
@@ -3412,7 +3432,7 @@ in which case the last item in the list
 is the header file to be checked,
 and the previous list items are
 header files whose
-<emphasis role="bold">#include</emphasis>
+<literal>#include</literal>
 lines should precede the
 header line being checked for.
 The optional argument
@@ -3427,7 +3447,7 @@ Returns 1 on success and 0 on failure.</para>
 
   <varlistentry>
   <term>SConf.CheckFunc(<emphasis>context,</emphasis>, <emphasis>function_name</emphasis>, [<emphasis>header</emphasis>, <emphasis>language</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckFunc(<emphasis>function_name</emphasis>, [<emphasis>header</emphasis>, <emphasis>language</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckFunc(<emphasis>function_name</emphasis>, [<emphasis>header</emphasis>, <emphasis>language</emphasis>])</term>
   <listitem>
 <para>Checks if the specified
 C or C++ function is available.
@@ -3463,7 +3483,7 @@ the default is "C".</para>
 
   <varlistentry>
   <term>SConf.CheckLib(<emphasis>context</emphasis>, [<emphasis>library</emphasis>, <emphasis>symbol</emphasis>, <emphasis>header</emphasis>, <emphasis>language</emphasis>, <emphasis>autoadd=1</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckLib([<emphasis>library</emphasis>, <emphasis>symbol</emphasis>, <emphasis>header</emphasis>, <emphasis>language</emphasis>, <emphasis>autoadd=1</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckLib([<emphasis>library</emphasis>, <emphasis>symbol</emphasis>, <emphasis>header</emphasis>, <emphasis>language</emphasis>, <emphasis>autoadd=1</emphasis>])</term>
   <listitem>
 <para>Checks if
 <emphasis>library</emphasis>
@@ -3488,7 +3508,7 @@ If
 is not set or is
 <emphasis role="bold">None</emphasis>,
 then
-<emphasis role="bold">SConf.CheckLib</emphasis>()
+<methodname>SConf.CheckLib</methodname>()
 just checks if
 you can link against the specified
 <emphasis>library</emphasis>.
@@ -3509,11 +3529,11 @@ This method returns 1 on success and 0 on error.</para>
 
   <varlistentry>
   <term>SConf.CheckLibWithHeader(<emphasis>context</emphasis>, <emphasis>library</emphasis>, <emphasis>header</emphasis>, <emphasis>language</emphasis>, [<emphasis>call</emphasis>, <emphasis>autoadd</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckLibWithHeader(<emphasis>library</emphasis>, <emphasis>header</emphasis>, <emphasis>language</emphasis>, [<emphasis>call</emphasis>, <emphasis>autoadd</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckLibWithHeader(<emphasis>library</emphasis>, <emphasis>header</emphasis>, <emphasis>language</emphasis>, [<emphasis>call</emphasis>, <emphasis>autoadd</emphasis>])</term>
   <listitem>
 
 <para>In contrast to the
-SConf.CheckLib
+<methodname>SConf.CheckLib</methodname>
 call, this call provides a more sophisticated way to check against libraries.
 Again,
 <emphasis>library</emphasis>
@@ -3526,7 +3546,7 @@ in which case the last item in the list
 is the header file to be checked,
 and the previous list items are
 header files whose
-<emphasis role="bold">#include</emphasis>
+<literal>#include</literal>
 lines should precede the
 header line being checked for.
 <emphasis>language</emphasis>
@@ -3547,7 +3567,7 @@ succeeds). This method returns 1 on success and 0 on error.</para>
 
   <varlistentry>
   <term>SConf.CheckType(<emphasis>context</emphasis>, <emphasis>type_name</emphasis>, [<emphasis>includes</emphasis>, <emphasis>language</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckType(<emphasis>type_name</emphasis>, [<emphasis>includes</emphasis>, <emphasis>language</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckType(<emphasis>type_name</emphasis>, [<emphasis>includes</emphasis>, <emphasis>language</emphasis>])</term>
   <listitem>
 <para>Checks for the existence of a type defined by
 <emphasis role="bold">typedef</emphasis>.
@@ -3555,7 +3575,7 @@ succeeds). This method returns 1 on success and 0 on error.</para>
 specifies the typedef name to check for.
 <emphasis>includes</emphasis>
 is a string containing one or more
-<emphasis role="bold">#include</emphasis>
+<literal>#include</literal>
 lines that will be inserted into the program
 that will be run to test for the existence of the type.
 The optional
@@ -3576,7 +3596,8 @@ sconf.CheckType('foo_type', '#include "my_types.h"', 'C++')
   </varlistentry>
 
   <varlistentry>
-  <term>Configure.CheckCC(<emphasis>self</emphasis>)</term>
+  <term>SConf.CheckCC(<emphasis>self</emphasis>)</term>
+  <term><replaceable>context</replaceable>.CheckCC(<emphasis>self</emphasis>)</term>
   <listitem>
 <para>Checks whether the C compiler (as defined by the CC &consvar;) works
 by trying to compile a small source file.</para>
@@ -3591,7 +3612,8 @@ not.</para>
   </varlistentry>
 
   <varlistentry>
-  <term>Configure.CheckCXX(<emphasis>self</emphasis>)</term>
+  <term>SConf.CheckCXX(<emphasis>self</emphasis>)</term>
+  <term><replaceable>context</replaceable>.CheckCXX(<emphasis>self</emphasis>)</term>
   <listitem>
 <para>Checks whether the C++ compiler (as defined by the CXX &consvar;)
 works by trying to compile a small source file. By default, SCons only detects
@@ -3604,7 +3626,8 @@ works or not.</para>
   </varlistentry>
 
   <varlistentry>
-  <term>Configure.CheckSHCC(<emphasis>self</emphasis>)</term>
+  <term>SConf.CheckSHCC(<emphasis>self</emphasis>)</term>
+  <term><replaceable>context</replaceable>.CheckSHCC(<emphasis>self</emphasis>)</term>
   <listitem>
 <para>Checks whether the C compiler (as defined by the SHCC &consvar;) works
 by trying to compile a small source file. By default, SCons only detects if
@@ -3618,7 +3641,8 @@ library, only that the compilation (not link) succeeds.</para>
   </varlistentry>
 
   <varlistentry>
-  <term>Configure.CheckSHCXX(<emphasis>self</emphasis>)</term>
+  <term>SConf.CheckSHCXX(<emphasis>self</emphasis>)</term>
+  <term><replaceable>context</replaceable>.CheckSHCXX(<emphasis>self</emphasis>)</term>
   <listitem>
 <para>Checks whether the C++ compiler (as defined by the SHCXX &consvar;)
 works by trying to compile a small source file. By default, SCons only detects
@@ -3630,26 +3654,10 @@ works or not. This does not check whether the object code can be used to build
 a shared library, only that the compilation (not link) succeeds.</para>
   </listitem>
   </varlistentry>
-</variablelist>
-<para>Example of a typical Configure usage:</para>
 
-<programlisting language="python">
-env = Environment()
-conf = Configure( env )
-if not conf.CheckCHeader( 'math.h' ):
-    print('We really need math.h!')
-    Exit(1)
-if conf.CheckLibWithHeader( 'qt', 'qapp.h', 'c++',
-        'QApplication qapp(0,0);' ):
-    # do stuff for qt - usage, e.g.
-    conf.env.Append( CPPFLAGS = '-DWITH_QT' )
-env = conf.Finish()
-</programlisting>
-
-<variablelist>
   <varlistentry>
   <term>SConf.CheckTypeSize(<emphasis>context</emphasis>, <emphasis>type_name</emphasis>, [<emphasis>header</emphasis>, <emphasis>language</emphasis>, <emphasis>expect</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckTypeSize(<emphasis>type_name</emphasis>, [<emphasis>header</emphasis>, <emphasis>language</emphasis>, <emphasis>expect</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckTypeSize(<emphasis>type_name</emphasis>, [<emphasis>header</emphasis>, <emphasis>language</emphasis>, <emphasis>expect</emphasis>])</term>
   <listitem>
 <para>Checks for the size of a type defined by
 <emphasis role="bold">typedef</emphasis>.
@@ -3681,7 +3689,7 @@ given in type_name has the expected size (in bytes).
 For example,</para>
 
 <programlisting language="python">
-CheckTypeSize('short', expect = 2)
+CheckTypeSize('short', expect=2)
 </programlisting>
 
 <para>will return success only if short is two bytes.</para>
@@ -3690,7 +3698,7 @@ CheckTypeSize('short', expect = 2)
 
   <varlistentry>
   <term>SConf.CheckDeclaration(<emphasis>context</emphasis>, <emphasis>symbol</emphasis>, [<emphasis>includes</emphasis>, <emphasis>language</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.CheckDeclaration(<emphasis>symbol</emphasis>, [<emphasis>includes</emphasis>, <emphasis>language</emphasis>])</term>
+  <term><replaceable>context</replaceable>.CheckDeclaration(<emphasis>symbol</emphasis>, [<emphasis>includes</emphasis>, <emphasis>language</emphasis>])</term>
   <listitem>
 <para>Checks if the specified
 <emphasis>symbol</emphasis>
@@ -3713,7 +3721,7 @@ the default is "C".</para>
 
   <varlistentry>
   <term>SConf.Define(<emphasis>context</emphasis>, <emphasis>symbol</emphasis>, [<emphasis>value</emphasis>, <emphasis>comment</emphasis>])</term>
-  <term><emphasis>sconf</emphasis>.Define(<emphasis>symbol</emphasis>, [<emphasis>value</emphasis>, <emphasis>comment</emphasis>])</term>
+  <term><replaceable>context</replaceable>.Define(<emphasis>symbol</emphasis>, [<emphasis>value</emphasis>, <emphasis>comment</emphasis>])</term>
   <listitem>
 <para>This function does not check for anything, but defines a
 preprocessor symbol that will be added to the configuration header file.
@@ -3724,23 +3732,20 @@ with the optional
 <emphasis role="bold">value</emphasis>
 and the optional comment
 <emphasis role="bold">comment</emphasis>.</para>
-  </listitem>
-  </varlistentry>
-</variablelist>
 
-<para>Examples:</para>
+<para>Define Examples:</para>
 
 <programlisting language="python">
 env = Environment()
-conf = Configure( env )
+conf = Configure(env)
 
 # Puts the following line in the config header file:
 #    #define A_SYMBOL
-conf.Define('A_SYMBOL')
+conf.Define("A_SYMBOL")
 
 # Puts the following line in the config header file:
 #    #define A_SYMBOL 1
-conf.Define('A_SYMBOL', 1)
+conf.Define("A_SYMBOL", 1)
 </programlisting>
 
 
@@ -3748,15 +3753,15 @@ conf.Define('A_SYMBOL', 1)
 
 <programlisting language="python">
 env = Environment()
-conf = Configure( env )
+conf = Configure(env)
 
 # Puts the following line in the config header file:
 #    #define A_SYMBOL YA
-conf.Define('A_SYMBOL', "YA")
+conf.Define("A_SYMBOL", "YA")
 
 # Puts the following line in the config header file:
 #    #define A_SYMBOL "YA"
-conf.Define('A_SYMBOL', '"YA"')
+conf.Define("A_SYMBOL", '"YA"')
 </programlisting>
 
 
@@ -3764,13 +3769,17 @@ conf.Define('A_SYMBOL', '"YA"')
 
 <programlisting language="python">
 env = Environment()
-conf = Configure( env )
+conf = Configure(env)
 
 # Puts the following lines in the config header file:
 #    /* Set to 1 if you have a symbol */
 #    #define A_SYMBOL 1
-conf.Define('A_SYMBOL', 1, 'Set to 1 if you have a symbol')
+conf.Define("A_SYMBOL", 1, "Set to 1 if you have a symbol")
 </programlisting>
+
+  </listitem>
+  </varlistentry>
+</variablelist>
 
 <para>You can define your own custom checks.
 in addition to the predefined checks.
@@ -3798,7 +3807,7 @@ will be displayed to the user, e.g. 'Checking for library X...'</para>
   </varlistentry>
 
   <varlistentry>
-  <term>CheckContext.Result(<emphasis>self,</emphasis>, <emphasis>res</emphasis>)</term>
+  <term>CheckContext.Result(<emphasis>self</emphasis>, <emphasis>res</emphasis>)</term>
   <listitem>
 
 <para>Usually called after the check is done.

--- a/doc/user/chtml.xsl
+++ b/doc/user/chtml.xsl
@@ -24,11 +24,11 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/html/chunk.xsl"/> 
+	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/html/chunk.xsl"/>
 
 <xsl:param name="base.dir" select="'scons-user/'"/>
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
@@ -57,5 +57,5 @@ set       toc,title
 <xsl:template match="mediaobject[@role = 'cover']">
 </xsl:template>
 
-</xsl:stylesheet> 
+</xsl:stylesheet>
 

--- a/doc/user/epub.xsl
+++ b/doc/user/epub.xsl
@@ -24,13 +24,13 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/epub/docbook.xsl"/> 
+	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/epub/docbook.xsl"/>
 
 <xsl:param name="html.stylesheet" select="'epub.css'"/>
 
-</xsl:stylesheet> 
+</xsl:stylesheet>
 

--- a/doc/user/html.xsl
+++ b/doc/user/html.xsl
@@ -24,15 +24,17 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/> 
+	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
 <xsl:param name="section.label.includes.component.label" select="1"/>
+<xsl:param name="variablelist.term.break.after" select="1"/>
+<xsl:param name="variablelist.term.separator"/>
 <xsl:param name="html.stylesheet" select="'scons.css'"/>
 <xsl:param name="generate.toc">
 /appendix toc,title
@@ -56,5 +58,5 @@ set       toc,title
 <xsl:template match="mediaobject[@role = 'cover']">
 </xsl:template>
 
-</xsl:stylesheet> 
+</xsl:stylesheet>
 

--- a/doc/user/pdf.xsl
+++ b/doc/user/pdf.xsl
@@ -25,19 +25,20 @@
 -->
 
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+	version="1.0">
 
-	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/fo/docbook.xsl"/> 
-	<xsl:include href="scons_title.xsl"/> 
+	<xsl:import href="../../src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/fo/docbook.xsl"/>
+	<xsl:include href="scons_title.xsl"/>
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
-<xsl:param name="section.autolabel" select="1"></xsl:param>
+<xsl:param name="section.autolabel" select="1"/>
 <xsl:param name="section.label.includes.component.label" select="1"/>
-<xsl:param name="paper.type" select="'letter'"></xsl:param>
+<xsl:param name="paper.type" select="'letter'"/>
 <xsl:param name="body.start.indent">0pt</xsl:param>
-<xsl:param name="shade.verbatim" select="1"></xsl:param>
-<xsl:param name="variablelist.term.break.after" select="1"></xsl:param>
+<xsl:param name="shade.verbatim" select="1"/>
+<xsl:param name="variablelist.term.break.after" select="1"/>
+<xsl:param name="variablelist.term.separator"/>
 
 <xsl:param name="generate.toc">
 /appendix toc,title
@@ -72,5 +73,5 @@ set       toc,title
 <xsl:template match="mediaobject[@role = 'cover']">
 </xsl:template>
 
-</xsl:stylesheet> 
+</xsl:stylesheet>
 

--- a/src/engine/SCons/Script/__init__.py
+++ b/src/engine/SCons/Script/__init__.py
@@ -288,8 +288,8 @@ def set_missing_sconscript_error(flag=1):
     _no_missing_sconscript = flag
     return old
 
-#
-def Variables(files=[], args=ARGUMENTS):
+
+def Variables(files=None, args=ARGUMENTS):
     return SCons.Variables.Variables(files, args)
 
 

--- a/src/engine/SCons/Variables/PathVariable.py
+++ b/src/engine/SCons/Variables/PathVariable.py
@@ -78,11 +78,13 @@ import SCons.Errors
 
 class _PathVariableClass(object):
 
-    def PathAccept(self, key, val, env):
+    @staticmethod
+    def PathAccept(key, val, env):
         """Accepts any path, no checking done."""
         pass
     
-    def PathIsDir(self, key, val, env):
+    @staticmethod
+    def PathIsDir(key, val, env):
         """Validator to check if Path is a directory."""
         if not os.path.isdir(val):
             if os.path.isfile(val):
@@ -91,7 +93,8 @@ class _PathVariableClass(object):
                 m = 'Directory path for option %s does not exist: %s'
             raise SCons.Errors.UserError(m % (key, val))
 
-    def PathIsDirCreate(self, key, val, env):
+    @staticmethod
+    def PathIsDirCreate(key, val, env):
         """Validator to check if Path is a directory,
            creating it if it does not exist."""
         if os.path.isfile(val):
@@ -100,7 +103,8 @@ class _PathVariableClass(object):
         if not os.path.isdir(val):
             os.makedirs(val)
 
-    def PathIsFile(self, key, val, env):
+    @staticmethod
+    def PathIsFile(key, val, env):
         """Validator to check if Path is a file"""
         if not os.path.isfile(val):
             if os.path.isdir(val):
@@ -109,7 +113,8 @@ class _PathVariableClass(object):
                 m = 'File path for option %s does not exist: %s'
             raise SCons.Errors.UserError(m % (key, val))
 
-    def PathExists(self, key, val, env):
+    @staticmethod
+    def PathExists(key, val, env):
         """Validator to check if Path exists"""
         if not os.path.exists(val):
             m = 'Path for option %s does not exist: %s'

--- a/src/engine/SCons/Variables/__init__.py
+++ b/src/engine/SCons/Variables/__init__.py
@@ -45,21 +45,20 @@ from .PathVariable import PathVariable # okay
 
 
 class Variables(object):
-    instance=None
-
     """
     Holds all the options, updates the environment with the variables,
     and renders the help text.
     """
+    instance=None
+
     def __init__(self, files=None, args=None, is_global=1):
         """
         files - [optional] List of option configuration files to load
             (backward compatibility) If a single string is passed it is
-                                     automatically placed in a file list
+            automatically placed in a file list
+        args - dictionary to override values set from files.
         """
-        # initialize arguments
-        if files is None:
-            files = []
+
         if args is None:
             args = {}
         self.options = []
@@ -74,7 +73,7 @@ class Variables(object):
 
         # create the singleton instance
         if is_global:
-            self=Variables.instance
+            self = Variables.instance
 
             if not Variables.instance:
                 Variables.instance=self


### PR DESCRIPTION
Various cleanups to sections **Configure Contexts**, **Command-Line Construction Variables** and **SConscript Variables**.

* `ListVariable` proto markup messed up
* When multiple variants of prototypes are listed as `<term>` entries in `<variablelist>`, insert line breaks beweeen them. PDF version already did this. This is a stylesheet change.
* The `.xsl` files in `doc/man` and `doc/user` converted via dos2unix to match the rest of the codebase (note this obscures visibility of the change from the previous item)
* `Variables` proto adjusted to `[files [, args]]` - both are not optional in the sense you could leave out `files` and specify `args` unless using keyword).
* `AddVariables` example reformatted and keywords added to encourage more readable usage.
* `Variables()` description said "read from file", but later text says "executed as Python scripts". The later text moved up and is consolidated into the introduction.
* `Variables()`: for consistency with the rest of the manpage, list the methods as `vars.Func` rather than as `Func`.
* SConscript Variables section: move the example of importing `SCons.Script` to the end, as the section is labeled to talk about use in SConscripts the other use should be secondary.
* Some language/grammar tweaks around cmdline variables.

Discovered a few minor tweaks to make to code implementing the above, so this is not completely doc-only. They should be no-op, for example Variables class had a class variable defined before the docstring, so it wouldn't be considered a docstring.  `_PathVariablesClass` had the check functions marked as `@staticmethod` since they don't act on an instance at all.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
