### PR TITLE
Use uuid lib for Visual Studio guids

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -120,6 +120,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - MSVC updates: pass on VSCMD_DEBUG and VSCMD_SKIP_SENDTELEMETRY to msvc
       tool setup if set in environment. Add powershell to default env
       (used to call telemetry script).
+    - MSVS - use the uuid module to generate GUIDs rather than hand rolled
+      method using md5 directly.
     - Docbook builder provides a fallback if lxml fails to generate
       a document with tostring().
 

--- a/src/engine/SCons/CacheDir.py
+++ b/src/engine/SCons/CacheDir.py
@@ -27,7 +27,6 @@ __doc__ = """
 CacheDir support
 """
 
-import hashlib
 import json
 import os
 import stat

--- a/src/engine/SCons/Tool/packaging/msi.py
+++ b/src/engine/SCons/Tool/packaging/msi.py
@@ -161,7 +161,7 @@ def generate_guids(root):
     To handle this requirement, the uuid is generated with an md5 hashing the
     whole subtree of a xml node.
     """
-    from hashlib import md5
+    import uuid
 
     # specify which tags need a guid and in which attribute this should be stored.
     needs_id = { 'Product'   : 'Id',
@@ -175,10 +175,8 @@ def generate_guids(root):
         node_list = root.getElementsByTagName(key)
         attribute = value
         for node in node_list:
-            hash = md5(node.toxml()).hexdigest()
-            hash_str = '%s-%s-%s-%s-%s' % ( hash[:8], hash[8:12], hash[12:16], hash[16:20], hash[20:] )
-            node.attributes[attribute] = hash_str
-
+            hash = uuid.uuid5(uuid.NAMESPACE_URL, node.toxml())
+            node.attributes[attribute] = str(hash)
 
 
 def string_wxsfile(target, source, env):

--- a/src/engine/SCons/Util.py
+++ b/src/engine/SCons/Util.py
@@ -1538,7 +1538,6 @@ def silent_intern(x):
         return x
 
 
-
 # From Dinu C. Gherman,
 # Python Cookbook, second edition, recipe 6.17, p. 277.
 # Also:
@@ -1568,6 +1567,7 @@ class Null(object):
         return self
     def __delattr__(self, name):
         return self
+
 
 class NullSeq(Null):
     def __len__(self):

--- a/test/MSVS/vs-7.0-variant_dir.py
+++ b/test/MSVS/vs-7.0-variant_dir.py
@@ -56,7 +56,7 @@ test.write(['src', 'SConscript'], SConscript_contents%{'HOST_ARCH': host_arch})
 
 test.run(arguments=".")
 
-project_guid = "{25F6CE89-8E22-2910-8B6E-FFE6DC1E2792}"
+project_guid = "{CB4637F1-2205-50B7-B115-DCFA0DA68FB1}"
 vcproj = test.read(['src', 'Test.vcproj'], 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct',
                               project_guid=project_guid)

--- a/test/MSVS/vs-7.1-variant_dir.py
+++ b/test/MSVS/vs-7.1-variant_dir.py
@@ -56,7 +56,7 @@ test.write(['src', 'SConscript'], SConscript_contents%{'HOST_ARCH': host_arch})
 
 test.run(arguments=".")
 
-project_guid = "{25F6CE89-8E22-2910-8B6E-FFE6DC1E2792}"
+project_guid = "{CB4637F1-2205-50B7-B115-DCFA0DA68FB1}"
 vcproj = test.read(['src', 'Test.vcproj'], 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct',
                               project_guid=project_guid)

--- a/test/MSVS/vs-variant_dir.py
+++ b/test/MSVS/vs-variant_dir.py
@@ -58,7 +58,7 @@ SConscript('src/SConscript', variant_dir='build')
 
     test.run(arguments=".")
 
-    project_guid = "{25F6CE89-8E22-2910-8B6E-FFE6DC1E2792}"
+    project_guid = "{CB4637F1-2205-50B7-B115-DCFA0DA68FB1}"
     vcproj = test.read(['src', project_file], 'r')
     expect = test.msvs_substitute(expected_vcprojfile, vc_version, None, 'SConstruct',
                                   project_guid=project_guid)

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -699,7 +699,7 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
             python = sys.executable
 
         if project_guid is None:
-            project_guid = "{E5466E26-0003-F18B-8F8A-BCD76C86388D}"
+            project_guid = "{B0CC4EE9-0174-51CD-A06A-41D0713E928A}"
 
         if 'SCONS_LIB_DIR' in os.environ:
             exec_script_main = "from os.path import join; import sys; sys.path = [ r'%s' ] + sys.path; import SCons.Script; SCons.Script.main()" % os.environ['SCONS_LIB_DIR']


### PR DESCRIPTION
In the Visual Studio area, use uuid (Python standard library) to generate GUID identifiers instead of specifically using md5. Simplifies things as uuid lib can provide already formatted strings of the form that we need.

This is split off from PR #3447 by request.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `src/CHANGES.txt` (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
