### PR TITLE
classes no longer explicitly inherit from object

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -149,6 +149,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       is lowest supported Python.
     - ParseFlags should not modify the user's passed in dict in case it's
       a compound data structure (e.g. values are lists) (issue #3665)
+    - In Py3 classes no longer need to be listed as deriving from object.
 
 
 

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -119,7 +119,7 @@ import SCons.Subst
 # we use these a lot, so try to optimize them
 from SCons.Util import is_String, is_List
 
-class _null(object):
+class _null:
     pass
 
 print_actions = 1
@@ -515,7 +515,7 @@ def Action(act, *args, **kw):
     return _do_create_action(act, kw)
 
 
-class ActionBase(object):
+class ActionBase:
     """Base class for all types of action objects that can be held by
     other objects (Builders, Executors, etc.)  This provides the
     common methods for manipulating and combining those actions."""
@@ -649,10 +649,14 @@ class _ActionAction(ActionBase):
             presub = self.presub
             if presub is _null:
                 presub = print_actions_presub
-        if exitstatfunc is _null: exitstatfunc = self.exitstatfunc
-        if show is _null:  show = print_actions
-        if execute is _null:  execute = execute_actions
-        if chdir is _null: chdir = self.chdir
+        if exitstatfunc is _null:
+            exitstatfunc = self.exitstatfunc
+        if show is _null:
+            show = print_actions
+        if execute is _null:
+            execute = execute_actions
+        if chdir is _null:
+            chdir = self.chdir
         save_cwd = None
         if chdir:
             save_cwd = os.getcwd()
@@ -795,12 +799,12 @@ def _subproc(scons_env, cmd, error='ignore', **kw):
     except EnvironmentError as e:
         if error == 'raise': raise
         # return a dummy Popen instance that only returns error
-        class dummyPopen(object):
+        class dummyPopen:
             def __init__(self, e): self.exception = e
             def communicate(self, input=None): return ('', '')
             def wait(self): return -self.exception.errno
             stdin = None
-            class f(object):
+            class f:
                 def read(self): return ''
                 def readline(self): return ''
                 def __iter__(self): return iter(())
@@ -1110,11 +1114,14 @@ class CommandGeneratorAction(ActionBase):
                  show=_null, execute=_null, chdir=_null, executor=None):
         act = self._generate(target, source, env, 0, executor)
         if act is None:
-            raise SCons.Errors.UserError("While building `%s': "
-                            "Cannot deduce file extension from source files: %s"
-                % (repr(list(map(str, target))), repr(list(map(str, source)))))
-        return act(target, source, env, exitstatfunc, presub,
-                   show, execute, chdir, executor)
+            raise SCons.Errors.UserError(
+                "While building `%s': "
+                "Cannot deduce file extension from source files: %s"
+                % (repr(list(map(str, target))), repr(list(map(str, source))))
+            )
+        return act(
+            target, source, env, exitstatfunc, presub, show, execute, chdir, executor
+        )
 
     def get_presig(self, target, source, env, executor=None):
         """Return the signature contents of this action's command line.
@@ -1372,7 +1379,7 @@ class ListAction(ActionBase):
         return list(result.keys())
 
 
-class ActionCaller(object):
+class ActionCaller:
     """A class for delaying calling an Action function with specific
     (positional and keyword) arguments until the Action is actually
     executed.
@@ -1443,7 +1450,7 @@ class ActionCaller(object):
         return self.parent.strfunc(*self.args, **self.kw)
 
 
-class ActionFactory(object):
+class ActionFactory:
     """A factory class that will wrap up an arbitrary function
     as an SCons-executable Action object.
 

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -32,7 +32,7 @@ def GlobalFunc():
     pass
 
 
-class GlobalActFunc(object):
+class GlobalActFunc:
     def __call__(self):
         pass
 
@@ -105,7 +105,7 @@ scons_env = SCons.Environment.Environment()
 sys.stdout = io.StringIO()
 
 
-class CmdStringHolder(object):
+class CmdStringHolder:
     def __init__(self, cmd, literal=None):
         self.data = str(cmd)
         self.literal = literal
@@ -131,7 +131,7 @@ class CmdStringHolder(object):
             return self.data
 
 
-class Environment(object):
+class Environment:
     def __init__(self, **kw):
         self.d = {}
         self.d['SHELL'] = scons_env['SHELL']
@@ -187,7 +187,7 @@ class Environment(object):
         return d
 
 
-class DummyNode(object):
+class DummyNode:
     def __init__(self, name):
         self.name = name
 
@@ -1008,21 +1008,21 @@ class CommandActionTestCase(unittest.TestCase):
         s = act.strfunction([], [], env)
         assert s == "sf was called", s
 
-        class actclass1(object):
+        class actclass1:
             def __init__(self, targets, sources, env):
                 pass
 
             def __call__(self):
                 return 1
 
-        class actclass2(object):
+        class actclass2:
             def __init__(self, targets, sources, env):
                 self.strfunction = 5
 
             def __call__(self):
                 return 2
 
-        class actclass3(object):
+        class actclass3:
             def __init__(self, targets, sources, env):
                 pass
 
@@ -1033,7 +1033,7 @@ class CommandActionTestCase(unittest.TestCase):
                 return 'actclass3 on %s to get %s' % (str(sources[0]),
                                                       str(targets[0]))
 
-        class actclass4(object):
+        class actclass4:
             def __init__(self, targets, sources, env):
                 pass
 
@@ -1164,7 +1164,7 @@ class CommandActionTestCase(unittest.TestCase):
         c = test.read(outfile, 'r')
         assert c == "act.py: 'out5' 'XYZZY'\nact.py: 'xyzzy5'\n", c
 
-        class Obj(object):
+        class Obj:
             def __init__(self, str):
                 self._str = str
 
@@ -1251,7 +1251,7 @@ class CommandActionTestCase(unittest.TestCase):
         """Test setting the command handler...
         """
 
-        class Test(object):
+        class Test:
             def __init__(self):
                 self.executed = 0
 
@@ -1265,7 +1265,7 @@ class CommandActionTestCase(unittest.TestCase):
         def escape_func(cmd):
             return '**' + cmd + '**'
 
-        class LiteralStr(object):
+        class LiteralStr:
             def __init__(self, x):
                 self.data = x
 
@@ -1464,7 +1464,7 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
         assert self.dummy == 2, self.dummy
         del self.dummy
 
-        class DummyFile(object):
+        class DummyFile:
             def __init__(self, t):
                 self.t = t
 
@@ -1596,7 +1596,7 @@ class FunctionActionTestCase(unittest.TestCase):
         s = str(a)
         assert s == "func1(target, source, env)", s
 
-        class class1(object):
+        class class1:
             def __call__(self):
                 pass
 
@@ -1645,7 +1645,7 @@ class FunctionActionTestCase(unittest.TestCase):
         c = test.read(outfile2, 'r')
         assert c == "function1\n", c
 
-        class class1a(object):
+        class class1a:
             def __init__(self, target, source, env):
                 with open(env['out'], 'w') as f:
                     f.write("class1a\n")
@@ -1656,7 +1656,7 @@ class FunctionActionTestCase(unittest.TestCase):
         c = test.read(outfile, 'r')
         assert c == "class1a\n", c
 
-        class class1b(object):
+        class class1b:
             def __call__(self, target, source, env):
                 with open(env['out'], 'w') as f:
                     f.write("class1b\n")
@@ -1742,7 +1742,7 @@ class FunctionActionTestCase(unittest.TestCase):
         c = a.get_contents(target=[], source=[], env=Environment(XYZ='foo'))
         assert c in matches_foo, repr(c)
 
-        class Foo(object):
+        class Foo:
             def get_contents(self, target, source, env):
                 return b'xyzzy'
 
@@ -1750,7 +1750,7 @@ class FunctionActionTestCase(unittest.TestCase):
         c = a.get_contents(target=[], source=[], env=Environment())
         assert c == b'xyzzy', repr(c)
 
-        class LocalClass(object):
+        class LocalClass:
             def LocalMethod(self):
                 pass
 
@@ -1847,13 +1847,13 @@ class ListActionTestCase(unittest.TestCase):
                 f.write("function2\n")
             return 0
 
-        class class2a(object):
+        class class2a:
             def __call__(self, target, source, env):
                 with open(env['out'], 'a') as f:
                     f.write("class2a\n")
                 return 0
 
-        class class2b(object):
+        class class2b:
             def __init__(self, target, source, env):
                 with open(env['out'], 'a') as f:
                     f.write("class2b\n")
@@ -2024,7 +2024,7 @@ class ActionCallerTestCase(unittest.TestCase):
         assert c == matches[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected one of \n" + repr(
             matches[sys.version_info[:2]])
 
-        class LocalActFunc(object):
+        class LocalActFunc:
             def __call__(self):
                 pass
 
@@ -2183,7 +2183,7 @@ class ActionCompareTestCase(unittest.TestCase):
         assert dog.get_name(env) == 'DOG', dog.get_name(env)
 
 
-class TestClass(object):
+class TestClass:
     """A test class used by ObjectContentsTestCase.test_object_contents"""
 
     def __init__(self):

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -111,7 +111,7 @@ import SCons.Memoize
 import SCons.Util
 import SCons.Warnings
 
-class _Null(object):
+class _Null:
     pass
 
 _null = _Null
@@ -328,7 +328,7 @@ def _node_errors(builder, env, tlist, slist):
         if len(slist) > 1:
             raise UserError("More than one source given for single-source builder: targets=%s sources=%s" % (list(map(str,tlist)), list(map(str,slist))))
 
-class EmitterProxy(object):
+class EmitterProxy:
     """This is a callable class that can act as a
     Builder emitter.  It holds on to a string that
     is a key into an Environment dictionary, and will
@@ -361,7 +361,7 @@ class EmitterProxy(object):
     def __lt__(self, other):
         return self.var < other.var
 
-class BuilderBase(object):
+class BuilderBase:
     """Base class for Builders, objects that create output
     nodes (files) from input nodes (files).
     """

--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -71,7 +71,7 @@ scons_env = SCons.Environment.Environment()
 
 env_arg2nodes_called = None
 
-class Environment(object):
+class Environment:
     def __init__(self, **kw):
         self.d = {}
         self.d['SHELL'] = scons_env['SHELL']
@@ -147,7 +147,7 @@ class Environment(object):
     def __eq__(self, other):
         return self.scanner == other.scanner or self.d == other.d
 
-class MyAction(object):
+class MyAction:
     def __init__(self, action):
         self.action = action
     def __call__(self, *args, **kw):
@@ -155,7 +155,7 @@ class MyAction(object):
     def get_executor(self, env, overrides, tlist, slist, executor_kw):
         return ['executor'] + [self.action]
 
-class MyNode_without_target_from_source(object):
+class MyNode_without_target_from_source:
     def __init__(self, name):
         self.name = name
         self.sources = []
@@ -219,7 +219,7 @@ class BuilderTestCase(unittest.TestCase):
             exc_caught = 1
         assert exc_caught, "did not catch expected InternalError exception"
 
-        class Node(object):
+        class Node:
              pass
 
         n = Node()
@@ -404,7 +404,7 @@ class BuilderTestCase(unittest.TestCase):
     def test_target_factory(self):
         """Test a Builder that creates target nodes of a specified class
         """
-        class Foo(object):
+        class Foo:
             pass
         def FooFactory(target):
             global Foo
@@ -416,7 +416,7 @@ class BuilderTestCase(unittest.TestCase):
     def test_source_factory(self):
         """Test a Builder that creates source nodes of a specified class
         """
-        class Foo(object):
+        class Foo:
             pass
         def FooFactory(source):
             global Foo
@@ -829,7 +829,7 @@ class BuilderTestCase(unittest.TestCase):
     def test_target_scanner(self):
         """Testing ability to set target and source scanners through a builder."""
         global instanced
