### PR TITLE
docs: update Variables content

### DIFF
--- a/doc/generated/examples/commandline_EnumVariable_3.xml
+++ b/doc/generated/examples/commandline_EnumVariable_3.xml
@@ -1,14 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q COLOR=Red foo.o</userinput>
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q -h</userinput>
 
-scons: *** Invalid value for option COLOR: Red.  Valid values are: ('red', 'green', 'blue')
-File "/home/my/project/SConstruct", line 5, in &lt;module&gt;
-% <userinput>scons -Q COLOR=BLUE foo.o</userinput>
+COLOR: Set background color (red|green|blue)
+    default: red
+    actual: red
 
-scons: *** Invalid value for option COLOR: BLUE.  Valid values are: ('red', 'green', 'blue')
-File "/home/my/project/SConstruct", line 5, in &lt;module&gt;
-% <userinput>scons -Q COLOR=nAvY foo.o</userinput>
-
-scons: *** Invalid value for option COLOR: nAvY.  Valid values are: ('red', 'green', 'blue')
-File "/home/my/project/SConstruct", line 5, in &lt;module&gt;
+Use scons -H for help about command-line options.
 </screen>

--- a/doc/generated/examples/commandline_EnumVariable_4.xml
+++ b/doc/generated/examples/commandline_EnumVariable_4.xml
@@ -1,0 +1,13 @@
+<screen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q COLOR=Red foo.o</userinput>
+
+scons: *** Invalid value for option COLOR: Red.  Valid values are: ('red', 'green', 'blue')
+File "/home/my/project/SConstruct", line 6, in &lt;module&gt;
+% <userinput>scons -Q COLOR=BLUE foo.o</userinput>
+
+scons: *** Invalid value for option COLOR: BLUE.  Valid values are: ('red', 'green', 'blue')
+File "/home/my/project/SConstruct", line 6, in &lt;module&gt;
+% <userinput>scons -Q COLOR=nAvY foo.o</userinput>
+
+scons: *** Invalid value for option COLOR: nAvY.  Valid values are: ('red', 'green', 'blue')
+File "/home/my/project/SConstruct", line 6, in &lt;module&gt;
+</screen>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -3957,7 +3957,7 @@ For example, libraries needed for the build may be in non-standard
 locations, or site-specific compiler options may need to be passed to the
 compiler.
 &SCons;
-provides a <firstterm>Variables</firstterm>
+provides a <firstterm>&Variables;</firstterm>
 object to support overriding &consvars;
 on the command line:</para>
 
@@ -4116,7 +4116,7 @@ env = Environment(variables=vars)
   <varlistentry>
   <term><replaceable>vars</replaceable>.<function>UnknownVariables</function>()</term>
   <listitem>
-<para>Return a dictionary containing any
+<para>Returns a dictionary containing any
 variables that were specified
 either in the files or the dictionary
 with which the Variables object was initialized,
@@ -4187,7 +4187,7 @@ Help(vars.GenerateHelpText(env, sort=cmp))
   <varlistentry>
   <term><replaceable>vars</replaceable>.<function>FormatVariableHelpText</function>(<parameter>env, opt, help, default, actual</parameter>)</term>
   <listitem>
-<para>Return a formatted string
+<para>Returns a formatted string
 containing the printable help text
 for one option.
 It is normally not called directly,
@@ -4225,7 +4225,7 @@ the &Add; or &AddVariables; method:</para>
   <varlistentry>
   <term><function>BoolVariable</function>(<parameter>key, help, default</parameter>)</term>
   <listitem>
-<para>Return a tuple of arguments
+<para>Returns a tuple of arguments
 to set up a Boolean option.
 The option will use
 the specified name
@@ -4260,7 +4260,7 @@ as false.</para>
   <varlistentry>
   <term><function>EnumVariable</function>(<parameter>key, help, default, allowed_values, [map, ignorecase]</parameter>)</term>
   <listitem>
-<para>Return a tuple of arguments
+<para>Returns a tuple of arguments
 to set up an option
 whose value may be one
 of a specified list of legal enumerated values.
@@ -4309,7 +4309,7 @@ converted to lower case.</para>
   <varlistentry>
   <term><function>ListVariable</function>(<parameter>key, help, default, names, [map]</parameter>)</term>
   <listitem>
-<para>Return a tuple of arguments
+<para>Returns a tuple of arguments
 to set up an option
 whose value may be one or more
 of a specified list of legal enumerated values.
@@ -4348,7 +4348,7 @@ reflected in the generated help message).  </para>
   <varlistentry>
   <term><function>PackageVariable</function>(<parameter>key, help, default</parameter>)</term>
   <listitem>
-<para>Return a tuple of arguments
+<para>Returns a tuple of arguments
 to set up an option
 whose value is a path name
 of a package that may be
@@ -4388,7 +4388,7 @@ to disable use of the specified option.</para>
   <varlistentry>
   <term><function>PathVariable</function>(<parameter>key, help, default, [validator]</parameter>)</term>
   <listitem>
-<para>Return a tuple of arguments
+<para>Returns a tuple of arguments
 to set up an option
 whose value is expected to be a path name.
 The option will use

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -3952,12 +3952,12 @@ env = conf.Finish()
 <title>Command-Line Construction Variables</title>
 
 <para>Often when building software,
-some variables must be specified at build time.
+some variables need to be specified at build time.
 For example, libraries needed for the build may be in non-standard
 locations, or site-specific compiler options may need to be passed to the
 compiler.
-&scons;
-provides a <firstterm>&Variables;</firstterm>
+&SCons;
+provides a <firstterm>Variables</firstterm>
 object to support overriding &consvars;
 on the command line:</para>
 
@@ -3965,37 +3965,38 @@ on the command line:</para>
 <userinput>scons VARIABLE=foo</userinput>
 </screen>
 
-<para>The variable values can also be specified in an SConscript file.
-To obtain the object for manipulating values,
+<para>The variable values can also be specified in an SConscript file.</para>
+
+<para>To obtain the object for manipulating values,
 call the &Variables; function:</para>
 
 <variablelist>
   <varlistentry>
