### PR TITLE
Fix generated tools doc intermediate file

### DIFF
--- a/bin/docs-update-generated.py
+++ b/bin/docs-update-generated.py
@@ -43,13 +43,21 @@ def generate_all():
                 print("Couldn't create destination folder %s! Exiting..." % gen_folder)
                 return
         # Call scons-proc.py
-        _ = subprocess.call([sys.executable,
-                              os.path.join('bin','scons-proc.py'),
-                              '-b', argpair('builders'),
-                              '-f', argpair('functions'),
-                              '-t', argpair('tools'),
-                              '-v', argpair('variables')] + flist,
-                             shell=False)
+        cp = subprocess.run([sys.executable,
+                             os.path.join('bin','scons-proc.py'),
+                             '-b', argpair('builders'),
+                             '-f', argpair('functions'),
+                             '-t', argpair('tools'),
+                             '-v', argpair('variables')] + flist,
+                            shell=False)
+
+        cp.check_returncode()  # bail if it failed
+        # lxml: fixup possibly broken tools.gen:
+        with open(os.path.join(gen_folder, 'tools.gen'), 'r') as f :
+            filedata = f.read()
+        filedata = filedata.replace(r'&amp;cv-link', r'&cv-link')
+        with open(os.path.join(gen_folder, 'tools.gen'), 'w') as f :
+            f.write(filedata)
     
     
 if __name__ == "__main__":

--- a/bin/scons-proc.py
+++ b/bin/scons-proc.py
@@ -144,12 +144,18 @@ class SCons_XML(object):
             if v.sets:
                 added = True
                 vp = stf.newNode("para")
+                # if using lxml, the &entity; entries will be encoded,
+                # effectively breaking them.  should fix,
+                # for now handled post-process in calling script.
                 s = ['&cv-link-%s;' % x for x in v.sets]
                 stf.setText(vp, 'Sets:  ' + ', '.join(s) + '.')
                 stf.appendNode(vl, vp)
             if v.uses:
                 added = True
                 vp = stf.newNode("para")
+                # if using lxml, the &entity; entries will be encoded,
+                # effectively breaking them.  should fix,
+                # for now handled post-process in calling script.
                 u = ['&cv-link-%s;' % x for x in v.uses]
                 stf.setText(vp, 'Uses:  ' + ', '.join(u) + '.')
                 stf.appendNode(vl, vp)


### PR DESCRIPTION
The process to generate tools.gen writes entities for links to construction variables used/set by each tool.  When this data is written out using lxml's tostring() method, this is encoded, causing
&foo; to become &amp;foo; which then doesn't work in later processing as these files are included, as they're no longer valid entity references for substitution.

This seems really hard to fix directly, because tostring() is working as documented by doing this, so for now - maybe forever in light of thoughts of converting docs to a different format - just postprocess
the file to undo the damage.

A hack, but fixes #3580

This does not affect any part of scons itself (code/doc/tests), as it is a doc-generation-tool change only.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