-        class TestScanner(object):
+        class TestScanner:
             pass
         tscan = TestScanner()
         sscan = TestScanner()
@@ -871,7 +871,7 @@ class BuilderTestCase(unittest.TestCase):
 
     def test_src_scanner(self):
         """Testing ability to set a source file scanner through a builder."""
-        class TestScanner(object):
+        class TestScanner:
             def key(self, env):
                  return 'TestScannerkey'
             def instance(self, env):
@@ -900,7 +900,7 @@ class BuilderTestCase(unittest.TestCase):
 
         # An Environment that has suffix-specified SCANNERS should
         # provide a source scanner to the target.
-        class EnvTestScanner(object):
+        class EnvTestScanner:
             def key(self, env):
                  return '.y'
             def instance(self, env):

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -135,7 +135,7 @@ def CachePushFunc(target, source, env):
 CachePush = SCons.Action.Action(CachePushFunc, None)
 
 
-class CacheDir(object):
+class CacheDir:
 
     def __init__(self, path):
         """

--- a/SCons/CacheDirTests.py
+++ b/SCons/CacheDirTests.py
@@ -36,7 +36,7 @@ import SCons.CacheDir
 
 built_it = None
 
-class Action(object):
+class Action:
     def __call__(self, targets, sources, env, **kw):
         global built_it
         if kw.get('execute', 1):
@@ -47,7 +47,7 @@ class Action(object):
     def get_contents(self, target, source, env):
         return bytearray('','utf-8')
 
-class Builder(object):
+class Builder:
     def __init__(self, environment, action):
         self.env = environment
         self.action = action
@@ -55,7 +55,7 @@ class Builder(object):
         self.source_scanner = None
         self.target_scanner = None
 
-class Environment(object):
+class Environment:
     def __init__(self, cachedir):
         self.cachedir = cachedir
     def Override(self, overrides):

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -498,7 +498,7 @@ def _defines(prefix, defs, suffix, env, c=_concat_ixes):
     return c(prefix, env.subst_path(processDefines(defs)), suffix, env)
 
 
-class NullCmdGenerator(object):
+class NullCmdGenerator:
     """This is a callable class that can be used in place of other
     command generators if you don't want them to do anything.
 
@@ -517,7 +517,7 @@ class NullCmdGenerator(object):
         return self.cmd
 
 
-class Variable_Method_Caller(object):
+class Variable_Method_Caller:
     """A class for finding a construction variable on the stack and
     calling one of its methods.
 

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -60,7 +60,7 @@ import SCons.Tool
 import SCons.Util
 import SCons.Warnings
 
-class _Null(object):
+class _Null:
     pass
 
 _null = _Null
@@ -191,7 +191,7 @@ def _delete_duplicates(l, keep_last):
 # BuilderWrapper a subclass that overrides __call__() to enforce specific
 # Builder calling conventions, simplified some of our higher-layer code.
 
-class MethodWrapper(object):
+class MethodWrapper:
     """
     A generic Wrapper class that associates a method (which can
     actually be any callable) with an object.  As part of creating this
@@ -334,7 +334,7 @@ def is_valid_construction_var(varstr):
 
 
 
-class SubstitutionEnvironment(object):
+class SubstitutionEnvironment:
     """Base class for different flavors of construction environments.
 
     This class contains a minimal set of methods that handle construction

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -101,7 +101,7 @@ class Builder(SCons.Builder.BuilderBase):
 
 scanned_it = {}
 
-class Scanner(object):
+class Scanner:
     """A dummy Scanner class for testing purposes.  "Scanning"
     a target is simply setting a value in the dictionary.
     """
@@ -137,7 +137,7 @@ class CLVar(UL):
     def __radd__(self, other):
         return UL.__radd__(self, CLVar(other))
 
-class DummyNode(object):
+class DummyNode:
     def __init__(self, name):
         self.name = name
     def __str__(self):
@@ -150,7 +150,7 @@ class DummyNode(object):
 def test_tool( env ):
     env['_F77INCFLAGS'] = '$( ${_concat(INCPREFIX, F77PATH, INCSUFFIX, __env__, RDirs, TARGET, SOURCE)} $)'
 
-class TestEnvironmentFixture(object):
+class TestEnvironmentFixture:
     def TestEnvironment(self, *args, **kw):
         if not kw or 'tools' not in kw:
             kw['tools'] = [test_tool]
@@ -283,7 +283,7 @@ class SubstitutionTestCase(unittest.TestCase):
         assert len(nodes) == 1, nodes
         assert isinstance(nodes[0], SConsNode), nodes[0]
 
-        class OtherNode(object):
+        class OtherNode:
             pass
         nodes = env.arg2nodes(OtherNode())
         assert len(nodes) == 1, nodes
@@ -525,13 +525,13 @@ class SubstitutionTestCase(unittest.TestCase):
     def test_subst_path(self):
         """Test substituting a path list
         """
-        class MyProxy(object):
+        class MyProxy:
             def __init__(self, val):
                 self.val = val
             def get(self):
                 return self.val + '-proxy'
 
-        class MyNode(object):
+        class MyNode:
             def __init__(self, val):
                 self.val = val
             def get_subst_proxy(self):
@@ -539,7 +539,7 @@ class SubstitutionTestCase(unittest.TestCase):
             def __str__(self):
                 return self.val
 
-        class MyObj(object):
+        class MyObj:
             def get(self):
                 return self
 
@@ -571,7 +571,7 @@ class SubstitutionTestCase(unittest.TestCase):
         r = env.subst_path(['$PROXY', MyProxy('my2'), n])
         assert r == ['my1-proxy', 'my2-proxy', n], r
 
-        class StringableObj(object):
+        class StringableObj:
             def __init__(self, s):
                 self.s = s
             def __str__(self):
@@ -899,7 +899,7 @@ class BaseTestCase(unittest.TestCase,TestEnvironmentFixture):
 
     def test_variables(self):
         """Test that variables only get applied once."""
-        class FakeOptions(object):
+        class FakeOptions:
             def __init__(self, key, val):
                 self.calls = 0
                 self.key = key
@@ -1300,7 +1300,7 @@ env4.builder1.env, env3)
 
     def test_platform(self):
         """Test specifying a platform callable when instantiating."""
-        class platform(object):
+        class platform:
             def __str__(self):        return "TestPlatform"
             def __call__(self, env):  env['XYZZY'] = 777
 
@@ -1315,7 +1315,7 @@ env4.builder1.env, env3)
 
     def test_Default_PLATFORM(self):
         """Test overriding the default PLATFORM variable"""
-        class platform(object):
+        class platform:
             def __str__(self):        return "DefaultTestPlatform"
             def __call__(self, env):  env['XYZZY'] = 888
 
@@ -1599,7 +1599,7 @@ def exists(env):
         assert isinstance(result, CLVar), repr(result)
         assert result == ['foo', 'bar'], result
 
-        class C(object):
+        class C:
             def __init__(self, name):
                 self.name = name
             def __str__(self):
@@ -1756,7 +1756,7 @@ def exists(env):
 
         # Ensure that lists and dictionaries are
         # deep copied, but not instances.
-        class TestA(object):
+        class TestA:
             pass
         env1 = self.TestEnvironment(XXX=TestA(), YYY = [ 1, 2, 3 ],
                            ZZZ = { 1:2, 3:4 })
@@ -1999,7 +1999,7 @@ def generate(env):
                           RPATH=[])
 
         orig_backtick = env.backtick
-        class my_backtick(object):
+        class my_backtick:
             def __init__(self, save_command, output):
                 self.save_command = save_command
                 self.output = output
@@ -2701,7 +2701,7 @@ def generate(env):
 
     def test_VariantDir(self):
         """Test the VariantDir() method"""
-        class MyFS(object):
+        class MyFS:
              def Dir(self, name):
                  return name
              def VariantDir(self, variant_dir, src_dir, duplicate):
@@ -2889,7 +2889,7 @@ def generate(env):
 
     def test_Dir(self):
         """Test the Dir() method"""
-        class MyFS(object):
+        class MyFS:
             def Dir(self, name):
                 return 'Dir(%s)' % name
 
@@ -2952,7 +2952,7 @@ def generate(env):
     def test_Execute(self):
         """Test the Execute() method"""
 
-        class MyAction(object):
+        class MyAction:
             def __init__(self, *args, **kw):
                 self.args = args
             def __call__(self, target, source, env):
@@ -2966,7 +2966,7 @@ def generate(env):
 
     def test_Entry(self):
         """Test the Entry() method"""
-        class MyFS(object):
+        class MyFS:
             def Entry(self, name):
                 return 'Entry(%s)' % name
 
@@ -2990,7 +2990,7 @@ def generate(env):
 
     def test_File(self):
         """Test the File() method"""
-        class MyFS(object):
+        class MyFS:
             def File(self, name):
                 return 'File(%s)' % name
 
@@ -3138,7 +3138,7 @@ def generate(env):
 
     def test_Repository(self):
         """Test the Repository() method."""
-        class MyFS(object):
+        class MyFS:
             def __init__(self):
                 self.list = []
             def Repository(self, *dirs):
@@ -3176,7 +3176,7 @@ def generate(env):
         """Test the SConsignFile() method"""
         import SCons.SConsign
 
-        class MyFS(object):
+        class MyFS:
             SConstruct_dir = os.sep + 'dir'
 
         env = self.TestEnvironment(FOO = 'SConsign',

--- a/SCons/EnvironmentValues.py
+++ b/SCons/EnvironmentValues.py
@@ -34,7 +34,7 @@ _separate_args = re.compile(r'(%s|\s+|[^\s$]+|\$)' % _dollar_exps_str)
 # space characters in the string result from the scons_subst() function.
 _space_sep = re.compile(r'[\t ]+(?![^{]*})')
 
-class ValueTypes(object):
+class ValueTypes:
     """
     Enum to store what type of value the variable holds.
     """
@@ -44,7 +44,7 @@ class ValueTypes(object):
     VARIABLE = 3
 
 
-class EnvironmentValue(object):
+class EnvironmentValue:
     """
     Hold a single value. We're going to cache parsed version of the file
     We're going to keep track of variables which feed into this values evaluation
@@ -87,8 +87,7 @@ class EnvironmentValue(object):
             pass
 
 
-
-class EnvironmentValues(object):
+class EnvironmentValues:
     """
     A class to hold all the environment variables
     """

--- a/SCons/Executor.py
+++ b/SCons/Executor.py
@@ -37,7 +37,7 @@ import SCons.Memoize
 import SCons.Util
 from SCons.compat import NoSlotsPyPy
 
-class Batch(object):
+class Batch:
     """Remembers exact association between targets
     and sources of executor."""
 
@@ -79,7 +79,7 @@ class TSList(collections.UserList):
         nl = self.func()
         return repr(nl)
 
-class TSObject(object):
+class TSObject:
     """A class that implements $TARGET or $SOURCE expansions by wrapping
     an Executor method.
     """

--- a/SCons/ExecutorTests.py
+++ b/SCons/ExecutorTests.py
@@ -29,7 +29,7 @@ import unittest
 import SCons.Executor
 
 
-class MyEnvironment(object):
+class MyEnvironment:
     def __init__(self, **kw):
         self._dict = {}
         self._dict.update(kw)
@@ -42,7 +42,7 @@ class MyEnvironment(object):
     def _update(self, dict):
         self._dict.update(dict)
 
-class MyAction(object):
+class MyAction:
     def __init__(self, actions=['action1', 'action2']):
         self.actions = actions
     def __call__(self, target, source, env, **kw):
@@ -59,13 +59,13 @@ class MyAction(object):
     def get_implicit_deps(self, target, source, env):
         return []
 
-class MyBuilder(object):
+class MyBuilder:
     def __init__(self, env, overrides):
         self.env = env
         self.overrides = overrides
         self.action = MyAction()
 
