### PR TITLE
let ZipBuilder actually use ZIPCOMSTR

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,8 +10,11 @@ NOTE: Please include a reference to any Issues resolved by your changes in the b
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Rocco Matano:
+    - Make setting ZIPCOMSTR actually have an effect.
+
   From Daniel Moody:
-    - Add no_progress (-Q) option as a set-able option. However, setting it in the 
+    - Add no_progress (-Q) option as a set-able option. However, setting it in the
       SConstruct/SConscript will still cause "scons: Reading SConscript files ..." to be
       printed, since the option is not set when the build scripts first get read.
     - Added check for SONAME in environment to setup symlinks correctly (Github Issue #3246)
@@ -44,9 +47,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add msys2 installed mingw default path to PATH for mingw tool.
       - C:\msys64\mingw64\bin
     - Purge obsolete internal build and tooling scripts
-    - Allow user specified location for vswhere.exe specified by VSWHERE. 
+    - Allow user specified location for vswhere.exe specified by VSWHERE.
       NOTE: This must be set at the time the 'msvc' 'msvs' and/or 'mslink' tool(s) are initialized to have any effect.
-    - Resolve Issue #3451 and Issue #3450 - Rewrite SCons setup.py and packaging. Move script logic to entry points so 
+    - Resolve Issue #3451 and Issue #3450 - Rewrite SCons setup.py and packaging. Move script logic to entry points so
       package can create scripts which use the correct version of Python.
     - Resolve Issue #3248 - Removing '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS
       NOTE: If your build depends on the above you must now add to your SHLIBVERSIONFLAGS

--- a/SCons/Tool/zip.py
+++ b/SCons/Tool/zip.py
@@ -58,7 +58,7 @@ def zip(target, source, env):
             zf.write(str(s), os.path.relpath(str(s), str(env.get('ZIPROOT', ''))))
     zf.close()
 
-zipAction = SCons.Action.Action(zip, varlist=['ZIPCOMPRESSION'])
+zipAction = SCons.Action.Action(zip, '$ZIPCOMSTR', varlist=['ZIPCOMPRESSION'])
 
 ZipBuilder = SCons.Builder.Builder(action = SCons.Action.Action('$ZIPCOM', '$ZIPCOMSTR'),
                                    source_factory = SCons.Node.FS.Entry,


### PR DESCRIPTION
Currently the only way to set ZIPCOMSTR in such a way that it is actually used is to do so when creating an environment:
`env = Environment(ZIPCOMSTR = "Zipping $TARGET")`

Unlike other *COMSTR (like CXXCOMSTR) setting ZIPCOMSTR after creating an environment has no effect:
```
env = Environment(tools=["zip"])
env["ZIPCOMSTR"] = "Zipping $TARGET"
```

With this change it does.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation