### PR TITLE
Updates to shared docs   [ci skip]

### DIFF
--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -572,20 +572,25 @@ searching the repositories.
 </arguments>
 <summary>
 <para>
-Creates and returns the default &consenv; object.
-The default &consenv; is used internally by SCons
+Instantiates and returns the default &consenv; object.
+The &defenv; is used internally by SCons
 in order to execute many of the global functions in this list
-(i.e. those not called as methods of a specific
-&consenv;), and to fetch source files transparently
-from source code management systems.
-The default environment is a singleton, so the keyword
+(that is, those not called as methods of a specific &consenv;).
+It is not mandatory to call &f-DefaultEnvironment;:
+the &defenv; will be instantiated automatically when the
+build phase begins if the function has not been called,
+however calling it explicitly gives the opportunity to
+affect and examine the contents of the &defenv;.
+</para>
+<para>
+The &defenv; is a singleton, so the keyword
 arguments affect it only on the first call, on subsequent
 calls the already-constructed object is returned and
-any arguments are ignored.
-The default environment can be modified in the same way
-as any &consenv;.
-Modifying the &defenv; has no effect on the environment
-constructed by a subsequent &f-Environment; call.
+any keyword arguments are silently ignored.
+The &defenv; can be modified after instantiation
+in the same way as any &consenv;.
+Modifying the &defenv; has no effect on the &consenv;
+constructed by an &f-link-Environment; or &f-link-Clone; call.
 </para>
 </summary>
 </scons_function>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -242,28 +242,25 @@ that are part of this construction environment.
 </arguments>
 <summary>
 <para>
-Creates an Action object for
+A factory function to create an Action object for
 the specified
-<varname>action</varname>.
+<parameter>action</parameter>.
 See the manpage section "Action Objects"
 for a complete explanation of the arguments and behavior.
 </para>
 
 <para>
-Note that the
-<function>env.Action</function>()
+Note that the &f-env-Action;
 form of the invocation will expand
 construction variables in any argument strings,
 including the
-<varname>action</varname>
+<parameter>action</parameter>
 argument, at the time it is called
 using the construction variables in the
-<varname>env</varname>
+<replaceable>env</replaceable>
 construction environment through which
-<function>env.Action</function>()
-was called.
-The
-<function>Action</function>()
+&f-env-Action; was called.
+The &f-Action; global function
 form delays all variable expansion
 until the Action object is actually used.
 </para>
@@ -283,27 +280,26 @@ When called with the
 <function>AddMethod</function>()
 form,
 adds the specified
-<varname>function</varname>
+<parameter>function</parameter>
 to the specified
-<varname>object</varname>
+<parameter>object</parameter>
 as the specified method
-<varname>name</varname>.
-When called with the
-<function>env.AddMethod</function>()
-form,
+<parameter>name</parameter>.
+When called using the
+&f-env-AddMethod; form,
 adds the specified
-<varname>function</varname>
+<parameter>function</parameter>
 to the construction environment
-<varname>env</varname>
+<replaceable>env</replaceable>
 as the specified method
-<varname>name</varname>.
+<parameter>name</parameter>.
 In both cases, if
-<varname>name</varname>
+<parameter>name</parameter>
 is omitted or
-<literal>None</literal>,
+<constant>None</constant>,
 the name of the
 specified
-<varname>function</varname>
+<parameter>function</parameter>
 itself is used for the method name.
 </para>
 
@@ -341,10 +337,10 @@ env.other_method_name('another arg')
 <summary>
 <para>
 Arranges for the specified
-<varname>action</varname>
+<parameter>action</parameter>
 to be performed
 after the specified
-<varname>target</varname>
+<parameter>target</parameter>
 has been built.
 The specified action(s) may be
 an Action object, or anything that
@@ -369,10 +365,10 @@ one or more targets in the list.
 <summary>
 <para>
 Arranges for the specified
-<varname>action</varname>
+<parameter>action</parameter>
 to be performed
 before the specified
-<varname>target</varname>
+<parameter>target</parameter>
 is built.
 The specified action(s) may be
 an Action object, or anything that
@@ -428,7 +424,7 @@ file into an object file.
 Creates one or more phony targets that
 expand to one or more other targets.
 An optional
-<varname>action</varname>
+<parameter>action</parameter>
 (command)
 or list of actions
 can be specified that will be executed
@@ -470,7 +466,7 @@ env.Alias('update', ['file1', 'file2'], "update_database $SOURCES")
 <summary>
 <para>
 Marks each given
-<varname>target</varname>
+<parameter>target</parameter>
 so that it is always assumed to be out of date,
 and will always be rebuilt if needed.
 Note, however, that
@@ -544,7 +540,7 @@ string, in which case a list will be returned instead of a string.
 
 <para>
 If
-<varname>delete_existing</varname>
+<parameter>delete_existing</parameter>
 is 0, then adding a path that already exists
 will not move it to the end; it will stay where it is in the list.
 </para>
@@ -605,7 +601,7 @@ env.AppendUnique(CCFLAGS = '-g', FOO = ['foo.yyy'])
 <para>
 Creates a Builder object for
 the specified
-<varname>action</varname>.
+<parameter>action</parameter>.
 See the manpage section "Builder Objects"
 for a complete explanation of the arguments and behavior.
 </para>
@@ -616,14 +612,13 @@ Note that the
 form of the invocation will expand
 construction variables in any arguments strings,
 including the
-<varname>action</varname>
+<parameter>action</parameter>
 argument,
 at the time it is called
 using the construction variables in the
-<varname>env</varname>
+<parameter>env</parameter>
 construction environment through which
-<function>env.Builder</function>()
-was called.
+&f-env-Builder; was called.
 The
 &f-Builder;
 form delays all variable expansion
@@ -638,68 +633,61 @@ until after the Builder object is actually called.
 </arguments>
 <summary>
 <para>
-Specifies that
+Direct
 &scons;
-will maintain a cache of derived files in
-<varname>cache_dir</varname>.
+to use a derived-file cache in
+<parameter>cache_dir</parameter>.
 The derived files in the cache will be shared
-among all the builds using the same
-&f-CacheDir;
-call.
+among all the builds specifying the same
+<parameter>cache_dir</parameter>.
 Specifying a
-<varname>cache_dir</varname>
+<parameter>cache_dir</parameter>
 of
-<literal>None</literal>
+<constant>None</constant>
 disables derived file caching.
 </para>
 
 <para>
-Calling
-<function>env.CacheDir</function>()
-will only affect targets built
+Calling the environment method
+&f-link-env-CacheDir;
+limits the effect to targets built
 through the specified construction environment.
-Calling
-&f-CacheDir;
+Calling the global function
+&f-link-CacheDir;
 sets a global default
 that will be used by all targets built
 through construction environments
-that do
-<emphasis>not</emphasis>
-have an
-<function>env.CacheDir</function>()
-specified.
+that do not set up environment-specific
+caching by calling &f-env-CacheDir;.
 </para>
 
 <para>
-When a
-<function>CacheDir</function>()
+When cachin
+<parameter>cache_dir</parameter>
 is being used and
 &scons;
 finds a derived file that needs to be rebuilt,
 it will first look in the cache to see if a