-  <term>Variables([<emphasis>files</emphasis>[, <emphasis>args</emphasis>]])</term>
+  <term><function>Variables</function>([<parameter>files, [args]]</parameter>)</term>
   <listitem>
-<para>If <emphasis>files</emphasis> is a file or
+<para>If <parameter>files</parameter> is a file or
 list of files, those are executed as Python scripts,
 and the values of (global) Python variables set in
-those files are added as &consvars; in the
-default &consenv;.
+those files are added as &consvars; in the &DefEnv;.
 If no files are specified,
 or the
-<emphasis>files</emphasis>
+<parameter>files</parameter>
 argument is
-<emphasis role="bold">None</emphasis>,
-then no files will be read. Example file content:</para>
+<constant>None</constant>,
+then no files will be read. The following example file
+contents could be used to set an alternative C compiler:</para>
 
 <programlisting language="python">
 CC = 'my_cc'
 </programlisting>
 
-<para>The optional argument
-<emphasis>args</emphasis>
-is a dictionary of
-values that will override anything read from the specified files;
+<para>If
+<parameter>args</parameter>
+is specified, it is a dictionary of
+values that will override anything read from
+<parameter>files</parameter>.
 it is primarily intended to be passed the
-<emphasis role="bold">ARGUMENTS</emphasis>
-dictionary that holds variables
+&ARGUMENTS; dictionary that holds variables
 specified on the command line.
 Example:</para>
 
@@ -4013,93 +4014,97 @@ vars = Variables(None, {FOO:'expansion', BAR:7})
 
   <variablelist>
   <varlistentry>
-  <term>Add(<emphasis>key</emphasis>, [<emphasis>help</emphasis>, <emphasis>default</emphasis>, <emphasis>validator</emphasis>, <emphasis>converter</emphasis>])</term>
+  <term><replaceable>vars</replaceable>.<function>Add</function>(<parameter>key, [help, default, validator, converter]</parameter>)</term>
   <listitem>
-<para>This adds a customizable &consvar; to the Variables object.
-<emphasis>key</emphasis>
+<para>Add a customizable &consvar; to the Variables object.
+<parameter>key</parameter>
 is the name of the variable.
-<emphasis>help</emphasis>
+<parameter>help</parameter>
 is the help text for the variable.
-<emphasis>default</emphasis>
+<parameter>default</parameter>
 is the default value of the variable;
 if the default value is
-<emphasis role="bold">None</emphasis>
+<constant>None</constant>
 and there is no explicit value specified,
-the &consvar; will
-<emphasis>not</emphasis>
+the &consvar; will not
 be added to the &consenv;.
-<emphasis>validator</emphasis>
-is called to validate the value of the variable, and should take three
-arguments: key, value, and environment.
+If set, <parameter>validator</parameter>
+is called to validate the value of the variable.
+A function supplied as a validator shall accept
+arguments: <parameter>key</parameter>,
+<parameter>value</parameter>, and <parameter>env</parameter>.
 The recommended way to handle an invalid value is
 to raise an exception (see example below).
-<emphasis>converter</emphasis>
+If set, <parameter>converter</parameter>
 is called to convert the value before putting it in the environment, and
 should take either a value, or the value and environment, as parameters.
-The
-<emphasis>converter</emphasis>
-must return a value,
+The converter function must return a value,
 which will be converted into a string
 before being validated by the
-<emphasis>validator</emphasis>
+<parameter>validator</parameter>
 (if any)
-and then added to the environment.</para>
+and then added to the &consenv;.</para>
 
 <para>Examples:</para>
 
 <programlisting language="python">
 vars.Add('CC', help='The C compiler')
 
-def validate_color(key, val, env):
+def valid_color(key, val, env):
     if not val in ['red', 'blue', 'yellow']:
         raise Exception("Invalid color value '%s'" % val)
+
 vars.Add('COLOR', validator=valid_color)
 </programlisting>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term>vars.AddVariables(<emphasis>list</emphasis>)</term>
+  <term><replaceable>vars</replaceable>.<function>AddVariables</function>(<parameter>args</parameter>)</term>
   <listitem>
-<para>A wrapper script that adds
+<para>A convenience method that adds
 multiple customizable &consvars;
-to a Variables object.
-<emphasis>list</emphasis>
-is a list of tuple or list objects
+to a Variables object in one call;
+equivalent to calling &Add; multiple times.
+The <parameter>args</parameter>
+are tuples (or lists)
 that contain the arguments
-for an individual call to the
-<emphasis role="bold">Add</emphasis>
-method.</para>
+for an individual call to the &Add; method.
+Since tuples are not Python mappings,
+the arguments cannot use the keyword form,
+but rather are positional arguments as documented
+for &Add;: a required name, the rest optional
+but must be in the specified in order if used.
+
+</para>
 
 <programlisting language="python">
 opt.AddVariables(
-       ('debug', '', 0),
-       ('CC', 'The C compiler'),
-       ('VALIDATE', 'An option for testing validation',
-        'notset', validator, None),
-    )
+    ("debug", "", 0),
+    ("CC", "The C compiler"),
+    ("VALIDATE", "An option for testing validation", "notset", validator, None),
+)
 </programlisting>
 
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term>vars.Update(<emphasis>env</emphasis>, [<emphasis>args</emphasis>])</term>
+  <term><replaceable>vars</replaceable>.<function>Update</function>(<parameter>env, [args]</parameter>)</term>
   <listitem>
-<para>This updates a &consenv;
-<emphasis>env</emphasis>
-with the customized &consvars;.
-Any specified variables that are
-<emphasis>not</emphasis>
+<para>Update a &consenv;
+<parameter>env</parameter>
+with the customized &consvars; .
+Any specified variables that are not
 configured for the Variables object
 will be saved and may be
-retrieved with the
-<emphasis role="bold">UnknownVariables</emphasis>()
+retrieved using the
+&UnknownVariables;
 method, below.</para>
 
 <para>Normally this method is not called directly,
