### PR TITLE
Some more fixups for project directory moves

### DIFF
--- a/README-SF.rst
+++ b/README-SF.rst
@@ -38,7 +38,7 @@ information:
 Latest Version
 ==============
 
-Before going further, you can check that this package you have is the latest
+Before going further, you can check that the package you have is the latest
 version at the SCons download page:
 
         http://www.scons.org/pages/download.html
@@ -47,13 +47,14 @@ version at the SCons download page:
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.5 or higher.
-There should be no other dependencies or requirements to run SCons.
+Running SCons requires Python 3.5 or higher. There should be no other
+dependencies or requirements to run scons, although the pywin32 Python
+package is strongly recommended if running on Windows systems.
 
 The default SCons configuration assumes use of the Microsoft Visual C++
-compiler suite on WIN32 systems, and assumes a C compiler named 'cc', a C++
-compiler named 'c++', and a Fortran compiler named 'g77' (such as found in the
-GNU C compiler suite) on any other type of system.  You may, of course,
+compiler suite on Win32 systems, and assumes a C compiler named 'cc', a C++
+compiler named 'c++', and a Fortran compiler named 'gfortran' (such as found
+in the GNU C compiler suite) on any other type of system.  You may, of course,
 override these default values by appropriate configuration of Environment
 construction variables.
 
@@ -72,29 +73,29 @@ Nothing special.
 Executing SCons Without Installing
 ==================================
 
-You can execute the local SCons directly from the src/ subdirectory by first
-setting the SCONS_LIB_DIR environment variable to the local src/engine
-subdirectory, and then executing the local src/script/scons.py script to
+You can execute the local SCons directly from the SCons subdirectory by first
+setting the SCONS_LIB_DIR environment variable to the local SCons
+subdirectory, and then executing the local scripts/scons.py script to
 populate the build/scons/ subdirectory.  You would do this as follows on a
 Linux or UNIX system (using sh or a derivative like bash or ksh)::
 
         $ setenv MYSCONS=`pwd`
-        $ python $MYSCONS/script/scons.py [arguments]
+        $ python $MYSCONS/scripts/scons.py [arguments]
 
 Or on Windows::
 
-        C:\scons>set MYSCONS=%cd%\src
-        C:\scons>python %MYSCONS%\script\scons.py [arguments]
+        C:\scons>set MYSCONS=%cd%
+        C:\scons>python %MYSCONS%\scripts\scons.py [arguments]
 
 An alternative approach is to skip the above and use::
 
-        $ python script/scons.py [arguments]
+        $ python scripts/scons.py [arguments]
 
 
 You can use the -C option to have SCons change directory to another location
 where you already have a build configuration set up::
 
-    $ python script/scons.py -C /some/other/location [arguments]
+    $ python scripts/scons.py -C /some/other/location [arguments]
 
 For simplicity in the following examples, we will only show the bootstrap.py
 approach.
@@ -146,23 +147,22 @@ Because SCons is implemented in a scripting language, you don't need to build
 it in order to make changes and test them.
 
 Virtually all of the SCons functionality exists in the "build engine," the
-src/engine/SCons subdirectory hierarchy that contains all of the modules that
-make up SCons.  The script/scons.py wrapper script exists mainly to find
+SCons subdirectory hierarchy that contains all of the modules that
+make up SCons.  The scripts/scons.py wrapper script exists mainly to find
 the appropriate build engine library and then execute it.
 
 In order to make your own changes locally and test them by hand, simply edit
-modules in the local src/engine/SCons subdirectory tree and use the local
-bootstrap.py script (see the section above about `Executing SCons Without
-Installing`_)::
+modules in the local SCons subdirectory tree and then running
+(see the section above about `Executing SCons Without Installing`_)::
 
-    $ python script/scons.py [arguments]
+    $ python scripts/scons.py [arguments]
 
 If you want to be able to just execute your modified version of SCons from the
 command line, you can make it executable and add its directory to your $PATH
 like so::
 
-    $ chmod 755 script/scons.py
-    $ export PATH=$PATH:`pwd`/script
+    $ chmod 755 scripts/scons.py
+    $ export PATH=$PATH:`pwd`/scripts
 
 You should then be able to run this version of SCons by just typing "scons.py"
 at your UNIX or Linux command line.
