### PR TITLE
Second try at fixing sets/uses Tool doc generation

### DIFF
--- a/bin/docs-update-generated.py
+++ b/bin/docs-update-generated.py
@@ -51,13 +51,9 @@ def generate_all():
                              '-v', argpair('variables')] + flist,
                             shell=False)
 
-        cp.check_returncode()  # bail if it failed
-        # lxml: fixup possibly broken tools.gen:
-        with open(os.path.join(gen_folder, 'tools.gen'), 'r') as f :
-            filedata = f.read()
-        filedata = filedata.replace(r'&amp;cv-link', r'&cv-link')
-        with open(os.path.join(gen_folder, 'tools.gen'), 'w') as f :
-            f.write(filedata)
+        # No-op: scons-proc doesn't actually set an exit code at the moment.
+        if cp.returncode:
+            print("Generation failed", file=sys.stderr)
     
     
 if __name__ == "__main__":

--- a/bin/scons-proc.py
+++ b/bin/scons-proc.py
@@ -141,23 +141,31 @@ class SCons_XML(object):
                     added = True
                     stf.appendNode(vl, stf.copyNode(s))
             
+            # Generate the text for sets/uses lists of construction vars.
+            # This used to include an entity reference which would be replaced
+            # by the link to the cvar, but with lxml, dumping out the tree
+            # with tostring() will encode the & introducing the entity,
+            # breaking it. Instead generate the actual link. (issue #3580)
             if v.sets:
                 added = True
                 vp = stf.newNode("para")
-                # if using lxml, the &entity; entries will be encoded,
-                # effectively breaking them.  should fix,
-                # for now handled post-process in calling script.
-                s = ['&cv-link-%s;' % x for x in v.sets]
-                stf.setText(vp, 'Sets:  ' + ', '.join(s) + '.')
+                stf.setText(vp, "Sets: ")
+                for setv in v.sets:
+                    link = stf.newSubNode(vp, "link", linkend="cv-%s" % setv)
+                    linktgt = stf.newSubNode(link, "varname")
+                    stf.setText(linktgt, "$" + setv)
+                    stf.setTail(link, " ")
                 stf.appendNode(vl, vp)
+
             if v.uses:
                 added = True
                 vp = stf.newNode("para")
-                # if using lxml, the &entity; entries will be encoded,
-                # effectively breaking them.  should fix,
-                # for now handled post-process in calling script.
-                u = ['&cv-link-%s;' % x for x in v.uses]
-                stf.setText(vp, 'Uses:  ' + ', '.join(u) + '.')
+                stf.setText(vp, "Uses: ")
+                for use in v.uses:
+                    link = stf.newSubNode(vp, "link", linkend="cv-%s" % use)
+                    linktgt = stf.newSubNode(link, "varname")
+                    stf.setText(linktgt, "$" + use)
+                    stf.setTail(link, " ")
                 stf.appendNode(vl, vp)
                 
             # Still nothing added to this list item?


### PR DESCRIPTION
Fixes #3580 a different way:  generate the link itself into the tools.gen file, instead of post-processing the broken entity reference back into a usable form. Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
