### PR TITLE
Generate groff-style manpages with Py3

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -89,6 +89,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed bug where changing TEXTFILESUFFIX would cause Substfile() to rebuild. (Github Issue #3540)
     - Script/Main.py now uses importlib instead of imp module.
     - Drop some Python 2-isms.
+    - Docbook builder provides a fallback if lxml fails to generate
+      a document with tostring().
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/src/engine/SCons/Tool/docbook/__init__.py
+++ b/src/engine/SCons/Tool/docbook/__init__.py
@@ -351,11 +351,16 @@ def __build_lxml(target, source, env):
     else:
         result = transform(doc)
 
+    # we'd like the resulting output to be readably formatted,
+    # so try pretty-print. Sometimes (esp. if the output is
+    # not an xml file) we end up with a None type somewhere in
+    # the transformed tree and tostring throws TypeError,
+    # so provide a fallback.
     try:
         with open(str(target[0]), "wb") as of:
             of.write(etree.tostring(result, pretty_print=True))
-    except:
-        pass
+    except TypeError:
+        result.write_output(str(target[0]))
 
     return None
 


### PR DESCRIPTION
groff-style (aka scons.1) manpages generated empty when using lxml for generation - that is, under Python 3.  No doc content impacts, or test impacts.

Fixes #3584

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
