### PR TITLE
Fix Issue #3693 - fix fieldname target -> output (per spec)

### DIFF
--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -84,7 +84,7 @@ def make_emit_compilation_DB_entry(comstr):
         entry = env.__COMPILATIONDB_Entry(
             target=dbtarget,
             source=[],
-            __COMPILATIONDB_UTARGET=target,
+            __COMPILATIONDB_UOUTPUT=target,
             __COMPILATIONDB_USOURCE=source,
             __COMPILATIONDB_UACTION=user_action,
             __COMPILATIONDB_ENV=env,
@@ -116,7 +116,7 @@ def compilation_db_entry_action(target, source, env, **kw):
     """
 
     command = env["__COMPILATIONDB_UACTION"].strfunction(
-        target=env["__COMPILATIONDB_UTARGET"],
+        target=env["__COMPILATIONDB_UOUTPUT"],
         source=env["__COMPILATIONDB_USOURCE"],
         env=env["__COMPILATIONDB_ENV"],
     )
@@ -125,7 +125,7 @@ def compilation_db_entry_action(target, source, env, **kw):
         "directory": env.Dir("#").abspath,
         "command": command,
         "file": env["__COMPILATIONDB_USOURCE"][0],
-        "target": env['__COMPILATIONDB_UTARGET'][0]
+        "output": env['__COMPILATIONDB_UOUTPUT'][0]
     }
 
     target[0].write(entry)
@@ -139,25 +139,25 @@ def write_compilation_db(target, source, env):
     for s in __COMPILATION_DB_ENTRIES:
         entry = s.read()
         source_file = entry['file']
-        target_file = entry['target']
+        output_file = entry['output']
 
         if use_abspath:
             source_file = source_file.abspath
-            target_file = target_file.abspath
+            output_file = output_file.abspath
         else:
             source_file = source_file.path
-            target_file = target_file.path
+            output_file = output_file.path
 
         path_entry = {'directory': entry['directory'],
                       'command': entry['command'],
                       'file': source_file,
-                      'target': target_file}
+                      'output': output_file}
 
         entries.append(path_entry)
 
-    with open(target[0].path, "w") as target_file:
+    with open(target[0].path, "w") as output_file:
         json.dump(
-            entries, target_file, sort_keys=True, indent=4, separators=(",", ": ")
+            entries, output_file, sort_keys=True, indent=4, separators=(",", ": ")
         )
 
 

--- a/SCons/Tool/compilation_db.xml
+++ b/SCons/Tool/compilation_db.xml
@@ -32,7 +32,7 @@ See its __doc__ string for a discussion of the format.
         <sets>
             <item>COMPILATIONDB_COMSTR</item>
             <item>__COMPILATIONDB_UACTION</item>
-            <item>__COMPILATIONDB_UTARGET</item>
+            <item>__COMPILATIONDB_UOUTPUT</item>
             <item>__COMPILATIONDB_USOURCE</item>
             <item>__COMPILATIONDB_ENV</item>
             <item>COMPILATIONDB_USE_ABSPATH</item>

--- a/SCons/Tool/compilation_db.xml
+++ b/SCons/Tool/compilation_db.xml
@@ -101,7 +101,7 @@ env.CompilationDatabase('my_output.json')
 <!--            </para>-->
 <!--        </summary>-->
 <!--    </cvar>-->
-<!--    <cvar name="__COMPILATIONDB_UTARGET">-->
+<!--    <cvar name="__COMPILATIONDB_UOUTPUT">-->
 <!--        <summary>-->
 <!--            <para>-->
 <!--                This variable stores the action for building a target.-->

--- a/test/CompilationDatabase/basic.py
+++ b/test/CompilationDatabase/basic.py
@@ -63,7 +63,7 @@ example_rel_file = """[
         "command": "%s mygcc.py cc -o test_main.o -c test_main.c",
         "directory": "%s",
         "file": "test_main.c",
-        "target": "test_main.o"
+        "output": "test_main.o"
     }
 ]""" % (sys.executable, test.workdir)
 
@@ -77,7 +77,7 @@ example_abs_file = """[
         "command": "%s mygcc.py cc -o test_main.o -c test_main.c",
         "directory": "%s",
         "file": "%s/test_main.c",
-        "target": "%s/test_main.o"
+        "output": "%s/test_main.o"
     }
 ]""" % (sys.executable, test.workdir, test.workdir, test.workdir)
 


### PR DESCRIPTION
Fixes #3693 

Change compilation db output json file field target to output per spec.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
