### PR TITLE
tests: use unittest decorator for skipping

### DIFF
--- a/src/engine/SCons/Node/FSTests.py
+++ b/src/engine/SCons/Node/FSTests.py
@@ -707,26 +707,27 @@ class BaseTestCase(_tempdirTestCase):
         nonexistent = fs.Entry('nonexistent')
         assert not nonexistent.isfile()
 
-    if sys.platform != 'win32' and hasattr(os, 'symlink'):
-        def test_islink(self):
-            """Test the Base.islink() method"""
-            test = self.test
-            test.subdir('dir')
-            test.write("file", "file\n")
-            test.symlink("symlink", "symlink")
-            fs = SCons.Node.FS.FS()
+    @unittest.skipUnless(sys.platform != 'win32' and hasattr(os, 'symlink'),
+                         "symlink is not used on Windows")
+    def test_islink(self):
+        """Test the Base.islink() method"""
+        test = self.test
+        test.subdir('dir')
+        test.write("file", "file\n")
+        test.symlink("symlink", "symlink")
+        fs = SCons.Node.FS.FS()
 
-            dir = fs.Entry('dir')
-            assert not dir.islink()
+        dir = fs.Entry('dir')
+        assert not dir.islink()
 
-            file = fs.Entry('file')
-            assert not file.islink()
+        file = fs.Entry('file')
+        assert not file.islink()
 
-            symlink = fs.Entry('symlink')
-            assert symlink.islink()
+        symlink = fs.Entry('symlink')
+        assert symlink.islink()
 
-            nonexistent = fs.Entry('nonexistent')
-            assert not nonexistent.islink()
+        nonexistent = fs.Entry('nonexistent')
+        assert not nonexistent.islink()
 
 
 class DirNodeInfoTestCase(_tempdirTestCase):
@@ -1339,13 +1340,15 @@ class FSTestCase(_tempdirTestCase):
         # get_contents() returns the binary contents.
         test.write("binary_file", "Foo\x1aBar")
         f1 = fs.File(test.workpath("binary_file"))
-        assert f1.get_contents() == bytearray("Foo\x1aBar", 'utf-8'), f1.get_contents()
+        assert f1.get_contents() == bytearray("Foo\x1aBar", 'utf-8'), \
+            f1.get_contents()
 
         # This tests to make sure we can decode UTF-8 text files.
         test_string = "Foo\x1aBar"
         test.write("utf8_file", test_string.encode('utf-8'))
         f1 = fs.File(test.workpath("utf8_file"))
-        f1.get_text_contents() == "Foo\x1aBar", f1.get_text_contents()
+        assert f1.get_text_contents() == "Foo\x1aBar", \
+            f1.get_text_contents()
 
         # Check for string which doesn't have BOM and isn't valid
         # ASCII
@@ -1846,10 +1849,9 @@ class FSTestCase(_tempdirTestCase):
         d = root._lookup_abs('/tmp/foo-nonexistent/nonexistent-dir', SCons.Node.FS.Dir)
         assert d.__class__ == SCons.Node.FS.Dir, str(d.__class__)
 
+    @unittest.skipUnless(sys.platform == "win32", "requires Windows")
     def test_lookup_uncpath(self):
         """Testing looking up a UNC path on Windows"""
-        if sys.platform not in ('win32',):
-            return
         test = self.test
         fs = self.fs
         path = '//servername/C$/foo'
@@ -1859,19 +1861,17 @@ class FSTestCase(_tempdirTestCase):
         assert str(f) == r'\\servername\C$\foo', \
             'UNC path %s got looked up as %s' % (path, f)
 
+    @unittest.skipUnless(sys.platform.startswith == "win32", "requires Windows")
     def test_unc_drive_letter(self):
         """Test drive-letter lookup for windows UNC-style directories"""
-        if sys.platform not in ('win32',):
-            return
         share = self.fs.Dir(r'\\SERVER\SHARE\Directory')
         assert str(share) == r'\\SERVER\SHARE\Directory', str(share)
 
+    @unittest.skipUnless(sys.platform == "win32", "requires Windows")
     def test_UNC_dirs_2689(self):
         """Test some UNC dirs that printed incorrectly and/or caused
         infinite recursion errors prior to r5180 (SCons 2.1)."""
         fs = self.fs
-        if sys.platform not in ('win32',):
-            return
         p = fs.Dir(r"\\computername\sharename").get_abspath()
         assert p == r"\\computername\sharename", p
         p = fs.Dir(r"\\\computername\sharename").get_abspath()


### PR DESCRIPTION
FSTests updated to use the suggested way of skipping tests - a decorator which does the check up front, rather than a manual check inside the function. Effect: test run will show 's' rather than '-' on skipped tests.

Restored an assert that got dropped in a previous change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
