### PR TITLE
Bump unsupported/deperecated Py versions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -144,6 +144,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       code restructuring (src/engine/SCons -> SCons)
     - Drop the with_metaclass jig which was designed to let class
       definitions using a metaclass be written the same for Py2/Py3.
+    - Bump python_version_unsupported (and deprecated) to indicate 3.5
+      is lowest supported Python.
 
 
 

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -10,8 +10,8 @@ some other module.  If it's specific to the "scons" script invocation,
 it goes here.
 """
 
-unsupported_python_version = (2, 6, 0)
-deprecated_python_version = (2, 7, 0)
+unsupported_python_version = (3, 4, 0)
+deprecated_python_version = (3, 4, 0)
 
 
 # __COPYRIGHT__


### PR DESCRIPTION
Othewise version requirement has been updated (including docs), but this location was still indicating 2.7 as supported.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
