### PR TITLE
Resolve issue #3248 - removed '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS for gnulink 

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -32,6 +32,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Purge obsolete internal build and tooling scripts
     - Resolve Issue #3451 and Issue #3450 - Rewrite SCons setup.py and packaging. Move script logic to entry points so 
       package can create scripts which use the correct version of Python.
+    - Resolve Issue #3248 - Removing '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS
+      NOTE: If your build depends on the above you must now add to your SHLIBVERSIONFLAGS
+
     
   From Jeremy Elson:
     - Updated design doc to use the correct syntax for Depends()

--- a/src/RELEASE.txt
+++ b/src/RELEASE.txt
@@ -1,33 +1,9 @@
-  A new SCons checkpoint release, 3.1.3.alpha.yyyymmdd, is now available
+  A new SCons release, 4.0.0, is now available
   on the SCons download page:
 
           https://scons.org/pages/download.html
 
-  XXX The primary purpose of this release ... XXX
-
-  A SCons "checkpoint release" is intended to provide early access to
-  new features so they can be tested in the field before being released
-  for adoption by other software distributions.
-
-  Note that a checkpoint release is developed using the same test-driven
-  development methodology as all SCons releases.  Existing SCons
-  functionality should all work as it does in previous releases (except
-  for any changes identified in the release notes) and early adopters
-  should be able to use a checkpoint release safely for production work
-  with existing SConscript files.  If not, it represents not only a bug
-  in SCons but also a hole in the regression test suite, and we want to
-  hear about it.
-
-  New features may be more lightly tested than in past releases,
-  especially as concerns their interaction with all of the other
-  functionality in SCons.  We are especially interested in hearing bug
-  reports about new functionality.
-
-  We do not recommend that downstream distributions (Debian, Fedora,
-  etc.) package a checkpoint release, mainly to avoid confusing the
-  "public" release numbering with the long checkpoint release names.
-
-  Here is a summary of the changes since 1.3.0:
+  Here is a summary of the changes since 3.1.2:
 
   NEW FUNCTIONALITY
 
@@ -39,8 +15,9 @@
 
   CHANGED/ENHANCED EXISTING FUNCTIONALITY
 
-    - List modifications to existing features, where the previous behavior
-      wouldn't actually be considered a bug
+    - Resolve Issue #3248 - Removing '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS
+      NOTE: If your build depends on the above you must now add to your SHLIBVERSIONFLAGS
+
 
   FIXES
 

--- a/src/engine/SCons/Tool/gnulink.py
+++ b/src/engine/SCons/Tool/gnulink.py
@@ -35,9 +35,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.Util
 import SCons.Tool
-import os
 import sys
-import re
 
 from . import link
 
@@ -57,21 +55,22 @@ def generate(env):
 
     # OpenBSD doesn't usually use SONAME for libraries
     use_soname = not sys.platform.startswith('openbsd')
-    link._setup_versioned_lib_variables(env, tool = 'gnulink', use_soname = use_soname)
+    link._setup_versioned_lib_variables(env, tool='gnulink', use_soname=use_soname)
     env['LINKCALLBACKS'] = link._versioned_lib_callbacks()
 
-    # For backward-compatibility with older SCons versions
-    env['SHLIBVERSIONFLAGS'] = SCons.Util.CLVar('-Wl,-Bsymbolic')
-    
+    # # For backward-compatibility with older SCons versions
+    # env['SHLIBVERSIONFLAGS'] = SCons.Util.CLVar('')
+
+
 def exists(env):
     # TODO: sync with link.smart_link() to choose a linker
-    linkers = { 'CXX': ['g++'], 'CC': ['gcc'] }
+    linkers = {'CXX': ['g++'], 'CC': ['gcc']}
     alltools = []
     for langvar, linktools in linkers.items():
-        if langvar in env: # use CC over CXX when user specified CC but not CXX
+        if langvar in env:  # use CC over CXX when user specified CC but not CXX
             return SCons.Tool.FindTool(linktools, env)
         alltools.extend(linktools)
-    return SCons.Tool.FindTool(alltools, env) # find CXX or CC
+    return SCons.Tool.FindTool(alltools, env)  # find CXX or CC
 
 # Local Variables:
 # tab-width:4

--- a/test/LINK/LDMODULEVERSIONFLAGS.py
+++ b/test/LINK/LDMODULEVERSIONFLAGS.py
@@ -40,7 +40,7 @@ tool_list = SCons.Platform.DefaultToolList(platform, env)
 
 test = TestSCons.TestSCons()
 if 'gnulink' in tool_list:
-    versionflags = r".+ -Wl,-Bsymbolic -Wl,-soname=libfoo.so.1( .+)+"
+    versionflags = r".+ -Wl,-soname=libfoo.so.1( .+)+"
 elif 'sunlink' in tool_list:
     versionflags = r".+ -h libfoo.so.1( .+)+"
 else:

--- a/test/LINK/SHLIBVERSIONFLAGS.py
+++ b/test/LINK/SHLIBVERSIONFLAGS.py
@@ -39,7 +39,7 @@ tool_list = SCons.Platform.DefaultToolList(platform, env)
 
 test = TestSCons.TestSCons()
 if 'gnulink' in tool_list:
-    versionflags = r".+ -Wl,-Bsymbolic -Wl,-soname=libfoo.so.1( .+)+"
+    versionflags = r".+ -Wl,-soname=libfoo.so.1( .+)+"
 elif 'sunlink' in tool_list:
     versionflags = r".+ -h libfoo.so.1( .+)+"
 elif 'applelink' in tool_list:


### PR DESCRIPTION
Resolve issue #3248  - removed '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS for gnulink 

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