-class MyNode(object):
+class MyNode:
     def __init__(self, name=None, pre=[], post=[]):
         self.name = name
         self.implicit = []
@@ -105,7 +105,7 @@ class MyNode(object):
     def is_up_to_date(self):
         return self.up_to_date
 
-class MyScanner(object):
+class MyScanner:
     def __init__(self, prefix):
         self.prefix = prefix
     def path(self, env, cwd, target, source):
@@ -194,7 +194,7 @@ class ExecutorTestCase(unittest.TestCase):
                                     [t],
                                     ['s1', 's2'])
 
-        class LocalScanner(object):
+        class LocalScanner:
             def path(self, env, dir, target, source):
                 target = list(map(str, target))
                 source = list(map(str, source))

--- a/SCons/Job.py
+++ b/SCons/Job.py
@@ -52,7 +52,7 @@ default_stack_size = 256
 interrupt_msg = 'Build interrupted.'
 
 
-class InterruptState(object):
+class InterruptState:
     def __init__(self):
         self.interrupted = False
 
@@ -63,7 +63,7 @@ class InterruptState(object):
         return self.interrupted
 
 
-class Jobs(object):
+class Jobs:
     """An instance of this class initializes N jobs, and provides
     methods for starting, stopping, and waiting on all N jobs.
     """
@@ -163,7 +163,7 @@ class Jobs(object):
         except AttributeError:
             pass
 
-class Serial(object):
+class Serial:
     """This class is used to execute tasks in series, and is more efficient
     than Parallel, but is only appropriate for non-parallel builds. Only
     one instance of this class should be in existence at a time.
@@ -264,7 +264,7 @@ else:
 
                 self.resultsQueue.put((task, ok))
 
-    class ThreadPool(object):
+    class ThreadPool:
         """This class is responsible for spawning and managing worker threads."""
 
         def __init__(self, num, stack_size, interrupted):
@@ -338,7 +338,7 @@ else:
                 worker.join(1.0)
             self.workers = []
 
-    class Parallel(object):
+    class Parallel:
         """This class is used to execute tasks in parallel, and is somewhat
         less efficient than Serial, but is appropriate for parallel builds.
 

--- a/SCons/JobTests.py
+++ b/SCons/JobTests.py
@@ -65,7 +65,7 @@ if num_jobs == 2:
 # how many tasks to perform for the test
 num_tasks = num_jobs*5
 
-class DummyLock(object):
+class DummyLock:
     """fake lock class to use if threads are not supported"""
     def acquire(self):
         pass
@@ -79,7 +79,7 @@ class NoThreadsException(Exception):
     def __str__(self):
         return "the interpreter doesn't support threads"
 
-class Task(object):
+class Task:
     """A dummy task class for testing purposes."""
 
     def __init__(self, i, taskmaster):
@@ -152,7 +152,7 @@ class RandomTask(Task):
             x = math.sin(i)
         time.sleep(0.01)
 
-class ExceptionTask(object):
+class ExceptionTask:
     """A dummy task class for testing purposes."""
 
     def __init__(self, i, taskmaster):
@@ -190,7 +190,7 @@ class ExceptionTask(object):
     def exception_set(self):
         self.taskmaster.exception_set()
 
-class Taskmaster(object):
+class Taskmaster:
     """A dummy taskmaster class for testing the job classes."""
 
     def __init__(self, n, test_case, Task):
@@ -405,7 +405,7 @@ import SCons.Taskmaster
 import SCons.Node
 import time
 
-class DummyNodeInfo(object):
+class DummyNodeInfo:
     def update(self, obj):
         pass
 

--- a/SCons/Memoize.py
+++ b/SCons/Memoize.py
@@ -104,7 +104,7 @@ use_memoizer = None
 # Global list of counter objects
 CounterList = {}
 
-class Counter(object):
+class Counter:
     """
     Base class for counting memoization hits and misses.
 

--- a/SCons/MemoizeTests.py
+++ b/SCons/MemoizeTests.py
@@ -31,7 +31,7 @@ import SCons.Memoize
 # Enable memoization counting
 SCons.Memoize.EnableMemoization()
 
-class FakeObject(object):
+class FakeObject:
     def __init__(self):
         self._memo = {}
 
@@ -76,7 +76,7 @@ class FakeObject(object):
     def get_memoizer_counter(self, name):
         return SCons.Memoize.CounterList.get(self.__class__.__name__+'.'+name, None)
 
-class Returner(object):
+class Returner:
     def __init__(self, result):
         self.result = result
         self.calls = 0

--- a/SCons/Node/AliasTests.py
+++ b/SCons/Node/AliasTests.py
@@ -51,7 +51,7 @@ class AliasTestCase(unittest.TestCase):
     def test_get_contents(self):
         """Test the get_contents() method
         """
-        class DummyNode(object):
+        class DummyNode:
             def __init__(self, contents):
                 self.contents = contents
             def get_csig(self):

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -367,7 +367,7 @@ def get_MkdirBuilder():
                                              name = "MkdirBuilder")
     return MkdirBuilder
 
-class _Null(object):
+class _Null:
     pass
 
 _null = _Null()
@@ -383,7 +383,7 @@ else:
 
 
 
-class DiskChecker(object):
+class DiskChecker:
     def __init__(self, type, do, ignore):
         self.type = type
         self.do = do
@@ -1094,7 +1094,7 @@ class Entry(Base):
 _classEntry = Entry
 
 
-class LocalFS(object):
+class LocalFS:
     """
     This class implements an abstraction layer for operations involving
     a local file system.  Essentially, this wraps any function in
@@ -3685,7 +3685,7 @@ def get_default_fs():
         default_fs = FS()
     return default_fs
 
-class FileFinder(object):
+class FileFinder:
     """
     """
 

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -46,7 +46,7 @@ built_it = None
 scanner_count = 0
 
 
-class Scanner(object):
+class Scanner:
     def __init__(self, node=None):
         global scanner_count
         scanner_count = scanner_count + 1
@@ -69,7 +69,7 @@ class Scanner(object):
         return nodes
 
 
-class Environment(object):
+class Environment:
     def __init__(self):
         self.scanner = Scanner()
 
@@ -89,7 +89,7 @@ class Environment(object):
         pass
 
 
-class Action(object):
+class Action:
     def __call__(self, targets, sources, env, **kw):
         global built_it
         if kw.get('execute', 1):
@@ -112,7 +112,7 @@ class Action(object):
         return []
 
 
-class Builder(object):
+class Builder:
     def __init__(self, factory, action=Action()):
         self.factory = factory
         self.env = Environment()
@@ -458,7 +458,7 @@ class VariantDirTestCase(unittest.TestCase):
         assert r == d1, "%s != %s" % (r, d1)
 
         # verify the link creation attempts in file_link()
-        class LinkSimulator(object):
+        class LinkSimulator:
             """A class to intercept os.[sym]link() calls and track them."""
 
             def __init__(self, duplicate, link, symlink, copy):
@@ -1299,7 +1299,7 @@ class FSTestCase(_tempdirTestCase):
 
         # Make sure we can scan this file even if the target isn't
         # a file that has a scanner (it might be an Alias, e.g.).
-        class DummyNode(object):
+        class DummyNode:
             pass
 
         deps = f12.get_found_includes(env, s, DummyNode())
@@ -2416,11 +2416,11 @@ class EntryTestCase(_tempdirTestCase):
         assert e4n.__class__ is SCons.Node.FS.File, e4n.__class__
         assert not exists, "e4n exists?"
 
-        class MyCalc(object):
+        class MyCalc:
             def __init__(self, val):
                 self.max_drift = 0
 
-                class M(object):
+                class M:
                     def __init__(self, val):
                         self.val = val
 
@@ -2556,7 +2556,7 @@ class FileTestCase(_tempdirTestCase):
                 SCons.Environment.Base.__init__(self)
                 self.decide_source = self._changed_timestamp_then_content
 
-        class FakeNodeInfo(object):
+        class FakeNodeInfo:
             def __init__(self, csig, timestamp):
                 self.csig = csig
                 self.timestamp = timestamp
@@ -3438,8 +3438,8 @@ class stored_infoTestCase(unittest.TestCase):
         bi = f.get_stored_info()
         assert hasattr(bi, 'ninfo')
 
-        class MySConsign(object):
-            class Null(object):
+        class MySConsign:
+            class Null:
                 def __init__(self):
                     self.xyzzy = 7
 

--- a/SCons/Node/NodeTests.py
+++ b/SCons/Node/NodeTests.py
@@ -55,7 +55,7 @@ def _actionAppend(a1, a2):
             raise Exception('Cannot Combine Actions')
     return MyListAction(all)
 
-class MyActionBase(object):
+class MyActionBase:
     def __add__(self, other):
         return _actionAppend(self, other)
 
@@ -82,7 +82,7 @@ class MyAction(MyActionBase):
     def get_implicit_deps(self, target, source, env):
         return []
 
-class MyExecutor(object):
+class MyExecutor:
     def __init__(self, env=None, targets=[], sources=[]):
         self.env = env
         self.targets = targets
@@ -113,7 +113,7 @@ class MyListAction(MyActionBase):
         for A in self.list:
             A(target, source, env)
 
-class Environment(object):
+class Environment:
     def __init__(self, **kw):
         self._dict = {}
         self._dict.update(kw)
@@ -139,7 +139,7 @@ class Environment(object):
 
         return []
 
-class Builder(object):
+class Builder:
     def __init__(self, env=None, is_explicit=1):
         if env is None: env = Environment()
         self.env = env
@@ -173,19 +173,19 @@ class ListBuilder(Builder):
         target = self.nodes[0]
         self.status = Builder.execute(self, target, source, env)
 
-class FailBuilder(object):
+class FailBuilder:
     def execute(self, target, source, env):
         return 1
 
-class ExceptBuilder(object):
+class ExceptBuilder:
     def execute(self, target, source, env):
         raise SCons.Errors.BuildError
 
-class ExceptBuilder2(object):
+class ExceptBuilder2:
     def execute(self, target, source, env):
         raise Exception("foo")
 
-class Scanner(object):
+class Scanner:
     called = None
     def __call__(self, node):
         self.called = 1
@@ -211,10 +211,10 @@ class MyNode(SCons.Node.Node):
     def get_found_includes(self, env, scanner, target):
         return scanner(self)
 
-class Calculator(object):
+class Calculator:
     def __init__(self, val):
         self.max_drift = 0
-        class M(object):
+        class M:
             def __init__(self, val):
                 self.val = val
             def signature(self, args):
@@ -401,7 +401,7 @@ class NodeTestCase(unittest.TestCase):
         else:
             self.fail("did not catch expected AttributeError")
 
-        class Builder(object):
+        class Builder:
             action = 'act'
             env = 'env1'
             overrides = {}
@@ -660,7 +660,7 @@ class NodeTestCase(unittest.TestCase):
 
         class testNode2(SCons.Node.Node):
             def __str__(self): return 'null_binfo'
-        class FS(object):
+        class FS:
             pass
         node = testNode2()
         node.fs = FS()
@@ -669,8 +669,8 @@ class NodeTestCase(unittest.TestCase):
         assert result is None, result
 
         def get_null_info():
-            class Null_SConsignEntry(object):
-                class Null_BuildInfo(object):
+            class Null_SConsignEntry:
+                class Null_BuildInfo:
                     def prepare_dependencies(self):
                         pass
                 binfo = Null_BuildInfo()

--- a/SCons/Node/PythonTests.py
+++ b/SCons/Node/PythonTests.py
@@ -50,7 +50,7 @@ class ValueTestCase(unittest.TestCase):
     def test_build(self):
         """Test "building" a Value Node
         """
-        class fake_executor(object):
+        class fake_executor:
             def __call__(self, node):
                 node.write('faked')
 

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -353,7 +353,7 @@ store_info_map = {0 : store_info_pass,
 
 # Classes for signature info for Nodes.
 
-class NodeInfoBase(object):
+class NodeInfoBase:
     """
     The generic base class for signature information for a Node.
 
@@ -448,7 +448,7 @@ class NodeInfoBase(object):
                 setattr(self, key, value)
 
 
-class BuildInfoBase(object):
+class BuildInfoBase:
     """
     The generic base class for build information for a Node.
 
@@ -559,7 +559,7 @@ class Node(object, metaclass=NoSlotsPyPy):
                  '_func_get_contents',
                  '_func_target_from_source']
 
-    class Attrs(object):
+    class Attrs:
         __slots__ = ('shared', '__dict__')
 
 
@@ -1712,7 +1712,7 @@ def get_children(node, parent): return node.children()
 def ignore_cycle(node, stack): pass
 def do_nothing(node, parent): pass
 
-class Walker(object):
+class Walker:
     """An iterator for walking a Node tree.
 
     This is depth-first, children are visited before the parent.

--- a/SCons/PathList.py
+++ b/SCons/PathList.py
@@ -66,7 +66,7 @@ def node_conv(obj):
         result = get()
     return result
 
-class _PathList(object):
+class _PathList:
     """
     An actual PathList object.
     """
@@ -143,7 +143,7 @@ class _PathList(object):
         return tuple(result)
 
 
-class PathListCache(object):
+class PathListCache:
     """
     A class to handle caching of PathList lookups.
 

--- a/SCons/PathListTests.py
+++ b/SCons/PathListTests.py
@@ -35,7 +35,7 @@ class subst_pathTestCase(unittest.TestCase):
 
     def setUp(self):
 
-        class FakeEnvironment(object):
+        class FakeEnvironment:
             def __init__(self, **kw):
                 self.kw = kw
             def subst(self, s, target=None, source=None, conv=lambda x: x):
@@ -59,7 +59,7 @@ class subst_pathTestCase(unittest.TestCase):
 
         import SCons.Node
 
-        class A(object):
+        class A:
             pass
 
         n = SCons.Node.Node()
@@ -74,7 +74,7 @@ class subst_pathTestCase(unittest.TestCase):
         """Test the subst_path() method on a non-Node object
         """
 
-        class A(object):
+        class A:
             def __str__(self):
                 return '<object A>'
 
@@ -90,7 +90,7 @@ class subst_pathTestCase(unittest.TestCase):
         """Test the subst_path() method on an object with a get() method
         """
 
-        class B(object):
+        class B:
             def get(self):
                 return 'b'
 

--- a/SCons/Platform/PlatformTests.py
+++ b/SCons/Platform/PlatformTests.py
@@ -214,8 +214,8 @@ class TempFileMungeTestCase(unittest.TestCase):
         SCons.Action.print_actions = 0
         # Create an instance of object derived class to allow setattrb
 
-        class Node(object):
-            class Attrs(object):
+        class Node:
+            class Attrs:
                 pass
 
             def __init__(self):

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -118,7 +118,7 @@ def DefaultToolList(platform, env):
     return SCons.Tool.tool_list(platform, env)
 
 
-class PlatformSpec(object):
+class PlatformSpec:
     def __init__(self, name, generate):
         self.name = name
         self.generate = generate
@@ -130,7 +130,7 @@ class PlatformSpec(object):
         return self.name
 
 
-class TempFileMunge(object):
+class TempFileMunge:
     """A callable class.  You can set an Environment variable to this,
     then call it with a string argument, then it will perform temporary
     file substitution on it.  This is used to circumvent the long command

--- a/SCons/Platform/virtualenvTests.py
+++ b/SCons/Platform/virtualenvTests.py
@@ -59,7 +59,7 @@ class Environment(collections.UserDict):
         else:
             self['ENV'][key] = os.path.pathsep.join([value, current])
 
-class SysPrefixes(object):
+class SysPrefixes:
     """Used to temporarily mock sys.prefix, sys.real_prefix and sys.base_prefix"""
     def __init__(self, prefix, real_prefix=None, base_prefix=None):
         self._prefix = prefix

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -298,7 +298,7 @@ def get_program_files_dir():
     return val
 
 
-class ArchDefinition(object):
+class ArchDefinition:
     """
     Determine which windows CPU were running on.
     A class for defining architecture-specific settings and logic.

--- a/SCons/SConf.py
+++ b/SCons/SConf.py
@@ -189,7 +189,7 @@ class SConfBuildInfo(SCons.Node.FS.FileBuildInfo):
         self.string = string
 
 
-class Streamer(object):
+class Streamer:
     """
     'Sniffer' for a file-like writable object. Similar to the unix tool tee.
     """
@@ -374,7 +374,7 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
                     sconsign.set_entry(t.name, sconsign_entry)
                     sconsign.merge()
 
-class SConfBase(object):
+class SConfBase:
     """This is simply a class to represent a configure context. After
     creating a SConf object, you can call any tests. After finished with your
     tests, be sure to call the Finish() method, which returns the modified
@@ -692,7 +692,7 @@ class SConfBase(object):
                 return( 1, outputStr)
         return (0, "")
 
-    class TestWrapper(object):
+    class TestWrapper:
         """A wrapper around Tests (to ensure sanity)"""
         def __init__(self, test, sconf):
             self.test = test
@@ -802,7 +802,7 @@ class SConfBase(object):
             _ac_config_hs[self.config_h] = self.config_h_text
         self.env.fs = self.lastEnvFs
 
-class CheckContext(object):
+class CheckContext:
     """Provides a context for configure tests. Defines how a test writes to the
     screen and log file.
 

--- a/SCons/SConfTests.py
+++ b/SCons/SConfTests.py
@@ -158,7 +158,7 @@ class SConfTestCase(unittest.TestCase):
         import SCons.Builder
         import SCons.Node
 
-        class MyAction(object):
+        class MyAction:
             def get_contents(self, target, source, env):
                 return 'MyBuilder-MyAction $SOURCE $TARGET'
 
@@ -170,7 +170,7 @@ class SConfTestCase(unittest.TestCase):
                 self.action = MyAction()
 
             def __call__(self, env, target, source):
-                class MyNode(object):
+                class MyNode:
                     def __init__(self, name):
                         self.name = name
                         self.state = SCons.Node.no_state
@@ -215,7 +215,7 @@ class SConfTestCase(unittest.TestCase):
                     def get_stored_info(self):
                         pass
                     def get_executor(self):
-                        class Executor(object):
+                        class Executor:
                             def __init__(self, targets):
                                 self.targets = targets
                             def get_all_targets(self):

--- a/SCons/SConsign.py
+++ b/SCons/SConsign.py
@@ -120,7 +120,7 @@ def write():
             closemethod()
 
 
-class SConsignEntry(object):
+class SConsignEntry:
     """
     Wrapper class for the generic entry in a .sconsign file.
     The Node subclass populates it with attributes as it pleases.
@@ -163,7 +163,7 @@ class SConsignEntry(object):
                 setattr(self, key, value)
 
 
-class Base(object):
+class Base:
     """
     This is the controlling class for the signatures for the collection of
     entries associated with a specific directory.  The actual directory

--- a/SCons/SConsignTests.py
+++ b/SCons/SConsignTests.py
@@ -34,11 +34,11 @@ import SCons.dblite
 
 import SCons.SConsign
 
-class BuildInfo(object):
+class BuildInfo:
     def merge(self, object):
         pass
 
-class DummySConsignEntry(object):
+class DummySConsignEntry:
     def __init__(self, name):
         self.name = name
         self.binfo = BuildInfo()
@@ -47,12 +47,12 @@ class DummySConsignEntry(object):
     def convert_from_sconsign(self, dir, name):
         self.c_from_s = 1
 
-class FS(object):
+class FS:
     def __init__(self, top):
         self.Top = top
         self.Top.repositories = []
 
-class DummyNode(object):
+class DummyNode:
     def __init__(self, path='not_a_valid_path', binfo=None):
         self.path = path
         self.tpath = path
@@ -315,7 +315,7 @@ class SConsignFileTestCase(SConsignTestCase):
         assert SCons.SConsign.DB_Name is file, SCons.SConsign.DB_Name
         assert SCons.SConsign.DB_Module is None, SCons.SConsign.DB_Module
 
-        class Fake_DBM(object):
+        class Fake_DBM:
             def open(self, name, mode):
                 self.name = name
                 self.mode = mode
@@ -349,7 +349,7 @@ class writeTestCase(SConsignTestCase):
         test = self.test
         file = test.workpath('sconsign_file')
 
-        class Fake_DBM(object):
+        class Fake_DBM:
             def __getitem__(self, key):
                 return None
             def __setitem__(self, key, value):

--- a/SCons/Scanner/C.py
+++ b/SCons/Scanner/C.py
@@ -80,7 +80,7 @@ def dictify_CPPDEFINES(env):
         return {cppdefines : None}
     return cppdefines
 
-class SConsCPPScannerWrapper(object):
+class SConsCPPScannerWrapper:
     """
     The SCons wrapper around a cpp.py scanner.
 
@@ -172,7 +172,7 @@ class SConsCPPConditionalScanner(SCons.cpp.PreProcessor):
             return ""
 
 
-class SConsCPPConditionalScannerWrapper(object):
+class SConsCPPConditionalScannerWrapper:
     """
     The SCons wrapper around a cpp.py scanner.
 

--- a/SCons/Scanner/CTests.py
+++ b/SCons/Scanner/CTests.py
@@ -332,7 +332,7 @@ class CScannerTestCase9(unittest.TestCase):
     def runTest(self):
         """Generate a warning when we can't find a #included file"""
         SCons.Warnings.enableWarningClass(SCons.Warnings.DependencyWarning)
-        class TestOut(object):
+        class TestOut:
             def __call__(self, x):
                 self.out = x
 

--- a/SCons/Scanner/DirTests.py
+++ b/SCons/Scanner/DirTests.py
@@ -42,7 +42,7 @@ import SCons.Scanner.Dir
 #    def Entry(self, name):
 #        return self.fs.Entry(name)
 
-class DummyEnvironment(object):
+class DummyEnvironment:
     def __init__(self, root):
         self.fs = SCons.Node.FS.FS(root)
     def Dir(self, name):

--- a/SCons/Scanner/FortranTests.py
+++ b/SCons/Scanner/FortranTests.py
@@ -204,7 +204,7 @@ test.write(['modules', 'use.mod'], "\n")
 
 # define some helpers:
 
-class DummyEnvironment(object):
+class DummyEnvironment:
     def __init__(self, listCppPath):
         self.path = listCppPath
         self.fs = SCons.Node.FS.FS(test.workpath(''))
@@ -403,7 +403,7 @@ class FortranScannerTestCase11(unittest.TestCase):
     def runTest(self):
         SCons.Warnings.enableWarningClass(SCons.Warnings.DependencyWarning)
 
-        class TestOut(object):
+        class TestOut:
             def __call__(self, x):
                 self.out = x
 

--- a/SCons/Scanner/IDLTests.py
+++ b/SCons/Scanner/IDLTests.py
@@ -189,7 +189,7 @@ test.write([ 'repository', 'src', 'ddd.idl'], "\n")
 
 # define some helpers:
 
-class DummyEnvironment(object):
+class DummyEnvironment:
     def __init__(self, listCppPath):
         self.path = listCppPath
         self.fs = SCons.Node.FS.FS(test.workpath(''))
@@ -341,7 +341,7 @@ class IDLScannerTestCase7(unittest.TestCase):
 class IDLScannerTestCase8(unittest.TestCase):
     def runTest(self):
         SCons.Warnings.enableWarningClass(SCons.Warnings.DependencyWarning)
-        class TestOut(object):
+        class TestOut:
             def __call__(self, x):
                 self.out = x
 

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -42,7 +42,7 @@ LatexGraphics = [ '.png', '.jpg', '.gif', '.tif']
 
 
 # Used as a return value of modify_env_var if the variable is not set.
-class _Null(object):
+class _Null:
     pass
 _null = _Null
 
@@ -77,7 +77,7 @@ def modify_env_var(env, var, abspath):
 
     return save
 
-class FindENVPathDirs(object):
+class FindENVPathDirs:
     """
     A class to bind a specific E{*}PATH variable name to a function that
     will return all of the E{*}path directories.
@@ -211,7 +211,7 @@ class LaTeX(SCons.Scanner.Base):
                 return []
             return self.scan_recurse(node, path)
 
-        class FindMultiPathDirs(object):
+        class FindMultiPathDirs:
             """The stock FindPathDirs function has the wrong granularity:
             it is called once per target, while we need the path that depends
             on what kind of included files is being searched. This wrapper
@@ -239,7 +239,7 @@ class LaTeX(SCons.Scanner.Base):
                 # To prevent "dict is not hashable error"
                 return tuple(di.items())
 
-        class LaTeXScanCheck(object):
+        class LaTeXScanCheck:
             """Skip all but LaTeX source files, i.e., do not scan *.eps,
             *.pdf, *.jpg, etc.
             """

--- a/SCons/Scanner/ProgTests.py
+++ b/SCons/Scanner/ProgTests.py
@@ -46,7 +46,7 @@ for h in libs:
 
 # define some helpers:
 
-class DummyEnvironment(object):
+class DummyEnvironment:
     def __init__(self, **kw):
         self._dict = {'LIBSUFFIXES' : '.lib'}
         self._dict.update(kw)
@@ -89,7 +89,7 @@ class DummyEnvironment(object):
     def File(self, filename):
         return self.fs.File(test.workpath(filename))
 
-class DummyNode(object):
+class DummyNode:
     def __init__(self, name):
         self.name = name
     def rexists(self):

--- a/SCons/Scanner/ScannerTests.py
+++ b/SCons/Scanner/ScannerTests.py
@@ -32,7 +32,7 @@ import TestUnit
 
 import SCons.Scanner
 
-class DummyFS(object):
+class DummyFS:
     def File(self, name):
         return DummyNode(name)
 
@@ -56,7 +56,7 @@ class DummyEnvironment(collections.UserDict):
     def get_factory(self, factory):
         return factory or self.fs.File
 
-class DummyNode(object):
+class DummyNode:
     def __init__(self, name, search_result=()):
         self.name = name
         self.search_result = tuple(search_result)
@@ -108,7 +108,7 @@ class ScannerTestCase(unittest.TestCase):
 
 class BaseTestCase(unittest.TestCase):
 
-    class skey_node(object):
+    class skey_node:
         def __init__(self, key):
             self.key = key
         def scanner_key(self):
@@ -340,7 +340,7 @@ class BaseTestCase(unittest.TestCase):
         assert s == 'xyzzy', s
 
 class SelectorTestCase(unittest.TestCase):
-    class skey_node(object):
+    class skey_node:
         def __init__(self, key):
             self.key = key
         def scanner_key(self):
@@ -399,7 +399,7 @@ class SelectorTestCase(unittest.TestCase):
 class CurrentTestCase(unittest.TestCase):
     def test_class(self):
         """Test the Scanner.Current class"""
-        class MyNode(object):
+        class MyNode:
             def __init__(self):
                 self.called_has_builder = None
                 self.called_is_up_to_date = None
@@ -484,7 +484,7 @@ class ClassicTestCase(unittest.TestCase):
 
     def test_scan(self):
         """Test the Scanner.Classic scan() method"""
-        class MyNode(object):
+        class MyNode:
             def __init__(self, name):
                 self.name = name
                 self._rfile = self

--- a/SCons/Scanner/__init__.py
+++ b/SCons/Scanner/__init__.py
@@ -35,7 +35,7 @@ import SCons.Node.FS
 import SCons.Util
 
 
-class _Null(object):
+class _Null:
     pass
 
 # This is used instead of None as a default argument value so None can be
@@ -61,7 +61,7 @@ def Scanner(function, *args, **kw):
 
 
 
-class FindPathDirs(object):
+class FindPathDirs:
     """
     A class to bind a specific E{*}PATH variable name to a function that
     will return all of the E{*}path directories.
@@ -81,7 +81,7 @@ class FindPathDirs(object):
 
 
 
-class Base(object):
+class Base:
     """
     The base class for dependency scanners.  This implements
     straightforward, single-pass scanning of a single file.

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -109,7 +109,7 @@ display = SCons.Util.display
 progress_display = SCons.Util.DisplayEngine()
 
 
-class Progressor(object):
+class Progressor:
     prev = ''
     count = 0
     target_string = '$TARGET'
@@ -429,7 +429,7 @@ class QuestionTask(SCons.Taskmaster.AlwaysTask):
         pass
 
 
-class TreePrinter(object):
+class TreePrinter:
     def __init__(self, derived=False, prune=False, status=False, sLineDraw=False):
         self.derived = derived
         self.prune = prune
@@ -459,7 +459,7 @@ def python_version_deprecated(version=sys.version_info):
     return version < deprecated_python_version
 
 
-class FakeOptionParser(object):
+class FakeOptionParser:
     """
     A do-nothing option parser, used for the initial OptionsParser variable.
 
@@ -471,7 +471,7 @@ class FakeOptionParser(object):
     without blowing up.
 
     """
-    class FakeOptionValues(object):
+    class FakeOptionValues:
         def __getattr__(self, attr):
             return None
     values = FakeOptionValues()
@@ -495,7 +495,7 @@ def SetOption(name, value):
 def PrintHelp(file=None):
     OptionsParser.print_help(file=file)
 
-class Stats(object):
+class Stats:
     def __init__(self):
         self.stats = []
         self.labels = []

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -626,11 +626,13 @@ will overwrite itself on a display:
 
 <example_commands>
 import sys
-class ProgressCounter(object):
+
+class ProgressCounter:
     count = 0
     def __call__(self, node, *args, **kw):
         self.count += 100
         sys.stderr.write('Evaluated %s nodes\r' % self.count)
+
 Progress(ProgressCounter(), interval=100)
 </example_commands>
 

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -110,7 +110,7 @@ def compute_exports(exports):
 
     return retval
 
-class Frame(object):
+class Frame:
     """A frame on the SConstruct/SConscript call stack"""
     def __init__(self, fs, exports, sconscript):
         self.globals = BuildDefaultGlobals()
@@ -639,7 +639,7 @@ def get_DefaultEnvironmentProxy():
         _DefaultEnvironmentProxy = SCons.Environment.NoSubstitutionProxy(default_env)
     return _DefaultEnvironmentProxy
 
-class DefaultEnvironmentCall(object):
+class DefaultEnvironmentCall:
     """A class that implements "global function" calls of
     Environment methods by fetching the specified method from the
     DefaultEnvironment's class.  Note that this uses an intermediate

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -58,7 +58,7 @@ def raise_exception(exception, target, s):
 
 
 
-class Literal(object):
+class Literal:
     """A wrapper for a string.  If you use this object wrapped
     around a string, then it will be interpreted as literal.
     When passed to the command interpreter, all special
@@ -89,7 +89,7 @@ class Literal(object):
     def __hash__(self):
         return hash(self.lstr)
 
-class SpecialAttrWrapper(object):
+class SpecialAttrWrapper:
     """This is a wrapper for what we call a 'Node special attribute.'
     This is any of the attributes of a Node that we can reference from
     Environment variable substitution, such as $TARGET.abspath or
@@ -171,7 +171,7 @@ def escape_list(mylist, escape_func):
             return e(escape_func)
     return list(map(escape, mylist))
 
-class NLWrapper(object):
+class NLWrapper:
     """A wrapper class that delays turning a list of sources or targets
     into a NodeList until it's needed.  The specified function supplied
     when the object is initialized is responsible for turning raw nodes
@@ -232,7 +232,7 @@ class Targets_or_Sources(collections.UserList):
         nl = self.nl._create_nodelist()
         return repr(nl)
 
-class Target_or_Source(object):
+class Target_or_Source:
     """A class that implements $TARGET or $SOURCE expansions by in turn
     wrapping a NLWrapper.  This class handles the different methods used
     to access an individual proxy Node, calling the NLWrapper to create
@@ -332,7 +332,7 @@ def subst_dict(target, source):
     return dict
 
 
-class StringSubber(object):
+class StringSubber:
     """A class to construct the results of a scons_subst() call.
 
     This binds a specific construction environment, mode, target and

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -34,7 +34,7 @@ import SCons.Errors
 
 from SCons.Subst import *
 
-class DummyNode(object):
+class DummyNode:
     """Simple node work-alike."""
     def __init__(self, name):
         self.name = os.path.normpath(name)
@@ -47,7 +47,7 @@ class DummyNode(object):
     def get_subst_proxy(self):
         return self
 
-class DummyEnv(object):
+class DummyEnv:
     def __init__(self, dict={}):
         self.dict = dict
 
@@ -82,7 +82,7 @@ def CmdGen1(target, source, env, for_signature):
     assert str(source) == 's', source
     return "${CMDGEN2('foo', %d)}" % for_signature
 
-class CmdGen2(object):
+class CmdGen2:
     def __init__(self, mystr, forsig):
         self.mystr = mystr
         self.expect_for_signature = forsig
@@ -105,7 +105,7 @@ class SubstTestCase(unittest.TestCase):
         """Simple node work-alike with some extra stuff for testing."""
         def __init__(self, name):
             DummyNode.__init__(self, name)
-            class Attribute(object):
+            class Attribute:
                 pass
             self.attribute = Attribute()
             self.attribute.attr1 = 'attr$1-' + os.path.basename(name)
@@ -114,7 +114,7 @@ class SubstTestCase(unittest.TestCase):
             return self.name + extra
         foo = 1
 
-    class TestLiteral(object):
+    class TestLiteral:
         def __init__(self, literal):
             self.literal = literal
         def __str__(self):
@@ -122,7 +122,7 @@ class SubstTestCase(unittest.TestCase):
         def is_literal(self):
             return 1
 
-    class TestCallable(object):
+    class TestCallable:
         def __init__(self, value):
             self.value = value
         def __call__(self):
@@ -523,7 +523,7 @@ class scons_subst_TestCase(SubstTestCase):
         """Test scons_subst():  handling attribute errors"""
         env = DummyEnv(self.loc)
         try:
-            class Foo(object):
+            class Foo:
                 pass
             scons_subst('${foo.bar}', env, gvars={'foo':Foo()})
         except SCons.Errors.UserError as e:
@@ -980,7 +980,7 @@ class scons_subst_list_TestCase(SubstTestCase):
         """Test scons_subst_list():  handling attribute errors"""
         env = DummyEnv()
         try:
-            class Foo(object):
+            class Foo:
                 pass
             scons_subst_list('${foo.bar}', env, gvars={'foo':Foo()})
         except SCons.Errors.UserError as e:
@@ -1125,7 +1125,7 @@ class quote_spaces_TestCase(unittest.TestCase):
         q = quote_spaces('x\tx')
         assert q == '"x\tx"', q
 
-    class Node(object):
+    class Node:
         def __init__(self, name, children=[]):
             self.children = children
             self.name = name
@@ -1207,7 +1207,7 @@ class subst_dict_TestCase(unittest.TestCase):
         assert SOURCES == ['s1', 's2'], d['SOURCES']
         assert str(d['SOURCE']) == 's1', d['SOURCE']
 
-        class V(object):
+        class V:
             # Fake Value node with no rfile() method.
             def __init__(self, name):
                 self.name = name

--- a/SCons/Taskmaster.py
+++ b/SCons/Taskmaster.py
@@ -79,7 +79,7 @@ print_prepare = 0               # set by option --debug=prepare
 
 CollectStats = None
 
