### PR TITLE
Fix docbook 4.5 vs 5 usage

### DIFF
--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -56,9 +56,9 @@ import SCons.Tool
 
 
 def platform_default():
-    r"""Return the platform string for our execution environment.
+    """Return the platform string for our execution environment.
 
-    The returned value should map to one of the SCons/Platform/*.py
+    The returned value should map to one of the SCons/Platform/\*.py
     files.  Since scons is architecture independent, though, we don't
     care about the machine architecture.
     """

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -41,7 +41,6 @@
 
 <reference xmlns="http://www.scons.org/dbxsd/v1.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns:xlink="http://www.w3.org/1999/xlink"
            xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
 
   <referenceinfo>
@@ -7448,22 +7447,22 @@ and will silently revert to non-cached behavior in such cases.</para>
   <simplelist type="vert">
   <member>
     The SCons User Guide at
-    <link xlink:href="https://scons.org/doc/production/HTML/scons-user.html"/>
+    <ulink url="https://scons.org/doc/production/HTML/scons-user.html"/>
  </member>
   <member>The SCons Design Document (old)</member>
   <member>
     The SCons Cookbook at
-    <link xlink:href="https://scons-cookbook.readthedocs.io"/>
+    <ulink url="https://scons-cookbook.readthedocs.io"/>
     for examples of how to solve various problems with &SCons;.
   </member>
   <member>
     SCons source code
-    <link xlink:href="https://github.com/SCons/scons">
-    on GitHub</link>
+    <ulink url="https://github.com/SCons/scons">
+    on GitHub</ulink>
   </member>
   <member>
     The SCons API Reference
-    <link xlink:href="https://scons.org/doc/production/HTML/scons-api/index.html"/>
+    <ulink url="https://scons.org/doc/production/HTML/scons-api/index.html"/>
     (for internal details)
    </member>
   </simplelist>

--- a/doc/user/main.xml
+++ b/doc/user/main.xml
@@ -62,7 +62,6 @@
 
 <book xmlns="http://www.scons.org/dbxsd/v1.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
       xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
   <bookinfo>
     <title>SCons &buildversion;</title>

--- a/doc/user/misc.xml
+++ b/doc/user/misc.xml
@@ -685,9 +685,9 @@ env.Command('directory_build_info',
         </para>
         <para>
             See
-            <link xlink:href="https://clang.llvm.org/docs/JSONCompilationDatabase.html">
+            <ulink url="https://clang.llvm.org/docs/JSONCompilationDatabase.html">
                 <citetitle>JSON Compilation Database Format Specification</citetitle>
-            </link>
+            </ulink>
             for complete information
         </para>
 


### PR DESCRIPTION
Recent changes introduced the use of the Docbook 5 syntax for external links (`<link xlink:href="https://www.example.com"/>`), which works okay for the doc build, but breaks the internal tools which do formal validation against the scons-modified docbook DTD ("sconsdoc") because sconsdoc is a modification of Docbook 4.5, thus pinning us to that version (for validation, etc)

`xlink` was a Docbook 5 introduction to use more standard W3C syntax for the links (xlink is a W3C spec of its own).

Back off this new usage: go back to the old usage pattern (`<ulink url="https://www.example.com">`), because trying to uplift sconsdoc looks a fairly substantial task. Maybe later?

Signed-off-by: Mats Wichmann <mats@linux.com>

Affects only doc.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
