### PR TITLE
Minor: drop engine prefix from docstrings

### DIFF
--- a/SCons/Platform/aix.py
+++ b/SCons/Platform/aix.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Platform.aix
+"""SCons.Platform.aix
 
 Platform-specific initialization for IBM AIX systems.
 

--- a/SCons/Platform/darwin.py
+++ b/SCons/Platform/darwin.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Platform.darwin
+"""SCons.Platform.darwin
 
 Platform-specific initialization for Mac OS X systems.
 

--- a/SCons/Platform/hpux.py
+++ b/SCons/Platform/hpux.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Platform.hpux
+"""SCons.Platform.hpux
 
 Platform-specific initialization for HP-UX systems.
 

--- a/SCons/Platform/sunos.py
+++ b/SCons/Platform/sunos.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Platform.sunos
+"""SCons.Platform.sunos
 
 Platform-specific initialization for Sun systems.
 

--- a/SCons/Tool/aixf77.py
+++ b/SCons/Tool/aixf77.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.aixf77
+"""SCons.Tool.aixf77
 
 Tool-specific initialization for IBM Visual Age f77 Fortran compiler.
 

--- a/SCons/Tool/cvf.py
+++ b/SCons/Tool/cvf.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.cvf
+"""SCons.Tool.cvf
 
 Tool-specific initialization for the Compaq Visual Fortran compiler.
 

--- a/SCons/Tool/f03.py
+++ b/SCons/Tool/f03.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.f03
+"""SCons.Tool.f03
 
 Tool-specific initialization for the generic Posix f03 Fortran compiler.
 

--- a/SCons/Tool/f08.py
+++ b/SCons/Tool/f08.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.f08
+"""SCons.Tool.f08
 
 Tool-specific initialization for the generic Posix f08 Fortran compiler.
 

--- a/SCons/Tool/f77.py
+++ b/SCons/Tool/f77.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.f77
+"""SCons.Tool.f77
 
 Tool-specific initialization for the generic Posix f77 Fortran compiler.
 

--- a/SCons/Tool/f90.py
+++ b/SCons/Tool/f90.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.f90
+"""SCons.Tool.f90
 
 Tool-specific initialization for the generic Posix f90 Fortran compiler.
 

--- a/SCons/Tool/f95.py
+++ b/SCons/Tool/f95.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.f95
+"""SCons.Tool.f95
 
 Tool-specific initialization for the generic Posix f95 Fortran compiler.
 

--- a/SCons/Tool/g77.py
+++ b/SCons/Tool/g77.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.g77
+"""SCons.Tool.g77
 
 Tool-specific initialization for g77.
 

--- a/SCons/Tool/icc.py
+++ b/SCons/Tool/icc.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.icc
+"""SCons.Tool.icc
 
 Tool-specific initialization for the OS/2 icc compiler.
 

--- a/SCons/Tool/icl.py
+++ b/SCons/Tool/icl.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.icl
+"""SCons.Tool.icl
 
 Tool-specific initialization for the Intel C/C++ compiler.
 

--- a/SCons/Tool/mssdk.py
+++ b/SCons/Tool/mssdk.py
@@ -23,7 +23,7 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-"""engine.SCons.Tool.mssdk
+"""SCons.Tool.mssdk
 
 Tool-specific initialization for Microsoft SDKs, both Platform
 SDKs and Windows SDKs.

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.msvc
+"""SCons.Tool.msvc
 
 Tool-specific initialization for Microsoft Visual C/C++.
 

--- a/SCons/Tool/sunar.py
+++ b/SCons/Tool/sunar.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Tool.sunar
+"""SCons.Tool.sunar
 
 Tool-specific initialization for Solaris (Forte) ar (library archive). If CC
 exists, static libraries should be built with it, so that template

--- a/SCons/Variables/BoolVariable.py
+++ b/SCons/Variables/BoolVariable.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Variables.BoolVariable
+"""SCons.Variables.BoolVariable
 
 This file defines the option type for SCons implementing true/false values.
 

--- a/SCons/Variables/EnumVariable.py
+++ b/SCons/Variables/EnumVariable.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Variables.EnumVariable
+"""SCons.Variables.EnumVariable
 
 This file defines the option type for SCons allowing only specified
 input-values.

--- a/SCons/Variables/ListVariable.py
+++ b/SCons/Variables/ListVariable.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Variables.ListVariable
+"""SCons.Variables.ListVariable
 
 This file defines the option type for SCons implementing 'lists'.
 

--- a/SCons/Variables/PackageVariable.py
+++ b/SCons/Variables/PackageVariable.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Variables.PackageVariable
+"""SCons.Variables.PackageVariable
 
 This file defines the option type for SCons implementing 'package
 activation'.

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -1,4 +1,4 @@
-"""engine.SCons.Variables
+"""SCons.Variables
 
 This file defines the Variables class that is used to add user-friendly
 customizable variables to an SCons build.


### PR DESCRIPTION
A number of module docstrings start with the module name, these end up appearing in API docs. Drop the "`engine/`" prefix where it appears.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