-class Stats(object):
+class Stats:
     """
     A simple class for holding statistics about the disposition of a
     Node by the Taskmaster.  If we're collecting statistics, each Node
@@ -116,7 +116,7 @@ def dump_stats():
 
 
 
-class Task(object):
+class Task:
     """
     Default SCons build engine task.
 
@@ -605,7 +605,7 @@ def find_cycle(stack, visited):
     return None
 
 
-class Taskmaster(object):
+class Taskmaster:
     """
     The Taskmaster for walking the dependency DAG.
     """

--- a/SCons/TaskmasterTests.py
+++ b/SCons/TaskmasterTests.py
@@ -39,7 +39,7 @@ visited_nodes = []
 executed = None
 scan_called = 0
 
-class Node(object):
+class Node:
     def __init__(self, name, kids = [], scans = []):
         self.name = name
         self.kids = kids
@@ -49,7 +49,7 @@ class Node(object):
         self.scanner = None
         self.targets = [self]
         self.prerequisites = None
-        class Builder(object):
+        class Builder:
             def targets(self, node):
                 return node.targets
         self.builder = Builder()
@@ -217,7 +217,7 @@ class Node(object):
 
     def get_executor(self):
         if not hasattr(self, 'executor'):
-            class Executor(object):
+            class Executor:
                 def prepare(self):
                     pass
                 def get_action_targets(self):
@@ -883,7 +883,7 @@ class TaskmasterTestCase(unittest.TestCase):
         assert n10.prepared
 
         # Make sure we call an Executor's prepare() method.
-        class ExceptionExecutor(object):
+        class ExceptionExecutor:
             def prepare(self):
                 raise Exception("Executor.prepare() exception")
             def get_all_targets(self):

--- a/SCons/Tool/FortranCommonTests.py
+++ b/SCons/Tool/FortranCommonTests.py
@@ -41,7 +41,7 @@ test = TestCmd.TestCmd(workdir='')
 os.chdir(test.workpath(''))
 
 
-class DummyEnvironment(object):
+class DummyEnvironment:
     dictionary = None  # type: Dict[Any, Any]
 
     def __init__(self, list_cpp_path):

--- a/SCons/Tool/GettextCommon.py
+++ b/SCons/Tool/GettextCommon.py
@@ -69,7 +69,7 @@ SCons.Warnings.enableWarningClass(MsgfmtNotFound)
 #############################################################################
 
 #############################################################################
-class _POTargetFactory(object):
+class _POTargetFactory:
     """ A factory of `PO` target files.
 
     Factory defaults differ from these of `SCons.Node.FS.FS`.  We set `precious`
@@ -269,7 +269,7 @@ def _translate(env, target=None, source=SCons.Environment._null, *args, **kw):
 #############################################################################
 
 #############################################################################
-class RPaths(object):
+class RPaths:
     """ Callable object, which returns pathnames relative to SCons current
     working directory.
 

--- a/SCons/Tool/JavaCommon.py
+++ b/SCons/Tool/JavaCommon.py
@@ -92,7 +92,7 @@ if java_parsing:
                           r'/\*|\*/|\[\])')
 
 
-    class OuterState(object):
+    class OuterState:
         """The initial state for parsing a Java file for classes,
         interfaces, and anonymous inner classes."""
 
@@ -222,7 +222,7 @@ if java_parsing:
             self.package = package
 
 
-    class ScopeState(object):
+    class ScopeState:
         """
         A state that parses code within a scope normally,
         within the confines of a scope.
@@ -290,7 +290,7 @@ if java_parsing:
             return self
 
 
-    class AnonClassState(object):
+    class AnonClassState:
         """A state that looks for anonymous inner classes."""
 
         def __init__(self, old_state):
@@ -330,7 +330,7 @@ if java_parsing:
             return self.old_state.parseToken(token)
 
 
-    class SkipState(object):
+    class SkipState:
         """A state that will skip a specified number of tokens before
         reverting to the previous state."""
 
@@ -345,7 +345,7 @@ if java_parsing:
             return self
 
 
-    class ClassState(object):
+    class ClassState:
         """A state we go into when we hit a class or interface keyword."""
 
         def __init__(self, outer_state):
@@ -376,7 +376,7 @@ if java_parsing:
             return self.outer_state
 
 
-    class IgnoreState(object):
+    class IgnoreState:
         """A state that will ignore all tokens until it gets to a
         specified token."""
 
@@ -390,7 +390,7 @@ if java_parsing:
             return self
 
 
-    class PackageState(object):
+    class PackageState:
         """The state we enter when we encounter the package keyword.
         We assume the next token will be the package name."""
 

--- a/SCons/Tool/MSCommon/arch.py
+++ b/SCons/Tool/MSCommon/arch.py
@@ -28,7 +28,7 @@ __doc__ = """Module to define supported Windows chip architectures.
 
 import os
 
-class ArchDefinition(object):
+class ArchDefinition:
     """
     A class for defining architecture-specific settings and logic.
     """

--- a/SCons/Tool/MSCommon/sdk.py
+++ b/SCons/Tool/MSCommon/sdk.py
@@ -58,7 +58,7 @@ _CURINSTALLED_SDK_HKEY_ROOT = \
         r"Software\Microsoft\Microsoft SDKs\Windows\CurrentInstallFolder"
 
 
-class SDKDefinition(object):
+class SDKDefinition:
     """
     An abstract base class for trying to find installed SDK directories.
     """

--- a/SCons/Tool/MSCommon/vs.py
+++ b/SCons/Tool/MSCommon/vs.py
@@ -40,7 +40,7 @@ from .common import debug, \
 
 import SCons.Tool.MSCommon.vc
 
-class VisualStudio(object):
+class VisualStudio:
     """
     An abstract base class for trying to find installed versions of
     Visual Studio.

--- a/SCons/Tool/ToolTests.py
+++ b/SCons/Tool/ToolTests.py
@@ -33,7 +33,7 @@ import SCons.Errors
 import SCons.Tool
 
 
-class DummyEnvironment(object):
+class DummyEnvironment:
     def __init__(self):
         self.dict = {}
     def Detect(self, progs):

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -102,7 +102,7 @@ TOOL_ALIASES = {
 }
 
 
-class Tool(object):
+class Tool:
     def __init__(self, name, toolpath=None, **kw):
         if toolpath is None:
             toolpath = []
@@ -363,7 +363,7 @@ def _call_env_subst(env, string, *args, **kw):
     return env.subst(string, *args, **kw2)
 
 
-class _ShLibInfoSupport(object):
+class _ShLibInfoSupport:
     @property
     def libtype(self):
         return 'ShLib'
@@ -381,7 +381,7 @@ class _ShLibInfoSupport(object):
         return _call_env_subst(env, '$SHLIBNOVERSIONSYMLINKS', *args, **kw)
 
 
-class _LdModInfoSupport(object):
+class _LdModInfoSupport:
     @property
     def libtype(self):
         return 'LdMod'
@@ -399,7 +399,7 @@ class _LdModInfoSupport(object):
         return _call_env_subst(env, '$LDMODULENOVERSIONSYMLINKS', *args, **kw)
 
 
-class _ImpLibInfoSupport(object):
+class _ImpLibInfoSupport:
     @property
     def libtype(self):
         return 'ImpLib'
@@ -443,7 +443,7 @@ class _ImpLibInfoSupport(object):
         return disable
 
 
-class _LibInfoGeneratorBase(object):
+class _LibInfoGeneratorBase:
     """Generator base class for library-related info such as suffixes for
     versioned libraries, symlink maps, sonames etc. It handles commonities
     of SharedLibrary and LoadableModule
@@ -1011,7 +1011,7 @@ def CreateJavaFileBuilder(env):
     return java_file
 
 
-class ToolInitializerMethod(object):
+class ToolInitializerMethod:
     """
     This is added to a construction environment in place of a
     method(s) normally called for a Builder (env.Object, env.StaticObject,
@@ -1061,7 +1061,7 @@ class ToolInitializerMethod(object):
         return builder(*args, **kw)
 
 
-class ToolInitializer(object):
+class ToolInitializer:
     """
     A class for delayed initialization of Tools modules.
 

--- a/SCons/Tool/install.py
+++ b/SCons/Tool/install.py
@@ -249,7 +249,7 @@ def add_versioned_targets_to_INSTALLED_FILES(target, source, env):
     _UNIQUE_INSTALLED_FILES = None
     return (target, source)
 
-class DESTDIR_factory(object):
+class DESTDIR_factory:
     """ A node factory, where all files will be relative to the dir supplied
     in the constructor.
     """

--- a/SCons/Tool/javac.py
+++ b/SCons/Tool/javac.py
@@ -136,7 +136,7 @@ JavaBuilder = SCons.Builder.Builder(action = JavaAction,
                     target_factory = SCons.Node.FS.Entry,
                     source_factory = SCons.Node.FS.Entry)
 
-class pathopt(object):
+class pathopt:
     """
     Callable object for generating javac-style path options from
     a construction variable (e.g. -classpath, -sourcepath).

--- a/SCons/Tool/javacTests.py
+++ b/SCons/Tool/javacTests.py
@@ -26,7 +26,7 @@ import unittest
 
 import SCons.Tool.javac
 
-class DummyNode(object):
+class DummyNode:
     def __init__(self, val):
         self.val = val
 

--- a/SCons/Tool/linkloc.py
+++ b/SCons/Tool/linkloc.py
@@ -61,7 +61,7 @@ def repl_linker_command(m):
         # to find it with recursive substitution
         return m.group(1) + '#' + m.group(2)
 
-class LinklocGenerator(object):
+class LinklocGenerator:
     def __init__(self, cmdline):
         self.cmdline = cmdline
 

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -170,7 +170,7 @@ else:
     python_executable = os.path.join('$$(PYTHON_ROOT)',
                                      os.path.split(sys.executable)[1])
 
-class Config(object):
+class Config:
     pass
 
 def splitFully(path):
@@ -200,7 +200,7 @@ def makeHierarchy(sources):
         #    print 'Warning: failed to decompose path for '+str(file)
     return hierarchy
 
-class _UserGenerator(object):
+class _UserGenerator:
     """
     Base class for .dsp.user file generator
     """
@@ -413,7 +413,7 @@ class _GenerateV10User(_UserGenerator):
                 self.usrfile.write(self.usrconf % locals())
         self.usrfile.write('</Project>')
 
-class _DSPGenerator(object):
+class _DSPGenerator:
     """ Base class for DSP generators """
 
     srcargs = [
@@ -1458,7 +1458,7 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
 
         _GenerateV10User.Build(self)
 
-class _DSWGenerator(object):
+class _DSWGenerator:
     """ Base class for DSW generators """
     def __init__(self, dswfile, source, env):
         self.dswfile = os.path.normpath(str(dswfile))

--- a/SCons/Tool/msvsTests.py
+++ b/SCons/Tool/msvsTests.py
@@ -390,7 +390,7 @@ regdata_cv = r'''[HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion]
 
 regdata_none = []
 
-class DummyEnv(object):
+class DummyEnv:
     def __init__(self, dict=None):
         self.fs = SCons.Node.FS.FS()
         if dict:
@@ -425,14 +425,14 @@ class DummyEnv(object):
         return self.fs.Dir(name)
 
 
-class RegKey(object):
+class RegKey:
     """key class for storing an 'open' registry key"""
     def __init__(self,key):
         self.key = key
 
 # Warning: this is NOT case-insensitive, unlike the Windows registry.
 # So e.g. HKLM\Software is NOT the same key as HKLM\SOFTWARE.
-class RegNode(object):
+class RegNode:
     """node in the dummy registry"""
     def __init__(self,name):
         self.valdict = {}
@@ -507,7 +507,7 @@ class RegNode(object):
             rv = rv + indent + '}\n'
         return rv
 
-class DummyRegistry(object):
+class DummyRegistry:
     """registry class for storing fake registry attributes"""
     def __init__(self,data):
         """parse input data into the fake registry"""

--- a/SCons/Tool/mwcc.py
+++ b/SCons/Tool/mwcc.py
@@ -119,7 +119,7 @@ def find_versions():
     return versions
 
 
-class MWVersion(object):
+class MWVersion:
     def __init__(self, version, path, platform):
         self.version = version
         self.path = path

--- a/SCons/Tool/packaging/rpm.py
+++ b/SCons/Tool/packaging/rpm.py
@@ -301,7 +301,7 @@ def build_specfile_filesection(spec, files):
 
     return str
 
-class SimpleTagCompiler(object):
+class SimpleTagCompiler:
     """ This class is a simple string substition utility:
     the replacement specfication is stored in the tagset dictionary, something
     like:

