### PR TITLE
Fix testing subdir usage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -185,6 +185,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       different doc format, should that choice be made); significant
       rewordings in manpage.  Manpage Examples moved to an external
       repository / website (scons-cookbook.readthedocs.io).
+    - Clean up test harness and tests' use of subdir, file_fixture and
+      dir_fixture.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/test/AS/AS.py
+++ b/test/AS/AS.py
@@ -40,7 +40,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myas.py'))
+test.file_fixture(['fixture', 'myas.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/AS/ASFLAGS.py
+++ b/test/AS/ASFLAGS.py
@@ -35,7 +35,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myas_args.py'))
+test.file_fixture(['fixture', 'myas_args.py'])
 
 o = ' -x'
 o_c = ' -x -c'

--- a/test/AS/ASPP.py
+++ b/test/AS/ASPP.py
@@ -35,7 +35,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myas.py'))
+test.file_fixture(['fixture', 'myas.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/AS/ASPPFLAGS.py
+++ b/test/AS/ASPPFLAGS.py
@@ -35,7 +35,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myas_args.py'))
+test.file_fixture(['fixture', 'myas_args.py'])
 
 o = ' -x'
 o_c = ' -x -c'

--- a/test/CC/CCVERSION.py
+++ b/test/CC/CCVERSION.py
@@ -37,7 +37,7 @@ if sys.platform == 'win32':
     test.skip_test('CCVERSION not set with MSVC, skipping test.')
 
 test.dir_fixture('CCVERSION-fixture')
-test.file_fixture(os.path.join('CC-fixture', 'foo.c'))
+test.file_fixture(['CC-fixture', 'foo.c'])
 
 test.write('SConstruct', """
 cc = Environment().Dictionary('CC')

--- a/test/Fortran/F03.py
+++ b/test/Fortran/F03.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F03FILESUFFIXES.py
+++ b/test/Fortran/F03FILESUFFIXES.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test default file suffix: .f90/.F90 for F90
 test.write('SConstruct', """

--- a/test/Fortran/F03FILESUFFIXES2.py
+++ b/test/Fortran/F03FILESUFFIXES2.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non-default file suffix: .f/.F for F03
 test.write('SConstruct', """

--- a/test/Fortran/F03FLAGS.py
+++ b/test/Fortran/F03FLAGS.py
@@ -33,7 +33,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F08.py
+++ b/test/Fortran/F08.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F08FILESUFFIXES.py
+++ b/test/Fortran/F08FILESUFFIXES.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test default file suffix: .f90/.F90 for F90
 test.write('SConstruct', """

--- a/test/Fortran/F08FILESUFFIXES2.py
+++ b/test/Fortran/F08FILESUFFIXES2.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non-default file suffix: .f/.F for F08
 test.write('SConstruct', """

--- a/test/Fortran/F08FLAGS.py
+++ b/test/Fortran/F08FLAGS.py
@@ -33,7 +33,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F77.py
+++ b/test/Fortran/F77.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F77FILESUFFIXES.py
+++ b/test/Fortran/F77FILESUFFIXES.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test default file suffix: .f77/.F77 for F77
 test.write('SConstruct', """

--- a/test/Fortran/F77FILESUFFIXES2.py
+++ b/test/Fortran/F77FILESUFFIXES2.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non-default file suffix: .f/.F for F77
 test.write('SConstruct', """

--- a/test/Fortran/F77FLAGS.py
+++ b/test/Fortran/F77FLAGS.py
@@ -33,7 +33,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F90.py
+++ b/test/Fortran/F90.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F90FILESUFFIXES.py
+++ b/test/Fortran/F90FILESUFFIXES.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test default file suffix: .f90/.F90 for F90
 test.write('SConstruct', """

--- a/test/Fortran/F90FILESUFFIXES2.py
+++ b/test/Fortran/F90FILESUFFIXES2.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non-default file suffix: .f/.F for F90
 test.write('SConstruct', """

--- a/test/Fortran/F90FLAGS.py
+++ b/test/Fortran/F90FLAGS.py
@@ -34,7 +34,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F95.py
+++ b/test/Fortran/F95.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/F95FILESUFFIXES.py
+++ b/test/Fortran/F95FILESUFFIXES.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test default file suffix: .f90/.F90 for F90
 test.write('SConstruct', """

--- a/test/Fortran/F95FILESUFFIXES2.py
+++ b/test/Fortran/F95FILESUFFIXES2.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non-default file suffix: .f/.F for F95
 test.write('SConstruct', """

--- a/test/Fortran/F95FLAGS.py
+++ b/test/Fortran/F95FLAGS.py
@@ -33,7 +33,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/FORTRAN.py
+++ b/test/Fortran/FORTRAN.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/FORTRANFILESUFFIXES.py
+++ b/test/Fortran/FORTRANFILESUFFIXES.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test default file suffix: .f/.F for FORTRAN
 test.write('SConstruct', """

--- a/test/Fortran/FORTRANFILESUFFIXES2.py
+++ b/test/Fortran/FORTRANFILESUFFIXES2.py
@@ -33,7 +33,7 @@ _exe   = TestSCons._exe
 test = TestSCons.TestSCons()
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non default file suffix: .f, .f90 and .f95 for FORTRAN
 test.write('SConstruct', """

--- a/test/Fortran/FORTRANFLAGS.py
+++ b/test/Fortran/FORTRANFLAGS.py
@@ -33,7 +33,7 @@ test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
 test.file_fixture('mylink.py')
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(LINK = r'%(_python_)s mylink.py',

--- a/test/Fortran/SHF03.py
+++ b/test/Fortran/SHF03.py
@@ -33,7 +33,7 @@ obj_   = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
 
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF03 = r'%(_python_)s myfortran.py g03',

--- a/test/Fortran/SHF08.py
+++ b/test/Fortran/SHF08.py
@@ -33,7 +33,7 @@ obj_   = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
 
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF08 = r'%(_python_)s myfortran.py g08',

--- a/test/Fortran/SHF77.py
+++ b/test/Fortran/SHF77.py
@@ -33,7 +33,7 @@ obj_   = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
 
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF77 = r'%(_python_)s myfortran.py g77',

--- a/test/Fortran/SHF77FLAGS.py
+++ b/test/Fortran/SHF77FLAGS.py
@@ -33,7 +33,7 @@ _obj = TestSCons._shobj
 obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF77 = r'%(_python_)s myfortran_flags.py g77')

--- a/test/Fortran/SHF90.py
+++ b/test/Fortran/SHF90.py
@@ -33,7 +33,7 @@ obj_   = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
 
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF90 = r'%(_python_)s myfortran.py g90',

--- a/test/Fortran/SHF90FLAGS.py
+++ b/test/Fortran/SHF90FLAGS.py
@@ -33,7 +33,7 @@ _obj = TestSCons._shobj
 obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF90 = r'%(_python_)s myfortran_flags.py g90',

--- a/test/Fortran/SHF95.py
+++ b/test/Fortran/SHF95.py
@@ -33,7 +33,7 @@ obj_   = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
 
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF95 = r'%(_python_)s myfortran.py g95',

--- a/test/Fortran/SHF95FLAGS.py
+++ b/test/Fortran/SHF95FLAGS.py
@@ -33,7 +33,7 @@ _obj = TestSCons._shobj
 obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(SHF95 = r'%(_python_)s myfortran_flags.py g95',

--- a/test/Fortran/SHFORTRAN.py
+++ b/test/Fortran/SHFORTRAN.py
@@ -33,7 +33,7 @@ obj_   = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
 
-test.file_fixture(os.path.join('fixture', 'myfortran.py'))
+test.file_fixture(['fixture', 'myfortran.py'])
 
 test.write('SConstruct', """
 env = Environment(SHFORTRAN = r'%(_python_)s myfortran.py fortran')

--- a/test/Fortran/SHFORTRANFLAGS.py
+++ b/test/Fortran/SHFORTRANFLAGS.py
@@ -32,7 +32,7 @@ _obj   = TestSCons._shobj
 obj_   = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
-test.file_fixture(os.path.join('fixture', 'myfortran_flags.py'))
+test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
 env = Environment(SHFORTRAN = r'%(_python_)s myfortran_flags.py fortran')

--- a/test/QT/QTFLAGS.py
+++ b/test/QT/QTFLAGS.py
@@ -35,28 +35,31 @@ _exe = TestSCons._exe
 
 test = TestSCons.TestSCons()
 
-test.subdir( 'qt', ['qt', 'bin'], ['qt', 'include'], ['qt', 'lib'],
-             'work1', 'work2')
-
 test.Qt_dummy_installation()
+test.subdir('work1', 'work2')
 
-test.run(chdir=test.workpath('qt','lib'), arguments = '.',
-         stderr=TestSCons.noisy_ar,
-         match=TestSCons.match_re_dotall)
+test.run(
+    chdir=test.workpath('qt', 'lib'),
+    arguments='.',
+    stderr=TestSCons.noisy_ar,
+    match=TestSCons.match_re_dotall,
+)
 
 QT = test.workpath('qt')
 QT_LIB = 'myqt'
-QT_MOC = '%s %s' % (_python_, test.workpath('qt','bin','mymoc.py'))
-QT_UIC = '%s %s' % (_python_, test.workpath('qt','bin','myuic.py'))
+QT_MOC = '%s %s' % (_python_, test.workpath('qt', 'bin', 'mymoc.py'))
+QT_UIC = '%s %s' % (_python_, test.workpath('qt', 'bin', 'myuic.py'))
 
-def createSConstruct(test,place,overrides):
-    test.write(place, """
-env = Environment(QTDIR = r'%s',
-                  QT_LIB = r'%s',
-                  QT_MOC = r'%s',
-                  QT_UIC = r'%s',
-                  %s
-                  tools=['default','qt'])
+def createSConstruct(test, place, overrides):
+    test.write(place, """\
+env = Environment(
+    tools=['default','qt'],
+    QTDIR = r'%s',
+    QT_LIB = r'%s',
+    QT_MOC = r'%s',
+    QT_UIC = r'%s',
+    %s  # last because 'overrides' may add comma
+)
 if ARGUMENTS.get('variant_dir', 0):
     if ARGUMENTS.get('chdir', 0):
         SConscriptChdir(1)
@@ -67,7 +70,7 @@ if ARGUMENTS.get('variant_dir', 0):
 else:
     sconscript = File('SConscript')
 Export("env")
-SConscript( sconscript )
+SConscript(sconscript)
 """ % (QT, QT_LIB, QT_MOC, QT_UIC, overrides))
 
 

--- a/test/packaging/sandbox-test/sandbox-test.py
+++ b/test/packaging/sandbox-test/sandbox-test.py
@@ -35,17 +35,16 @@ python = TestSCons.python
 test = TestSCons.TestSCons()
 
 tar = test.detect('TAR', 'tar')
-
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
-test.dir_fixture('src','src')
+test.dir_fixture('src', dstdir='src')
 test.file_fixture('SConstruct')
 
 test.run(stderr=None)
 
-test.must_exist( 'libfoobar-1.2.3.tar.gz' )
-test.must_exist( 'libfoobar-1.2.3.zip' )
+test.must_exist('libfoobar-1.2.3.tar.gz')
+test.must_exist('libfoobar-1.2.3.zip')
 
 test.pass_test()
 

--- a/test/packaging/use-builddir.py
+++ b/test/packaging/use-builddir.py
@@ -51,15 +51,16 @@ test.write("src/main.c", "")
 test.write("SConstruct", """\
 VariantDir('build', 'src')
 DefaultEnvironment(tools=[])
-env=Environment(tools=['packaging', 'filesystem', 'zip'])
-env.Package( NAME        = 'libfoo',
-             PACKAGEROOT = 'build/libfoo',
-             VERSION     = '1.2.3',
-             PACKAGETYPE = 'src_zip',
-             target      = 'build/libfoo-1.2.3.zip',
-             source      = [ 'src/main.c', 'SConstruct' ] )
-""",
+env = Environment(tools=['packaging', 'filesystem', 'zip'])
+env.Package(
+    NAME='libfoo',
+    PACKAGEROOT='build/libfoo',
+    VERSION='1.2.3',
+    PACKAGETYPE='src_zip',
+    target='build/libfoo-1.2.3.zip',
+    source=['src/main.c', 'SConstruct'],
 )
+""")
 
 test.run(stderr=None)
 
@@ -68,8 +69,8 @@ test.must_exist("build/libfoo-1.2.3.zip")
 # TEST: builddir not placed in archive
 # XXX: VariantDir should be stripped.
 #
-test.subdir("src")
-test.subdir("build")
+#test.subdir("src")  # already created above
+#test.subdir("build")  # already created above
 test.subdir("temp")
 
 test.write("src/main.c", "")
@@ -77,13 +78,14 @@ test.write("src/main.c", "")
 test.write("SConstruct", """\
 DefaultEnvironment(tools=[])
 VariantDir('build', 'src')
-env=Environment(tools=['packaging', 'filesystem', 'tar'])
-env.Package( NAME        = 'libfoo',
-             VERSION     = '1.2.3',
-             PAKCAGETYPE = 'src_targz',
-             source      = [ 'src/main.c', 'SConstruct' ] )
-""",
+env = Environment(tools=['packaging', 'filesystem', 'tar'])
+env.Package(
+    NAME='libfoo',
+    VERSION='1.2.3',
+    PAKCAGETYPE='src_targz',
+    source=['src/main.c', 'SConstruct'],
 )
+""")
 
 test.run(stderr=None)
 


### PR DESCRIPTION
Various tests called `subdir` several times with the same directory, which is pointless.  In previous code, this emitted a message though it did not fail.  Stop doing that.

The `dir_fixture()` method did some convoluted things to make sure the directories to write to exist, change this around to simplify.  The `subdir()` method already combines the testdir, so `dir_fixture` doesn't need to.  Also handle more cleanly the case of the target directory being an absolute path, which seems to have been intended, but would not work.

Also clean up `file_fixture()` along the same principles.

Change the `subdir()` method to not need to be given an ordered list of directories; instead call `os.makedirs` on each so intermediate dirs are made automatically.  Along the way, the print about making a directory that already existed vanishes.

The `TestCmdTests.py` file needed some updating after these changes - it was assuming things would fail that no longer fail; the code in that test class was reordered and commented.

Tests which did `os.path.join` on directory pieces when calling `file_fixture` no longer do so, since `file_fixture` (and `dir_fixture`) do joining on an arg which is a list of paths like many other scons functions.

The testing doc was updated to fix some wording and reflect the above changes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
