### PR TITLE
python tool not default + minor wording tweaks

### DIFF
--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -1275,13 +1275,17 @@ def tool_list(platform, env):
         'tar', 'zip',
         # File builders (text)
         'textfile',
-        # Python scanner tool
-        'python',
     ], env)
 
-    tools = ([linker, c_compiler, cxx_compiler,
-              fortran_compiler, assembler, ar, d_compiler]
-             + other_tools)
+    tools = [
+        linker,
+        c_compiler,
+        cxx_compiler,
+        fortran_compiler,
+        assembler,
+        ar,
+        d_compiler,
+    ] + other_tools
 
     return [x for x in tools if x]
 

--- a/SCons/Tool/python.xml
+++ b/SCons/Tool/python.xml
@@ -31,6 +31,7 @@ When loaded, the scanner will attempt to find implicit
 dependencies for any Python source files in the list of sources
 provided to an Action that uses this environment.
 </para>
+<para><emphasis>Available since &scons; 4.0.</emphasis>.</para>
 </summary>
 </tool>
 

--- a/SCons/Tool/python.xml
+++ b/SCons/Tool/python.xml
@@ -26,9 +26,10 @@ See its __doc__ string for a discussion of the format.
 <tool name="python">
 <summary>
 <para>
-Loads the Python scanner scanner into the invoking environment. When loaded, the scanner will
-attempt to find implicit dependencies for any Python source files in the list of sources
-provided to an actual that uses this environment.
+Loads the Python source scanner into the invoking environment.
+When loaded, the scanner will attempt to find implicit
+dependencies for any Python source files in the list of sources
+provided to an Action that uses this environment.
 </para>
 </summary>
 </tool>


### PR DESCRIPTION
Do not add the python tool (which adds Python suffices to `SourceFileScanner`) in the list of default tools. At the moment, it causes problems for SCons' own documentation build.

Minor wording fix in python tool doc.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
