### PR TITLE
If ParseFlags called with dict argument, leave unchanged

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -147,6 +147,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       definitions using a metaclass be written the same for Py2/Py3.
     - Bump python_version_unsupported (and deprecated) to indicate 3.5
       is lowest supported Python.
+    - ParseFlags should not modify the user's passed in dict in case it's
+      a compound data structure (e.g. values are lists) (issue #3665)
 
 
 

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -855,8 +855,7 @@ class SubstitutionEnvironment(object):
                         t.append(v)
             else:
                 ### keep right-most occurence
-                orig.reverse()
-                for v in orig:
+                for v in orig[::-1]:
                     if v not in t:
                         t.insert(0, v)
             self[key] = t

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -856,6 +856,20 @@ sys.exit(0)
         assert env['A'] == ['aaa'], env['A']
         assert env['B'] == ['bbb'], env['B']
 
+        # issue #3665: if merging dict which is a compound object
+        # (i.e. value can be lists, etc.), the value object should not
+        # be modified. per the issue, this happened if key not in env.
+        env = SubstitutionEnvironment()
+        try:
+            del env['CFLAGS']  # just to be sure
+        except KeyError:
+            pass
+        flags = {'CFLAGS': ['-pipe', '-pthread', '-g']}
+        import copy
+        saveflags = copy.deepcopy(flags)
+        env.MergeFlags(flags)
+        self.assertEqual(flags, saveflags)
+
 
 class BaseTestCase(unittest.TestCase,TestEnvironmentFixture):
 


### PR DESCRIPTION
Previously, if the dict values were mutable elements, i.e. lists, and the key was not for a *PATH variable, the value would be reversed before being processed into the env. Instead use a slice to iterate over.

Fixes issue #3665

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