-but is called indirectly by passing the Variables object to
-the Environment() function:</para>
+but rather invoked indirectly by passing the Variables object to
+the &f-link-Environment; function:</para>
 
 <programlisting language="python">
 env = Environment(variables=vars)
@@ -4109,9 +4114,9 @@ env = Environment(variables=vars)
   </varlistentry>
 
   <varlistentry>
-  <term>vars.UnknownVariables(<emphasis>)</emphasis></term>
+  <term><replaceable>vars</replaceable>.<function>UnknownVariables</function>()</term>
   <listitem>
-<para>Returns a dictionary containing any
+<para>Return a dictionary containing any
 variables that were specified
 either in the files or the dictionary
 with which the Variables object was initialized,
@@ -4128,10 +4133,10 @@ for key, value in vars.UnknownVariables():
   </varlistentry>
 
   <varlistentry>
-  <term>vars.Save(<emphasis>filename</emphasis>, <emphasis>env</emphasis>)</term>
+  <term><replaceable>vars</replaceable>.<function>Save</function>(<parameter>filename, env</parameter>)</term>
   <listitem>
-<para>This saves the currently set variables into a script file named
-<emphasis>filename</emphasis>
+<para>Save the currently set variables into a script file named
+by <parameter>filename</parameter>
 that can be used on the next invocation to automatically load the current
 settings.  This method combined with the Variables method can be used to
 support caching of variables between runs.</para>
@@ -4148,32 +4153,31 @@ vars.Save('variables.cache', env)
   </varlistentry>
 
   <varlistentry>
-  <term>vars.GenerateHelpText(<emphasis>env</emphasis>, [<emphasis>sort</emphasis>])</term>
+  <term><replaceable>vars</replaceable>.<function>GenerateHelpText</function>(<parameter>env, [sort]</parameter>)</term>
   <listitem>
-<para>This generates help text documenting the customizable construction
-variables suitable to passing in to the Help() function.
-<emphasis>env</emphasis>
+<para>Generate help text documenting the customizable construction
+variables, suitable for passing in to the &f-link-Help; function.
+<parameter>env</parameter>
 is the &consenv; that will be used to get the actual values
-of customizable variables. Calling with
-an optional
-<emphasis>sort</emphasis>
-function
-will cause the output to be sorted
-by the specified argument.
-The specific
-<emphasis>sort</emphasis>
-function
-should take two arguments
-and return
--1, 0 or 1
-(like the standard Python
-<emphasis>cmp</emphasis>
-function).
+of the customizable variables. If the (optional)
+value of <parameter>sort</parameter>
+is callable, it is used as a comparison function to
+determine how to sort the added variables.
+This function must accept two arguments, compare them,
+and return a negative integer if the first is
+less-than the second, zero for equality, or a positive integer
+for greater-than.
 
-Optionally a Boolean value of True for <emphasis>sort</emphasis> will cause a standard alphabetical sort to be performed</para>
+Optionally a Boolean value of <constant>True</constant>
+for <parameter>sort</parameter> will cause a standard
+alphabetical sort to be performed.</para>
 
 <programlisting language="python">
 Help(vars.GenerateHelpText(env))
+
+def cmp(a, b):
+    return (a &gt; b) - (a &lt; b)
+
 Help(vars.GenerateHelpText(env, sort=cmp))
 </programlisting>
 
@@ -4181,20 +4185,18 @@ Help(vars.GenerateHelpText(env, sort=cmp))
   </varlistentry>
 
   <varlistentry>
-  <term>FormatVariableHelpText(<emphasis>env</emphasis>, <emphasis>opt</emphasis>, <emphasis>help</emphasis>, <emphasis>default</emphasis>, <emphasis>actual</emphasis>)</term>
+  <term><replaceable>vars</replaceable>.<function>FormatVariableHelpText</function>(<parameter>env, opt, help, default, actual</parameter>)</term>
   <listitem>
-<para>This method returns a formatted string
+<para>Return a formatted string
 containing the printable help text
 for one option.
 It is normally not called directly,
-but is called by the
-<emphasis>GenerateHelpText</emphasis>()
+but is called by the &GenerateHelpText;
 method to create the returned help text.
 It may be overridden with your own
 function that takes the arguments specified above
 and returns a string of help text formatted to your liking.
-Note that
-<emphasis>GenerateHelpText</emphasis>()
+Note that &GenerateHelpText;
 will not put any blank lines or extra
 characters in between the entries,
 so you must add those characters to the returned
@@ -4203,7 +4205,7 @@ string if you want the entries separated.</para>
 <programlisting language="python">
 def my_format(env, opt, help, default, actual):
     fmt = "\n%s: default=%s actual=%s (%s)\n"
-    return fmt % (opt, default. actual, help)
+    return fmt % (opt, default, actual, help)
 vars.FormatVariableHelpText = my_format
 </programlisting>
   </listitem>
@@ -4215,47 +4217,48 @@ vars.FormatVariableHelpText = my_format
 &scons;
 provides a number of functions
 that make it easy to set up
-various types of Variables:</para>
+various types of Variables.
+Each of these return a tuple ready to be passed to
+the &Add; or &AddVariables; method:</para>
 
   <variablelist>
   <varlistentry>
-  <term>BoolVariable(<emphasis>key</emphasis>, <emphasis>help</emphasis>, <emphasis>default</emphasis>)</term>
+  <term><function>BoolVariable</function>(<parameter>key, help, default</parameter>)</term>
   <listitem>
 <para>Return a tuple of arguments
 to set up a Boolean option.
 The option will use
 the specified name
-<emphasis>key</emphasis>,
+<parameter>key</parameter>,
 have a default value of
-<emphasis>default</emphasis>,
-and display the specified
-<emphasis>help</emphasis>
-text.
+<parameter>default</parameter>,
+and <parameter>help</parameter>
+will form the descriptive part of the help text.
 The option will interpret the values
