### PR TITLE
Update doc wording for IMPLICIT_COMMAND_DEPENDENCIES

### DIFF
--- a/src/engine/SCons/Action.py
+++ b/src/engine/SCons/Action.py
@@ -964,7 +964,7 @@ class CommandAction(_ActionAction):
         if is_String(icd) and icd[:1] == '$':
             icd = env.subst(icd)
 
-        if not icd or icd in ('0', 'None'):
+        if not icd or str(icd).lower in ('0', 'none', 'false', 'no', 'off'):
             return []
 
         try:

--- a/src/engine/SCons/Action.xml
+++ b/src/engine/SCons/Action.xml
@@ -35,19 +35,39 @@ executed to build targets.
 By default, SCons will add
 to each target
 an implicit dependency on the command
-represented by the first argument on any
-command line it executes.
+represented by the first argument of any
+command line it executes (which is typically
+the command itself). By setting such
+a dependency, &SCons; can determine that
+a target should be rebuilt if the command changes,
+such as when a compiler is upgraded to a new version.
 The specific file for the dependency is
 found by searching the
 <varname>PATH</varname>
 variable in the
-<varname>ENV</varname>
-environment used to execute the command.
+<varname>ENV</varname> dictionary
+in the &consenv; used to execute the command.
+The default is the same as
+setting the &consvar;
+&cv-IMPLICIT_COMMAND_DEPENDENCIES;
+to a true value (<literal>True</literal>,
+any non-zero number, etc.).
 </para>
 
 <para>
-If the construction variable
-&cv-IMPLICIT_COMMAND_DEPENDENCIES;
+Action strings can be segmented by the
+use of an AND operator, <literal>&amp;&amp;</literal>.
+In a segemented string, each segment is a separate
+<quote>command line</quote>, these are run
+sequentially until one fails or the entire
+sequence has been executed. If an
+action string is segmented, then the selected
+behavior of &cv-IMPLICIT_COMMAND_DEPENDENCIES;
+is applied to each segment.
+</para>
+
+<para>
+If &cv-IMPLICIT_COMMAND_DEPENDENCIES;
 is set to a false value
 (<literal>None</literal>,
 <literal>False</literal>,
@@ -55,50 +75,45 @@ is set to a false value
 etc.),
 then the implicit dependency will
 not be added to the targets
-built with that construction environment.
+built with that &consenv;.
 </para>
 
 <para>
-If the construction variable
-&cv-IMPLICIT_COMMAND_DEPENDENCIES;
-is set to <literal>2</literal> or higher,
-then that number of entries in the command
-string will be scanned for relative or absolute
-paths. The count will reset after any
-<literal>&amp;&amp;</literal> entries are found.
-The first command in the action string and
-the first after any <literal>&amp;&amp;</literal>
-entries will be found by searching the
-<varname>PATH</varname> variable in the
-<varname>ENV</varname> environment used to
-execute the command. All other commands will
-only be found if they are absolute paths or
-valid paths relative to the working directory.
-</para>
-
-<para>
-If the construction variable
-&cv-IMPLICIT_COMMAND_DEPENDENCIES;
-is set to <literal>all</literal>, then
-all entries in all command strings will be
-scanned for relative or absolute paths. If
-any are present, they will be added as
+If &cv-IMPLICIT_COMMAND_DEPENDENCIES;
+is set to integer <literal>2</literal> or higher,
+then that number of arguments in the command line
+will be scanned for relative or absolute paths.
+If any are present, they will be added as
 implicit dependencies to the targets built
-with that construction environment.
-not be added to the targets built with that
-construction environment. The first command
-in the action string and the first after any
-<literal>&amp;&amp;</literal> entries will be found
-by searching the <varname>PATH</varname>
-variable in the <varname>ENV</varname>
-environment used to execute the command.
-All other commands will only be found if they
+with that &consenv;.
+The first argument in the command line will be
+searched for using the <varname>PATH</varname>
+variable in the <varname>ENV</varname> dictionary
+in the &consenv; used to execute the command.
+The other arguments will only be found if they
+are absolute paths or valid paths relative
+to the working directory.
+</para>
+
+<para>
+If &cv-IMPLICIT_COMMAND_DEPENDENCIES;
+is set to <literal>all</literal>,
+then all arguments in the command line will be
+scanned for relative or absolute paths.
+If any are present, they will be added as
+implicit dependencies to the targets built
+with that &consenv;.
+The first argument in the command line will be
+searched for using the <varname>PATH</varname>
+variable in the <varname>ENV</varname> dictionary
+in the &consenv; used to execute the command.
+The other arguments will only be found if they
 are absolute paths or valid paths relative
 to the working directory.
 </para>
 
 <example_commands>
-env = Environment(IMPLICIT_COMMAND_DEPENDENCIES = 0)
+env = Environment(IMPLICIT_COMMAND_DEPENDENCIES=False)
 </example_commands>
 </summary>
 </cvar>

--- a/src/engine/SCons/Action.xml
+++ b/src/engine/SCons/Action.xml
@@ -50,8 +50,10 @@ in the &consenv; used to execute the command.
 The default is the same as
 setting the &consvar;
 &cv-IMPLICIT_COMMAND_DEPENDENCIES;
-to a true value (<literal>True</literal>,
-any non-zero number, etc.).
+to a True-like value (<quote>true</quote>,
+<quote>yes</quote>,
+or <quote>1</quote> - but not a number
+greater than one, as that has a different meaning).
 </para>
 
 <para>
@@ -68,10 +70,11 @@ is applied to each segment.
 
 <para>
 If &cv-IMPLICIT_COMMAND_DEPENDENCIES;
-is set to a false value
-(<literal>None</literal>,
-<literal>False</literal>,
-<literal>0</literal>,
+is set to a False-like value
+(<quote>none</quote>,
+<quote>false</quote>,
+<quote>no</quote>,
+<quote>0</quote>,
 etc.),
 then the implicit dependency will
 not be added to the targets
@@ -80,7 +83,7 @@ built with that &consenv;.
 
 <para>
 If &cv-IMPLICIT_COMMAND_DEPENDENCIES;
-is set to integer <literal>2</literal> or higher,
+is set to <quote>2</quote> or higher,
 then that number of arguments in the command line
 will be scanned for relative or absolute paths.
 If any are present, they will be added as
@@ -97,7 +100,7 @@ to the working directory.
 
 <para>
 If &cv-IMPLICIT_COMMAND_DEPENDENCIES;
-is set to <literal>all</literal>,
+is set to <quote>all</quote>,
 then all arguments in the command line will be
 scanned for relative or absolute paths.
 If any are present, they will be added as


### PR DESCRIPTION
Reword, remove a bit of redundancy by describing actions containing && in one place instead of repeatedly. Actually mention the case of setting the cvar to True. Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
