### PR TITLE
Integrate the stubprocess.py wrapper from Parts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Dirk Baechle:
     - Added Docker images for building and testing SCons. (issue #3585)
+    - Integrated stubprocess.py wrapper from the Parts project in order
+      to speed up large builds. It's available as an experimental option
+      '--stubprocess-wrapper' for now.
 
   From James Benton:
     - Improve Visual Studio solution/project generation code to add support

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -20,6 +20,12 @@
     - Add CompilationDatabase() builder in compilation_db tool. Contributed by MongoDB.
       Setting COMPILATIONDB_USE_ABSPATH to True|False controls whether the files are absolute or relative
       paths.  Address Issue #3693 and #3694 found during development.
+    - Added a new command-line option "--stubprocess-wrapper", which will try to wrap the
+      subprocess.Popen() call when activated. Enabling this option can give a significant speedup
+      for the build of large projects that consume a lot of memory and create many files.
+      Small builds however may experience a slow-down, which is why we declared this option
+      an "experimental feature" for the moment. Please also refer to the corresponding entry
+      in the MAN page for more information.
 
 
   DEPRECATED FUNCTIONALITY

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -54,6 +54,9 @@ import SCons.Errors
 import SCons.Subst
 import SCons.Tool
 
+# Gets set to True in Main._main() when the '--stubprocess-wrapper'
+# option was given on the command-line for speeding up large builds.
+stubprocess_wrapper = False
 
 def platform_default():
     r"""Return the platform string for our execution environment.

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -44,6 +44,24 @@ from SCons.Platform import TempFileMunge
 from SCons.Platform.virtualenv import ImportVirtualenv
 from SCons.Platform.virtualenv import ignore_virtualenv, enable_virtualenv
 
+# Create a copy of the subprocess.Popen by subclassing
+class PopenWrapped(subprocess.Popen):
+    pass
+
+# We sneak our new 'wrapped' Popen into the subprocess module,
+# such that the original subprocess.Popen() is guaranteed to stay
+# unchanged. Otherwise, wrapping the Popen() directly might interfere
+# with user SConstructs where subprocess is imported directly.
+# Here we try to ensure that only SCons' spawn calls are redirected
+# through the PopenWrapped().
+subprocess.PopenWrapped = PopenWrapped
+
+# Now try to import and activate Parts' stubprocess wrapper for
+# speeding up process forks...if this isn't possible for some reason,
+# our subprocess.PopenWrapped() will still behave exactly the same as the
+# builtin subprocess.Popen().
+import SCons.Platform.stubprocess
+
 exitvalmap = {
     2 : 127,
     13 : 126,
@@ -63,14 +81,14 @@ def escape(arg):
 
 
 def exec_subprocess(l, env):
-    proc = subprocess.Popen(l, env = env, close_fds = True)
+    proc = subprocess.PopenWrapped(l, env = env, close_fds = True)
     return proc.wait()
 
 def subprocess_spawn(sh, escape, cmd, args, env):
     return exec_subprocess([sh, '-c', ' '.join(args)], env)
 
 def exec_popen3(l, env, stdout, stderr):
-    proc = subprocess.Popen(l, env = env, close_fds = True,
+    proc = subprocess.PopenWrapped(l, env = env, close_fds = True,
                             stdout = stdout,
                             stderr = stderr)
     return proc.wait()

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -40,27 +40,30 @@ import sys
 import select
 
 import SCons.Util
-from SCons.Platform import TempFileMunge
+from SCons.Platform import TempFileMunge, stubprocess_wrapper
 from SCons.Platform.virtualenv import ImportVirtualenv
 from SCons.Platform.virtualenv import ignore_virtualenv, enable_virtualenv
 
-# Create a copy of the subprocess.Popen by subclassing
-class PopenWrapped(subprocess.Popen):
-    pass
-
-# We sneak our new 'wrapped' Popen into the subprocess module,
-# such that the original subprocess.Popen() is guaranteed to stay
-# unchanged. Otherwise, wrapping the Popen() directly might interfere
-# with user SConstructs where subprocess is imported directly.
-# Here we try to ensure that only SCons' spawn calls are redirected
-# through the PopenWrapped().
-subprocess.PopenWrapped = PopenWrapped
-
-# Now try to import and activate Parts' stubprocess wrapper for
-# speeding up process forks...if this isn't possible for some reason,
-# our subprocess.PopenWrapped() will still behave exactly the same as the
-# builtin subprocess.Popen().
-import SCons.Platform.stubprocess
+if stubprocess_wrapper:
+    # Create a copy of the subprocess.Popen by subclassing
+    class PopenWrapped(subprocess.Popen):
+        pass
+    
+    # We sneak our new 'wrapped' Popen into the subprocess module,
+    # such that the original subprocess.Popen() is guaranteed to stay
+    # unchanged. Otherwise, wrapping the Popen() directly might interfere
+    # with user SConstructs where subprocess is imported directly.
+    # Here we try to ensure that only SCons' spawn calls are redirected
+    # through the PopenWrapped().
+    subprocess.PopenWrapped = PopenWrapped
+    
+    # Now try to import and activate Parts' stubprocess wrapper for
+    # speeding up process forks...if this isn't possible for some reason,
+    # our subprocess.PopenWrapped() will still behave exactly the same as the
+    # builtin subprocess.Popen().
+    import SCons.Platform.stubprocess
+else:
+    subprocess.PopenWrapped = subprocess.Popen
 
 exitvalmap = {
     2 : 127,

--- a/SCons/Platform/stubprocess.py
+++ b/SCons/Platform/stubprocess.py
@@ -1,0 +1,350 @@
+'''
+We have faced an issue with forking processes on RHEL 5.10.
+When parent process consumes a realy big amount of memory fork call becomes very slow
+because it needs to copy memory pages from parent to child process.
+To overcome the issue we use posix_spawn function. The function calls vfork followed by
+execve call. This avoids copying of memory pages and saves time but it also prevents us
+from redirecting standard input and output because when it is requested posix_spawn
+function uses fork instead of vfork and we have the slowdown again.
+
+To make the IO redirection we do not start a requested sub-process immidiately but
+use intermediate python script which redirects the IO. The whole call chain looks like this:
+
+Popen("/foo/bar") -> fork -> execve(["python", __file__]) -> execve("/foo/bar")
+
+All parameters needed for I/O redirection are passed in pickle via temporary file.
+'''
+
+
+import sys
+from builtins import range
+
+if sys.platform in ('linux2',):  # 'darwin'): #Fix me later..
+    import types
+    import time
+    import os
+    import pickle as pickle
+    import fcntl
+    import errno
+    import traceback
+    import base64
+
+    try:
+        cloexec_flag = fcntl.FD_CLOEXEC
+    except AttributeError:
+        cloexec_flag = 1
+
+    def _set_cloexec_flag(fd, cloexec=True):
+        '''
+        Utility function to modify close-on-exec flag of specified file descriptor
+        '''
+        old = fcntl.fcntl(fd, fcntl.F_GETFD)
+        if cloexec:
+            fcntl.fcntl(fd, fcntl.F_SETFD, old | cloexec_flag)
+        else:
+            fcntl.fcntl(fd, fcntl.F_SETFD, old & ~cloexec_flag)
+
+    if __name__ == '__main__':
+        try:
+            MAXFD = os.sysconf("SC_OPEN_MAX")
+        except Exception:
+            MAXFD = 256
+
+        try:
+            from os import closerange
+        except ImportError:
+            def _close_fds(but):
+                '''
+                Closes all open file descriptors
+                '''
+                for i in range(3, MAXFD):
+                    try:
+                        if i != but:
+                            os.close(i)
+                    except Exception:
+                        pass
+        else:
+            def _close_fds(but):
+                closerange(3, but)
+                closerange(but + 1, MAXFD)
+
+        def report_exception(errpipe_write):
+            exc_type, exc_value, tb = sys.exc_info()
+            del exc_type, tb
+            # Save the traceback and attach it to the exception object
+            exc_lines = traceback.format_exc()
+            exc_value.child_traceback = ''.join(exc_lines)
+            os.write(errpipe_write, pickle.dumps(exc_value))
+
+        def do_execv(args=None, executable=None, close_fds=None, cwd=None, env=None,
+                     shell=None, p2cread=None, p2cwrite=None, c2pread=None, c2pwrite=None,
+                     errread=None, errwrite=None, errpipe_read=None, errpipe_write=None):
+            '''
+            The function redirects IO, prepares command-line, sets up environment and
+            executes execve function.
+            '''
+            os.close(errpipe_read)
+            _set_cloexec_flag(errpipe_write, True)
+            try:
+
+                if shell:
+                    args = [executable or "/bin/sh", "-c"] + args
+
+                if executable is None:
+                    executable = args[0]
+
+                # Close parent's pipe ends
+                for parent_end, child_end in ((p2cwrite, p2cread), (c2pread, c2pwrite),
+                                              (errread, errwrite)):
+                    if parent_end is not None:
+                        os.close(parent_end)
+                    if child_end is not None:
+                        _set_cloexec_flag(True)
+
+                # When duping fds, if there arises a situation
+                # where one of the fds is either 0, 1 or 2, it
+                # is possible that it is overwritten (#12607).
+                if c2pwrite == 0:
+                    c2pwrite = os.dup(c2pwrite)
+                if errwrite == 0 or errwrite == 1:
+                    errwrite = os.dup(errwrite)
+
+                # Dup fds for child
+                def _dup2(a, b):
+                    # dup2() removes the CLOEXEC flag but
+                    # we must do it ourselves if dup2()
+                    # would be a no-op (issue #10806).
+                    if a == b:
+                        _set_cloexec_flag(a, False)
+                    elif a is not None:
+                        os.dup2(a, b)
+                _dup2(p2cread, 0)
+                _dup2(c2pwrite, 1)
+                _dup2(errwrite, 2)
+
+                # Close pipe fds.  Make sure we don't close the
+                # same fd more than once, or standard fds.
+                closed = set([None])
+                for fd in [p2cread, c2pwrite, errwrite]:
+                    if fd not in closed and fd > 2:
+                        os.close(fd)
+                        closed.add(fd)
+
+                # Close all other fds, if asked for
+                if close_fds:
+                    _close_fds(errpipe_write)
+
+                if cwd is not None:
+                    os.chdir(cwd)
+
+                if env is None:
+                    os.execvp(executable, args)
+                else:
+                    os.execvpe(executable, args, env)
+            except Exception:
+                report_exception(errpipe_write)
+
+            # This exitcode won't be reported to applications, so it
+            # really doesn't matter what we return.
+            os._exit(255)
+
+        errpipe_write = int(sys.argv[1])
+        try:
+            if sys.argv[2] == '@':
+                with open(sys.argv[3], 'rb') as data:
+                    data = data.read()
+                os.unlink(sys.argv[3])
+            else:
+                data = sys.argv[2]
+            params = pickle.loads(base64.decodestring(data))
+            do_execv(**params)
+        except Exception:
+            report_exception(errpipe_write)
+
+    else:
+        import ctypes
+        import tempfile
+
+        try:
+            ARG_MAX = os.sysconf('SC_ARG_MAX')
+        except Exception:
+            ARG_MAX = 32768
+
+        try:
+            from subprocess import _eintr_retry_call
+        except ImportError:
+            def _eintr_retry_call(func, *args, **kw):
+                while True:
+                    try:
+                        return func(*args, **kw)
+                    except OSError as err:
+                        if err.errno == errno.EINTR:
+                            continue
+                        raise
+
+        try:
+            # We support only Linux and Mac OS X now.
+            libc = ctypes.CDLL("libc.so.6" if 'linux' in sys.platform else 'libc.dylib', use_errno=True)
+            posix_spawn = libc.posix_spawn
+        except (OSError, AttributeError):
+            # OSError is raised when no libc.so.6 is found on the system
+            # AttributeError is raised when no posix_spawn function can be found
+            pass
+        else:
+            posix_spawn.restype = ctypes.c_int
+            posix_spawn.argtypes = (
+                ctypes.POINTER(ctypes.c_int),  # ppid
+                ctypes.c_char_p,  # executable
+                ctypes.c_void_p,  # file_actions
+                ctypes.c_void_p,  # attrp
+                ctypes.POINTER(ctypes.c_char_p),  # argv
+                ctypes.POINTER(ctypes.c_char_p),  # env
+            )
+
+            # In Python older than 2.7.6 subprocess.Popen._execute_child accepts 17 arguments.
+            # In Python 2.7.6 it accepts 18 args.
+            # To workaround the issue we use _unpack_args* functions. Both 27 and 276 return
+            # a tuple containing args in order they are passed to Python 2.7.6 _execute_child
+            # function.
+
+            def _unpack_args_27(args):
+                result = (self, argv, executable, preexec_fn, close_fds,
+                          cwd, env, universal_newlines,
+                          startupinfo, creationflags, shell, to_close,
+                          p2cread, p2cwrite,
+                          c2pread, c2pwrite,
+                          errread, errwrite) = args[:11] + (set(),) + args[11:]
+                to_close.update((p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite))
+                return result
+
+            def _unpack_args_276(args):
+                try:
+                    result = (self, argv, executable, preexec_fn, close_fds,
+                              cwd, env, universal_newlines,
+                              startupinfo, creationflags, shell, to_close,
+                              p2cread, p2cwrite,
+                              c2pread, c2pwrite,
+                              errread, errwrite) = args
+                except ValueError:
+                    global _unpack_args
+                    _unpack_args = _unpack_args_27
+                    return _unpack_args_27(args)
+                else:
+                    return result
+
+            _unpack_args = _unpack_args_276
+
+            def _close_in_parent(fd, to_close):
+                os.close(fd)
+                to_close.remove(fd)
+
+            def _wrap_execute_child(klass):
+                wrapped_execute_child = klass._execute_child
+
+                def _execute_child(*argv):
+
+                    (self, args, executable, preexec_fn, close_fds,
+                     cwd, env, universal_newlines,
+                     startupinfo, creationflags, shell, to_close,
+                     p2cread, p2cwrite,
+                     c2pread, c2pwrite,
+                     errread, errwrite) = _unpack_args(argv)
+
+                    if preexec_fn:
+                        return wrapped_execute_child(*argv)
+
+                    for fd in (p2cread, p2cwrite,
+                               c2pread, c2pwrite,
+                               errread, errwrite):
+                        if fd is not None:
+                            _set_cloexec_flag(fd, False)
+
+                    errpipe_read, errpipe_write = os.pipe()
+
+                    if isinstance(args, (str,)):
+                        args = [str(args)]
+                    else:
+                        args = [str(x) for x in args]
+
+                    if env:
+                        env = dict((str(key), str(value))
+                                   for (key, value) in env.items())
+                    else:
+                        env = None
+                    if executable:
+                        executable = str(executable)
+                    else:
+                        executable = None
+                    if cwd:
+                        cwd = str(cwd)
+                    else:
+                        cwd = None
+
+                    data = base64.encodestring(
+                        pickle.dumps(
+                            dict(
+                                args=args, executable=executable, close_fds=bool(close_fds),
+                                cwd=cwd, env=env, shell=bool(shell),
+                                p2cread=p2cread, p2cwrite=p2cwrite,
+                                c2pread=c2pread, c2pwrite=c2pwrite,
+                                errread=errread, errwrite=errwrite,
+                                errpipe_read=errpipe_read, errpipe_write=errpipe_write,
+                            ), pickle.HIGHEST_PROTOCOL))
+
+                    use_file = len(data) >= ARG_MAX
+
+                    if use_file:
+                        with tempfile.NamedTemporaryFile(delete=False) as the_file:
+                            the_file.write(data)
+                        argv = (sys.executable, __file__, str(errpipe_write), '@',
+                                the_file.name, 0)
+                    else:
+                        argv = (sys.executable, __file__, str(errpipe_write), data, 0)
+                    argv = (ctypes.c_char_p * len(argv))(*argv)
+
+                    pid = ctypes.c_int()
+
+                    os_environ = (ctypes.c_char_p * (len(os.environ) + 1))(
+                        *(['{0}={1}'.format(*value) for value in os.environ.items()] + [0]))
+
+                    try:
+                        ret = posix_spawn(ctypes.byref(pid), ctypes.c_char_p(sys.executable),
+                                          ctypes.c_void_p(), ctypes.c_void_p(),
+                                          ctypes.cast(argv, ctypes.POINTER(ctypes.c_char_p)),
+                                          ctypes.cast(os_environ, ctypes.POINTER(ctypes.c_char_p)))
+                        err = ctypes.get_errno()
+                        os.close(errpipe_write)
+                        if ret:
+                            raise OSError(err, os.strerror(err))
+                        self.pid = pid.value
+                        self._child_created = True
+                        # Wait for exec to fail or succeed; possibly raising exception
+                        # Exception limited to 1M
+                        data = _eintr_retry_call(os.read, errpipe_read, 1048576)
+                        if data:
+                            try:
+                                _eintr_retry_call(os.waitpid, self.pid, 0)
+                            except OSError as e:
+                                if e.errno != errno.ECHILD:
+                                    raise
+                            raise pickle.loads(data)
+                    finally:
+                        if use_file:
+                            try:
+                                os.unlink(the_file.name)
+                            except Exception:
+                                pass
+                        os.close(errpipe_read)
+                        if p2cread is not None and p2cwrite is not None:
+                            _close_in_parent(p2cread, to_close)
+                        if c2pwrite is not None and c2pread is not None:
+                            _close_in_parent(c2pwrite, to_close)
+                        if errwrite is not None and errread is not None:
+                            _close_in_parent(errwrite, to_close)
+
+                klass._execute_child = _execute_child
+
+            import subprocess
+            _wrap_execute_child(subprocess.Popen)
+
+# vim: set et ts=4 sw=4 ai :

--- a/SCons/Platform/stubprocess.py
+++ b/SCons/Platform/stubprocess.py
@@ -62,12 +62,7 @@ All parameters needed for I/O redirection are passed in pickle via temporary fil
 import sys
 from builtins import range
 
-# We currently support 'darwin' platforms, or Linux with a version
-# smaller than v3.7.2. Starting with this release, CPython provides
-# its own implementation of posix_spawn inside _execute_child, so we
-# don't have to patch anything.
-if (sys.platform in ('darwin',) or
-    (sys.platform == 'linux' and (sys.version_info < (3, 7, 2)))):
+if sys.platform in ('linux', 'darwin'):
      
     import os
     import pickle
@@ -289,7 +284,7 @@ if (sys.platform in ('darwin',) or
                 return result
 
             def _unpack_args_369(args):
-                """ Args from Python 2.6.9 on were:
+                """ Args from Python 3.6.9 on were:
                     (self, argv, executable, preexec_fn, close_fds, pass_fds
                      cwd, env,
                      startupinfo, creationflags, shell,

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -988,6 +988,10 @@ def _main(parser):
     if options.interactive:
         SCons.Node.interactive = True
 
+    # Also set the stubprocess wrapper option, if requested.
+    if options.stubprocess_wrapper:
+        SCons.Platform.stubprocess_wrapper = True
+
     # That should cover (most of) the options.  Next, set up the variables
     # that hold command-line arguments, so the SConscript files that we
     # read and execute have access to them.

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -448,6 +448,14 @@ which corresponds to <option>--implicit-deps-unchanged</option>;
 </listitem>
 </varlistentry>
 <varlistentry>
+<term><literal>stubprocess_wrapper</literal></term>
+<listitem>
+<para>
+which corresponds to <option>--stubprocess-wrapper</option>;
+</para>
+</listitem>
+</varlistentry>
+<varlistentry>
 <term><literal>interactive</literal></term>
 <listitem>
 <para>

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -829,6 +829,11 @@ def Parser(version):
                   help="Set the stack size of the threads used to run jobs to N kilobytes.",
                   metavar="N")
 
+    op.add_option('--stubprocess-wrapper',
+                  dest='stubprocess_wrapper', default=False,
+                  action="store_true",
+                  help="Install the stubprocess wrapper for speeding up large builds.")
+
     op.add_option('--taskmastertrace',
                   nargs=1,
                   dest="taskmastertrace_file", default=None,

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1220,6 +1220,7 @@ command:</para>
 -n, --no-exec, --just-print, --dry-run, --recon
 -Q
 -s, --silent, --quiet
+--stubprocess-wrapper
 --taskmastertrace=FILE
 --tree=OPTIONS
 </literallayout>
@@ -1667,6 +1668,32 @@ build process.
 The default value is to use a stack size of 256 kilobytes, which should
 be appropriate for most uses.  You should not need to increase this value
 unless you encounter stack overflow errors.</para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
+  <term><option>--stubprocess-wrapper</option></term>
+  <listitem>
+<para>Tries to activate the <filename>stubprocess.py</filename> wrapper from the <emphasis>Parts</emphasis>
+project for speeding up builds. This wrapper uses pickling of the Actions' arguments
+and calls itself again as a <emphasis>main</emphasis> Python script in order to let us use the fast
+<emphasis>vfork</emphasis> from the libc library. Currently, only the platforms
+<function>linux</function> and <function>darwin</function> are supported.</para>
+
+<para>Please note that the build time can actually grow when enabling this
+option, depending on the size of your project! Unfortunately, the redirection
+through a script lets us suffer from the startup times of the Python
+interpreter while searching and loading its required modules. So, if you have only a
+handful of files, all <emphasis>vfork</emphasis> benefits might get eaten
+up by the additional starting time for Python in each executed Action. As a result,
+your build gets slower in total.</para>
+
+<para>It's not possible to come up with a single recommendation, like: "If your project
+has more than 20000 files, use this option". Apart from the number of files to build,
+the memory consumed by the overall process, your OS and your HDD, it's also the Python interpreter
+version and which modules and dist-packages you have installed in it, that are all affecting
+the break-even point. In the end you simply have to try it out, and continue to use this
+option if you happen to find that it speeds up your build.</para>
   </listitem>
   </varlistentry>
 


### PR DESCRIPTION
With this PR we integrate the stubprocess.py wrapper from Parts to our project. It's made available as an experimental feature (for now) via the '--stubprocess-wrapper' command line option.

I considered to simply always activate the wrapper, but the following reasons speak against it:

1. It can slow down builds with low memory consumption and/or low number of files. See also the 'man page' entry for this feature in 'doc/man/scons.xml'.
2. Python itself is now adding support for vfork starting in v3.7.2, but only for 'linux' platforms at the moment. However, a few Python releases from now this wrapper might be superfluous.
3. I had to patch the original version a lot to make it work under Python3, but I couldn't test my changes under OSx.
4. So far, Python3 has changed the interface for the subprocess._execute_child() call several times, and the wrapper should handle all of those at the moment. But as soon as Python changes again, users' builds would break immediately and no work-around (except patching the stubprocess wrapper) would be available.

I ran the wrapper against several 'artificial' builds (created with a Perl script by E. Melski) with the following results (all in parallel with '-j 4'):

```
Small (approx 6000 files)
-------------------------

normal:    1m4.336s
wrapper:   1m38.203s

Large (approx 78000 files)
--------------------------

normal:   14m33.155s
wrapper:  14m6.347s

Very large (approx 400000 files)
--------------------------------

normal:  406m9.926s
wrapper: 111m6.048s
```


There are no additional test cases provided with this PR, running the whole testsuite without the '--stubprocess-wrapper' option didn't show any additional fails on my machine. I also verified that the wrapper works fine in "interactive" mode.

For this current implementation of the wrapper, a Python3 floor version of 3.4 is assumed.


After this PR gets integrated, I plan to do a little report on the scaling of the wrapper over the numbers of cores and the number of files to build. I will then work my results into the 'WhySConsIsNotSlow' Wiki page and update it accordingly.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
