### PR TITLE
Use inspect.signature to check function signature instead of relying on TypeErrors when evaluation in subst()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,12 +10,6 @@ NOTE: Please include a reference to any Issues resolved by your changes in the b
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-  From Daniel Moody:
-    - Add no_progress (-Q) option as a set-able option. However, setting it in the 
-      SConstruct/SConscript will still cause "scons: Reading SConscript files ..." to be
-      printed, since the option is not set when the build scripts first get read.
-    - Added check for SONAME in environment to setup symlinks correctly (Github Issue #3246)
-
   From James Benton:
     - Improve Visual Studio solution/project generation code to add support
       for a per-variant cppflags. Intellisense can be affected by cppflags,
@@ -85,6 +79,16 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       * Ignore `#include DYNAMIC_INCLUDE` directive that depends on a dynamic
         macro which is not located in a state TABLE.
       * Cleanup CPP expressions before evaluating (strip comments, carriage returns)
+
+  From Daniel Moody:
+    - Add no_progress (-Q) option as a set-able option. However, setting it in the 
+      SConstruct/SConscript will still cause "scons: Reading SConscript files ..." to be
+      printed, since the option is not set when the build scripts first get read.
+    - Added check for SONAME in environment to setup symlinks correctly (Github Issue #3246)
+    - User callable's called during substition expansion could possibly throw a TypeError 
+      exception, however SCons was using TypeError to detect if the callable had a different 
+      signature than expected, and would silently fail to report user's exceptions. Fixed to 
+      use signature module to detect function signature instead of TypeError. (Github Issue #3654)
 
   From Andrew Morrow:
     - Fix Issue #3469 - Fixed improper reuse of temporary and compiled files by Configure when changing

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -591,12 +591,13 @@ class ListSubber(collections.UserList):
                 self.substitute(a, lvars, 1)
                 self.next_word()
         elif callable(s):
-            try:
+            if (s and
+                set(signature(s).parameters.keys()) == set(['target', 'source', 'env', 'for_signature'])):
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
                      env=self.env,
                      for_signature=(self.mode != SUBST_CMD))
-            except TypeError:
+            else:
                 # This probably indicates that it's a callable
                 # object that doesn't match our calling arguments
                 # (like an Action).

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -420,7 +420,10 @@ class StringSubber(object):
                 return conv(substitute(l, lvars))
             return list(map(func, s))
         elif callable(s):
-            if (s and
+            # SCons has the unusual Null class where any __getattr__ call returns it's self, 
+            # which does not work the signature module, and the Null class returns an empty
+            # string if called on, so we make an exception in this condition for Null class
+            if (isinstance(s, SCons.Util.Null) or
                 set(signature(s).parameters.keys()) == set(['target', 'source', 'env', 'for_signature'])):
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
@@ -591,7 +594,10 @@ class ListSubber(collections.UserList):
                 self.substitute(a, lvars, 1)
                 self.next_word()
         elif callable(s):
-            if (s and
+            # SCons has the unusual Null class where any __getattr__ call returns it's self, 
+            # which does not work the signature module, and the Null class returns an empty
+            # string if called on, so we make an exception in this condition for Null class
+            if (isinstance(s, SCons.Util.Null) or
                 set(signature(s).parameters.keys()) == set(['target', 'source', 'env', 'for_signature'])):
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -30,7 +30,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import collections
 import re
-
+from inspect import signature
 import SCons.Errors
 
 from SCons.Util import is_String, is_Sequence
@@ -420,12 +420,13 @@ class StringSubber(object):
                 return conv(substitute(l, lvars))
             return list(map(func, s))
         elif callable(s):
-            try:
+            if (s and
+                set(signature(s).parameters.keys()) == set(['target', 'source', 'env', 'for_signature'])):
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
                      env=self.env,
                      for_signature=(self.mode != SUBST_CMD))
-            except TypeError:
+            else:
                 # This probably indicates that it's a callable
                 # object that doesn't match our calling arguments
                 # (like an Action).

--- a/test/Subst/TypeError.py
+++ b/test/Subst/TypeError.py
@@ -85,36 +85,12 @@ expect = expect_build % (r' \[foo\.bar\]', r'\$\{func\(1\)\}')
 
 test.run(status=2, stderr=expect)
 
-# callable exceptions:
-test.write('foo.c', """\
-#include <stdio.h>
-#include <stdlib.h>
-int
-main(int argc, char *argv[])
-{
-        argv[argc++] = "--";
-        printf("foo.c");
-        exit (0);
-}
-""")
-
-test.write('SConstruct', """\
-
-class TestCallable(object):
-    def __init__(self, thing, makePathsRelative = True, debug = False):
-        pass
-    def __call__(self, target, source, env, for_signature):
-       raise TypeError("User callable exception")
-
-env = Environment()
-env["TESTCLASS"] = TestCallable
-env["CCCOM"] = "$CC $_CCCOMCOM $CCFLAGS -o ${TESTCLASS('$TARGET')} -c ${TESTCLASS('$SOURCES')}"
-
-env.Program(target='foo', source='foo.c')
-""")
+# user callable exceptions (Github issue #3654):
+test.file_fixture('test_main.c')
+test.file_fixture('./fixture/SConstruct.callable_exception', 'SConstruct')
 
 test.run(status=2, stderr=r'.*TypeError\s:\sUser\scallable\sexception.*')
-print(test.stdout())
+
 test.pass_test()
 
 # Local Variables:

--- a/test/Subst/TypeError.py
+++ b/test/Subst/TypeError.py
@@ -85,8 +85,36 @@ expect = expect_build % (r' \[foo\.bar\]', r'\$\{func\(1\)\}')
 
 test.run(status=2, stderr=expect)
 
+# callable exceptions:
+test.write('foo.c', """\
+#include <stdio.h>
+#include <stdlib.h>
+int
+main(int argc, char *argv[])
+{
+        argv[argc++] = "--";
+        printf("foo.c");
+        exit (0);
+}
+""")
 
+test.write('SConstruct', """\
 
+class TestCallable(object):
+    def __init__(self, thing, makePathsRelative = True, debug = False):
+        pass
+    def __call__(self, target, source, env, for_signature):
+       raise TypeError("User callable exception")
+
+env = Environment()
+env["TESTCLASS"] = TestCallable
+env["CCCOM"] = "$CC $_CCCOMCOM $CCFLAGS -o ${TESTCLASS('$TARGET')} -c ${TESTCLASS('$SOURCES')}"
+
+env.Program(target='foo', source='foo.c')
+""")
+
+test.run(status=2, stderr=r'.*TypeError\s:\sUser\scallable\sexception.*')
+print(test.stdout())
 test.pass_test()
 
 # Local Variables:

--- a/test/Subst/fixture/SConstruct.callable_exception
+++ b/test/Subst/fixture/SConstruct.callable_exception
@@ -1,0 +1,11 @@
+class TestCallable(object):
+    def __init__(self, thing, makePathsRelative = True, debug = False):
+        pass
+    def __call__(self, target, source, env, for_signature):
+       raise TypeError("User callable exception")
+
+env = Environment()
+env["TESTCLASS"] = TestCallable
+env["CCCOM"] = "$CC $_CCCOMCOM $CCFLAGS -o ${TESTCLASS('$TARGET')} -c ${TESTCLASS('$SOURCES')}"
+
+env.Program(target='test_main', source='test_main.c')


### PR DESCRIPTION
Possible solution for issue #3654. I will write tests if there is no objections to this solution.

Also possible there are other places similar logic should be implemented.

fixes #3654 

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