-<emphasis role="bold">y</emphasis>,
-<emphasis role="bold">yes</emphasis>,
-<emphasis role="bold">t</emphasis>,
-<emphasis role="bold">true</emphasis>,
-<literal>1</literal>,
-<emphasis role="bold">on</emphasis>
+<userinput>y</userinput>,
+<userinput>yes</userinput>,
+<userinput>t</userinput>,
+<userinput>true</userinput>,
+<userinput>1</userinput>,
+<userinput>on</userinput>
 and
-<emphasis role="bold">all</emphasis>
+<userinput>all</userinput>
 as true,
 and the values
-<emphasis role="bold">n</emphasis>,
-<emphasis role="bold">no</emphasis>,
-<emphasis role="bold">f</emphasis>,
-<emphasis role="bold">false</emphasis>,
-<literal>0</literal>,
-<emphasis role="bold">off</emphasis>
+<userinput>n</userinput>,
+<userinput>no</userinput>,
+<userinput>f</userinput>,
+<userinput>false</userinput>,
+<userinput>0</userinput>,
+<userinput>off</userinput>
 and
-<emphasis role="bold">none</emphasis>
+<userinput>none</userinput>
 as false.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term>EnumVariable(<emphasis>key</emphasis>, <emphasis>help</emphasis>, <emphasis>default</emphasis>, <emphasis>allowed_values</emphasis>, [<emphasis>map</emphasis>, <emphasis>ignorecase</emphasis>])</term>
+  <term><function>EnumVariable</function>(<parameter>key, help, default, allowed_values, [map, ignorecase]</parameter>)</term>
   <listitem>
 <para>Return a tuple of arguments
 to set up an option
@@ -4263,49 +4266,48 @@ whose value may be one
 of a specified list of legal enumerated values.
 The option will use
 the specified name
-<emphasis>key</emphasis>,
+<parameter>key</parameter>,
 have a default value of
-<emphasis>default</emphasis>,
-and display the specified
-<emphasis>help</emphasis>
-text.
+<parameter>default</parameter>,
+and <parameter>help</parameter>
+will form the descriptive part of the help text.
 The option will only support those
 values in the
-<emphasis>allowed_values</emphasis>
+<parameter>allowed_values</parameter>
 list.
 The optional
-<emphasis>map</emphasis>
+<parameter>map</parameter>
 argument is a dictionary
 that can be used to convert
 input values into specific legal values
 in the
-<emphasis>allowed_values</emphasis>
+<parameter>allowed_values</parameter>
 list.
 If the value of
-<emphasis>ignore_case</emphasis>
+<parameter>ignore_case</parameter>
 is
 <literal>0</literal>
 (the default),
 then the values are case-sensitive.
 If the value of
-<emphasis>ignore_case</emphasis>
+<parameter>ignore_case</parameter>
 is
 <literal>1</literal>,
 then values will be matched
-case-insensitive.
+case-insensitively.
 If the value of
-<emphasis>ignore_case</emphasis>
+<parameter>ignore_case</parameter>
 is
 <literal>2</literal>,
 then values will be matched
-case-insensitive,
+case-insensitively,
 and all input values will be
 converted to lower case.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term>ListVariable(<emphasis>key</emphasis>, <emphasis>help</emphasis>, <emphasis>default</emphasis>, <emphasis>names</emphasis>, [<emphasis>,</emphasis>map<emphasis>])</emphasis></term>
+  <term><function>ListVariable</function>(<parameter>key, help, default, names, [map]</parameter>)</term>
   <listitem>
 <para>Return a tuple of arguments
 to set up an option
@@ -4313,36 +4315,38 @@ whose value may be one or more
 of a specified list of legal enumerated values.
 The option will use
 the specified name
-<emphasis>key</emphasis>,
+<parameter>key</parameter>,
 have a default value of
-<emphasis>default</emphasis>,
-and display the specified
-<emphasis>help</emphasis>
-text.
-The option will only support the values
-<emphasis role="bold">all</emphasis>,
-<emphasis role="bold">none</emphasis>,
+<parameter>default</parameter>,
+and <parameter>help</parameter>
+will form the descriptive part of the help text.
+The option will only accept the values
+<quote>all</quote>,
+<quote>none</quote>,
 or the values in the
-<emphasis>names</emphasis>
+<parameter>names</parameter>
 list.
 More than one value may be specified,
-with all values separated by commas.
+separated by commas.
 The default may be a string of
 comma-separated default values,
 or a list of the default values.
 The optional
-<emphasis>map</emphasis>
+<parameter>map</parameter>
 argument is a dictionary
 that can be used to convert
 input values into specific legal values
 in the
-<emphasis>names</emphasis>
-list.</para>
+<parameter>names</parameter>
+list.
+(Note that the additional values accepted through
+the use of a <parameter>map</parameter> are not
+reflected in the generated help message).  </para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term>PackageVariable(<emphasis>key</emphasis>, <emphasis>help</emphasis>, <emphasis>default</emphasis>)</term>
+  <term><function>PackageVariable</function>(<parameter>key, help, default</parameter>)</term>
   <listitem>
 <para>Return a tuple of arguments
 to set up an option
@@ -4352,52 +4356,50 @@ enabled, disabled or
 given an explicit path name.
 The option will use
 the specified name
-<emphasis>key</emphasis>,
+<parameter>key</parameter>,
 have a default value of
-<emphasis>default</emphasis>,
-and display the specified
-<emphasis>help</emphasis>
-text.
+<parameter>default</parameter>,
+and <parameter>help</parameter>
+will form the descriptive part of the help text.
 The option will support the values
-<emphasis role="bold">yes</emphasis>,
-<emphasis role="bold">true</emphasis>,
-<emphasis role="bold">on</emphasis>,
-<emphasis role="bold">enable</emphasis>
+<userinput>yes</userinput>,
+<userinput>true</userinput>,
+<userinput>on</userinput>,
+<userinput>enable</userinput>
 or
-<emphasis role="bold">search</emphasis>,
+<userinput>search</userinput>,
 in which case the specified
-<emphasis>default</emphasis>
+<parameter>default</parameter>
 will be used,
 or the option may be set to an
 arbitrary string
 (typically the path name to a package
 that is being enabled).
 The option will also support the values
