### PR TITLE
Fix RootDir.abspath and RootDir.path

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -45,6 +45,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added new module SCons.Scanner.Python to allow scanning .py files.
     - Added support for explicitly passing a name when creating Value() nodes. This may be useful
       when the value can't be converted to a string or if having a name is otherwise desirable.
+    - Fixed usage of abspath and path for RootDir objects on Windows. Previously
+      env.fs.Dir("T:").abspath would return "T:\T:" and now it correctly returns "T:".
 
   From Iosif Kurazs:
     - Added a new flag called "linedraw" for the command line argument  "--tree"

--- a/src/engine/SCons/Node/FS.py
+++ b/src/engine/SCons/Node/FS.py
@@ -2246,7 +2246,7 @@ class RootDir(Dir):
     this directory.
     """
 
-    __slots__ = ('_lookupDict', )
+    __slots__ = ('_lookupDict', 'abspath', 'path')
 
     def __init__(self, drive, fs):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Node.FS.RootDir')
@@ -2287,6 +2287,12 @@ class RootDir(Dir):
         self._path = dirname
         self._tpath = dirname
         self.dirname = dirname
+
+        # EntryProxy interferes with this class and turns drive paths on
+        # Windows such as "C:" into "C:\C:". Avoid this problem by setting
+        # commonly-accessed attributes directly.
+        self.abspath = self._abspath
+        self.path = self._path
 
         self._morph()
 

--- a/test/Dir/DriveAbsPath.py
+++ b/test/Dir/DriveAbsPath.py
@@ -28,15 +28,12 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test to confirm that Dir(drive_path).abspath works on Windows.
 """
 
-import os
-import stat
-
 import TestSCons
 from TestCmd import IS_WINDOWS
 
+test = TestSCons.TestSCons()
 
 if IS_WINDOWS:
-    test = TestSCons.TestSCons()
     test.dir_fixture('DriveAbsPath')
     test.run()
 

--- a/test/Dir/DriveAbsPath.py
+++ b/test/Dir/DriveAbsPath.py
@@ -25,7 +25,11 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Test to confirm that Dir(drive_path).abspath works on Windows.
+Test to confirm that Dir(drive_path).abspath works on Windows. This verifies
+that SCons no longer has an issue with Dir('T:').abspath returning 'T:\T:'.
+Instead, it verifies that Dir('T:') correctly returns an instance of the
+RootDir class and that class has abspath and path accessors that work
+correctly.
 """
 
 import TestSCons
@@ -36,8 +40,9 @@ test = TestSCons.TestSCons()
 if IS_WINDOWS:
     test.dir_fixture('DriveAbsPath')
     test.run()
-
-test.pass_test()
+    test.pass_test()
+else:
+    test.skip_test('Skipping Windows-only test.')
 
 # Local Variables:
 # tab-width:4

--- a/test/Dir/DriveAbsPath.py
+++ b/test/Dir/DriveAbsPath.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Test to confirm that Dir(drive_path).abspath works on Windows.
+"""
+
+import os
+import stat
+
+import TestSCons
+from TestCmd import IS_WINDOWS
+
+
+if IS_WINDOWS:
+    test = TestSCons.TestSCons()
+    test.dir_fixture('DriveAbsPath')
+    test.run()
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Dir/DriveAbsPath/SConstruct
+++ b/test/Dir/DriveAbsPath/SConstruct
@@ -6,7 +6,7 @@ drive = os.path.splitdrive(os.getcwd())[0]
 drive_dir = env.fs.Dir(drive)
 
 if not isinstance(drive_dir, SCons.Node.FS.RootDir):
-	raise Exception('env.fs.Dir("%s") returned a %s instance of a RootDir' %
+	raise Exception('env.fs.Dir("%s") returned a %s instead of a RootDir' %
 					(drive, type(drive_dir)))
 
 drive_abspath1 = drive_dir._abspath

--- a/test/Dir/DriveAbsPath/SConstruct
+++ b/test/Dir/DriveAbsPath/SConstruct
@@ -1,0 +1,32 @@
+import os
+import SCons
+
+env = Environment()
+drive = os.path.splitdrive(os.getcwd())[0]
+drive_dir = env.fs.Dir(drive)
+
+if not isinstance(drive_dir, SCons.Node.FS.RootDir):
+	raise Exception('env.fs.Dir("%s") returned a %s instance of a RootDir' %
+					(drive, type(drive_dir)))
+
+drive_abspath1 = drive_dir._abspath
+drive_abspath2 = drive_dir.abspath
+if drive_abspath1 != drive_abspath2:
+	raise Exception('Calculated _abspath %s is not the same as abspath %s' %
+					(drive_abspath1, drive_abspath2))
+elif not os.path.exists(drive_abspath1):
+	raise Exception('Calculated abspath %s does not exist' % drive_abspath1)
+elif drive.rstrip(os.path.sep) != drive_abspath1.rstrip(os.path.sep):
+	raise Exception('Real drive %s and calculated abspath %s are not the '
+					'same' % (drive, drive_abspath1))
+
+drive_path1 = drive_dir._path
+drive_path2 = drive_dir.path
+if drive_path1 != drive_path2:
+	raise Exception('Calculated _path %s is not the same as path %s' %
+					(drive_path1, drive_path2))
+elif not os.path.exists(drive_path1):
+	raise Exception('Calculated path %s does not exist' % drive_path1)
+elif drive.rstrip(os.path.sep) != drive_path1.rstrip(os.path.sep):
+	raise Exception('Real drive %s and calculated abspath %s are not the '
+					'same' % (drive, drive_abs))


### PR DESCRIPTION
The RootDir class was returning different values for path and _path as well as
different values for abspath and _abspath. This is because the underscored
versions were being set in the RootDir constructor, while the non-underscored
versions were going through the EntryProxy wrapper, which is only coded to do
a simple append of paths.

I considered trying to fix EntryProxy to detect this case but instead went with
a simpler approach where RootDir overrides the attributes that it wants to
avoid EntryProxy calls. Right now I have this as path and abspath.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