-derived file has already been built
-from identical input files and an identical build action
-(as incorporated into the MD5 build signature).
-If so,
-&scons;
-will retrieve the file from the cache.
+file with matching build signature exists
+(indicating the input file(s) and build action(s)
+were identical to those for the current target),
+and if so, will retrieve the file from the cache.
 If the derived file is not present in the cache,
 &scons;
-will rebuild it and
-then place a copy of the built file in the cache
-(identified by its MD5 build signature),
-so that it may be retrieved by other
-builds that need to build the same derived file
-from identical inputs.
+will build it and
+then place a copy of the built file in the cache,
+identified by its build signature, for future use.
 </para>
 
 <para>
-Use of a specified
-&f-CacheDir;
+Derived-file caching
 may be disabled for any invocation
-by using the
+of &scons; by giving the
 <option>--cache-disable</option>
-option.
+command line option.
+Cache updating may be disabled, leaving cache
+fetching enabled, by giving the
+<option>--cache-readonly</option>.
 </para>
 
 <para>
@@ -713,32 +701,31 @@ derived files in the cache,
 even if they already existed
 and were not built by this invocation.
 This is useful to populate a cache
-the first time
-&f-CacheDir;
-is added to a build,
-or after using the
-<option>--cache-disable</option>
-option.
+the first time a
+<parameter>cache_dir</parameter>
+is used for a build,
+or to bring a cache up to date after
+a build with cache updating disabled 
+(<option>--cache-disable</option>
+or <option>--cache-readonly</option>)
+has been done.
 </para>
 
 <para>
 When using
 &f-CacheDir;,
 &scons;
