### PR TITLE
Fix error recently introduced in Package()

### DIFF
--- a/SCons/Tool/packaging/__init__.py
+++ b/SCons/Tool/packaging/__init__.py
@@ -239,20 +239,19 @@ def options(opts):
 #
 
 def copy_attr(f1, f2):
-    """ copies the special packaging file attributes from f1 to f2.
+    """ Copies the special packaging file attributes from f1 to f2.
     """
     if f1._tags:
         pattrs = [
             tag
             for tag in f1._tags
-            if lambda tag: not hasattr(f2, tag) and tag.startswith('PACKAGING_')
+            if not hasattr(f2, tag) and tag.startswith('PACKAGING_')
         ]
         for attr in pattrs:
             f2.Tag(attr, f1.GetTag(attr))
 
 def putintopackageroot(target, source, env, pkgroot, honor_install_location=1):
-    """ Uses the CopyAs builder to copy all source files to the directory given
-    in pkgroot.
+    """ Copies all source files to the directory given in pkgroot.
 
     If honor_install_location is set and the copied source file has an
     PACKAGING_INSTALL_LOCATION attribute, the PACKAGING_INSTALL_LOCATION is


### PR DESCRIPTION
A recent edit changed a call to a named lamba (which checkers frown on) to a comprehension - but didn't eliminate all of it, leaving a syntax error. Not sure why this passed the CI builds, but was certainly failing a number of packaging tests in local experiments.

No test/doc changes - exising test was showing the problem.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
