### PR TITLE
Output proper file paths in compilation db when using VariantDir

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -55,7 +55,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       tool.
     - Add CompilationDatabase() builder in compilation_db tool. Contributed by MongoDB.
       Setting COMPILATIONDB_USE_ABSPATH to True|False controls whether the files are absolute or relative
-      paths.
+      paths.  Address Issue #3693 and #3694 found during development.
 
   From Andrii Doroshenko:
     - Extended `Environment.Dump()` to select a format to serialize construction variables (pretty, json).

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -142,10 +142,10 @@ def write_compilation_db(target, source, env):
         output_file = entry['output']
 
         if use_abspath:
-            source_file = source_file.abspath
+            source_file = source_file.srcnode().abspath
             output_file = output_file.abspath
         else:
-            source_file = source_file.path
+            source_file = source_file.srcnode().path
             output_file = output_file.path
 
         path_entry = {'directory': entry['directory'],

--- a/test/CompilationDatabase/fixture/SConstruct_variant
+++ b/test/CompilationDatabase/fixture/SConstruct_variant
@@ -1,0 +1,40 @@
+import sys
+
+DefaultEnvironment(tools=[])
+env = Environment(
+    PYTHON=sys.executable,
+    LINK='$PYTHON mylink.py',
+    LINKFLAGS=[],
+    CC='$PYTHON mygcc.py cc',
+    CXX='$PYTHON mygcc.py c++',
+    tools=['gcc','g++','gnulink'],
+)
+env.Tool('compilation_db')
+
+env_abs = env.Clone(COMPILATIONDB_USE_ABSPATH=True)
+env_abs.CompilationDatabase('compile_commands_clone_abs.json')
+
+# Should be relative paths
+env.CompilationDatabase('compile_commands_only_arg.json')
+env.CompilationDatabase(target='compile_commands_target.json')
+
+# Should default name compile_commands.json
+env.CompilationDatabase()
+
+# Should be absolute paths
+env.CompilationDatabase('compile_commands_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
+env.CompilationDatabase(target='compile_commands_target_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
+
+# Should be relative paths
+env.CompilationDatabase('compile_commands_over_rel.json', COMPILATIONDB_USE_ABSPATH=False)
+
+# Try 1/0 for COMPILATIONDB_USE_ABSPATH
+env.CompilationDatabase('compile_commands_over_abs_1.json', COMPILATIONDB_USE_ABSPATH=1)
+env.CompilationDatabase('compile_commands_over_abs_0.json', COMPILATIONDB_USE_ABSPATH=0)
+
+env.VariantDir('build','src')
+env.Program('build/main', 'build/test_main.c')
+
+env.VariantDir('build2','src', duplicate=0)
+env.Program('build2/main', 'build2/test_main.c')
+

--- a/test/CompilationDatabase/variant_dir.py
+++ b/test/CompilationDatabase/variant_dir.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Test CompilationDatabase and several variations of ways to call it
+and values of COMPILATIONDB_USE_ABSPATH
+"""
+
+import sys
+import os
+import os.path
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.file_fixture('mylink.py')
+test.file_fixture('mygcc.py')
+
+test.verbose_set(1)
+test.file_fixture('fixture/SConstruct_variant', 'SConstruct')
+test.file_fixture('test_main.c', 'src/test_main.c')
+test.run()
+
+rel_files = [
+    'compile_commands_only_arg.json',
+    'compile_commands_target.json',
+    'compile_commands.json',
+    'compile_commands_over_rel.json',
+    'compile_commands_over_abs_0.json'
+]
+
+abs_files = [
+    'compile_commands_clone_abs.json',
+    'compile_commands_over_abs.json',
+    'compile_commands_target_over_abs.json',
+    'compile_commands_over_abs_1.json',
+]
+
+example_rel_file = """[
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output_file)s -c %(variant_src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(src_file)s",
+        "output": "%(output_file)s"
+    },
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output2_file)s -c %(src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(src_file)s",
+        "output": "%(output2_file)s"
+    }
+]""" % {'exe': sys.executable,
+        'workdir': test.workdir,
+        'src_file': os.path.join('src', 'test_main.c'),
+        'output_file': os.path.join('build', 'test_main.o'),
+        'output2_file': os.path.join('build2', 'test_main.o'),
+        'variant_src_file': os.path.join('build', 'test_main.c')
+        }
+
+if sys.platform == 'win32':
+    example_rel_file = example_rel_file.replace('\\', '\\\\')
+
+for f in rel_files:
+    # print("Checking:%s" % f)
+    test.must_exist(f)
+    test.must_match(f, example_rel_file, mode='r')
+
+example_abs_file = """[
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output_file)s -c %(variant_src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(abs_src_file)s",
+        "output": "%(abs_output_file)s"
+    },
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output2_file)s -c %(src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(abs_src_file)s",
+        "output": "%(abs_output2_file)s"
+    }
+]""" % {'exe': sys.executable,
+        'workdir': test.workdir,
+        'src_file': os.path.join('src', 'test_main.c'),
+        'abs_src_file': os.path.join(test.workdir, 'src', 'test_main.c'),
+        'abs_output_file': os.path.join(test.workdir, 'build', 'test_main.o'),
+        'abs_output2_file': os.path.join(test.workdir, 'build2', 'test_main.o'),
+        'output_file': os.path.join('build', 'test_main.o'),
+        'output2_file': os.path.join('build2', 'test_main.o'),
+        'variant_src_file': os.path.join('build', 'test_main.c')}
+
+if sys.platform == 'win32':
+    example_abs_file = example_abs_file.replace('\\', '\\\\')
+
+for f in abs_files:
+    test.must_exist(f)
+    test.must_match(f, example_abs_file, mode='r')
+
+test.pass_test()


### PR DESCRIPTION
Fix #3694 

Properly handle variant_dir (and with and without duplicate) and output,file paths.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
