### PR TITLE
Fix userguide entity typo

### DIFF
--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -265,7 +265,7 @@ if not GetOption('help'):
 
       <para>
 
-      &f-Getoption; can be used to retrieve the values of options
+      &f-GetOption; can be used to retrieve the values of options
       defined by calls to &f-link-AddOption;. A &f-GetOption; call
       must appear after the &f-AddOption; call for that option.
       If the &f-AddOption; call supplied a <parameter>dest</parameter>


### PR DESCRIPTION
`&f-GetOption;` was not properly camelcased in a recent commit.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