--- a/SCons/Tool/qt.py
+++ b/SCons/Tool/qt.py
@@ -115,7 +115,7 @@ def find_file(filename, paths, node_factory):
             return node
     return None
 
-class _Automoc(object):
+class _Automoc:
     """
     Callable class, which works as an emitter for Programs, SharedLibraries and
     StaticLibraries.

--- a/SCons/Tool/xgettext.py
+++ b/SCons/Tool/xgettext.py
@@ -45,7 +45,7 @@ from SCons.Tool.GettextCommon import _xgettext_exists
 
 
 #############################################################################
-class _CmdRunner(object):
+class _CmdRunner:
     """ Callable object, which runs shell command storing its stdout and stderr to
     variables. It also provides `strfunction()` method, which shall be used by
     scons Action objects to print command string. """

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -187,7 +187,7 @@ def get_environment_var(varstr):
         return None
 
 
-class DisplayEngine(object):
+class DisplayEngine:
     print_it = True
 
     def __call__(self, text, append_newline=1):
@@ -571,7 +571,7 @@ def semi_deepcopy(x):
         return x
 
 
-class Proxy(object):
+class Proxy:
     """A simple generic Proxy class, forwarding all calls to
     subject.  So, for the benefit of the python newbie, what does
     this really mean?  Well, it means that you can take an object, let's
@@ -621,7 +621,7 @@ class Proxy(object):
         return self.__dict__ == other.__dict__
 
 
-class Delegate(object):
+class Delegate:
     """A Python Descriptor class that delegates attribute fetches
     to an underlying wrapped subject of a Proxy.  Typical use:
 
@@ -1246,7 +1246,7 @@ def logical_lines(physical_lines, joiner=''.join):
         yield joiner(logical_line)
 
 
-class LogicalLines(object):
+class LogicalLines:
     """ Wrapper class for the logical_lines method.
 
         Allows us to read all "logical" lines at once from a
@@ -1352,7 +1352,7 @@ class UniqueList(UserList):
         self.unique = False
 
 
-class Unbuffered(object):
+class Unbuffered:
     """
     A proxy class that wraps a file object, flushing after every write,
     and delegating everything else to the wrapped object.
@@ -1544,8 +1544,7 @@ def silent_intern(x):
 # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/68205
 # ASPN: Python Cookbook: Null Object Design Pattern
 
-#TODO??? class Null(object):
-class Null(object):
+class Null:
     """ Null objects always and reliably "do nothing." """
     def __new__(cls, *args, **kwargs):
         if '_instance' not in vars(cls):
@@ -1570,6 +1569,7 @@ class Null(object):
 
 
 class NullSeq(Null):
+    """ A Null object that can also be iterated over. """
     def __len__(self):
         return 0
     def __iter__(self):

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -37,7 +37,7 @@ import SCons.Errors
 
 from SCons.Util import *
 
-class OutBuffer(object):
+class OutBuffer:
     def __init__(self):
         self.buffer = ""
 
@@ -64,7 +64,7 @@ class UtilTestCase(unittest.TestCase):
         assert splitext('foo.bar') == ('foo', '.bar')
         assert splitext(os.path.join('foo.bar', 'blat')) == (os.path.join('foo.bar', 'blat'), '')
 
-    class Node(object):
+    class Node:
         def __init__(self, name, children=[]):
             self.children = children
             self.name = name
@@ -433,7 +433,7 @@ class UtilTestCase(unittest.TestCase):
     def test_Proxy(self):
         """Test generic Proxy class."""
 
-        class Subject(object):
+        class Subject:
             def foo(self):
                 return 1
 
@@ -657,7 +657,7 @@ class UtilTestCase(unittest.TestCase):
     def test_Selector(self):
         """Test the Selector class"""
 
-        class MyNode(object):
+        class MyNode:
             def __init__(self, name):
                 self.name = name
 
@@ -790,7 +790,7 @@ class NodeListTestCase(unittest.TestCase):
     def test_simple_attributes(self):
         """Test simple attributes of a NodeList class"""
 
-        class TestClass(object):
+        class TestClass:
             def __init__(self, name, child=None):
                 self.child = child
                 self.bar = name
@@ -807,7 +807,7 @@ class NodeListTestCase(unittest.TestCase):
     def test_callable_attributes(self):
         """Test callable attributes of a NodeList class"""
 
-        class TestClass(object):
+        class TestClass:
             def __init__(self, name, child=None):
                 self.child = child
                 self.bar = name
@@ -854,7 +854,7 @@ class flattenTestCase(unittest.TestCase):
         self.assertEqual(sorted(result), [1, 2, 3])
 
 
-class OsEnviron(object):
+class OsEnviron:
     """Used to temporarily mock os.environ"""
 
     def __init__(self, environ):

--- a/SCons/Utilities/sconsign.py
+++ b/SCons/Utilities/sconsign.py
@@ -71,7 +71,7 @@ def my_import(mname):
     return imp.load_module(mname, fp, pathname, description)
 
 
-class Flagger(object):
+class Flagger:
     default_value = 1
 
     def __setitem__(self, item, value):
@@ -288,7 +288,7 @@ def printentries(entries, location):
             printfield(name, entry.binfo)
 
 
-class Do_SConsignDB(object):
+class Do_SConsignDB:
     def __init__(self, dbm_name, dbm):
         self.dbm_name = dbm_name
         self.dbm = dbm

--- a/SCons/Variables/PathVariable.py
+++ b/SCons/Variables/PathVariable.py
@@ -76,7 +76,7 @@ import os.path
 
 import SCons.Errors
 
-class _PathVariableClass(object):
+class _PathVariableClass:
 
     @staticmethod
     def PathAccept(key, val, env):

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -34,7 +34,7 @@ import SCons.Warnings
 from SCons.Util import cmp
 
 
-class Environment(object):
+class Environment:
     def __init__(self):
         self.dict = {}
     def subst(self, x):
@@ -402,7 +402,7 @@ class VariablesTestCase(unittest.TestCase):
                                 'OPT_BOOL_2' : 2})
 
         # Test against some old bugs
-        class Foo(object):
+        class Foo:
             def __init__(self, x):
                 self.x = x
             def __str__(self):

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -44,7 +44,7 @@ from .PackageVariable import PackageVariable # naja
 from .PathVariable import PathVariable # okay
 
 
-class Variables(object):
+class Variables:
     """
     Holds all the options, updates the environment with the variables,
     and renders the help text.
@@ -79,7 +79,7 @@ class Variables(object):
                 Variables.instance=self
 
     def _do_add(self, key, help="", default=None, validator=None, converter=None):
-        class Variable(object):
+        class Variable:
             pass
 
         option = Variable()

--- a/SCons/WarningsTests.py
+++ b/SCons/WarningsTests.py
@@ -28,7 +28,7 @@ import unittest
 
 import SCons.Warnings
 
-class TestOutput(object):
+class TestOutput:
     def __call__(self, x):
         args = x.args[0]
         if len(args) == 1:

--- a/SCons/cpp.py
+++ b/SCons/cpp.py
@@ -184,7 +184,7 @@ del override
 
 
 
-class FunctionEvaluator(object):
+class FunctionEvaluator:
     """
     Handles delayed evaluation of a #define function call.
     """
@@ -241,7 +241,7 @@ function_arg_separator = re.compile(r',\s*')
 
 
 
-class PreProcessor(object):
+class PreProcessor:
 
     """
     The main workhorse class for handling C pre-processing.

--- a/SCons/dblite.py
+++ b/SCons/dblite.py
@@ -26,7 +26,7 @@ dblite_suffix = '.dblite'
 tmp_suffix = '.tmp'
 
 
-class dblite(object):
+class dblite:
     """
     Squirrel away references to the functions in various modules
     that we'll use when our __del__() method calls our sync() method

--- a/bench/dependency-func.py
+++ b/bench/dependency-func.py
@@ -71,7 +71,7 @@ def Func02(t):
 #       {'keyword' : 'arguments'},
 #   ),
 
