### PR TITLE
Python 3.9 support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -142,6 +142,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       has different function.
     - Update xml files in SCons to reflect changed relative paths after
       code restructuring (src/engine/SCons -> SCons)
+    - Preliminary Python 3.9 support - elimination of some warnings.
 
 
 

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1512,11 +1512,11 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         func_matches = {
-            (2, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         meth_matches = [
@@ -1691,20 +1691,20 @@ class FunctionActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (2, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
 
         }
 
         meth_matches = {
-            (2, 7): bytearray(b'1, 1, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 5): bytearray(b'1, 1, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 9): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         def factory(act, **kw):
@@ -1945,11 +1945,11 @@ class LazyActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (2, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
             (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         meth_matches = [
@@ -2004,11 +2004,11 @@ class ActionCallerTestCase(unittest.TestCase):
             pass
 
         matches = {
-            (2, 7): b'd\x00\x00S',
             (3, 5): b'd\x00\x00S',
             (3, 6): b'd\x00S\x00',
             (3, 7): b'd\x00S\x00',
             (3, 8): b'd\x00S\x00',
+            (3, 9): b'd\x00S\x00',
 
         }
 
@@ -2205,11 +2205,11 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (2, 7): bytearray(b'3, 3, 0, 0,(),(),(|\x00\x00S),(),()'),
             (3, 5): bytearray(b'3, 3, 0, 0,(),(),(|\x00\x00S),(),()'),
             (3, 6): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
             (3, 7): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
             (3, 8): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
+            (3, 9): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
         }
 
         c = SCons.Action._function_contents(func1)
@@ -2227,8 +2227,6 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (2, 7): bytearray(
-                b"{TestClass:__main__}[[[(<type \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<type \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01\x00|\x00\x00_\x00\x00d\x02\x00|\x00\x00_\x01\x00d\x00\x00S),(),(),2, 2, 0, 0,(),(),(d\x00\x00S),(),()}}{{{a=a,b=b}}}"),
             (3, 5): bytearray(
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01\x00|\x00\x00_\x00\x00d\x02\x00|\x00\x00_\x01\x00d\x00\x00S),(),(),2, 2, 0, 0,(),(),(d\x00\x00S),(),()}}{{{a=a,b=b}}}"),
             (3, 6): bytearray(
@@ -2236,6 +2234,8 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 7): bytearray(
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
             (3, 8): bytearray(
+                b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
+            (3, 9): bytearray(
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
         }
 
@@ -2250,11 +2250,11 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (2, 7): bytearray(b'0, 0, 0, 0,(Hello, World!),(),(d\x00\x00GHd\x01\x00S)'),
             (3, 5): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00\x00d\x00\x00\x83\x01\x00\x01d\x01\x00S)'),
             (3, 6): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
             (3, 7): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
             (3, 8): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
+            (3, 9): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
         }
 
         assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(expected[

--- a/SCons/cpp.py
+++ b/SCons/cpp.py
@@ -105,10 +105,10 @@ CPP_Expression = re.compile(e, re.M)
 # A list with RE to cleanup CPP Expressions (tuples)
 # We should remove all comments and carriage returns (\r) before evaluating
 CPP_Expression_Cleaner_List = [
-    "/\*.*\*/",
-    "/\*.*",
-    "//.*",
-    "\r"
+    r"/\*.*\*/",
+    r"/\*.*",
+    r"//.*",
+    r"\r"
 ]
 CPP_Expression_Cleaner_RE = re.compile(
     r"\s*(" + "|".join(CPP_Expression_Cleaner_List) + ")")

--- a/test/Dir/DriveAbsPath.py
+++ b/test/Dir/DriveAbsPath.py
@@ -24,7 +24,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""
+r"""
 Test to confirm that Dir(drive_path).abspath works on Windows. This verifies
 that SCons no longer has an issue with Dir('T:').abspath returning 'T:\T:'.
 Instead, it verifies that Dir('T:') correctly returns an instance of the

--- a/test/LINK/applelink.py
+++ b/test/LINK/applelink.py
@@ -86,7 +86,7 @@ for SHLIBVERSION, APPLELINK_CURRENT_VERSION, APPLELINK_COMPATIBILITY_VERSION, sh
         #     **locals())
         otool_output = "libfoo.{SHLIBVERSION}.dylib:\n\tlibfoo.{SHLIBVERSION}.dylib (compatibility version {APPLELINK_COMPATIBILITY_VERSION}, current version {APPLELINK_CURRENT_VERSION})\n\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version REPLACEME)\n".format(**locals())
         otool_output = re.escape(otool_output)
-        otool_output = otool_output.replace('REPLACEME','\d+\.\d+\.\d+')
+        otool_output = otool_output.replace('REPLACEME',r'\d+\.\d+\.\d+')
 
 
         test.run(program='/usr/bin/otool', arguments='-L libfoo.%s.dylib' % SHLIBVERSION, stdout=otool_output, match=TestSCons.match_re_dotall)
@@ -145,7 +145,7 @@ for SHLIBVERSION, \
             APPLELINK_COMPATIBILITY_VERSION = '0.0.0'
         otool_output = "libfoo.{SHLIBVERSION}.dylib:\n\tlibfoo.{SHLIBVERSION}.dylib (compatibility version {APPLELINK_COMPATIBILITY_VERSION}, current version {APPLELINK_CURRENT_VERSION})\n\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version REPLACEME)\n".format(
             **locals())
-        otool_output = re.escape(otool_output).replace('REPLACEME','\d+\.\d+\.\d+')
+        otool_output = re.escape(otool_output).replace('REPLACEME',r'\d+\.\d+\.\d+')
 
         test.run(program='/usr/bin/otool', arguments='-L libfoo.%s.dylib' % SHLIBVERSION, stdout=otool_output, match=TestSCons.match_re_dotall)
 


### PR DESCRIPTION
Fixes to ActionTests to support bytecode, etc.

Eliminate some warnings when running testsuite (rawstrings)

No doc impact.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
