### PR TITLE
Add support for passing c++ flags through to Visual Studio project generation.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -115,6 +115,14 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Docbook builder provides a fallback if lxml fails to generate
       a document with tostring().
 
+  From James Benton:
+    - Improve Visual Studio solution/project generation code to add support
+      for a per-variant cppflags. Intellisense can be affected by cppflags,
+      this is especially important when it comes to /std:c++* which specifies
+      what C++ standard version to target. SCons will append /Zc:__cplusplus
+      to the project's cppflags when a /std:c++* flag is found as this is
+      required for intellisense to use the C++ standard version from cppflags.
+
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000
 

--- a/src/engine/SCons/Tool/msvs.xml
+++ b/src/engine/SCons/Tool/msvs.xml
@@ -145,6 +145,25 @@ See its __doc__ string for a discussion of the format.
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term>cppflags</term>
+          <listitem>
+            <para>
+              Compiler flags for the different variants.
+              If a /std:c++ flag is found then /Zc:__cplusplus is
+              appended to the flags if not already found, this
+              ensures that intellisense uses the /std:c++ switch.
+              The number of <literal>cppflags</literal> entries
+              must match the number of <literal>variant</literal>
+              entries, or be empty (not specified). If you give
+              only one, it will automatically be propagated to all
+              variants. If you don't give this parameter, SCons
+              will combine the invoking environment's
+              <literal>CCFLAGS</literal>, <literal>CXXFLAGS</literal>,
+              <literal>CPPFLAGS</literal> entries for all variants.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term>cpppaths</term>
           <listitem>
             <para>

--- a/src/engine/SCons/Tool/msvsTests.py
+++ b/src/engine/SCons/Tool/msvsTests.py
@@ -677,6 +677,9 @@ class msvsTestCase(unittest.TestCase):
         list_cppdefines = [['_A', '_B', 'C'], ['_B', '_C_'], ['D'], []]
         list_cpppaths = [[r'C:\test1'], [r'C:\test1;C:\test2'],
                          [self.fs.Dir('subdir')], []]
+        list_cppflags = [['/std:c++17', '/Zc:__cplusplus'],
+                         ['/std:c++14', '/Zc:__cplusplus'],
+                         ['/std:c++11', '/Zc:__cplusplus'], []]
 
         def TestParamsFromList(test_variant, test_list):
             """
@@ -716,36 +719,39 @@ class msvsTestCase(unittest.TestCase):
         tests_cmdargs = TestParamsFromList(list_variant, list_cmdargs)
         tests_cppdefines = TestParamsFromList(list_variant, list_cppdefines)
         tests_cpppaths = TestParamsFromList(list_variant, list_cpppaths)
+        tests_cppflags = TestParamsFromList(list_variant, list_cppflags)
 
         # Run the test for each test case
         for param_cmdargs, expected_cmdargs in tests_cmdargs:
             for param_cppdefines, expected_cppdefines in tests_cppdefines:
                 for param_cpppaths, expected_cpppaths in tests_cpppaths:
-                    debug('Testing %s. with :\n  variant = %s \n  cmdargs = "%s" \n  cppdefines = "%s" \n  cpppaths = "%s"' % \
-                          (str_function_test, list_variant, param_cmdargs, param_cppdefines, param_cpppaths))
-                    param_configs = []
-                    expected_configs = {}
-                    for platform in ['Win32', 'x64']:
-                        for variant in ['Debug', 'Release']:
-                            variant_platform = '%s|%s' % (variant, platform)
-                            runfile = '%s\\%s\\test.exe' % (platform, variant)
-                            buildtarget = '%s\\%s\\test.exe' % (platform, variant)
-                            outdir = '%s\\%s' % (platform, variant)
-            
-                            # Create parameter list for this variant_platform
-                            param_configs.append([variant_platform, runfile, buildtarget, outdir])
-            
-                            # Create expected dictionary result for this variant_platform
-                            expected_configs[variant_platform] = {
-                                'variant': variant,
-                                'platform': platform, 
-                                'runfile': runfile,
-                                'buildtarget': buildtarget, 
-                                'outdir': outdir,
-                                'cmdargs': expected_cmdargs[variant_platform],
-                                'cppdefines': expected_cppdefines[variant_platform],
-                                'cpppaths': expected_cpppaths[variant_platform],
-                            }
+                    for param_cppflags, expected_cppflags in tests_cppflags:
+                        print('Testing %s. with :\n  variant = %s \n  cmdargs = "%s" \n  cppdefines = "%s" \n  cpppaths = "%s" \n  cppflags = "%s"' % \
+                              (str_function_test, list_variant, param_cmdargs, param_cppdefines, param_cpppaths, param_cppflags))
+                        param_configs = []
+                        expected_configs = {}
+                        for platform in ['Win32', 'x64']:
+                            for variant in ['Debug', 'Release']:
+                                variant_platform = '%s|%s' % (variant, platform)
+                                runfile = '%s\\%s\\test.exe' % (platform, variant)
+                                buildtarget = '%s\\%s\\test.exe' % (platform, variant)
+                                outdir = '%s\\%s' % (platform, variant)
+
+                                # Create parameter list for this variant_platform
+                                param_configs.append([variant_platform, runfile, buildtarget, outdir])
+
+                                # Create expected dictionary result for this variant_platform
+                                expected_configs[variant_platform] = {
+                                    'variant': variant,
+                                    'platform': platform,
+                                    'runfile': runfile,
+                                    'buildtarget': buildtarget,
+                                    'outdir': outdir,
+                                    'cmdargs': expected_cmdargs[variant_platform],
+                                    'cppdefines': expected_cppdefines[variant_platform],
+                                    'cpppaths': expected_cpppaths[variant_platform],
+                                    'cppflags': expected_cppflags[variant_platform],
+                                }
 
             # Create parameter environment with final parameter dictionary
             param_dict = dict(list(zip(('variant', 'runfile', 'buildtarget', 'outdir'),
@@ -753,6 +759,7 @@ class msvsTestCase(unittest.TestCase):
             param_dict['cmdargs'] = param_cmdargs
             param_dict['cppdefines'] = param_cppdefines
             param_dict['cpppaths'] = param_cpppaths
+            param_dict['cppflags'] = param_cppflags
 
             # Hack to be able to run the test with a 'DummyEnv'
             class _DummyEnv(DummyEnv):


### PR DESCRIPTION
These flags can affect intellisense, for example if you are using C++17
you will have intellisense errors unless you set the appropriate compiler flags 
to inform inform intellisense of the C++ version you are using, e.g. /std:c++17
and /Zc:__cplusplus.

For more information see the page on /Zc:__cplusplus:
https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