@@ -182,13 +182,13 @@ Python comes with a good interactive debugger.  When debugging changes by hand
 of the Python debugger by specifying the --debug=pdb option::
 
     $ scons --debug=pdb [arguments]
-    > /home/knight/SCons/src/engine/SCons/Script/Main.py(927)_main()
+    > /home/knight/scons/SCons/Script/Main.py(927)_main()
     -> default_warnings = [ SCons.Warnings.CorruptSConsignWarning,
     (Pdb)
 
 Once in the debugger, you can set breakpoints at lines in files in the build
 engine modules by providing the path name of the file relative to the
-src/engine subdirectory (that is, including the SCons/ as the first directory
+top directory (that is, including the SCons/ as the first directory
 component)::
 
     (Pdb) b SCons/Tool/msvc.py:158
@@ -205,9 +205,11 @@ call within a test script.
 The most effective technique for debugging problems that occur during an
 automated test is to use the good old tried-and-true technique of adding
 statements to print tracing information.  But note that you can't just use
-"print" statement, or even "sys.stdout.write()" because those change the
+the "print" function, or even "sys.stdout.write()" because those change the
 SCons output, and the automated tests usually look for matches of specific
-output strings to decide if a given SCons invocations passes the test.
+output strings to decide if a given SCons invocation passes the test -
+so these additions may cause apparent failures different than the one you
+are trying to debug.
 
 To deal with this, SCons supports a Trace() function that (by default) will
 print messages to your console screen ("/dev/tty" on UNIX or Linux, "con" on
@@ -241,8 +243,8 @@ Tests are run by the runtest.py script in this directory.
 
 There are two types of tests in this package:
 
-1. Unit tests for individual SCons modules live underneath the src/engine/
-   subdirectory and are the same base name as the module with "Tests.py"
+1. Unit tests for individual SCons modules live underneath the SCons
+   subdirectory and have the same base name as the module with "Tests.py"
    appended--for example, the unit test for the Builder.py module is the
    BuilderTests.py script.
 
@@ -250,7 +252,7 @@ There are two types of tests in this package:
 
 You may specifically list one or more tests to be run::
 
-        $ python runtest.py src/engine/SCons/BuilderTests.py
+        $ python runtest.py SCons/BuilderTests.py
 
         $ python runtest.py test/option-j.py test/Program.py
 
@@ -276,9 +278,8 @@ If more than one test is run, the runtest.py script prints a summary of how
 many tests passed, failed, or yielded no result, and lists any unsuccessful
 tests.
 
-The above invocations all test directly the files underneath the src/
+The above invocations all test directly the files underneath the SCons/
 subdirectory, and do not require that a build be performed first.
-
 
 Development Workflow
 ====================
@@ -306,21 +307,21 @@ platform, Windows users can translate as appropriate)):
 - Confirm that the bug still exists in this version of SCons by using the -C
    option to run the broken build::
 
-      $ python script/scons.py -C /home/me/broken_project .
+      $ python scripts/scons.py -C /home/me/broken_project .
 
 - Fix the bug in SCons by editing appropriate module files underneath
-  src/engine/SCons.
+  SCons.
 
 - Confirm that you've fixed the bug affecting your project::
 
-      $ python script/scons.py -C /home/me/broken_project .
+      $ python scripts/scons.py -C /home/me/broken_project .
 
 - Test to see if your fix had any unintended side effects that break existing
   functionality::
 
       $ python runtest.py -a -o test.log
 
-  Be patient, there are more than 700 test scripts in the whole suite.  If you
+  Be patient, there are more than 1100 test scripts in the whole suite.  If you
   are on UNIX/Linux, you can use::
 
       $ python runtest.py -a | tee test.log
@@ -330,7 +331,9 @@ platform, Windows users can translate as appropriate)):
   If any test scripts fail, they will be listed in a summary at the end of the
   log file.  Some test scripts may also report NO RESULT because (for example)
   your local system is the wrong type or doesn't have some installed utilities
-  necessary to run the script.  In general, you can ignore the NO RESULT list.
+  necessary to run the script.  In general, you can ignore the NO RESULT list,
+  beyond having checked once that the tests that matter to your change are
+  actually being executed on your test system!
 
 - Cut-and-paste the list of failed tests into a file::
 