-<emphasis role="bold">no</emphasis>,
-<emphasis role="bold">false</emphasis>,
-<emphasis role="bold">off</emphasis>
+<userinput>no</userinput>,
+<userinput>false</userinput>,
+<userinput>off</userinput>
 or
-<emphasis role="bold">disable</emphasis>
+<userinput>disable</userinput>
 to disable use of the specified option.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term>PathVariable(<emphasis>key</emphasis>, <emphasis>help</emphasis>, <emphasis>default</emphasis>, [<emphasis>validator</emphasis>])</term>
+  <term><function>PathVariable</function>(<parameter>key, help, default, [validator]</parameter>)</term>
   <listitem>
 <para>Return a tuple of arguments
 to set up an option
 whose value is expected to be a path name.
 The option will use
 the specified name
-<emphasis>key</emphasis>,
+<parameter>key</parameter>,
 have a default value of
-<emphasis>default</emphasis>,
-and display the specified
-<emphasis>help</emphasis>
-text.
+<parameter>default</parameter>,
+and <parameter>help</parameter>
+will form the descriptive part of the help text.
 An additional
-<emphasis>validator</emphasis>
+<parameter>validator</parameter>
 may be specified
 that will be called to
 verify that the specified path
@@ -4407,38 +4409,40 @@ following ready-made validators:</para>
 
   <variablelist>  <!-- nested list -->
   <varlistentry>
-    <term>PathVariable.PathExists</term>
+    <term><literal>PathVariable</literal>.<function>PathExists</function></term>
     <listitem>
-<para>Verify that the specified path exists (the default).</para>
+<para>Verify that the specified path exists
+(this the default behavior if no
+<parameter>validator</parameter> is supplied).</para>
     </listitem>
   </varlistentry>
 
   <varlistentry>
-    <term>PathVariable.PathIsFile</term>
+    <term><literal>PathVariable</literal>.<function>PathIsFile</function></term>
     <listitem>
-<para>Verify that the specified path is an existing file.</para>
+<para>Verify that the specified path exists and is a regular file.</para>
     </listitem>
   </varlistentry>
 
   <varlistentry>
-    <term>PathVariable.PathIsDir</term>
+    <term><literal>PathVariable</literal>.<function>PathIsDir</function></term>
     <listitem>
-<para>Verify that the specified path is an existing directory.</para>
+<para>Verify that the specified path exists and is a directory.</para>
     </listitem>
   </varlistentry>
 
   <varlistentry>
-    <term>PathVariable.PathIsDirCreate</term>
+    <term><literal>PathVariable</literal>.<function>PathIsDirCreate</function></term>
     <listitem>
-<para>Verify that the specified path is a directory
-and will create the specified directory if the path does not exist.</para>
+<para>Verify that the specified path exists and is a directory;
+if it does not exist, create the directory.</para>
     </listitem>
   </varlistentry>
 
   <varlistentry>
-    <term>PathVariable.PathAccept</term>
+    <term><literal>PathVariable</literal>.<function>PathAccept</function></term>
     <listitem>
-<para>Simply accept the specific path name argument without validation,
+<para>Accept the specific path name argument without validation,
 suitable for when you want your users
 to be able to specify a directory path that will be
 created as part of the build process, for example.</para>
@@ -4451,12 +4455,12 @@ You may supply your own
 <emphasis>validator</emphasis>
 function,
 which must accept three arguments