-will report,
-"Retrieved `file' from cache,"
+will report
+<computeroutput>Retrieved `file' from cache</computeroutput>
 unless the
 <option>--cache-show</option>
 option is being used.
-When the
+With the
 <option>--cache-show</option>
-option is used,
-&scons;
-will print the action that
-<emphasis>would</emphasis>
-have been used to build the file,
-without any indication that
-the file was actually retrieved from the cache.
+option, &scons;
+will print the action that would
+have been used to build the file
+whether or not it was retreived from the cache.
 This is useful to generate build logs
 that are equivalent regardless of whether
 a given derived file has been built in-place
@@ -854,7 +841,7 @@ env4 = env.Clone(tools = ['msvc', MyTool])
 
 <para>
 The
-<varname>parse_flags</varname>
+<parameter>parse_flags</parameter>
 keyword argument is also recognized to allow merging command-line
 style arguments into the appropriate construction
 variables (see &f-link-env-MergeFlags;).
@@ -890,21 +877,23 @@ for the calling syntax and details.
 </arguments>
 <summary>
 <para>
-Executes a specific action
+Executes a specific <parameter>action</parameter>
 (or list of actions)
-to build a target file or files.
+to build a <parameter>target</parameter> file or files
+from a <parameter>source<parameter> file or files.
 This is more convenient
 than defining a separate Builder object
 for a single special-case build.
 </para>
 
 <para>
-&b-Command; builder accepts
-<varname>source_scanner</varname>,
-<varname>target_scanner</varname>,
-<varname>source_factory</varname>, and
-<varname>target_factory</varname>
-keyword arguments. The *_scanner args can
+The
+&Command; function accepts
+<parameter>source_scanner</parameter>,
+<parameter>target_scanner</parameter>,
+<parameter>source_factory</parameter>, and
+<parameter>target_factory</parameter>
+keyword arguments. These arguments can
 be used to specify
 a Scanner object
 that will be used to apply a custom
@@ -916,12 +905,12 @@ if any of the sources will be directories
 that must be scanned on-disk for
 changes to files that aren't
 already specified in other Builder of function calls.
-The *_factory args take a factory function that the
-Command will use to turn any sources or targets
+The <paramter>*_factory</parameter> arguments take a factory function that
+&Command; will use to turn any sources or targets
 specified as strings into SCons Nodes.
-See the sections "Builder Objects"
-below, for more information about how these
-args work in a Builder.
+See the manpage section "Builder Objects"
+for more information about how these
+arguments work in a Builder.
 </para>
 
 <para>
@@ -936,13 +925,11 @@ or a callable Python object;
 see the manpage section "Action Objects"
 for more complete information.
 Also note that a string specifying an external command
-may be preceded by an
-<literal>@</literal>
-(at-sign)
+may be preceded by an at-sign
+(<literal>@</literal>)
 to suppress printing the command in question,
-or by a
-<literal>-</literal>
-(hyphen)
+or by a hyphen
+(<literal>-</literal>)
 to ignore the exit status of the external command.
 </para>
 
@@ -951,26 +938,35 @@ Examples:
 </para>
 
 <example_commands>
-env.Command('foo.out', 'foo.in',
-            "$FOO_BUILD &lt; $SOURCES &gt; $TARGET")
+env.Command(
+    target='foo.out',
+    source='foo.in',
+    action="$FOO_BUILD &lt; $SOURCES &gt; $TARGET"
+)
 
-env.Command('bar.out', 'bar.in',
-            ["rm -f $TARGET",
-             "$BAR_BUILD &lt; $SOURCES &gt; $TARGET"],
-            ENV={'PATH': '/usr/local/bin/'})
+env.Command(
+    target='bar.out',
+    source='bar.in',
+    action=["rm -f $TARGET", "$BAR_BUILD &lt; $SOURCES &gt; $TARGET"],
+    ENV={'PATH': '/usr/local/bin/'},
+)
 
+
+import os
 def rename(env, target, source):
-    import os
     os.rename('.tmp', str(target[0]))
 
-env.Command('baz.out', 'baz.in',
-            ["$BAZ_BUILD &lt; $SOURCES &gt; .tmp",
-	     rename])
+
+env.Command(
+    target='baz.out',
+    source='baz.in',
+    action=["$BAZ_BUILD &lt; $SOURCES &gt; .tmp", rename],
+)
 </example_commands>
 
 <para>
 Note that the
-&f-Command;
+&Command;
 function will usually assume, by default,
 that the specified targets and/or sources are Files,
 if no other part of the configuration
@@ -981,7 +977,7 @@ be treated as directories
 by using the
 &f-link-Dir;
 or
-<function>env.Dir</function>
+&f-link-env-Dir;
 functions.
 </para>
 
@@ -1021,18 +1017,6 @@ for a complete explanation of the arguments and behavior.
 </summary>
 </scons_function>
 
-<scons_function name="Copy">
-<arguments signature="env">
-([key=val, ...])
-</arguments>
-<summary>
-<para>
-A now-deprecated synonym for
-<function>env.Clone</function>().
-</para>
-</summary>
-</scons_function>
-
 <scons_function name="Decider">
 <arguments>
 (function)
@@ -1042,9 +1026,8 @@ A now-deprecated synonym for
 Specifies that all up-to-date decisions for
 targets built through this construction environment
 will be handled by the specified
-<varname>function</varname>.
-The
-<varname>function</varname>
+<parameter>function</parameter>.
+<parameter>function</parameter>
 can be one of the following strings
 that specify the type of decision function
 to be performed:
@@ -1053,7 +1036,7 @@ to be performed:
 <para>
 <variablelist>
 <varlistentry>
-<term><literal>timestamp-newer</literal></term>
+<term><literal>"timestamp-newer"</literal></term>
 <listitem>
 <para>
 Specifies that a target shall be considered out of date and rebuilt
@@ -1067,7 +1050,7 @@ can be used a synonym for
 </listitem>
 </varlistentry>
 <varlistentry>
-<term><literal>timestamp-match</literal></term>
+<term><literal>"timestamp-match"</literal></term>
 <listitem>
 <para>
 Specifies that a target shall be considered out of date and rebuilt
@@ -1084,7 +1067,7 @@ timestamp, such as can happen when restoring files from backup archives.
 </listitem>
 </varlistentry>
 <varlistentry>
-<term><literal>MD5</literal></term>
+<term><literal>"MD5"</literal></term>
 <listitem>
 <para>
 Specifies that a target shall be considered out of date and rebuilt
@@ -1101,7 +1084,7 @@ can be used as a synonym for
 </listitem>
 </varlistentry>
 <varlistentry>
-<term><literal>MD5-timestamp</literal></term>
+<term><literal>"MD5-timestamp"</literal></term>
 <listitem>
 <para>
 Specifies that a target shall be considered out of date and rebuilt
@@ -1148,7 +1131,7 @@ env.Decider('content')
 
 <para>
 In addition to the above already-available functions, the
-<varname>function</varname>
+<parameter>function</parameter>
 argument may be a Python function you supply.
 Such a function must accept the following four arguments:
 </para>
@@ -1161,10 +1144,10 @@ Such a function must accept the following four arguments:
 <para>
 The Node (file) which
 should cause the
-<varname>target</varname>
+<parameter>target</parameter>
 to be rebuilt
 if it has "changed" since the last tme
-<varname>target</varname>
+<parameter>target</parameter>
 was built.
 </para>
 </listitem>
@@ -1177,7 +1160,7 @@ The Node (file) being built.
 In the normal case,
 this is what should get rebuilt
 if the
-<varname>dependency</varname>
+<parameter>dependency</parameter>
 has "changed."
 </para>
 </listitem>
@@ -1187,9 +1170,9 @@ has "changed."
 <listitem>
 <para>
 Stored information about the state of the
-<varname>dependency</varname>
+<parameter>dependency</parameter>
 the last time the
-<varname>target</varname>
+<parameter>target</parameter>
 was built.
 This can be consulted to match various
 file characteristics
@@ -1203,11 +1186,11 @@ size, or content signature.
 <listitem>
 <para>
 If set, use this Node instead of the one specified by
-<varname>dependency</varname>
+<parameter>dependency</parameter>
 to determine if the dependency has changed.
 This argument is optional so should be written
 as a default argument (typically it would be
-written as <literal>repo_node=None</literal>).
+written as <parameter>repo_node=None</parameter>).
 A caller will normally only set this if the
 target only exists in a Repository.
 </para>
@@ -1219,14 +1202,14 @@ target only exists in a Repository.
 
 <para>
 The
-<varname>function</varname>
+<parameter>function</parameter>
 should return a value which evaluates
 <constant>True</constant>
 if the
-<varname>dependency</varname>
+<parameter>dependency</parameter>
 has "changed" since the last time
 the
-<varname>target</varname>
+<parameter>target</parameter>
 was built
 (indicating that the target
 <emphasis>should</emphasis>
@@ -1264,15 +1247,15 @@ env.Decider(my_decider)
 <para>
 Specifies an explicit dependency;
 the
-<varname>target</varname>
+<parameter>target</parameter>
 will be rebuilt
 whenever the
-<varname>dependency</varname>
+<parameter>dependency</parameter>
 has changed.
 Both the specified
-<varname>target</varname>
+<parameter>target</parameter>
 and
-<varname>dependency</varname>
+<parameter>dependency</parameter>
 can be a string
 (usually the path name of a file or directory)
 or Node objects,
@@ -1317,9 +1300,9 @@ Find an executable from one or more choices:
 Returns the first value from <parameter>progs</parameter>
 that was found, or <constant>None</constant>.
 Executable is searched by checking the paths specified
-by <replaceable>env</replaceable><literal>['ENV']['PATH']</literal>.
+by <parameter>env</parameter><literal>['ENV']['PATH']</literal>.
 On Windows systems, additionally applies the filename suffixes found in
-<replaceable>env</replaceable><literal>['ENV']['PATHEXT']</literal>
+<parameter>env</parameter><literal>['ENV']['PATHEXT']</literal>
 but will not include any such extension in the return value.
 &f-env-Detect; is a wrapper around &f-link-env-WhereIs;.
 </para>
@@ -1359,24 +1342,24 @@ cc_values = env.Dictionary('CC', 'CCFLAGS', 'CCCOM')
 <para>
 Returns Directory Node(s).
 A Directory Node is an object that represents a directory.
-<varname>name</varname>
+<parameter>name</parameter>
 can be a relative or absolute path or a list of such paths.
-<varname>directory</varname>
+<parameter>directory</parameter>
 is an optional directory that will be used as the parent directory.
 If no
-<varname>directory</varname>
+<parameter>directory</parameter>
 is specified, the current script's directory is used as the parent.
 </para>
 
 <para>
 If
-<varname>name</varname>
+<parameter>name</parameter>
 is a single pathname, the corresponding node is returned.
 If
-<varname>name</varname>
+<parameter>name</parameter>
 is a list, SCons returns a list of nodes.
 Construction variables are expanded in
-<varname>name</varname>.
+<parameter>name</parameter>.
 </para>
 
 <para>
@@ -1397,7 +1380,7 @@ for more information.
 </arguments>
 <summary>
 <para>
-Serializes the construction variables to a string.
+Serializes &cpnsvars; to a string.
 The method supports the following formats specified by
 <parameter>format</parameter>:
 <variablelist>
@@ -1405,7 +1388,7 @@ The method supports the following formats specified by
 <term><literal>pretty</literal></term>
 <listitem>
 <para>
-Returns a pretty printable representation of the environment (if
+Returns a pretty printed representation of the environment (if
 <parameter>format</parameter>
 is not specified, this is the default).
 </para>
@@ -1421,10 +1404,11 @@ Returns a JSON-formatted string representation of the environment.
 </varlistentry>
 </variablelist>
 
-<varname>key</varname>,
-if not
-<literal>None</literal>,
-should be a string containing the name of the variable of interest.
+If <varname>key</varname> is 
+<constant>None</constant> (the default) the entire
+dictionary of &consvars; is serialized.
+If supplied, it is taken as the name of a &consvar;
+whose value is serialized.
 </para>
 
 <para>
@@ -1476,7 +1460,7 @@ will print:
 <para>
 Return a new construction environment
 initialized with the specified
-<varname>key</varname><literal>=</literal><varname>value</varname>
+<parameter>key</parameter>=<replaceable>value</replaceable>
 pairs.
 </para>
 </summary>
@@ -1490,16 +1474,20 @@ pairs.
 <para>
 Executes an Action object.
 The specified
-<varname>action</varname>
+<parameter>action</parameter>
 may be an Action object
 (see manpage section "Action Objects"
-for a complete explanation of the arguments and behavior),
+for an explanation of behavior),
 or it may be a command-line string,
 list of commands,
 or executable Python function,
 each of which will be converted
 into an Action object
 and then executed.
+Any additional arguments to &f-Execute;
+(<parameter>strfunction</parameter>, <parameter>varlist</parameter>)
+are passed on to the &f-link-Action; factory function
+which actually creates the Action object.
 The exit value of the command
 or return value of the Python function
 will be returned.
@@ -1509,7 +1497,7 @@ will be returned.
 Note that
 &scons;
 will print an error message if the executed
-<varname>action</varname>
+<parameter>action</parameter>
 fails--that is,
 exits with or returns a non-zero value.
 &scons;
@@ -1518,7 +1506,7 @@ will
 however,
 automatically terminate the build
 if the specified
-<varname>action</varname>
+<parameter>action</parameter>
 fails.
 If you want the build to stop in response to a failed
 &f-Execute;
@@ -1544,24 +1532,24 @@ if Execute("mkdir sub/dir/ectory"):
 <para>
 Returns File Node(s).
 A File Node is an object that represents a file.
-<varname>name</varname>
+<parameter>name</parameter>
 can be a relative or absolute path or a list of such paths.
-<varname>directory</varname>
+<parameter>directory</parameter>
 is an optional directory that will be used as the parent directory.
 If no
-<varname>directory</varname>
+<parameter>directory</parameter>
 is specified, the current script's directory is used as the parent.
 </para>
 
 <para>
 If
-<varname>name</varname>
+<parameter>name</parameter>
 is a single pathname, the corresponding node is returned.
 If
-<varname>name</varname>
+<parameter>name</parameter>
 is a list, SCons returns a list of nodes.
 Construction variables are expanded in
-<varname>name</varname>.
+<parameter>name</parameter>.
 </para>
 
 <para>
@@ -1583,10 +1571,10 @@ for more information.
 <summary>
 <para>
 Search for
-<varname>file</varname>
+<parameter>file</parameter>
 in the path specified by
-<varname>dirs</varname>.
-<varname>dirs</varname>
+<parameter>dirs</parameter>.
+<parameter>dirs</parameter>
 may be a list of directory names or a single directory name.
 In addition to searching for files that exist in the filesystem,
 this function also searches for derived files
@@ -1650,9 +1638,9 @@ FindInstalledFiles()
 Returns the list of nodes which serve as the source of the built files.
 It does so by inspecting the dependency tree starting at the optional
 argument
-<varname>node</varname>
+<parameter>node</parameter>
 which defaults to the '"."'-node. It will then return all leaves of
-<varname>node</varname>.
+<parameter>node</parameter>.
 These are all children which have no further children.
 </para>
 
@@ -1721,7 +1709,7 @@ Program(source = objects)
 # If you need to manipulate the list directly using Python, you need to
 # call Flatten() yourself, or otherwise handle nested lists:
 for object in Flatten(objects):
-    print str(object)
+    print(str(object))
 </example_commands>
 </summary>
 </scons_function>
@@ -1735,10 +1723,10 @@ for object in Flatten(objects):
 Returns the
 &scons;
 path name (or names) for the specified
-<varname>file</varname>
+<parameter>file</parameter>
 (or files).
 The specified
-<varname>file</varname>
+<parameter>file</parameter>
 or files
 may be
 &scons;
@@ -1754,21 +1742,20 @@ Nodes or strings representing path names.
 <summary>
 <para>
 Returns Nodes (or strings) that match the specified
-<varname>pattern</varname>,
+<parameter>pattern</parameter>,
 relative to the directory of the current
 &SConscript;
 file.
-The
-<function>env.Glob</function>()
-form performs string substition on
-<varname>pattern</varname>
+The evironment method form (&f-env-Glob;)
+performs string substition on
+<parameter>pattern</parameter>
 and returns whatever matches
 the resulting expanded pattern.
 </para>
 
 <para>
 The specified
-<varname>pattern</varname>
+<parameter>pattern</parameter>
 uses Unix shell style metacharacters for matching:
 </para>
 
@@ -1802,14 +1789,14 @@ function)
 and
 returns a Node (or string, if so configured)
 in the local (SConscript) directory
-if matching Node is found
+if a matching Node is found
 anywhere in a corresponding
 repository or source directory.
 </para>
 
 <para>
 The
-<varname>ondisk</varname>
+<parameter>ondisk</parameter>
 argument may be set to a value which evaluates
 <constant>False</constant>
 to disable the search for matches on disk,
@@ -1822,7 +1809,7 @@ for any on-disk matches found.
 
 <para>
 The
-<varname>source</varname>
+<parameter>source</parameter>
 argument may be set to a value which evaluates
 <constant>True</constant>
 to specify that,
@@ -1835,7 +1822,7 @@ not the local directory.
 
 <para>
 The
-<varname>strings</varname>
+<parameter>strings</parameter>
 argument may be set to a value which evaluates
 <constant>True</constant>
 to have the
@@ -1861,7 +1848,7 @@ directory.)
 
 <para>
 The
-<varname>exclude</varname>
+<parameter>exclude</parameter>
 argument may be set to a pattern or a list of patterns
 (following the same Unix shell semantics)
 which must be filtered out of returned elements.
@@ -1890,7 +1877,7 @@ sources = Glob("*.cpp", exclude=["os_*_specific_*.cpp"]) + \
 <summary>
 <para>
 When
-<varname>flag</varname>
+<parameter>flag</parameter>
 is non-zero,
 adds the names of the default builders
 (Program, Library, etc.)
@@ -1898,7 +1885,7 @@ to the global name space
 so they can be called without an explicit construction environment.
 (This is the default.)
 When
-<varname>flag</varname>
+<parameter>flag</parameter>
 is zero,
 the names of the default builders are removed
 from the global name space
@@ -1956,7 +1943,7 @@ env.Ignore('bar','bar/foobar.obj')
 <summary>
 <para>
 The specified
-<varname>string</varname>
+<parameter>string</parameter>
 will be preserved as-is
 and not have construction variables expanded.
 </para>
@@ -1970,7 +1957,7 @@ and not have construction variables expanded.
 <summary>
 <para>
 The specified
-<varname>targets</varname>
+<parameter>targets</parameter>
 will have copies made in the local tree,
 even if an already up-to-date copy
 exists in a repository.
@@ -1987,14 +1974,14 @@ Returns a list of the target Node or Nodes.
 <summary>
 <para>
 Merges the elements of the specified
-<varname>arg</varname>,
+<parameter>arg</parameter>,
 which must be a dictionary, to the construction
 environment's copy of the shell environment
 in env['ENV'].
 (This is the environment which is passed
 to subshells spawned by SCons.)
 Note that
-<varname>arg</varname>
+<parameter>arg</parameter>
 must be a single value,
 so multiple strings must
 be passed in as a list,
@@ -2011,7 +1998,7 @@ since this function calls
 or
 &f-link-PrependENVPath;
 depending on the
-<varname>prepend</varname>
+<parameter>prepend</parameter>
 argument.  See those functions for more details.
 </para>
 
@@ -2036,17 +2023,17 @@ env.MergeShellPaths({'INCLUDE':['c:/inc1', 'c:/inc2']}, prepend=0 )
 <summary>
 <para>
 Merges the specified
-<varname>arg</varname>
+<parameter>arg</parameter>
 values to the construction environment's construction variables.
 If the
-<varname>arg</varname>
+<parameter>arg</parameter>
 argument is not a dictionary,
 it is converted to one by calling
 &f-link-env-ParseFlags;
 on the argument
 before the values are merged.
 Note that
-<varname>arg</varname>
+<parameter>arg</parameter>
 must be a single value,
 so multiple strings must
 be passed in as a list,
@@ -2198,11 +2185,11 @@ NoClean(env.Program('hello', 'hello.c'))
 <summary>
 <para>
 Calls the specified
-<varname>function</varname>
+<parameter>function</parameter>
 to modify the environment as specified by the output of
-<varname>command</varname>.
+<parameter>command</parameter>.
 The default
-<varname>function</varname>
+<parameter>function</parameter>
 is
 &f-link-env-MergeFlags;,
 which expects the output of a typical
@@ -2240,7 +2227,7 @@ for a table of options and construction variables.
 <summary>
 <para>
 Parses the contents of the specified
-<varname>filename</varname>
+<parameter>filename</parameter>
 as a list of dependencies in the style of
 &Make;
 or
@@ -2252,10 +2239,10 @@ and explicitly establishes all of the listed dependencies.
 By default,
 it is not an error
 if the specified
-<varname>filename</varname>
+<parameter>filename</parameter>
 does not exist.
 The optional
-<varname>must_exist</varname>
+<parameter>must_exist</parameter>
 argument may be set to a non-zero
 value to have
 scons
@@ -2266,7 +2253,7 @@ or is otherwise inaccessible.
 
 <para>
 The optional
-<varname>only_one</varname>
+<parameter>only_one</parameter>
 argument may be set to a non-zero
 value to have
 scons
@@ -2288,7 +2275,7 @@ file.
 
 <para>
 The
-<varname>filename</varname>
+<parameter>filename</parameter>
 and all of the files listed therein
 will be interpreted relative to
 the directory of the
@@ -2417,7 +2404,7 @@ env = Environment(platform = Platform('win32'))
 The
 &f-env-Platform;
 form applies the callable object for the specified platform
-<varname>string</varname>
+<parameter>string</parameter>
 to the environment through which the method was called.
 </para>
 
@@ -2502,7 +2489,7 @@ string, in which case a list will be returned instead of a string.
 
 <para>
 If
-<varname>delete_existing</varname>
+<parameter>delete_existing</parameter>
 is 0, then adding a path that already exists
 will not move it to the beginning;
 it will stay where it is in the list.
@@ -2570,16 +2557,16 @@ env.PrependUnique(CCFLAGS = '-g', FOO = ['foo.yyy'])
 This returns a Directory Node similar to Dir.
 The python module / package is looked up and if located
 the directory is returned for the location.
-<varname>modulename</varname>
+<parameter>modulename</parameter>
 Is a named python package / module to
 lookup the directory for it's location.
 </para>
 <para>
 If
-<varname>modulename</varname>
+<parameter>modulename</parameter>
 is a list, SCons returns a list of Dir nodes.
 Construction variables are expanded in
-<varname>modulename</varname>.
+<parameter>modulename</parameter>.
 </para>
 </summary>
 </scons_function>
@@ -2611,7 +2598,7 @@ env.Replace(CCFLAGS = '-g', FOO = 'foo.xxx')
 <summary>
 <para>
 Specifies that
-<varname>directory</varname>
+<parameter>directory</parameter>
 is a repository to be searched for files.
 Multiple calls to
 &f-Repository;
@@ -2695,7 +2682,7 @@ env.Requires('foo', 'file-that-must-be-built-before-foo')
 <para>
 Creates a Scanner object for
 the specified
-<varname>function</varname>.
+<parameter>function</parameter>.
 See manpage section "Scanner Objects"
 for a complete explanation of the arguments and behavior.
 </para>
@@ -2760,18 +2747,18 @@ This tells
 &scons;
 to store all file signatures
 in the specified database
-<varname>file</varname>.
+<parameter>file</parameter>.
 If the
-<varname>file</varname>
+<parameter>file</parameter>
 name is omitted,
 <filename>.sconsign</filename>
 is used by default.
 (The actual file name(s) stored on disk
 may have an appropriated suffix appended
 by the
-<varname> dbm_module</varname>.)
+<parameter>dbm_module</parameter>.)
 If
-<varname>file</varname>
+<parameter>file</parameter>
 is not an absolute path name,
 the file is placed in the same directory as the top-level
 &SConstruct;
@@ -2780,9 +2767,9 @@ file.
 
 <para>
 If
-<varname>file</varname>
+<parameter>file</parameter>
 is
-<literal>None</literal>,
+<constant>None</constant>,
 then
 &scons;
 will store file signatures
@@ -2796,7 +2783,7 @@ prior to SCons 0.96.91 and 0.97.)
 
 <para>
 The optional
-<varname>dbm_module</varname>
+<parameter>dbm_module</parameter>
 argument can be used to specify
 which Python database module
 The default is to use a custom
@@ -2856,13 +2843,13 @@ if 'FOO' not in env: env['FOO'] = 'foo'
 <summary>
 <para>
 Declares
-<varname>side_effect</varname>
+<parameter>side_effect</parameter>
 as a side effect of building
-<varname>target</varname>.
+<parameter>target</parameter>.
 Both
-<varname>side_effect</varname>
+<parameter>side_effect</parameter>
 and
-<varname>target</varname>
+<parameter>target</parameter>
 can be a list, a file name, or a node.
 A side effect is a target file that is created or updated
 as a side effect of building other targets.
@@ -2884,23 +2871,23 @@ multiple build commands.
 Because multiple build commands may update
 the same side effect file,
 by default the
-<varname>side_effect</varname>
+<parameter>side_effect</parameter>
 target is
 <emphasis>not</emphasis>
 automatically removed
 when the
-<varname>target</varname>
+<parameter>target</parameter>
 is removed by the
 <option>-c</option>
 option.
 (Note, however, that the
-<varname>side_effect</varname>
+<parameter>side_effect</parameter>
 might be removed as part of
 cleaning the directory in which it lives.)
 If you want to make sure the
-<varname>side_effect</varname>
+<parameter>side_effect</parameter>
 is cleaned whenever a specific
-<varname>target</varname>
+<parameter>target</parameter>
 is cleaned,
 you must specify this explicitly
 with the
@@ -2917,13 +2904,13 @@ function.
 <summary>
 <para>
 Returns a list of file names or other objects.
-If <varname>arg</varname> is a string,
+If <parameter>arg</parameter> is a string,
 it will be split on strings of white-space characters
 within the string,
 making it easier to write long lists of file names.
-If <varname>arg</varname> is already a list,
+If <parameter>arg</parameter> is already a list,
 the list will be returned untouched.
-If <varname>arg</varname> is any other type of object,
+If <parameter>arg</parameter> is any other type of object,
 it will be returned as a list
 containing just the object.
 </para>
@@ -2952,7 +2939,7 @@ files = Split("""
 <para>
 Performs construction variable interpolation
 on the specified string or sequence argument
-<varname>input</varname>.
+<parameter>input</parameter>.
 </para>
 
 <para>
@@ -2967,14 +2954,14 @@ and
 <literal>$)</literal>
 character sequences will be stripped from the returned string,
 The optional
-<varname>raw</varname>
+<parameter>raw</parameter>
 argument may be set to
 <literal>1</literal>
 if you want to preserve white space and
 <literal>$(</literal>-<literal>$)</literal>
 sequences.
 The
-<varname>raw</varname>
+<parameter>raw</parameter>
 argument may be set to
 <literal>2</literal>
 if you want to strip
@@ -2997,9 +2984,9 @@ and the results will be returned as a list.
 
 <para>
 The optional
-<varname>target</varname>
+<parameter>target</parameter>
 and
-<varname>source</varname>
+<parameter>source</parameter>
 keyword arguments
 must be set to lists of
 target and source nodes, respectively,
@@ -3021,7 +3008,7 @@ as an SCons action.
 Returned string values or sequence elements
 are converted to their string representation by default.
 The optional
-<varname>conv</varname>
+<parameter>conv</parameter>
 argument
 may specify a conversion function
 that will be used in place of
@@ -3100,7 +3087,7 @@ as part of the <parameter>tools</parameter> keyword argument,
 or it can be called directly,
 passing a &consenv; to update as the argument.
 Either approach will also update the
-<varname>TOOLS</varname> &consvar;.
+&cv-TOOLS; &consvar;.
 </para>
 
 <para>
@@ -3128,17 +3115,17 @@ u(env)  # adds 'opengl' to the TOOLS variable
 Returns a Node object representing the specified Python value.  Value
 Nodes can be used as dependencies of targets.  If the result of
 calling
-<function>str</function>(<varname>value</varname>)
+<function>str</function>(<parameter>value</parameter>)
 changes between SCons runs, any targets depending on
-<function>Value</function>(<varname>value</varname>)
+<function>Value</function>(<parameter>value</parameter>)
 will be rebuilt.
 (This is true even when using timestamps to decide if
 files are up-to-date.)
 When using timestamp source signatures, Value Nodes'
 timestamps are equal to the system time when the Node is created.
-<varname>name</varname> can be provided as an alternative name
+<parameter>name</parameter> can be provided as an alternative name
 for the resulting <literal>Value</literal> node; this is advised
-if the <varname>value</varname> parameter can't be converted to
+if the <parameter>value</parameter> parameter can't be converted to
 a string.
 </para>
 
@@ -3148,7 +3135,7 @@ The returned Value Node object has a
 method that can be used to "build" a Value Node
 by setting a new value.
 The optional
-<varname>built_value</varname>
+<parameter>built_value</parameter>
 argument can be specified
 when the Value Node is created
 to indicate the Node should already be considered
@@ -3208,11 +3195,11 @@ Use the
 &f-VariantDir;
 function to create a copy of your sources in another location:
 if a name under
-<varname>variant_dir</varname>
+<parameter>variant_dir</parameter>
 is not found but exists under
-<varname>src_dir</varname>,
+<parameter>src_dir</parameter>,
 the file or directory is copied to
-<varname>variant_dir</varname>.
+<parameter>variant_dir</parameter>.
 Target files can be built in a different directory
 than the original sources by simply refering to the sources (and targets)
 within the variant tree.
@@ -3221,15 +3208,15 @@ within the variant tree.
 <para>
 &f-VariantDir;
 can be called multiple times with the same
-<varname>src_dir</varname>
+<parameter>src_dir</parameter>
 to set up multiple builds with different options
-(<varname>variants</varname>).
+(<parameter>variants</parameter>).
 The
-<varname>src_dir</varname>
+<parameter>src_dir</parameter>
 location must be in or underneath the SConstruct file's directory, and
-<varname>variant_dir</varname>
+<parameter>variant_dir</parameter>
 may not be underneath
-<varname>src_dir</varname>.
+<parameter>src_dir</parameter>.
 <!--
 TODO: Can the above restrictions be clarified or relaxed?
 TODO: The latter restriction is clearly not completely right;
@@ -3258,7 +3245,7 @@ see also the
 command-line option.
 Moreover, only the files needed for the build are duplicated;
 files and directories that are not used are not present in
-<varname>variant_dir</varname>.
+<parameter>variant_dir</parameter>.
 </para>
 
 <para>
@@ -3270,9 +3257,9 @@ argument to
 This will cause
 &scons;
 to invoke Builders using the path names of source files in
-<varname>src_dir</varname>
+<parameter>src_dir</parameter>
 and the path names of derived files within
-<varname>variant_dir</varname>.
+<parameter>variant_dir</parameter>.
 This is always more efficient than
 <literal>duplicate=1</literal>,
 and is usually safe for most builds
@@ -3285,7 +3272,7 @@ Note that
 works most naturally with a subsidiary SConscript file.
 However, you would then call the subsidiary SConscript file
 not in the source directory, but in the
-<varname>variant_dir</varname>,
+<parameter>variant_dir</parameter>,
 regardless of the value of
 <literal>duplicate</literal>.
 This is how you tell
@@ -3340,52 +3327,52 @@ SConscript(dirs='doc', variant_dir='build/doc', duplicate=0)
 <summary>
 <para>
 Searches for the specified executable
-<varname>program</varname>,
+<parameter>program</parameter>,
 returning the full path to the program
 or <constant>None</constant>.
 </para>
 <para>
 When called as a &consenv; method,
 searches the paths in the
-<varname>path</varname> keyword argument,
+<parameter>path</parameter> keyword argument,
 or if <constant>None</constant> (the default)
 the paths listed in the &consenv;
-(<replaceable>env</replaceable><literal>['ENV']['PATH']</literal>).
+(<parameter>env</parameter><literal>['ENV']['PATH']</literal>).
 The external environment's path list
 (<literal>os.environ['PATH']</literal>)
 is used as a fallback if the key
-<replaceable>env</replaceable><literal>['ENV']['PATH']</literal>
+<parameter>env</parameter><literal>['ENV']['PATH']</literal>
 does not exist.
 </para>
 <para>
 On Windows systems, searches for executable
 programs with any of the file extensions listed in the
-<varname>pathext</varname> keyword argument,
-or if <literal>None</literal> (the default)
+<parameter>pathext</parameter> keyword argument,
+or if <constant>None</constant> (the default)
 the pathname extensions listed in the &consenv;
-(<replaceable>env</replaceable><literal>['ENV']['PATHEXT']</literal>).
+(<parameter>env</parameter><literal>['ENV']['PATHEXT']</literal>).
 The external environment's pathname extensions list
 (<literal>os.environ['PATHEXT']</literal>)
 is used as a fallback if the key
-<replaceable>env</replaceable><literal>['ENV']['PATHEXT']</literal>
+<parameter>env</parameter><literal>['ENV']['PATHEXT']</literal>
 does not exist.
 </para>
 <para>
 When called as a global function, uses the external
-environment's path 
+environment's path
 <literal>os.environ['PATH']</literal>
 and path extensions
 <literal>os.environ['PATHEXT']</literal>,
 respectively, if
-<varname>path</varname> and
-<varname>pathext</varname> are
+<parameter>path</parameter> and
+<parameter>pathext</parameter> are
 <constant>None</constant>.
 </para>
 <para>
 Will not select any
 path name or names
 in the optional
-<varname>reject</varname>
+<parameter>reject</parameter>
 list.
 </para>
 

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -662,7 +662,7 @@ caching by calling &f-env-CacheDir;.
 </para>
 
 <para>
-When cachin
+When a
 <parameter>cache_dir</parameter>
 is being used and
 &scons;
@@ -1027,10 +1027,10 @@ Specifies that all up-to-date decisions for
 targets built through this construction environment
 will be handled by the specified
 <parameter>function</parameter>.
-<parameter>function</parameter>
-can be one of the following strings
-that specify the type of decision function
-to be performed:
+<parameter>function</parameter> can be the name of
+a function or one of the following strings
+that specify the predefined decision function
+that will be applied:
 </para>
 
 <para>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -905,7 +905,7 @@ if any of the sources will be directories
 that must be scanned on-disk for
 changes to files that aren't
 already specified in other Builder of function calls.
-The <paramter>*_factory</parameter> arguments take a factory function that
+The <parameter>*_factory</parameter> arguments take a factory function that
 &Command; will use to turn any sources or targets
 specified as strings into SCons Nodes.
 See the manpage section "Builder Objects"

--- a/SCons/Errors.py
+++ b/SCons/Errors.py
@@ -73,7 +73,7 @@ class BuildError(Exception):
     Information about the cause of the location of the error:
     ---------------------------------------------------------
 
-    node : the error occured while building this target node(s)
+    node : the error occurred while building this target node(s)
 
     executor : the executor that caused the build to fail (might
                be None if the build failures is not due to the

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -30,59 +30,59 @@ See its __doc__ string for a discussion of the format.
 </arguments>
 <summary>
 <para>
-This function adds a new command-line option to be recognized.
-The specified
-<varname>arguments</varname>
-are the same as supported by the <function>add_option</function>
-method in the standard Python library module <emphasis>optparse</emphasis>,
-with a few additional capabilities noted below;
-see the documentation for
+Adds a local (project-specific) command-line option.
+<parameter>arguments</parameter>
+are the same as those supported by the <function>add_option</function>
+method in the standard Python library module <systemitem>optparse</systemitem>,
+with a few additional capabilities noted below.
+See the documentation for
 <emphasis>optparse</emphasis>
 for a thorough discussion of its option-processing capabities.
 </para>
 
 <para>
 In addition to the arguments and values supported by the
-<function>optparse.add_option</function>()
-method,
-the SCons
-&f-AddOption;
-function allows you to set the
-<literal>nargs</literal>
+<emphasis>optparse</emphasis>
+<function>add_option</function>
+method, &f-AddOption;
+allows setting the
+<parameter>nargs</parameter>
 keyword value to
-<literal>'?'</literal>
-(a string with just the question mark)
-to indicate that the specified long option(s) take(s) an
-<emphasis>optional</emphasis>
-argument.
-When
-<literal>nargs = '?'</literal>
-is passed to the
-&f-AddOption;
-function, the
-<literal>const</literal>
-keyword argument
-may be used to supply the "default"
-value that should be used when the
-option is specified on the command line
-without an explicit argument.
+a string consisting of a question mark
+(<literal>'?'</literal>)
+to indicate that the option argument for
+that option string is optional.
+If the option string is present on the
+command line but has no matching option
+argument, the value of the
+<parameter>const</parameter>
+keyword argument is produced as the value
+of the option.
+If the option string is omitted from
+the command line, the value of the
+<parameter>default</parameter>
+keyword argument is produced, as usual;
+if there is no
+<parameter>default</parameter>
+keyword argument in the &f-AddOption; call,
+<constant>None</constant> is produced.
 </para>
 
 <para>
-If no
-<literal>default=</literal>
-keyword argument is supplied when calling
-&f-AddOption;,
-the option will have a default value of
-<literal>None</literal>.
-</para>
-
-<para>
-Unlike regular <emphasis>optparse</emphasis>, option names
-added via <function>AddOption</function> must be matched
-exactly, the automatic matching of abbreviations on the
-command line for long options is not supported.
-To allow specific abbreviations,
+<systemitem>optparse</systemitem> recognizes
+abbreviations of long option names,
+as long as they can be unambiguously resolved.
+For example, if
+<function>add_option</function> is called to
+define a <option>--devicename</option> option,
+it will recognize <option>--device</option>,
+<option>--dev</option>
+and so forth as long as there is no other option
+which could also match to the same abbreviation.
+Options added via
+<function>AddOption</function> do not support
+the automatic recognition of abbreviations.
+Instead, to allow specific abbreviations,
 include them in the &f-AddOption; call.
 </para>
 
@@ -90,45 +90,40 @@ include them in the &f-AddOption; call.
 Once a new command-line option has been added with
 &f-AddOption;,
 the option value may be accessed using
-&f-GetOption;
+&f-link-GetOption;
 or
-<function>env.GetOption</function>().
-<!--
-The value may also be set, using
+&f-link-env-GetOption;.
+&f-link-SetOption; is not currently supported for
+options added with &f-AddOption;.
+<!-- was:
+The value may also be set using
 &f-SetOption;
 or
 <function>env.SetOption</function>(),
 if conditions in a
 &SConscript;
 require overriding any default value.
-Note, however, that a
+Note however that a
 value specified on the command line will
 <emphasis>always</emphasis>
 override a value set by any SConscript file.
 -->
-&f-SetOption; is not currently supported for
-options added with &f-AddOption;.
 </para>
 
 <para>
-Any specified
-<literal>help=</literal>
-strings for the new option(s)
-will be displayed by the
-<option>-H</option>
-or
-<option>-h</option>
-options
-(the latter only if no other help text is
-specified in the SConscript files).
-The help text for the local options specified by
-&f-AddOption;
-will appear below the SCons options themselves,
-under a separate
-<literal>Local Options</literal>
-heading.
-The options will appear in the help text
-in the order in which the
+Help text for an option is a combination
+of the string supplied in the
+<parameter>help</parameter> keyword
+argument to &f-AddOption; and information
+collected from the other keyword arguments.
+Such help is displayed if the
+<option>-h</option> command line option
+is used (but not with <option>-H</option>).
+Help for all local options is displayed
+under the separate heading
+<emphasis role="bold">Local Options</emphasis>.
+The options are unsorted - they will appear
+in the help text in the order in which the
 &f-AddOption;
 calls occur.
 </para>
@@ -138,27 +133,50 @@ Example:
 </para>
 
 <example_commands>
-AddOption('--prefix',
-          dest='prefix',
-          nargs=1, type='string',
-          action='store',
-          metavar='DIR',
-          help='installation prefix')
-env = Environment(PREFIX = GetOption('prefix'))
+AddOption(
+    '--prefix',
+    dest='prefix',
+    nargs=1,
+    type='string',
+    action='store',
+    metavar='DIR',
+    help='installation prefix',
+)
+env = Environment(PREFIX=GetOption('prefix'))
 </example_commands>
+
+<para>For that example,
+the following help text would be produced:</para>
+
+<screen>
+Local Options:
+  --prefix=DIR                installation prefix
+</screen>
+
+<para>
+Help text for local options may be unavailable if
+the &f-link-Help; function has been called,
+see the &f-Help; documentation for details.
+</para>
 
 <note>
 <para>
-While &AddOption; behaves like
-<function>add_option</function>,
-from the <emphasis>optparse</emphasis> module,
+As an artifact of the internal implementation,
 the behavior of options added by &AddOption;
-which take arguments is underfined in
-<command>scons</command> if whitespace
+which take option arguments is undefined
+<emphasis>if</emphasis> whitespace
 (rather than an <literal>=</literal> sign) is used as
-the separator on the command line when
-the option is invoked.
-Such usage should be avoided.
+the separator on the command line.
+Users should avoid such usage; it is recommended
+to add a note to this effect to project documentation
+if the situation is likely to arise.
+In addition, if the <parameter>nargs</parameter>
+keyword is used to specify more than one following
+option argument (that is, with a value of <constant>2</constant>
+or greater), such arguments would necessarily
+be whitespace separated, triggering the issue.
+Developers should not use &AddOption; this way.
+Future versions of &SCons; will likely forbid such usage.
 </para>
 </note>
 
@@ -582,22 +600,21 @@ evaluating Nodes (e.g. files).
 <para>
 If the first specified argument is a Python callable
 (a function or an object that has a
-<function>__call__</function>()
-method),
+<methodname>__call__</methodname> method),
 the function will be called
 once every
 <varname>interval</varname>
-times a Node is evaluated.
+times a Node is evaluated (default <constant>1</constant>).
 The callable will be passed the evaluated Node
 as its only argument.
 (For future compatibility,
 it's a good idea to also add
-<literal>*args</literal>
+<parameter>*args</parameter>
 and
-<literal>**kw</literal>
-as arguments to your function or method.
+<parameter>**kwargs</parameter>
+as arguments to your function or method signatures.
 This will prevent the code from breaking
-if SCons ever changes the interface
+if &SCons; ever changes the interface
 to call the function with additional arguments in the future.)
 </para>
 
@@ -608,7 +625,7 @@ every 10 Nodes:
 </para>
 
 <example_commands>
-def my_progress_function(node, *args, **kw):
+def my_progress_function(node, *args, **kwargs):
     print('Evaluating node %s!' % node)
 Progress(my_progress_function, interval=10)
 </example_commands>
@@ -626,8 +643,7 @@ will overwrite itself on a display:
 
 <example_commands>
 import sys
-
-class ProgressCounter:
+class ProgressCounter(object):
     count = 0
     def __call__(self, node, *args, **kw):
         self.count += 100
@@ -637,18 +653,28 @@ Progress(ProgressCounter(), interval=100)
 </example_commands>
 
 <para>
-If the first argument
-&f-link-Progress;
-is a string,
-the string will be displayed
-every
+If the first argument to
+&f-Progress; is a string or list of strings,
+it is taken as text to be displayed every
 <varname>interval</varname>
 evaluated Nodes.
-The default is to print the string on standard output;
-an alternate output stream
+If the first argument is a list of strings,
+then each string in the list will be displayed
+in rotating fashion every
+<varname>interval</varname>
+evaluated Nodes.
+</para>
+
+<para>
+The default is to print the string on standard output.
+An alternate output stream
 may be specified with the
-<literal>file=</literal>
-argument.
+<parameter>file</parameter>
+keyword argument, which the
+caller must pass already opened.
+</para>
+
+<para>
 The following will print a series of dots
 on the error output,
 one dot for every 100 evaluated Nodes:
@@ -661,7 +687,7 @@ Progress('.', interval=100, file=sys.stderr)
 
 <para>
 If the string contains the verbatim substring
-&cv-TARGET;,
+<literal>$TARGET;</literal>,
 it will be replaced with the Node.
 Note that, for performance reasons, this is
 <emphasis>not</emphasis>
@@ -670,12 +696,13 @@ so you can not use other variables
 or use curly braces.
 The following example will print the name of
 every evaluated Node,
-using a
-<literal>\r</literal>
-(carriage return) to cause each line to overwritten by the next line,
+using a carriage return)
+(<literal>\r</literal>)
+to cause each line to overwritten by the next line,
 and the
-<literal>overwrite=</literal>
-keyword argument to make sure the previously-printed
+<parameter>overwrite</parameter>
+keyword argument (default <literal>False</literal>)
+to make sure the previously-printed
 file name is overwritten with blank spaces:
 </para>
 
@@ -685,15 +712,9 @@ Progress('$TARGET\r', overwrite=True)
 </example_commands>
 
 <para>
-If the first argument to
-&f-Progress;
-is a list of strings,
-then each string in the list will be displayed
-in rotating fashion every
-<varname>interval</varname>
-evaluated Nodes.
-This can be used to implement a "spinner"
-on the user's screen as follows:
+A list of strings can be used to implement a "spinner"
+on the user's screen as follows, changing every
+five evaluated Nodes:
 </para>
 
 <example_commands>

--- a/SCons/Script/SConscript.xml
+++ b/SCons/Script/SConscript.xml
@@ -248,22 +248,24 @@ file is found.
 </arguments>
 <summary>
 <para>
-This specifies help text to be printed if the
+Specifies a local help message to be printed if the
 <option>-h</option>
 argument is given to
 &scons;.
-If
+Subsequent calls to
 &f-Help;
-is called multiple times, the text is appended together in the order that
-&f-Help;
-is called. With append set to False, any
-&f-Help;
-text generated with
-&f-AddOption;
-is clobbered. If append is True, the AddOption help is prepended to the help
-string, thus preserving the
-<option>-h</option>
-message.
+append <parameter>text</parameter> to the previously
+defined local help text.
+</para>
+<para>
+For the first call to &f-Help; only,
+if <parameter>append</parameter> is <constant>False</constant>
+(the default)
+any local help message generated through
+&f-link-AddOption; calls is replaced.
+If <parameter>append</parameter> is <constant>True</constant>,
+<parameter>text</parameter> is appended to
+the existing help text.
 </para>
 </summary>
 </scons_function>


### PR DESCRIPTION
Mostly update markup to more "standard" markup conventions.

There are some substantive wording changes to `CacheDir` descriptions in `Environment.xml`, and to the `AddOption`/`Help` descriptions in `Main.xml` and `SConscript.xml` files. 

Doc-only change - affects both manpage and user guide.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