@@ -357,7 +360,7 @@ platform, Windows users can translate as appropriate)):
   the tests to pass didn't break the fix you originally put in, and didn't
   introduce any *additional* unintended side effects that broke other tests::
 
-      $ python script/scons.py -C /home/me/broken_project .
+      $ python scripts/scons.py -C /home/me/broken_project .
       $ python runtest.py -a -o test.log
 
   If you find any newly-broken tests, add them to your "failed.txt" file and
@@ -383,7 +386,7 @@ If you don't have SCons already installed on your
 system, you can use the supplied bootstrap.py script (see the section above
 about `Executing SCons Without Installing`_)::
 
-        $ python script/scons.py build/scons
+        $ python scripts/scons.py build/scons
 
 Depending on the utilities installed on your system, any or all of the
 following packages will be built::
@@ -473,7 +476,7 @@ README-local
 
 runtest.py
     Script for running SCons tests.  By default, this will run a test against
-    the code in the local src/ tree, so you don't have to do a build before
+    the code in the local SCons tree, so you don't have to do a build before
     testing your changes.
 
 SConstruct
@@ -487,13 +490,13 @@ SConstruct
     this file for an example of how easy it is to use SCons to build "normal"
     software.)
 
-src/
+SCons/
     Where the actual source code is kept, of course.
 
 test/
     End-to-end tests of the SCons utility itself.  These are separate from the
     individual module unit tests, which live side-by-side with the modules
-    under src/.
+    under SCons.
 
 testing/
     SCons testing framework.
@@ -501,8 +504,8 @@ testing/
 Documentation
 =============
 
-See the src/RELEASE.txt file for notes about this specific release, including
-known problems.  See the src/CHANGES.txt file for a list of changes since the
+See the RELEASE.txt file for notes about this specific release, including
+known problems.  See the CHANGES.txt file for a list of changes since the
 previous release.
 
 The doc/man/scons.1 man page is included in this package, and contains a

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ information:
 Latest Version
 ==============
 
-Before going further, you can check that this package you have is the latest
+Before going further, you can check that the package you have is the latest
 version at the SCons download page:
 
         http://www.scons.org/pages/download.html
@@ -72,13 +72,14 @@ version at the SCons download page:
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.5 or higher.
-There should be no other dependencies or requirements to run SCons.
+Running SCons requires Python 3.5 or higher. There should be no other
+dependencies or requirements to run scons, although the pywin32 Python
+package is strongly recommended if running on Windows systems.
 
 The default SCons configuration assumes use of the Microsoft Visual C++
-compiler suite on WIN32 systems, and assumes a C compiler named 'cc', a C++
-compiler named 'c++', and a Fortran compiler named 'g77' (such as found in the
-GNU C compiler suite) on any other type of system.  You may, of course,
+compiler suite on Win32 systems, and assumes a C compiler named 'cc', a C++
+compiler named 'c++', and a Fortran compiler named 'gfortran' (such as found
+in the GNU C compiler suite) on any other type of system.  You may, of course,
 override these default values by appropriate configuration of Environment
 construction variables.
 
@@ -97,29 +98,29 @@ Nothing special.
 Executing SCons Without Installing
 ==================================
 
-You can execute the local SCons directly from the src/ subdirectory by first
-setting the SCONS_LIB_DIR environment variable to the local src/engine
-subdirectory, and then executing the local src/script/scons.py script to
+You can execute the local SCons directly from the SCons subdirectory by first
+setting the SCONS_LIB_DIR environment variable to the local SCons
+subdirectory, and then executing the local scripts/scons.py script to
 populate the build/scons/ subdirectory.  You would do this as follows on a
 Linux or UNIX system (using sh or a derivative like bash or ksh)::
 
         $ setenv MYSCONS=`pwd`
-        $ python $MYSCONS/script/scons.py [arguments]
+        $ python $MYSCONS/scripts/scons.py [arguments]
 
 Or on Windows::
 
-        C:\scons>set MYSCONS=%cd%\src
-        C:\scons>python %MYSCONS%\script\scons.py [arguments]
+        C:\scons>set MYSCONS=%cd%
+        C:\scons>python %MYSCONS%\scripts\scons.py [arguments]
 
 An alternative approach is to skip the above and use::
 