-class A(object):
+class A:
     pass
 
 Data = [

--- a/bench/env.__setitem__.py
+++ b/bench/env.__setitem__.py
@@ -18,7 +18,7 @@ import timeit
 # These wrap the basic timeit function to make it a little more
 # convenient to do side-by-side tests of code.
 
-class Timing(object):
+class Timing:
     def __init__(self, name, num, init, statement):
         self.__timer = timeit.Timer(statement, init)
         self.__num   = num
@@ -95,7 +95,7 @@ global_valid_var = re.compile(r'[_a-zA-Z]\w*$')
 # After we're done should be the one that shows up at the top of the
 # list as we run our timings.
 
-class Environment(object):
+class Environment:
     _special_set = {
         'BUILDERS' : None,
         'SCANNERS' : None,

--- a/bench/is_types.py
+++ b/bench/is_types.py
@@ -244,7 +244,7 @@ def Func12(obj):
 #       {'keyword' : 'arguments'},
 #   ),
 
-class A(object):
+class A:
     pass
 
 Data = [

--- a/bin/Command.py
+++ b/bin/Command.py
@@ -13,7 +13,7 @@ class Usage(Exception):
     def __init__(self, msg):
         self.msg = msg
 
-class CommandRunner(object):
+class CommandRunner:
     """
     Representation of a command to be executed.
     """

--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -251,7 +251,7 @@ class DoctypeDeclaration:
         return content
 
 if not has_libxml2:
-    class TreeFactory(object):
+    class TreeFactory:
         def __init__(self):
             pass
 
@@ -391,7 +391,7 @@ if not has_libxml2:
             return [root]
 
 else:
-    class TreeFactory(object):
+    class TreeFactory:
         def __init__(self):
             pass
 
@@ -622,7 +622,7 @@ else:
 tf = TreeFactory()
 
 
-class SConsDocTree(object):
+class SConsDocTree:
     def __init__(self):
         self.nsmap = {'dbx': dbxsd}
         self.doc = None
@@ -707,7 +707,7 @@ def validate_all_xml(dpaths, xsdfile=default_xsd):
     return True
 
 
-class Item(object):
+class Item:
     def __init__(self, name):
         self.name = name
         self.sort_name = name.lower()
@@ -745,7 +745,7 @@ class ConstructionVariable(Item):
     pass
 
 
-class Arguments(object):
+class Arguments:
     def __init__(self, signature, body=None):
         if not body:
             body = []
@@ -763,7 +763,7 @@ class Arguments(object):
         self.body.append(data)
 
 
-class SConsDocHandler(object):
+class SConsDocHandler:
     def __init__(self):
         self.builders = {}
         self.functions = {}

--- a/bin/SConsExamples.py
+++ b/bin/SConsExamples.py
@@ -477,7 +477,7 @@ def my_RDirs(self, pathlist, orig_RDirs=orig_RDirs):
     return [str(x).replace(os.sep, Sep) for x in orig_RDirs(self, pathlist)]
 SCons.Node.FS.File.RDirs = my_RDirs
 
-class Curry(object):
+class Curry:
     def __init__(self, fun, *args, **kwargs):
         self.fun = fun
         self.pending = args[:]
@@ -498,7 +498,7 @@ def Str(target, source, env, cmd=""):
         result.append(' '.join(map(str, cmd)))
     return '\\n'.join(result)
 
-class ToolSurrogate(object):
+class ToolSurrogate:
     def __init__(self, tool, variable, func, varlist):
         self.tool = tool
         if not isinstance(variable, list):

--- a/bin/caller-tree.py
+++ b/bin/caller-tree.py
@@ -41,7 +41,7 @@
 # fine-grained performance tuning.
 import sys
 
-class Entry(object):
+class Entry:
     def __init__(self, file_line_func):
         self.file_line_func = file_line_func
         self.called_by = []

--- a/bin/import-test.py
+++ b/bin/import-test.py
@@ -35,7 +35,7 @@ directory = sys.argv[1]
 Top = None
 TopPath = None
 
-class Dir(object):
+class Dir:
     def __init__(self, path):
         self.path = path
         self.entries = {}

--- a/bin/linecount.py
+++ b/bin/linecount.py
@@ -27,7 +27,7 @@ import os.path
 
 fmt = "%-16s  %5s  %7s  %9s  %11s  %11s"
 
-class Collection(object):
+class Collection:
   def __init__(self, name, files=None, pred=None):
     self._name = name
     if files is None:

--- a/bin/scons-proc.py
+++ b/bin/scons-proc.py
@@ -222,7 +222,7 @@ class SCons_XML:
                              v.tag, v.entityfunc(), v.tag))
         f.close()
 
-class Proxy(object):
+class Proxy:
     def __init__(self, subject):
         """Wrap an object as a Proxy object"""
         self.__subject = subject

--- a/bin/scons-time.py
+++ b/bin/scons-time.py
@@ -57,7 +57,7 @@ def HACK_for_exec(cmd, *args):
         exec(cmd, args[0], args[1])
 
 
-class Plotter(object):
+class Plotter:
     def increment_size(self, largest):
         """
         Return the size of each horizontal increment line for a specified
@@ -81,7 +81,7 @@ class Plotter(object):
         return ((largest + increment - 1) // increment) * increment
 
 
-class Line(object):
+class Line:
     def __init__(self, points, type, title, label, comment, fmt="%s %s"):
         self.points = points
         self.type = type
@@ -260,7 +260,7 @@ def tee_to_file(command, log):
     return '%s 2>&1 | tee %s' % (command, log)
 
 
-class SConsTimer(object):
+class SConsTimer:
     """
     Usage: scons-time SUBCOMMAND [ARGUMENTS]
     Type "scons-time help SUBCOMMAND" for help on a specific subcommand.

--- a/bin/time-scons.py
+++ b/bin/time-scons.py
@@ -46,7 +46,7 @@ TimeSCons_revision = 4569
 TimeSCons_pieces = ['testing/framework', 'timings', 'runtest.py']
 
 
-class CommandRunner(object):
+class CommandRunner:
     """
     Executor class for commands, including "commands" implemented by
     Python functions.

--- a/bin/update-release-info.py
+++ b/bin/update-release-info.py
@@ -67,7 +67,7 @@ import argparse
 DEBUG = os.environ.get('DEBUG', 0)
 
 
-class ReleaseInfo(object):
+class ReleaseInfo:
     def __init__(self, args):
         self.config = {}
         self.args = args
@@ -181,7 +181,7 @@ class ReleaseInfo(object):
                          + ' %+.4d' % min)
 
 
-class UpdateFile(object):
+class UpdateFile:
     """ XXX """
 
     rel_info = None

--- a/doc/generated/builders.gen
+++ b/doc/generated/builders.gen
@@ -11,7 +11,7 @@
     %variables-mod;
 ]>
 
-<variablelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+<variablelist xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
   <varlistentry id="b-CFile">
     <term><function>CFile</function>()</term>
     <term><replaceable>env</replaceable>.<methodname>CFile</methodname>()</term>

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -11,7 +11,7 @@
     %variables-mod;
 ]>
 
-<variablelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+<variablelist xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
   <varlistentry id="f-Action">
     <term><function>Action</function>(<parameter>action, [cmd/str/fun, [var, ...]] [option=value, ...]</parameter>)</term>
     <term><replaceable>env</replaceable>.<methodname>Action</methodname>(<parameter>action, [cmd/str/fun, [var, ...]] [option=value, ...]</parameter>)</term>
@@ -3043,11 +3043,13 @@ will overwrite itself on a display:
 
 <example_commands>
 import sys
-class ProgressCounter(object):
+
+class ProgressCounter:
     count = 0
     def __call__(self, node, *args, **kw):
         self.count += 100
         sys.stderr.write('Evaluated %s nodes\r' % self.count)
+
 Progress(ProgressCounter(), interval=100)
 </example_commands>
 
@@ -3769,6 +3771,19 @@ which corresponds to <option>--random</option>; and
 <para>
 which corresponds to <option>--silent</option>.
 </para>
+</listitem>
+</varlistentry>
+<varlistentry>
+<term><literal>no_progress</literal></term>
+<listitem>
+<para>
+which corresponds to -Q.
+</para>
+<para>
+    Note: The initial progress output will still be output as this is done before the SConstruct/SConscript which contains the SetOption is processed
+    <literal>scons: Reading SConscript files ...</literal>
+</para>
+<para><emphasis>Available since <command>scons</command> 4.0.</emphasis></para>
 </listitem>
 </varlistentry>
 <varlistentry>

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -11,7 +11,7 @@
     %variables-mod;
 ]>
 
-<variablelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+<variablelist xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
   <varlistentry id="t-386asm">
     <term>386asm</term>
     <listitem><para>

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -11,7 +11,7 @@
     %variables-mod;
 ]>
 
-<variablelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.scons.org/dbxsd/v1.0" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+<variablelist xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
   <varlistentry id="cv-__LDMODULEVERSIONFLAGS">
     <term>
       <envar>__LDMODULEVERSIONFLAGS</envar>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2683,8 +2683,8 @@ you can either build a new list by hand:</para>
 foo = Object('foo.c')
 bar = Object('bar.c')
 objects = ['begin.o'] + foo + ['middle.o'] + bar + ['end.o']
-for object in objects:
-    print(str(object))
+for obj in objects:
+    print(str(obj))
 </programlisting>
 
 <para>Or you can use the &Flatten;
@@ -2696,8 +2696,8 @@ which may be more convenient:</para>
 foo = Object('foo.c')
 bar = Object('bar.c')
 objects = Flatten(['begin.o', foo, 'middle.o', bar, 'end.o'])
-for object in objects:
-    print(str(object))
+for obj in objects:
+    print(str(obj))
 </programlisting>
 
 <para>SCons builder calls return
@@ -6307,7 +6307,7 @@ be associated with the
 instantiation of the class:</para>
 
 <programlisting language="python">
-class foo(object):
+class foo:
     def __init__(self, arg):
         self.arg = arg
 

--- a/site_scons/BuildCommandLine.py
+++ b/site_scons/BuildCommandLine.py
@@ -4,7 +4,7 @@ import socket
 
 from SCons.Script import ARGUMENTS
 
-class BuildCommandLine(object):
+class BuildCommandLine:
 
     git = None
 

--- a/src/test_strings.py
+++ b/src/test_strings.py
@@ -51,7 +51,7 @@ build_scons     = build_path('scons')
 build_local     = build_path('scons-local', 'scons-local-'+scons_version)
 build_src       = build_path('scons-src')
 
-class Checker(object):
+class Checker:
     def __init__(self, directory,
                  search_list = [],
                  remove_list = [],

--- a/test/Actions/actions.py
+++ b/test/Actions/actions.py
@@ -86,7 +86,7 @@ test.up_to_date(arguments = '.')
 test.write('SConstruct', """
 import subprocess
 assert 'string' not in globals()
-class bld(object):
+class bld:
     def __init__(self):
         self.cmd = r'%(_python_)s build.py %%s 4 %%s'
     def __call__(self, env, target, source):

--- a/test/Batch/SConstruct_changed_sources_alwaysBuild
+++ b/test/Batch/SConstruct_changed_sources_alwaysBuild
@@ -3,6 +3,6 @@
 obj = Object('changed_sources_main.cpp')
 AlwaysBuild(obj)
 
-program = Program('test', source = [object])
+program = Program('test', source=[obj])
 
 Default(program)

--- a/test/Batch/SConstruct_changed_sources_alwaysBuild
+++ b/test/Batch/SConstruct_changed_sources_alwaysBuild
@@ -1,7 +1,7 @@
 # Testcase for tigris bug 2622
 
-object = Object('changed_sources_main.cpp')
-AlwaysBuild(object)
+obj = Object('changed_sources_main.cpp')
+AlwaysBuild(obj)
 
 program = Program('test', source = [object])
 

--- a/test/CPPPATH/expand-object.py
+++ b/test/CPPPATH/expand-object.py
@@ -34,7 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
-class XXX(object):
+class XXX:
     def __init__(self, value):
         self.value = value
     def __str__(self):

--- a/test/CPPPATH/list-expansion.py
+++ b/test/CPPPATH/list-expansion.py
@@ -42,7 +42,7 @@ test = TestSCons.TestSCons()
 test.subdir('sub1', 'sub2', 'sub3', 'sub4')
 
 test.write('SConstruct', """\
-class _inc_test(object):
+class _inc_test:
     def __init__(self, name):
         self.name = name
 

--- a/test/Progress/object.py
+++ b/test/Progress/object.py
@@ -36,7 +36,7 @@ test.write('SConstruct', """\
 import sys
 env = Environment()
 env['BUILDERS']['C'] = Builder(action=Copy('$TARGET', '$SOURCE'))
-class my_progress(object):
+class my_progress:
     count = 0
     def __call__(self, node, *args, **kw):
         self.count = self.count + 1

--- a/test/Scanner/generated.py
+++ b/test/Scanner/generated.py
@@ -316,7 +316,7 @@ def write_out(fname, dict):
 # because the .__*__() methods in new-style classes are not looked
 # up on the instance, but resolve to the actual wrapped class methods,
 # so we have to handle those directly.
-class CScannerCounter(object):
+class CScannerCounter:
     def __init__(self, original_CScanner, *args, **kw):
         self.original_CScanner = original_CScanner
     def __eq__(self, *args, **kw):

--- a/test/ToolSurrogate.py
+++ b/test/ToolSurrogate.py
@@ -34,7 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-class Curry(object):
+class Curry:
     def __init__(self, fun, *args, **kwargs):
         self.fun = fun
         self.pending = args[:]
@@ -55,7 +55,7 @@ def Str(target, source, env, cmd=""):
         result.append(" ".join(map(str, cmd)))
     return '\\n'.join(result)
 
-class ToolSurrogate(object):
+class ToolSurrogate:
     def __init__(self, tool, variable, func):
         self.tool = tool
         self.variable = variable

--- a/test/Value.py
+++ b/test/Value.py
@@ -37,7 +37,7 @@ python = TestSCons.python
 SConstruct_content = """
 Decider(r'%(source_signature)s')
 
-class Custom(object):
+class Custom:
     def __init__(self, value):  self.value = value
     def __str__(self):          return "C=" + str(self.value)
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -311,7 +311,7 @@ IS_WINDOWS = sys.platform == 'win32'
 IS_64_BIT = sys.maxsize > 2**32
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
 
-class null(object):
+class null:
     pass
 
 
@@ -946,7 +946,7 @@ def _clean():
 atexit.register(_clean)
 
 
-class TestCmd(object):
+class TestCmd:
     """Class TestCmd
     """
 


### PR DESCRIPTION
In Python3 this is the default.

No functional, test, or doc changes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
