### PR TITLE
[WIP] Add a check for bad opts which are abbrev of good

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -162,6 +162,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       check and test is no longer needed.
     - Close various logfiles (trace, cache, taskmastertrace, configure)
       when done using atexit calls.
+    - Generate an error if AddOption uses an "abbreviation" for an option
+      string (e.g. via a user error) rather than swallowing silently (#3653)
 
 
 

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -49,6 +49,7 @@ import time
 import traceback
 import sysconfig
 import platform
+from contextlib import suppress
 
 import SCons.CacheDir
 import SCons.Debug
@@ -485,6 +486,12 @@ def AddOption(*args, **kw):
     if 'default' not in kw:
         kw['default'] = None
     result = OptionsParser.add_local_option(*args, **kw)
+
+    # Converting '?' to int gives ValueError; None gives TypeError. Skip those.
+    with suppress(ValueError, TypeError):
+        if int(result.nargs) > 1:
+            msg = "AddOption() with nargs > 1 may produce unexpected results."
+            SCons.Warnings.warn(SCons.Warnings.AddOptionWarning, msg)
     return result
 
 def GetOption(name):
@@ -857,9 +864,10 @@ def _main(parser):
     # suppress) appropriate warnings about anything that might happen,
     # as configured by the user.
 
-    default_warnings = [ SCons.Warnings.WarningOnByDefault,
-                         SCons.Warnings.DeprecatedWarning,
-                       ]
+    default_warnings = [
+        SCons.Warnings.WarningOnByDefault,
+        SCons.Warnings.DeprecatedWarning,
+    ]
 
     for warning in default_warnings:
         SCons.Warnings.enableWarningClass(warning)

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1036,6 +1036,7 @@ def _main(parser):
         revert_io()
         sys.stderr.write("scons: *** %s  Stop.\n" % e)
         sys.exit(2)
+    OptionsParser.cleanup()
     global sconscript_time
     sconscript_time = time.time() - start_time
 

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -36,13 +36,13 @@ are the same as those supported by the <function>add_option</function>
 method in the standard Python library module <systemitem>optparse</systemitem>,
 with a few additional capabilities noted below.
 See the documentation for
-<emphasis>optparse</emphasis>
+<systemitem>optparse</systemitem>
 for a thorough discussion of its option-processing capabities.
 </para>
 
 <para>
 In addition to the arguments and values supported by the
-<emphasis>optparse</emphasis>
+<systemitem>optparse</systemitem>
 <function>add_option</function>
 method, &f-AddOption;
 allows setting the
@@ -70,6 +70,7 @@ keyword argument in the &f-AddOption; call,
 
 <para>
 <systemitem>optparse</systemitem> recognizes
+<emphasis>optparse</emphasis> recognizes
 abbreviations of long option names,
 as long as they can be unambiguously resolved.
 For example, if

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -398,7 +398,7 @@ class SConsOptionParser(optparse.OptionParser):
         """
         Adds a local option to the parser.
 
-        This is initiated by a SetOption() call to add a user-defined
+        This is initiated by an AddOption() call to add a user-defined
         command-line option.  We add the option to a separate option
         group for the local options, creating the group if necessary.
         """
@@ -437,7 +437,9 @@ class SConsOptionParser(optparse.OptionParser):
         """
         xtra_args = [a for a in self.largs if a.startswith('--')]
         if xtra_args:
-            self.error(_("no such option: %s") % " ".join(xtra_args))
+            #self.error(_("no such option: %s") % " ".join(xtra_args))
+            msg = "illegal option abbreviations detected: %s" % " ".join(xtra_args)
+            SCons.Warnings.warn(SCons.Warnings.AddOptionWarning, msg)
 
 class SConsIndentedHelpFormatter(optparse.IndentedHelpFormatter):
     def format_usage(self, usage):

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -425,6 +425,20 @@ class SConsOptionParser(optparse.OptionParser):
 
         return result
 
+    def cleanup(self):
+        """If there are leftover unprocessed options, fail.
+
+        Unrecognized options are saved for later processing, since
+        a later AddOption might enable them. Although abbreviations
+        of AddOption option strings don't trigger a match, they
+        also can't trigger an error because of that. This method
+        provides a way sweep through is to catch those cases still left
+        when all sconscripts are read.
+        """
+        xtra_args = [a for a in self.largs if a.startswith('--')]
+        if xtra_args:
+            self.error(_("no such option: %s") % " ".join(xtra_args))
+
 class SConsIndentedHelpFormatter(optparse.IndentedHelpFormatter):
     def format_usage(self, usage):
         return "usage: %s\n" % usage

--- a/test/AddOption/longopts.py
+++ b/test/AddOption/longopts.py
@@ -33,7 +33,7 @@ case below...
 
 import TestSCons
 
-test = TestSCons.TestSCons()
+test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 test.write('SConstruct', """\
 AddOption('--myargument', dest='myargument', type='string', default='gully')
@@ -64,7 +64,7 @@ scons: warning: illegal option abbreviations detected: --myargumen=helloworld
 """ + TestSCons.file_expr
 
 test.run('-Q -q . --myargumen=helloworld',
-         stdout="myargument: gully\nmyarg: balla\n",
+         #stdout="myargument: gully\nmyarg: balla\n",
          stderr=expect)
 
 

--- a/test/AddOption/longopts.py
+++ b/test/AddOption/longopts.py
@@ -51,6 +51,16 @@ test.run('-Q -q . --myargument=helloworld',
 test.run('-Q -q . --myarg=helloworld',
          stdout="myargument: gully\nmyarg: helloworld\n")
 
+# Issue #3653: add a check for an abbreviation which never gets AddOption'd.
+test.run('-Q -q --myargumen=helloworld', status=2,
+         stdout="myargument: gully\nmyarg: balla\n",
+         stderr="""\
+usage: scons [OPTION] [TARGET] ...
+
+SCons Error: no such option: --myargumen=helloworld
+""")
+
+
 test.pass_test()
 
 # Local Variables:

--- a/test/AddOption/longopts.py
+++ b/test/AddOption/longopts.py
@@ -52,13 +52,20 @@ test.run('-Q -q . --myarg=helloworld',
          stdout="myargument: gully\nmyarg: helloworld\n")
 
 # Issue #3653: add a check for an abbreviation which never gets AddOption'd.
-test.run('-Q -q --myargumen=helloworld', status=2,
-         stdout="myargument: gully\nmyarg: balla\n",
-         stderr="""\
-usage: scons [OPTION] [TARGET] ...
+#test.run('-Q -q --myargumen=helloworld', status=2,
+#         stdout="myargument: gully\nmyarg: balla\n",
+#         stderr="""\
+#usage: scons [OPTION] [TARGET] ...
+#
+#SCons Error: no such option: --myargumen=helloworld
+#""")
+expect = r"""
+scons: warning: illegal option abbreviations detected: --myargumen=helloworld
+""" + TestSCons.file_expr
 
-SCons Error: no such option: --myargumen=helloworld
-""")
+test.run('-Q -q . --myargumen=helloworld',
+         stdout="myargument: gully\nmyarg: balla\n",
+         stderr=expect)
 
 
 test.pass_test()


### PR DESCRIPTION
Adds a post-processing step called after sconscript processing is done which checks if there are any leftover options. Previously, some options would sneak through silently if they were an abbreviation of another option added by AddOption.

Marked as WIP to see if this is a suitable approach. There was also some discussion of having this transition in gradually as a warning/deprecationwarning.

_Note: at the moment this has some surprises_.  Test `test/option-unknown.py` tries a long option where no `AddOption` calls have taken place at all, and it still triggers the abbreviation warning.

Fixes #3653

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