-        $ python script/scons.py [arguments]
+        $ python scripts/scons.py [arguments]
 
 
 You can use the -C option to have SCons change directory to another location
 where you already have a build configuration set up::
 
-    $ python script/scons.py -C /some/other/location [arguments]
+    $ python scripts/scons.py -C /some/other/location [arguments]
 
 For simplicity in the following examples, we will only show the bootstrap.py
 approach.
@@ -171,23 +172,22 @@ Because SCons is implemented in a scripting language, you don't need to build
 it in order to make changes and test them.
 
 Virtually all of the SCons functionality exists in the "build engine," the
-src/engine/SCons subdirectory hierarchy that contains all of the modules that
-make up SCons.  The script/scons.py wrapper script exists mainly to find
+SCons subdirectory hierarchy that contains all of the modules that
+make up SCons.  The scripts/scons.py wrapper script exists mainly to find
 the appropriate build engine library and then execute it.
 
 In order to make your own changes locally and test them by hand, simply edit
-modules in the local src/engine/SCons subdirectory tree and use the local
-bootstrap.py script (see the section above about `Executing SCons Without
-Installing`_)::
+modules in the local SCons subdirectory tree and then running
+(see the section above about `Executing SCons Without Installing`_)::
 
-    $ python script/scons.py [arguments]
+    $ python scripts/scons.py [arguments]
 
 If you want to be able to just execute your modified version of SCons from the
 command line, you can make it executable and add its directory to your $PATH
 like so::
 
-    $ chmod 755 script/scons.py
-    $ export PATH=$PATH:`pwd`/script
+    $ chmod 755 scripts/scons.py
+    $ export PATH=$PATH:`pwd`/scripts
 
 You should then be able to run this version of SCons by just typing "scons.py"
 at your UNIX or Linux command line.
@@ -207,13 +207,13 @@ Python comes with a good interactive debugger.  When debugging changes by hand
 of the Python debugger by specifying the --debug=pdb option::
 
     $ scons --debug=pdb [arguments]
-    > /home/knight/SCons/src/engine/SCons/Script/Main.py(927)_main()
+    > /home/knight/scons/SCons/Script/Main.py(927)_main()
     -> default_warnings = [ SCons.Warnings.CorruptSConsignWarning,
     (Pdb)
 
 Once in the debugger, you can set breakpoints at lines in files in the build
 engine modules by providing the path name of the file relative to the
-src/engine subdirectory (that is, including the SCons/ as the first directory
+top directory (that is, including the SCons/ as the first directory
 component)::
 
     (Pdb) b SCons/Tool/msvc.py:158
@@ -230,9 +230,11 @@ call within a test script.
 The most effective technique for debugging problems that occur during an
 automated test is to use the good old tried-and-true technique of adding
 statements to print tracing information.  But note that you can't just use
-"print" statement, or even "sys.stdout.write()" because those change the
+the "print" function, or even "sys.stdout.write()" because those change the
 SCons output, and the automated tests usually look for matches of specific
-output strings to decide if a given SCons invocations passes the test.
+output strings to decide if a given SCons invocation passes the test -
+so these additions may cause apparent failures different than the one you
+are trying to debug.
 
 To deal with this, SCons supports a Trace() function that (by default) will
 print messages to your console screen ("/dev/tty" on UNIX or Linux, "con" on
@@ -266,8 +268,8 @@ Tests are run by the runtest.py script in this directory.
 
 There are two types of tests in this package:
 
-1. Unit tests for individual SCons modules live underneath the src/engine/
-   subdirectory and are the same base name as the module with "Tests.py"
+1. Unit tests for individual SCons modules live underneath the SCons
+   subdirectory and have the same base name as the module with "Tests.py"
    appended--for example, the unit test for the Builder.py module is the
    BuilderTests.py script.
 
@@ -275,7 +277,7 @@ There are two types of tests in this package:
 
 You may specifically list one or more tests to be run::
 
-        $ python runtest.py src/engine/SCons/BuilderTests.py
+        $ python runtest.py SCons/BuilderTests.py
 
         $ python runtest.py test/option-j.py test/Program.py
 
@@ -302,7 +304,7 @@ many tests passed, failed, or yielded no result, and lists any unsuccessful
 tests.
 
 The above invocations all test directly the files underneath the SCons/
-subdirectory, and do not require that a build be performed first. 
+subdirectory, and do not require that a build be performed first.
 
 Development Workflow
 ====================
@@ -330,21 +332,21 @@ platform, Windows users can translate as appropriate)):
 - Confirm that the bug still exists in this version of SCons by using the -C
    option to run the broken build::
 
-      $ python script/scons.py -C /home/me/broken_project .
+      $ python scripts/scons.py -C /home/me/broken_project .
 
 - Fix the bug in SCons by editing appropriate module files underneath
   SCons.
 
 - Confirm that you've fixed the bug affecting your project::
 
-      $ python script/scons.py -C /home/me/broken_project .
+      $ python scripts/scons.py -C /home/me/broken_project .
 
 - Test to see if your fix had any unintended side effects that break existing
   functionality::
 
       $ python runtest.py -a -o test.log
 
-  Be patient, there are more than 700 test scripts in the whole suite.  If you
+  Be patient, there are more than 1100 test scripts in the whole suite.  If you
   are on UNIX/Linux, you can use::
 
       $ python runtest.py -a | tee test.log
@@ -354,7 +356,9 @@ platform, Windows users can translate as appropriate)):
   If any test scripts fail, they will be listed in a summary at the end of the
   log file.  Some test scripts may also report NO RESULT because (for example)
   your local system is the wrong type or doesn't have some installed utilities
