### PR TITLE
Update travis install 05/2020

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 
 install:
   # needed for Docbook tests, must be in virtualenv context
-  - pip install lxml==4.3.3
+  - pip install lxml==4.5.0
   # do the rest of the image setup
   - ./.travis/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 
 # Used: travis encrypt "chat.freenode.net#scons" --add notifications.irc

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ jobs:
       python: 3.8
       dist: bionic  # required for Python >= 3.8
 
+    - <<: *test_job
+      python: 3.9-dev
+      dist: bionic  # required for Python >= 3.8
+
     - &coverage_jobs
       dist: bionic
       python: 3.7

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -40,9 +40,14 @@ else
     sudo apt-get -y install python-pip python-dev build-essential libpcre3-dev autoconf automake libtool bison subversion git
 
     # dependencies for D tests
-    sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
-    wget -qO - https://dlang.org/d-keyring.gpg | sudo apt-key add -
-    sudo apt-get update && sudo apt-get -y --allow-unauthenticated install dmd-bin
+    sudo wget https://netcologne.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
+    sudo apt-get update --allow-insecure-repositories
+    sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
+    sudo apt-get update && sudo apt-get install dmd-compiler dub
+
+#    sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
+#    wget -qO - https://dlang.org/d-keyring.gpg | sudo apt-key add -
+#    sudo apt-get update && sudo apt-get -y --allow-unauthenticated install dmd-bin
 
     # dependencies for ldc tests
     export SCONS_LDC_VERSION=1.21.0

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -51,5 +51,5 @@ else
     tar xf ldc2-${SCONS_LDC_VERSION}-linux-x86_64.tar.xz
     sudo cp -rf ldc2-${SCONS_LDC_VERSION}-linux-x86_64/* /
 
-    ls -l /usr/lib/*python*{so,a}*
+    ls -l /usr/lib*/*python*{so,a}*
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -56,5 +56,6 @@ else
     tar xf ldc2-${SCONS_LDC_VERSION}-linux-x86_64.tar.xz
     sudo cp -rf ldc2-${SCONS_LDC_VERSION}-linux-x86_64/* /
 
-    ls -l /usr/lib*/*python*{so,a}*
+    # Failing.. ?
+#    ls -l /usr/lib*/*python*{so,a}*
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -19,6 +19,9 @@ else
         sudo ln -s /usr/local/clang-5.0.0/bin/clang++ /usr/bin/clang++
     fi
 
+    # dependencies for rpm packaging tests
+    sudo apt-get -y install rpm
+    
     # dependencies for gdc tests
     sudo apt-get -y install gdc
 
@@ -42,17 +45,11 @@ else
     sudo apt-get update && sudo apt-get -y --allow-unauthenticated install dmd-bin
 
     # dependencies for ldc tests
-    wget https://github.com/ldc-developers/ldc/releases/download/v1.15.0/ldc2-1.15.0-linux-x86_64.tar.xz
-    tar xf ldc2-1.15.0-linux-x86_64.tar.xz
-    sudo cp -rf ldc2-1.15.0-linux-x86_64/* /
+    export SCONS_LDC_VERSION=1.21.0
+    wget https://github.com/ldc-developers/ldc/releases/download/v${SCONS_LDC_VERSION}/ldc2-${SCONS_LDC_VERSION}-linux-x86_64.tar.xz
+#    wget https://github.com/ldc-developers/ldc/releases/download/v1.15.0/ldc2-1.15.0-linux-x86_64.tar.xz
+    tar xf ldc2-${SCONS_LDC_VERSION}-linux-x86_64.tar.xz
+    sudo cp -rf ldc2-${SCONS_LDC_VERSION}-linux-x86_64/* /
 
     ls -l /usr/lib/*python*{so,a}*
-
-    # For now skip swig if py27
-    if [[ "$PYVER" == 27 ]]; then
-        # dependencies for swig tests
-        wget https://github.com/swig/swig/archive/rel-3.0.12.tar.gz
-        tar xzf rel-3.0.12.tar.gz
-        cd swig-rel-3.0.12 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install && cd ..
-    fi
 fi

--- a/test/packaging/rpm/explicit-target.py
+++ b/test/packaging/rpm/explicit-target.py
@@ -30,6 +30,7 @@ Test the ability to create a rpm package from a explicit target name.
 
 import os
 import TestSCons
+import sys
 
 _python_ = TestSCons._python_
 
@@ -75,9 +76,15 @@ env.Package( NAME           = 'foo',
         )
 """ % locals())
 
+
+if sys.version_info.minor >= 8:
+    line_number = 12
+else:
+    line_number = 23
+
 expect = """
 scons: *** Setting target is not supported for rpm.
-""" + test.python_file_line(test.workpath('SConstruct'), 12)
+""" + test.python_file_line(test.workpath('SConstruct'), line_number)
 
 test.run(arguments='', status=2, stderr=expect)
 


### PR DESCRIPTION
This PR is only travis-ci updates

* Add python 3.9-dev
* Update LDC to 1.21.0
* Remove blurb skipping swig install if python 2.7
* Add installing rpm for rpm packaging tests.
