### PR TITLE
Add highlighting to funcs/builders

### DIFF
--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -257,17 +257,21 @@ if not has_libxml2:
             pass
 
         @staticmethod
-        def newNode(tag):
-            return etree.Element(tag)
+        def newNode(tag, **kwargs):
+            return etree.Element(tag, **kwargs)
 
         @staticmethod
-        def newEtreeNode(tag, init_ns=False):
+        def newSubNode(parent, tag, **kwargs):
+            return etree.SubElement(parent, tag, **kwargs)
+
+        @staticmethod
+        def newEtreeNode(tag, init_ns=False, **kwargs):
             if init_ns:
                 NSMAP = {None: dbxsd,
                          'xsi' : xsi}
-                return etree.Element(tag, nsmap=NSMAP)
+                return etree.Element(tag, nsmap=NSMAP, **kwargs)
 
-            return etree.Element(tag)
+            return etree.Element(tag, **kwargs)
 
         @staticmethod
         def copyNode(node):
@@ -296,6 +300,14 @@ if not has_libxml2:
         @staticmethod
         def setText(root, txt):
             root.text = txt
+
+        @staticmethod
+        def getTail(root):
+            return root.tail
+
+        @staticmethod
+        def setTail(root, txt):
+            root.tail = txt
 
         @staticmethod
         def writeGenTree(root, fp):
@@ -387,12 +399,16 @@ else:
             pass
 
         @staticmethod
-        def newNode(tag):
-            return libxml2.newNode(tag)
+        def newNode(tag, **kwargs):
+            return etree.Element(tag, **kwargs)
 
         @staticmethod
-        def newEtreeNode(tag, init_ns=False):
-            return etree.Element(tag)
+        def newSubNode(parent, tag, **kwargs):
+            return etree.SubElement(parent, tag, **kwargs)
+
+        @staticmethod
+        def newEtreeNode(tag, init_ns=False, **kwargs):
+            return etree.Element(tag, **kwargs)
 
         @staticmethod
         def copyNode(node):
@@ -436,6 +452,14 @@ else:
                 root.setContent(txt)
             else:
                 root.text = txt
+
+        @staticmethod
+        def getTail(root):
+            return root.tail
+
+        @staticmethod
+        def setTail(root, txt):
+            root.tail = txt
 
         @staticmethod
         def writeGenTree(root, fp):

--- a/bin/scons-proc.py
+++ b/bin/scons-proc.py
@@ -293,7 +293,7 @@ class Function(SConsThing):
         """emit xml for an scons function
 
         The signature attribute controls whether to emit the
-        global function, the enviroment method, or both.
+        global function, the environment method, or both.
         """
         if self.arguments is None:
             a = stf.newNode("arguments")


### PR DESCRIPTION
When generating documentation from SConsXML markup, add some markup to match the Python doc style better. We will now get this style:

**foo**(args)
*env*.**foo**(args)

as opposed to the old

foo(args)
env.foo(args)

That is, the function name is highlighted, and for the environment method, env looks like a variable (which it is), rather than the literal name env.

Old generated markup:
```
  <varlistentry id="f-Action">
    <term>
      <literal>Action(action, [cmd/str/fun, [var, ...]] [option=value, ...])</literal>
    </term>
    <term>
      <literal>env.Action(action, [cmd/str/fun, [var, ...]] [option=value, ...])</literal>
    </term>
```

New generated markup:
```
  <varlistentry id="f-Action">
    <term>
      <literal><emphasis role="bold">Action</emphasis>(action, [cmd/str/fun, [var, ...]] [option=value, ...])</literal>
    </term>
    <term>
      <literal><replaceable>env</replaceable>.<emphasis role="bold">Action</emphasis>(action, [cmd/str/fun, [var, ...]] [option=value, ...])</literal>
    </term>
```

The methods to create an element now take keyword args, so they can pass them on to the etree.Element method, which understands an attribute keyword we need for one of these changes.  Added a method to create a SubElement, which makes usage clearer.  To complement the *Text
methods, *Tail methods were added to set/get the `.tail` attribute of a node.

This change is to the tools only, and affects the result of doing `python bin/docs-update-generated.py`

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