-(<emphasis>key</emphasis>,
+(<parameter>key</parameter>,
 the name of the variable to be set;
-<emphasis>val</emphasis>,
+<parameter>val</parameter>,
 the specified value being checked;
 and
-<emphasis>env</emphasis>,
+<parameter>env</parameter>,
 the &consenv;)
 and should raise an exception
 if the specified value is not acceptable.</para>
@@ -7220,7 +7224,7 @@ line or in the file <filename>custom.py</filename>.</para>
 
 <programlisting language="python">
 vars = Variables('custom.py')
-vars.Add('CC', 'The C compiler.')
+vars.Add('CC', help='The C compiler.')
 env = Environment(variables=vars)
 Help(vars.GenerateHelpText(env))
 </programlisting>

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -998,7 +998,7 @@ bar.c
 
       <para>
 
-      Historical note:  In old &SCons; (prior to 1.0),
+      Historical note:  In old &SCons; (prior to 0.98.1),
       these build variables were known as "command-line build options."
       The class was named the &Options; class,
       and the predefined functions to construct options were named

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -873,7 +873,7 @@ cppdefines = []
 for key, value in ARGLIST:
     if key == 'define':
         cppdefines.append(value)
-env = Environment(CPPDEFINES = cppdefines)
+env = Environment(CPPDEFINES=cppdefines)
 env.Object('prog.c')
        </file>
        <file name="prog.c">
@@ -943,8 +943,7 @@ prog.c
       a program for release,
       and that the value of this variable
       should be added to the command line
-      with the appropriate <literal>-D</literal> option
-      (or other command line option)
+      with the appropriate define
       to pass the value to the C compiler.
       Here's how you might do that by setting
       the appropriate value in a dictionary for the
@@ -955,9 +954,8 @@ prog.c
       <scons_example name="commandline_Variables1">
         <file name="SConstruct" printme="1">
 vars = Variables(None, ARGUMENTS)
-vars.Add('RELEASE', 'Set to 1 to build for release', 0)
-env = Environment(variables = vars,
-                  CPPDEFINES={'RELEASE_BUILD' : '${RELEASE}'})
+vars.Add('RELEASE', default=0)
+env = Environment(variables=vars, CPPDEFINES={'RELEASE_BUILD': '${RELEASE}'})
 env.Program(['foo.c', 'bar.c'])
         </file>
         <file name="foo.c">
@@ -975,11 +973,8 @@ bar.c
       (the <literal>vars = Variables(None, ARGUMENTS)</literal> call).
       It then uses the object's &Add;
       method to indicate that the &RELEASE;
-      variable can be set on the command line,
-      and that its default value will be <literal>0</literal>
-      (the third argument to the &Add; method).
-      The second argument is a line of help text;
-      we'll learn how to use it in the next section.
+      variable can be set on the command line, and that
+      if not set the default value will be <literal>0</literal>.
 
       </para>
 
@@ -1003,18 +998,19 @@ bar.c
 
       <para>
 
-      NOTE:  Before &SCons; release 0.98.1, these build variables
-      were known as "command-line build options."
-      The class was actually named the &Options; class,
-      and in the sections below,
-      the various functions were named
+      Historical note:  In old &SCons; (prior to 1.0),
+      these build variables were known as "command-line build options."
+      The class was named the &Options; class,
+      and the predefined functions to construct options were named
       &BoolOption;, &EnumOption;, &ListOption;,
-      &PathOption;, &PackageOption; and &AddOptions;.
-      These older names still work,
-      and you may encounter them in older
-      &SConscript; files,
-      but they have been officially deprecated
-      as of &SCons; version 2.0.
+      &PathOption;, &PackageOption; and &AddOptions; (contrast
+      with the current names in "Pre-Defined Build Variable Functions"
+      below.  You may encounter these names in older
+      &SConscript; files, wiki pages, blog entries, StackExchange
+      articles, etc.
+      These old names no longer work, but a mental substitution
+      of <quote>Variable</quote>" for <quote>Option</quote>
+      will let the concepts transfer to current usage models.
 
       </para>
 
@@ -1032,12 +1028,17 @@ bar.c
       when the user runs <literal>scons -h</literal>.
       You could write this text by hand,
       but &SCons; provides an easier way.
-      &Variables; objects support a
+      Variables objects support a
       &GenerateHelpText; method
       that will, as its name suggests,
       generate text that describes
       the various variables that
-      have been added to it.
+      have been added to it. The default text includes
+      the help string itself plus other information
+      such as allowed values.
+      (The generated text can also be customized by
+      replacing the <methodname>FormatVariableHelpText</methodname>
+      method).
       You then pass the output from this method to
       the &Help; function:
 
@@ -1046,8 +1047,8 @@ bar.c
       <scons_example name="commandline_Variables_Help">
         <file name="SConstruct" printme="1">
 vars = Variables(None, ARGUMENTS)
-vars.Add('RELEASE', 'Set to 1 to build for release', 0)
-env = Environment(variables = vars)
+vars.Add('RELEASE', help='Set to 1 to build for release', default=0)
+env = Environment(variables=vars)
 Help(vars.GenerateHelpText(env))
         </file>
       </scons_example>
@@ -1093,9 +1094,8 @@ Help(vars.GenerateHelpText(env))
       <scons_example name="commandline_Variables_custom_py_1">
         <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add('RELEASE', 'Set to 1 to build for release', 0)
-env = Environment(variables = vars,
-                  CPPDEFINES={'RELEASE_BUILD' : '${RELEASE}'})
+vars.Add('RELEASE', help='Set to 1 to build for release', default=0)
+env = Environment(variables=vars, CPPDEFINES={'RELEASE_BUILD': '${RELEASE}'})
 env.Program(['foo.c', 'bar.c'])
 Help(vars.GenerateHelpText(env))
         </file>
@@ -1139,12 +1139,11 @@ RELEASE = 1
 
       <scons_example name="commandline_Variables_custom_py_2">
         <file name="SConstruct">
-   vars = Variables('custom.py')
-   vars.Add('RELEASE', 'Set to 1 to build for release', 0)
-   env = Environment(variables = vars,
-                     CPPDEFINES={'RELEASE_BUILD' : '${RELEASE}'})
-   env.Program(['foo.c', 'bar.c'])
-   Help(vars.GenerateHelpText(env))
+vars = Variables('custom.py')
+vars.Add('RELEASE', help='Set to 1 to build for release', default=0)
+env = Environment(variables=vars, CPPDEFINES={'RELEASE_BUILD': '${RELEASE}'})
+env.Program(['foo.c', 'bar.c'])
+Help(vars.GenerateHelpText(env))
         </file>
         <file name="foo.c">
 foo.c
@@ -1195,6 +1194,8 @@ vars = Variables('custom.py', ARGUMENTS)
       &SCons; provides a number of functions
       that provide ready-made behaviors
       for various types of command-line build variables.
+      These functions all return a tuple which is ready
+      to be passed to an &Add; call.
 
       </para>
 
@@ -1230,9 +1231,10 @@ vars = Variables('custom.py', ARGUMENTS)
         <scons_example name="commandline_BoolVariable">
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add(BoolVariable('RELEASE', 'Set to build for release', 0))
-env = Environment(variables = vars,
-                  CPPDEFINES={'RELEASE_BUILD' : '${RELEASE}'})
+vars.Add(BoolVariable('RELEASE',
+                      help='Set to build for release',
+                      default=0))
+env = Environment(variables=vars, CPPDEFINES={'RELEASE_BUILD': '${RELEASE}'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1334,11 +1336,13 @@ foo.c
         <scons_example name="commandline_EnumVariable">
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add(EnumVariable('COLOR', 'Set background color', 'red',
-                    allowed_values=('red', 'green', 'blue')))
-env = Environment(variables = vars,
-                  CPPDEFINES={'COLOR' : '"${COLOR}"'})
+vars.Add(EnumVariable('COLOR',
+                      help='Set background color',
+                      default='red',
+                      allowed_values=('red', 'green', 'blue')))
+env = Environment(variables=vars, CPPDEFINES={'COLOR': '"${COLOR}"'})
 env.Program('foo.c')
+Help(vars.GenerateHelpText(env))
           </file>
           <file name="foo.c">
 foo.c
@@ -1373,6 +1377,20 @@ foo.c
 
         <para>
 
+        This example can also serve to further illustrate help
+        generation: the help message here picks up not only the
+        <parameter>help</parameter> text, but augments it with
+        information gathered from <parameter>allowed_values</parameter>
+        and <parameter>default</parameter>:
+
+        </para>
+
+        <scons_output example="commandline_EnumVariable" suffix="3">
+          <scons_output_command>scons -Q -h</scons_output_command>
+        </scons_output>
+
+        <para>
+
         The &EnumVariable; function also supports a way
         to map alternate names to allowed values.
         Suppose, for example,
@@ -1388,11 +1406,12 @@ foo.c
         <scons_example name="EnumVariable_map">
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add(EnumVariable('COLOR', 'Set background color', 'red',
-                    allowed_values=('red', 'green', 'blue'),
-                    map={'navy':'blue'}))
-env = Environment(variables = vars,
-                  CPPDEFINES={'COLOR' : '"${COLOR}"'})
+vars.Add(EnumVariable('COLOR',
+                      help='Set background color',
+                      default='red',
+                      allowed_values=('red', 'green', 'blue'),
+                      map={'navy':'blue'}))
+env = Environment(variables=vars, CPPDEFINES={'COLOR': '"${COLOR}"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1424,7 +1443,7 @@ foo.c
 
         </para>
 
-        <scons_output example="commandline_EnumVariable" suffix="3">
+        <scons_output example="commandline_EnumVariable" suffix="4">
           <scons_output_command>scons -Q COLOR=Red foo.o</scons_output_command>
           <scons_output_command>scons -Q COLOR=BLUE foo.o</scons_output_command>
           <scons_output_command>scons -Q COLOR=nAvY foo.o</scons_output_command>
@@ -1443,12 +1462,13 @@ foo.c
         <scons_example name="commandline_EnumVariable_ic1">
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add(EnumVariable('COLOR', 'Set background color', 'red',
-                    allowed_values=('red', 'green', 'blue'),
-                    map={'navy':'blue'},
-                    ignorecase=1))
-env = Environment(variables = vars,
-                  CPPDEFINES={'COLOR' : '"${COLOR}"'})
+vars.Add(EnumVariable('COLOR',
+                      help='Set background color',
+                      default='red',
+                      allowed_values=('red', 'green', 'blue'),
+                      map={'navy':'blue'},
+                      ignorecase=1))
+env = Environment(variables=vars, CPPDEFINES={'COLOR':'"${COLOR}"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1483,12 +1503,13 @@ foo.c
         <scons_example name="commandline_EnumVariable_ic2">
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add(EnumVariable('COLOR', 'Set background color', 'red',
-                    allowed_values=('red', 'green', 'blue'),
-                    map={'navy':'blue'},
-                    ignorecase=2))
-env = Environment(variables = vars,
-                  CPPDEFINES={'COLOR' : '"${COLOR}"'})
+vars.Add(EnumVariable('COLOR',
+                      help='Set background color',
+                      default='red',
+                      allowed_values=('red', 'green', 'blue'),
+                      map={'navy':'blue'},
+                      ignorecase=2))
+env = Environment(variables=vars, CPPDEFINES={'COLOR': '"${COLOR}"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1532,10 +1553,11 @@ foo.c
         <scons_example name="commandline_ListVariable">
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add(ListVariable('COLORS', 'List of colors', 0,
-                    ['red', 'green', 'blue']))
-env = Environment(variables = vars,
-                  CPPDEFINES={'COLORS' : '"${COLORS}"'})
+vars.Add(ListVariable('COLORS',
+                      help='List of colors',
+                      default=0,
+                      names=['red', 'green', 'blue']))
+env = Environment(variables=vars, CPPDEFINES={'COLORS': '"${COLORS}"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1604,10 +1626,9 @@ foo.c
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
 vars.Add(PathVariable('CONFIG',
-                    'Path to configuration file',
-                    '__ROOT__/etc/my_config'))
-env = Environment(variables = vars,
-                  CPPDEFINES={'CONFIG_FILE' : '"$CONFIG"'})
+                      help='Path to configuration file',
+                      default='__ROOT__/etc/my_config'))
+env = Environment(variables=vars, CPPDEFINES={'CONFIG_FILE': '"$CONFIG"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1652,7 +1673,7 @@ foo.c
         that you can use to change this behavior.
         If you want to ensure that any specified paths are,
         in fact, files and not directories,
-        use the &PathVariable_PathIsFile; method:
+        use the &PathVariable_PathIsFile; method as the validation function:
 
         </para>
 
@@ -1660,11 +1681,10 @@ foo.c
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
 vars.Add(PathVariable('CONFIG',
-                    'Path to configuration file',
-                    '__ROOT__/etc/my_config',
-                    PathVariable.PathIsFile))
-env = Environment(variables = vars,
-                  CPPDEFINES={'CONFIG_FILE' : '"$CONFIG"'})
+                      help='Path to configuration file',
+                      default='__ROOT__/etc/my_config',
+                      validator=PathVariable.PathIsFile))
+env = Environment(variables=vars, CPPDEFINES={'CONFIG_FILE': '"$CONFIG"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1679,7 +1699,7 @@ foo.c
 
         Conversely, to ensure that any specified paths are
         directories and not files,
-        use the &PathVariable_PathIsDir; method:
+        use the &PathVariable_PathIsDir; method as the validation function:
 
         </para>
 
@@ -1687,11 +1707,10 @@ foo.c
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
 vars.Add(PathVariable('DBDIR',
-                    'Path to database directory',
-                    '__ROOT__/var/my_dbdir',
-                    PathVariable.PathIsDir))
-env = Environment(variables = vars,
-                  CPPDEFINES={'DBDIR' : '"$DBDIR"'})
+                      help='Path to database directory',
+                      default='__ROOT__/var/my_dbdir',
+                      validator=PathVariable.PathIsDir))
+env = Environment(variables=vars, CPPDEFINES={'DBDIR': '"$DBDIR"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1708,7 +1727,7 @@ foo.c
         are directories,
         and you would like the directory created
         if it doesn't already exist,
-        use the &PathVariable_PathIsDirCreate; method:
+        use the &PathVariable_PathIsDirCreate; method as the validation function:
 
         </para>
 
@@ -1716,11 +1735,10 @@ foo.c
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
 vars.Add(PathVariable('DBDIR',
-                    'Path to database directory',
-                    '__ROOT__/var/my_dbdir',
-                    PathVariable.PathIsDirCreate))
-env = Environment(variables = vars,
-                  CPPDEFINES={'DBDIR' : '"$DBDIR"'})
+                      help='Path to database directory',
+                      default='__ROOT__/var/my_dbdir',
+                      validator=PathVariable.PathIsDirCreate))
+env = Environment(variables=vars, CPPDEFINES={'DBDIR': '"$DBDIR"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1744,11 +1762,10 @@ foo.c
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
 vars.Add(PathVariable('OUTPUT',
-                    'Path to output file or directory',
-                    None,
-                    PathVariable.PathAccept))
-env = Environment(variables = vars,
-                  CPPDEFINES={'OUTPUT' : '"$OUTPUT"'})
+                      help='Path to output file or directory',
+                      default=None,
+                      validator=PathVariable.PathAccept))
+env = Environment(variables=vars, CPPDEFINES={'OUTPUT': '"$OUTPUT"'})
 env.Program('foo.c')
           </file>
           <file name="foo.c">
@@ -1777,13 +1794,12 @@ foo.c
 
         <scons_example name="commandline_PackageVariable">
           <file name="SConstruct" printme="1">
-vars = Variables('custom.py')
-vars.Add(PackageVariable('PACKAGE',
-                       'Location package',
-                       '__ROOT__/opt/location'))
-env = Environment(variables = vars,
-                  CPPDEFINES={'PACKAGE' : '"$PACKAGE"'})
-env.Program('foo.c')
+vars = Variables("custom.py")
+vars.Add(PackageVariable("PACKAGE",
+                         help="Location package",
+                         default="__ROOT__/opt/location"))
+env = Environment(variables=vars, CPPDEFINES={"PACKAGE": '"$PACKAGE"'})
+env.Program("foo.c")
           </file>
           <file name="foo.c">
 foo.c
@@ -1798,8 +1814,8 @@ foo.c
 
         <para>
 
-        When the &SConscript; file uses the &PackageVariable; funciton,
-        user can now still use the default
+        When the &SConscript; file uses the &PackageVariable; function,
+        the user can still use the default
         or supply an overriding path name,
         but can now explicitly set the
         specified variable to a value
@@ -1828,16 +1844,17 @@ foo.c
       Lastly, &SCons; provides a way to add
       multiple build variables to a &Variables; object at once.
       Instead of having to call the &Add; method
-      multiple times,
-      you can call the &AddVariables;
-      method with a list of build variables
-      to be added to the object.
+      multiple times, you can call the &AddVariables;
+      method with the build variables to be added to the object.
       Each build variable is specified
       as either a tuple of arguments,
-      just like you'd pass to the &Add; method itself,
       or as a call to one of the pre-defined
-      functions for pre-packaged command-line build variables.
-      in any order:
+      functions for pre-packaged command-line build variables,
+      which returns such a tuple. Note that an individual tuple
+      cannot take keyword arguments in the way that a call to
+      &Add; or one of the build variable functions can.
+      The order of variables given to &AddVariables; does not
+      matter.
 
       </para>
 
@@ -1847,18 +1864,25 @@ vars = Variables()
 vars.AddVariables(
     ('RELEASE', 'Set to 1 to build for release', 0),
     ('CONFIG', 'Configuration file', '/etc/my_config'),
-    BoolVariable('warnings', 'compilation with -Wall and similiar', 1),
-    EnumVariable('debug', 'debug output and symbols', 'no',
-               allowed_values=('yes', 'no', 'full'),
-               map={}, ignorecase=0),  # case sensitive
+    BoolVariable('warnings',
+                 help='compilation with -Wall and similiar',
+                 default=1),
+    EnumVariable('debug',
+                 help='debug output and symbols',
+                 default='no',
+                 allowed_values=('yes', 'no', 'full'),
+                 map={},
+                 ignorecase=0),
     ListVariable('shared',
-               'libraries to build as shared libraries',
-               'all',
-               names = list_of_libs),
+                 help='libraries to build as shared libraries',
+                 default='all',
+                 names = list_of_libs),
     PackageVariable('x11',
-                  'use X11 installed here (yes = search some places)',
-                  'yes'),
-    PathVariable('qtdir', 'where the root of Qt is installed', qtdir),
+                    help='use X11 installed here (yes = search some places)',
+                    default='yes'),
+    PathVariable('qtdir',
+                 help='where the root of Qt is installed',
+                 default=qtdir),
 )
         </file>
       </scons_example>
@@ -1905,9 +1929,8 @@ vars.AddVariables(
       <scons_example name="commandline_UnknownVariables">
         <file name="SConstruct" printme="1">
 vars = Variables(None)
-vars.Add('RELEASE', 'Set to 1 to build for release', 0)
-env = Environment(variables = vars,
-                  CPPDEFINES={'RELEASE_BUILD' : '${RELEASE}'})
+vars.Add('RELEASE', help='Set to 1 to build for release', default=0)
+env = Environment(variables=vars, CPPDEFINES={'RELEASE_BUILD': '${RELEASE}'})
 unknown = vars.UnknownVariables()
 if unknown:
     print("Unknown variables: %s"%unknown.keys())


### PR DESCRIPTION
* Apply current formatting styles for funcs/methods (that is, func/method name is marked up, instance name is marked up, params are marked up, each with the appropriate docbook tag.
* Word around the obsolete reference to built-in `cmp` function, which no longer exists in Python 3.  We should probably transtion the API towards taking a key function instead, since that conversion is already done internally.
* Clarify the way `AddVariables` is described - it takes a list of tuples, but that "list" isn't a Python list object, but rather one or more tuples, varargs-style.  Also describe the content of the tuples.
* Tweak some other wordings on variable helpers and validators.
* Rework userguide chapter examples to use keyword arguments for calls to `Add` and for the `*Variable` functions.
* Add a User Guide example of a help message that is more than a simple one (reuses an `EnumVariable` example) to illustrate that the generated help text is more than the help=helpstring.
* Word differently the back-reference to `Options` in the User Guide.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