-  necessary to run the script.  In general, you can ignore the NO RESULT list.
+  necessary to run the script.  In general, you can ignore the NO RESULT list,
+  beyond having checked once that the tests that matter to your change are
+  actually being executed on your test system!
 
 - Cut-and-paste the list of failed tests into a file::
 
@@ -381,7 +385,7 @@ platform, Windows users can translate as appropriate)):
   the tests to pass didn't break the fix you originally put in, and didn't
   introduce any *additional* unintended side effects that broke other tests::
 
-      $ python script/scons.py -C /home/me/broken_project .
+      $ python scripts/scons.py -C /home/me/broken_project .
       $ python runtest.py -a -o test.log
 
   If you find any newly-broken tests, add them to your "failed.txt" file and
@@ -407,7 +411,7 @@ If you don't have SCons already installed on your
 system, you can use the supplied bootstrap.py script (see the section above
 about `Executing SCons Without Installing`_)::
 
-        $ python script/scons.py build/scons
+        $ python scripts/scons.py build/scons
 
 Depending on the utilities installed on your system, any or all of the
 following packages will be built::
@@ -525,8 +529,8 @@ testing/
 Documentation
 =============
 
-See the src/RELEASE.txt file for notes about this specific release, including
-known problems.  See the src/CHANGES.txt file for a list of changes since the
+See the RELEASE.txt file for notes about this specific release, including
+known problems.  See the CHANGES.txt file for a list of changes since the
 previous release.
 
 The doc/man/scons.1 man page is included in this package, and contains a

--- a/bin/scons-time.py
+++ b/bin/scons-time.py
@@ -1246,7 +1246,11 @@ class SConsTimer(object):
         return os.path.join(dir, 'scripts', 'scons.py')
 
     def scons_lib_dir_path(self, dir):
-        return os.path.join(dir, 'src', 'engine')
+        """build the path to the engine.
+
+        this used to join src/engine, but no longer.
+        """
+        return dir
 
     def prep_subversion_run(self, commands, removals):
         self.svn_tmpdir = tempfile.mkdtemp(prefix=self.name + '-svn-')

--- a/test/Interactive/configure.py
+++ b/test/Interactive/configure.py
@@ -21,7 +21,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify basic operation of the --interactive command line option to build
@@ -29,6 +28,8 @@ a target, while using a Configure context within the environment.
 
 Also tests that "b" can be used as a synonym for "build".
 """
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -118,15 +119,15 @@ test.finish(scons, stdout = expect_stdout, match=TestSCons.match_re)
 
 test.pass_test()
 
+
+# not used: just record here to help debugging the expect_stdout pattern
 actual_output_to_be_handled="""
-Actual output
-python3.6 ~/devel/scons/hg/scons/src/script/scons.py -Q --interactive
 scons>>> build foo.obj
