### PR TITLE
Fix Issue #3628 - limit pickle protocol to 4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,6 +56,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add CompilationDatabase() builder in compilation_db tool. Contributed by MongoDB.
       Setting COMPILATIONDB_USE_ABSPATH to True|False controls whether the files are absolute or relative
       paths.  Address Issue #3693 and #3694 found during development.
+    - Fixed Github Issue 3628 - Hardcoding pickle protocol to 4 (supports python 3.4+)
+      and skipping Python 3.8's new pickle protocol 5 whose main advantage is for out-of-band data buffers
 
   From Andrii Doroshenko:
     - Extended `Environment.Dump()` to select a format to serialize construction variables (pretty, json).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,7 +57,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Setting COMPILATIONDB_USE_ABSPATH to True|False controls whether the files are absolute or relative
       paths.  Address Issue #3693 and #3694 found during development.
     - Fixed Github Issue 3628 - Hardcoding pickle protocol to 4 (supports python 3.4+)
-      and skipping Python 3.8's new pickle protocol 5 whose main advantage is for out-of-band data buffers
+      and skipping Python 3.8's new pickle protocol 5 whose main advantage is for out-of-band data buffers.
+      NOTE: If you used Python 3.8 with SCons 3.0.0 or above, you may get a a pickle protocol error. Remove your
+      .sconsign.dblite. You will end up with a full rebuild.
 
   From Andrii Doroshenko:
     - Extended `Environment.Dump()` to select a format to serialize construction variables (pretty, json).

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -17,6 +17,10 @@
       when the value can't be converted to a string or if having a name is otherwise desirable.
     - Added a new flag called "linedraw" for the command line argument  "--tree"
       that instructs scons to use single line drawing characters to draw the dependency tree.
+    - Add CompilationDatabase() builder in compilation_db tool. Contributed by MongoDB.
+      Setting COMPILATIONDB_USE_ABSPATH to True|False controls whether the files are absolute or relative
+      paths.  Address Issue #3693 and #3694 found during development.
+
 
   DEPRECATED FUNCTIONALITY
 
@@ -43,6 +47,10 @@
       required for intellisense to use the C++ standard version from cppflags.
     - Allow user specified location for vswhere.exe specified by VSWHERE.
       NOTE: This must be set at the time the 'msvc' 'msvs' and/or 'mslink' tool(s) are initialized to have any effect.
+    - Fixed Github Issue 3628 - Hardcoding pickle protocol to 4 (supports python 3.4+)
+      and skipping Python 3.8's new pickle protocol 5 whose main advantage is for out-of-band data buffers.
+      NOTE: If you used Python 3.8 with SCons 3.0.0 or above, you may get a a pickle protocol error. Remove your
+      .sconsign.dblite. You will end up with a full rebuild.
 
 
   FIXES

--- a/SCons/compat/__init__.py
+++ b/SCons/compat/__init__.py
@@ -84,8 +84,9 @@ def rename_module(new, old):
 import pickle
 
 # Was pickle.HIGHEST_PROTOCOL
-# Changed to 2 so py3.5+'s pickle will be compatible with py2.7.
-PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
+# Changed to 4 so that python 3.8's not incompatible with previous versions
+# Python 3.8 introduced protocol 5 which is mainly an improvement for for out-of-band data buffers
+PICKLE_PROTOCOL = 4
 
 import shutil
 try:


### PR DESCRIPTION
Fixe #3628  - Hardcoding pickle protocol to 4 (supports python 3.4+)
      and skipping Python 3.8's new pickle protocol 5 whose main advantage is for out-of-band data buffers


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