-/opt/local/bin/python3.6 mycc.py foo.obj foo.cpp
+/usr/bin/python3 mycc.py foo.obj foo.cpp
 scons>>> build foo.obj
 scons: `foo.obj' is up to date.
 scons>>> b foo.obj
-/opt/local/bin/python3.6 mycc.py foo.obj foo.cpp
+/usr/bin/python3 mycc.py foo.obj foo.cpp
 scons>>> build foo.obj
 scons: `foo.obj' is up to date.
 scons>>>

--- a/test/scons-time/run/config/targets.py
+++ b/test/scons-time/run/config/targets.py
@@ -22,18 +22,18 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 """
 Verify specifying a list of targets through a config file.
 """
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import re
 
 import TestSCons_time
 
-test = TestSCons_time.TestSCons_time(match = TestSCons_time.match_re)
+test = TestSCons_time.TestSCons_time(match=TestSCons_time.match_re)
 
 test.write_fake_scons_py()
 
@@ -46,12 +46,12 @@ targets = 'target1 target2'
 test.run(arguments = 'run -f config foo.tar.gz')
 
 scons_py = re.escape(test.workpath('scripts', 'scons.py'))
-src_engine  = re.escape(test.workpath('src', 'engine'))
+src_engine = re.escape(test.workpath())
 
-prof1       = re.escape(test.workpath('foo-000-1.prof'))
-prof2       = re.escape(test.workpath('foo-000-2.prof'))
+prof1 = re.escape(test.workpath('foo-000-1.prof'))
+prof2 = re.escape(test.workpath('foo-000-2.prof'))
 
-sep         = re.escape(os.sep)
+sep = re.escape(os.sep)
 
 expect = """\
 %(scons_py)s

--- a/test/scons-time/run/option/quiet.py
+++ b/test/scons-time/run/option/quiet.py
@@ -64,6 +64,15 @@ test.must_exist('foo-000-0.log',
                 'foo-000-2.log',
                 'foo-000-2.prof')
 
+test.run(arguments='run -q foo.tar.gz', stdout=expect)
+
+test.must_exist('foo-001-0.log',
+                'foo-001-0.prof',
+                'foo-001-1.log',
+                'foo-001-1.prof',
+                'foo-001-2.log',
+                'foo-001-2.prof')
+
 test.run(arguments='run --quiet foo.tar.gz', stdout=expect)
 
 test.pass_test()

--- a/test/scons-time/run/option/quiet.py
+++ b/test/scons-time/run/option/quiet.py
@@ -22,11 +22,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 """
 Verify that the run -q and --quiet options suppress build output.
 """
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import re
 
@@ -34,11 +34,11 @@ import TestSCons_time
 
 python = TestSCons_time.python
 
-test = TestSCons_time.TestSCons_time(match = TestSCons_time.match_re,
-                                     diff = TestSCons_time.diff_re)
+test = TestSCons_time.TestSCons_time(match=TestSCons_time.match_re,
+                                     diff=TestSCons_time.diff_re)
 
 scons_py = re.escape(test.workpath('scripts', 'scons.py'))
-src_engine = re.escape(test.workpath('src', 'engine'))
+src_engine = re.escape(test.workpath())
 
 tmp_scons_time = test.tempdir_re()
 tmp_scons_time_foo = test.tempdir_re('foo')
@@ -55,7 +55,7 @@ SCONS_LIB_DIR = %(src_engine)s
 SConstruct file directory: %(tmp_scons_time_foo)s
 """ % locals()
 
-test.run(arguments = 'run -q foo.tar.gz', stdout = expect)
+test.run(arguments='run -q foo.tar.gz', stdout=expect)
 
 test.must_exist('foo-000-0.log',
                 'foo-000-0.prof',
@@ -64,20 +64,7 @@ test.must_exist('foo-000-0.log',
                 'foo-000-2.log',
                 'foo-000-2.prof')
 
-scons_py = test.workpath('src/script/scons.py')
-
-src_engine = test.workpath('src/engine')
-
-test.run(arguments = 'run -q foo.tar.gz', stdout = expect)
-
-test.must_exist('foo-001-0.log',
-                'foo-001-0.prof',
-                'foo-001-1.log',
-                'foo-001-1.prof',
-                'foo-001-2.log',
-                'foo-001-2.prof')
-
-test.run(arguments = 'run --quiet foo.tar.gz', stdout = expect)
+test.run(arguments='run --quiet foo.tar.gz', stdout=expect)
 
 test.pass_test()
 

--- a/test/scons-time/run/option/verbose.py
+++ b/test/scons-time/run/option/verbose.py
@@ -22,11 +22,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 """
 Verify that the run -v and --verbose options display command output.
 """
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 import re
@@ -36,11 +36,11 @@ import TestSCons_time
 _python_ = re.escape('"' + sys.executable + '"')
 
 
-test = TestSCons_time.TestSCons_time(match = TestSCons_time.match_re,
-                                     diff = TestSCons_time.diff_re)
+test = TestSCons_time.TestSCons_time(match=TestSCons_time.match_re,
+                                     diff=TestSCons_time.diff_re)
 
 scons_py = re.escape(test.workpath('scripts', 'scons.py'))
-src_engine = re.escape(test.workpath('src', 'engine'))
+src_engine = re.escape(test.workpath())
 
 tmp_scons_time = test.tempdir_re()
 tmp_scons_time_foo = test.tempdir_re('foo')
@@ -57,7 +57,7 @@ SCONS_LIB_DIR = %(src_engine)s
 SConstruct file directory: %(tmp_scons_time_foo)s
 """ % locals()
 
-test.run(arguments = 'run -q foo.tar.gz', stdout = expect)
+test.run(arguments='run -q foo.tar.gz', stdout=expect)
 
 test.must_exist('foo-000-0.log',
                 'foo-000-0.prof',
@@ -126,7 +126,7 @@ prof0 = re.escape(test.workpath('foo-001-0.prof'))
 prof1 = re.escape(test.workpath('foo-001-1.prof'))
 prof2 = re.escape(test.workpath('foo-001-2.prof'))
 
-test.run(arguments = 'run -v foo.tar.gz', stdout = expect % locals())
+test.run(arguments='run -v foo.tar.gz', stdout=expect % locals())
 
 test.must_exist('foo-001-0.log',
                 'foo-001-0.prof',
@@ -143,7 +143,7 @@ prof0 = re.escape(test.workpath('foo-002-0.prof'))
 prof1 = re.escape(test.workpath('foo-002-1.prof'))
 prof2 = re.escape(test.workpath('foo-002-2.prof'))
 
-test.run(arguments = 'run --verbose foo.tar.gz', stdout = expect % locals())
+test.run(arguments='run --verbose foo.tar.gz', stdout=expect % locals())
 
 
 test.pass_test()

--- a/testing/framework/TestRuntest.py
+++ b/testing/framework/TestRuntest.py
@@ -147,15 +147,13 @@ class TestRuntest(TestCommon):
         os.environ['PYTHONPATH'] = ''
 
     def write_fake_scons_source_tree(self):
-        os.mkdir('src')
-        os.mkdir('src/script')
-        self.write('src/script/scons.py', fake_scons_py)
+        os.mkdir('scripts')
+        self.write('scripts/scons.py', fake_scons_py)
 
-        os.mkdir('src/engine')
-        os.mkdir('src/engine/SCons')
-        self.write('src/engine/SCons/__init__.py', fake___init___py)
-        os.mkdir('src/engine/SCons/Script')
-        self.write('src/engine/SCons/Script/__init__.py', fake___init___py)
+        os.mkdir('SCons')
+        self.write('SCons/__init__.py', fake___init___py)
+        os.mkdir('SCons/Script')
+        self.write('SCons/Script/__init__.py', fake___init___py)
 
     def write_failing_test(self, name):
         self.write(name, failing_test_template)


### PR DESCRIPTION
Changes the top-level README, but there might be some more things that want to change here... will be depending on review.

scons-time forced `src/engine` into `SCONS_LIB_DIR`; it no longer does so, and the affected tests (of scons-time) were changed as well.  Discussion elsewhere about whether `SCONS_LIB_DIR` is still valuable may want to be be resolved before pushing this.

Some of the modified test scripts defined `__revision__` before their docstring, which meant that the docstring isn't actually the test's docstring. Moved *only* for those files otherwise modified; the per-file `__revision__` declaration will probably go away anyway at some point.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
