### PR TITLE
Fix for failing Docbook slides tests.

### DIFF
--- a/SCons/Tool/docbook/__init__.py
+++ b/SCons/Tool/docbook/__init__.py
@@ -255,7 +255,16 @@ def __generate_xsltproc_action(source, target, env, for_signature):
     base_dir = env.subst('$base_dir')
     if base_dir:
         # Yes, so replace target path by its filename
-        return cmd.replace('$TARGET','${TARGET.file}')
+        return cmd.replace('$TARGET', os.path.join(base_dir, '${TARGET.file}'))
+    return cmd
+
+def __generate_xsltproc_nobase_action(source, target, env, for_signature):
+    cmd = env['DOCBOOK_XSLTPROCCOM']
+    # Does the environment have a base_dir defined?
+    base_dir = env.subst('$base_dir')
+    if base_dir:
+        # Yes, so replace target path by its filename
+        return cmd.replace('$TARGET', '${TARGET.file}')
     return cmd
 
 
@@ -374,6 +383,12 @@ __xsltproc_builder = SCons.Builder.Builder(
         src_suffix = '.xml',
         source_scanner = docbook_xml_scanner,
         emitter = __emit_xsl_basedir)
+__xsltproc_nobase_builder = SCons.Builder.Builder(
+        action = SCons.Action.CommandGeneratorAction(__generate_xsltproc_nobase_action,
+                                                     {'cmdstr' : '$DOCBOOK_XSLTPROCCOMSTR'}),
+        src_suffix = '.xml',
+        source_scanner = docbook_xml_scanner,
+        emitter = __emit_xsl_basedir)
 __xmllint_builder = SCons.Builder.Builder(
         action = SCons.Action.Action('$DOCBOOK_XMLLINTCOM','$DOCBOOK_XMLLINTCOMSTR'),
         suffix = '.xml',
@@ -450,7 +465,7 @@ def DocbookEpub(env, target, source=None, *args, **kw):
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_EPUB', ['epub','docbook.xsl'])
 
     # Setup builder
-    __builder = __select_builder(__lxml_noresult_builder, __xsltproc_builder)
+    __builder = __select_builder(__lxml_noresult_builder, __xsltproc_nobase_builder)
 
     # Create targets
     result = []
@@ -519,7 +534,7 @@ def DocbookHtmlChunked(env, target, source=None, *args, **kw):
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_HTMLCHUNKED', ['html','chunkfast.xsl'])
 
     # Setup builder
-    __builder = __select_builder(__lxml_noresult_builder, __xsltproc_builder)
+    __builder = __select_builder(__lxml_noresult_builder, __xsltproc_nobase_builder)
 
     # Detect base dir
     base_dir = kw.get('base_dir', '')
@@ -554,7 +569,7 @@ def DocbookHtmlhelp(env, target, source=None, *args, **kw):
     __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_HTMLHELP', ['htmlhelp','htmlhelp.xsl'])
 
     # Setup builder
-    __builder = __select_builder(__lxml_noresult_builder, __xsltproc_builder)
+    __builder = __select_builder(__lxml_noresult_builder, __xsltproc_nobase_builder)
 
     # Detect base dir
     base_dir = kw.get('base_dir', '')
@@ -700,10 +715,10 @@ def DocbookSlidesHtml(env, target, source=None, *args, **kw):
         source = [source]
 
     # Init XSL stylesheet
-    __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_SLIDESHTML', ['slides','html','plain.xsl'])
+    __init_xsl_stylesheet(kw, env, '$DOCBOOK_DEFAULT_XSL_SLIDESHTML', ['slides','xhtml','plain.xsl'])
 
     # Setup builder
-    __builder = __select_builder(__lxml_noresult_builder, __xsltproc_builder)
+    __builder = __select_builder(__lxml_builder, __xsltproc_builder)
 
     # Detect base dir
     base_dir = kw.get('base_dir', '')

--- a/test/Docbook/basedir/slideshtml/image/.exclude_tests
+++ b/test/Docbook/basedir/slideshtml/image/.exclude_tests
@@ -1,0 +1,1 @@
+xsltver.py

--- a/test/Docbook/basedir/slideshtml/image/SConstruct
+++ b/test/Docbook/basedir/slideshtml/image/SConstruct
@@ -1,3 +1,12 @@
+import xsltver
+
+v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
+
+ns_ext = ''
+if v >= (1, 78, 0):
+    # Use namespace-aware input file
+    ns_ext = 'ns'
+    
 env = Environment(tools=['docbook'])
-env.DocbookSlidesHtml('virt', xsl='slides.xsl', base_dir='output/')
+env.DocbookSlidesHtml('virt'+ns_ext, xsl='slides.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/slideshtml/image/SConstruct.cmd
+++ b/test/Docbook/basedir/slideshtml/image/SConstruct.cmd
@@ -1,4 +1,13 @@
+import xsltver
+
+v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
+
+ns_ext = ''
+if v >= (1, 78, 0):
+    # Use namespace-aware input file
+    ns_ext = 'ns'
+
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
-env.DocbookSlidesHtml('virt', xsl='slides.xsl', base_dir='output/')
+env.DocbookSlidesHtml('virt'+ns_ext, xsl='slides.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/slideshtml/image/slides.xsl
+++ b/test/Docbook/basedir/slideshtml/image/slides.xsl
@@ -26,6 +26,7 @@
 <xsl:stylesheet
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+        xmlns:dbs="http://docbook.org/ns/docbook-slides"
 	version="1.0">
 
 	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl"/>
@@ -34,22 +35,5 @@
 <xsl:param name="section.autolabel" select="1"/>
 <xsl:param name="base.dir" select="'output/'"/>
 <xsl:param name="html.stylesheet" select="'scons.css'"/>
-<xsl:param name="generate.toc">
-/appendix toc,title
-article/appendix  nop
-/article  toc,title
-book      toc,title,figure,table,example,equation
-/chapter  toc,title
-part      toc,title
-/preface  toc,title
-reference toc,title
-/sect1    toc
-/sect2    toc
-/sect3    toc
-/sect4    toc
-/sect5    toc
-/section  toc
-set       toc,title
-</xsl:param>
 
 </xsl:stylesheet>

--- a/test/Docbook/basedir/slideshtml/image/virtns.xml
+++ b/test/Docbook/basedir/slideshtml/image/virtns.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dbs:slides xmlns="http://docbook.org/ns/docbook"
+            xmlns:dbs="http://docbook.org/ns/docbook-slides"
+            xmlns:xlink="http://www.w3.org/1999/xlink">
+  <info>
+    <title>Virtuelles Kopieren</title>
+
+    <titleabbrev>Virtuelles Kopieren</titleabbrev>
+
+    <copyright>
+      <year>2007</year>
+
+      <holder>Femutec GmbH</holder>
+    </copyright>
+
+    <author>
+      <firstname>Dirk</firstname>
+
+      <surname>Baechle</surname>
+    </author>
+
+    <pubdate>09.07.2007</pubdate>
+  </info>
+
+<dbs:foilgroup>
+<title>Group</title>
+  <dbs:foil>
+    <title>sfForming</title>
+
+  </dbs:foil>
+</dbs:foilgroup>
+</dbs:slides>
+

--- a/test/Docbook/basedir/slideshtml/image/xsltver.py
+++ b/test/Docbook/basedir/slideshtml/image/xsltver.py
@@ -1,0 +1,20 @@
+import os
+import re
+
+def detectXsltVersion(fpath):
+    """ Return a tuple with the version of the Docbook XSLT stylesheets,
+        or (0, 0, 0) if no stylesheets are installed or the VERSION
+        file couldn't be found/parsed correctly.
+    """
+    with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
+        re_version = re.compile("<fm:Version>([^<]+)</fm:Version>".encode('utf-8'))
+        m = re_version.search(fin.read())
+        if m:
+            try:
+                return tuple(map(int, m.group(1).split(b'.')))
+            except Exception:
+                return (0, 0, 0)
+            
+        return (0, 0, 0)
+        
+    return (0, 0, 0)

--- a/test/Docbook/basedir/slideshtml/slideshtml.py
+++ b/test/Docbook/basedir/slideshtml/slideshtml.py
@@ -46,16 +46,11 @@ test.dir_fixture('image')
 # Normal invocation
 test.run(stderr=None)
 test.must_not_be_empty(test.workpath('output/index.html'))
-test.must_not_be_empty(test.workpath('output/toc.html'))
-test.must_not_be_empty(test.workpath('output/foil01.html'))
-test.must_not_be_empty(test.workpath('output/foilgroup01.html'))
+test.must_contain(test.workpath('output/index.html'), 'sfForming')
 
 # Cleanup
 test.run(arguments='-c')
 test.must_not_exist(test.workpath('output/index.html'))
-test.must_not_exist(test.workpath('output/toc.html'))
-test.must_not_exist(test.workpath('output/foil01.html'))
-test.must_not_exist(test.workpath('output/foilgroup01.html'))
 
 test.pass_test()
 

--- a/test/Docbook/basedir/slideshtml/slideshtml_cmd.py
+++ b/test/Docbook/basedir/slideshtml/slideshtml_cmd.py
@@ -43,16 +43,11 @@ test.dir_fixture('image')
 # Normal invocation
 test.run(arguments=['-f','SConstruct.cmd'], stderr=None)
 test.must_not_be_empty(test.workpath('output/index.html'))
-test.must_not_be_empty(test.workpath('output/toc.html'))
-test.must_not_be_empty(test.workpath('output/foil01.html'))
-test.must_not_be_empty(test.workpath('output/foilgroup01.html'))
+test.must_contain(test.workpath('output/index.html'), 'sfForming')
 
 # Cleanup
 test.run(arguments=['-f','SConstruct.cmd','-c'], stderr=None)
 test.must_not_exist(test.workpath('output/index.html'))
-test.must_not_exist(test.workpath('output/toc.html'))
-test.must_not_exist(test.workpath('output/foil01.html'))
-test.must_not_exist(test.workpath('output/foilgroup01.html'))
 
 test.pass_test()
 

--- a/test/Docbook/basic/slideshtml/image/.exclude_tests
+++ b/test/Docbook/basic/slideshtml/image/.exclude_tests
@@ -1,0 +1,1 @@
+xsltver.py

--- a/test/Docbook/basic/slideshtml/image/SConstruct
+++ b/test/Docbook/basic/slideshtml/image/SConstruct
@@ -1,3 +1,12 @@
+import xsltver
+
+v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
+
+ns_ext = ''
+if v >= (1, 78, 0):
+    # Use namespace-aware input file
+    ns_ext = 'ns'
+
 env = Environment(tools=['docbook'])
-env.DocbookSlidesHtml('virt')
+env.DocbookSlidesHtml('virt'+ns_ext, xsl='/usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl')
 

--- a/test/Docbook/basic/slideshtml/image/SConstruct.cmd
+++ b/test/Docbook/basic/slideshtml/image/SConstruct.cmd
@@ -1,4 +1,13 @@
+import xsltver
+
+v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
+
+ns_ext = ''
+if v >= (1, 78, 0):
+    # Use namespace-aware input file
+    ns_ext = 'ns'
+
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
-env.DocbookSlidesHtml('virt')
+env.DocbookSlidesHtml('virt'+ns_ext, xsl='/usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl')
 

--- a/test/Docbook/basic/slideshtml/image/virtns.xml
+++ b/test/Docbook/basic/slideshtml/image/virtns.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dbs:slides xmlns="http://docbook.org/ns/docbook"
+            xmlns:dbs="http://docbook.org/ns/docbook-slides"
+            xmlns:xlink="http://www.w3.org/1999/xlink">
+  <info>
+    <title>Virtuelles Kopieren</title>
+
+    <titleabbrev>Virtuelles Kopieren</titleabbrev>
+
+    <copyright>
+      <year>2007</year>
+
+      <holder>Femutec GmbH</holder>
+    </copyright>
+
+    <author>
+      <firstname>Dirk</firstname>
+
+      <surname>Baechle</surname>
+    </author>
+
+    <pubdate>09.07.2007</pubdate>
+  </info>
+
+<dbs:foilgroup>
+<title>Group</title>
+  <dbs:foil>
+    <title>sfForming</title>
+
+  </dbs:foil>
+</dbs:foilgroup>
+</dbs:slides>
+

--- a/test/Docbook/basic/slideshtml/image/xsltver.py
+++ b/test/Docbook/basic/slideshtml/image/xsltver.py
@@ -1,0 +1,20 @@
+import os
+import re
+
+def detectXsltVersion(fpath):
+    """ Return a tuple with the version of the Docbook XSLT stylesheets,
+        or (0, 0, 0) if no stylesheets are installed or the VERSION
+        file couldn't be found/parsed correctly.
+    """
+    with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
+        re_version = re.compile("<fm:Version>([^<]+)</fm:Version>".encode('utf-8'))
+        m = re_version.search(fin.read())
+        if m:
+            try:
+                return tuple(map(int, m.group(1).split(b'.')))
+            except Exception:
+                return (0, 0, 0)
+            
+        return (0, 0, 0)
+        
+    return (0, 0, 0)

--- a/test/Docbook/basic/slideshtml/slideshtml.py
+++ b/test/Docbook/basic/slideshtml/slideshtml.py
@@ -46,16 +46,11 @@ test.dir_fixture('image')
 # Normal invocation
 test.run(stderr=None)
 test.must_not_be_empty(test.workpath('index.html'))
-test.must_not_be_empty(test.workpath('toc.html'))
-test.must_not_be_empty(test.workpath('foil01.html'))
-test.must_not_be_empty(test.workpath('foilgroup01.html'))
+test.must_contain(test.workpath('index.html'), 'sfForming')
 
 # Cleanup
 test.run(arguments='-c')
 test.must_not_exist(test.workpath('index.html'))
-test.must_not_exist(test.workpath('toc.html'))
-test.must_not_exist(test.workpath('foil01.html'))
-test.must_not_exist(test.workpath('foilgroup01.html'))
 
 test.pass_test()
 

--- a/test/Docbook/basic/slideshtml/slideshtml_cmd.py
+++ b/test/Docbook/basic/slideshtml/slideshtml_cmd.py
@@ -43,16 +43,11 @@ test.dir_fixture('image')
 # Normal invocation
 test.run(arguments=['-f','SConstruct.cmd'], stderr=None)
 test.must_not_be_empty(test.workpath('index.html'))
-test.must_not_be_empty(test.workpath('toc.html'))
-test.must_not_be_empty(test.workpath('foil01.html'))
-test.must_not_be_empty(test.workpath('foilgroup01.html'))
+test.must_contain(test.workpath('index.html'), 'sfForming')
 
 # Cleanup
 test.run(arguments=['-f','SConstruct.cmd','-c'], stderr=None)
 test.must_not_exist(test.workpath('index.html'))
-test.must_not_exist(test.workpath('toc.html'))
-test.must_not_exist(test.workpath('foil01.html'))
-test.must_not_exist(test.workpath('foilgroup01.html'))
 
 test.pass_test()
 

--- a/test/Docbook/rootname/slideshtml/image/.exclude_tests
+++ b/test/Docbook/rootname/slideshtml/image/.exclude_tests
@@ -1,0 +1,1 @@
+xsltver.py

--- a/test/Docbook/rootname/slideshtml/image/SConstruct
+++ b/test/Docbook/rootname/slideshtml/image/SConstruct
@@ -1,3 +1,12 @@
+import xsltver
+
+v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
+
+ns_ext = ''
+if v >= (1, 78, 0):
+    # Use namespace-aware input file
+    ns_ext = 'ns'
+    
 env = Environment(tools=['docbook'])
-env.DocbookSlidesHtml('manual.html', 'virt', xsl='slides.xsl')
+env.DocbookSlidesHtml('manual.html', 'virt'+ns_ext, xsl='slides.xsl')
 

--- a/test/Docbook/rootname/slideshtml/image/slides.xsl
+++ b/test/Docbook/rootname/slideshtml/image/slides.xsl
@@ -26,6 +26,7 @@
 <xsl:stylesheet
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:dbs="http://docbook.org/ns/docbook-slides"
 	version="1.0">
 
 	<xsl:import href="file:///usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl"/>
@@ -34,22 +35,5 @@
 <xsl:param name="section.autolabel" select="1"/>
 <xsl:param name="titlefoil.html" select="'manual.html'"/>
 <xsl:param name="html.stylesheet" select="'scons.css'"/>
-<xsl:param name="generate.toc">
-/appendix toc,title
-article/appendix  nop
-/article  toc,title
-book      toc,title,figure,table,example,equation
-/chapter  toc,title
-part      toc,title
-/preface  toc,title
-reference toc,title
-/sect1    toc
-/sect2    toc
-/sect3    toc
-/sect4    toc
-/sect5    toc
-/section  toc
-set       toc,title
-</xsl:param>
 
 </xsl:stylesheet>

--- a/test/Docbook/rootname/slideshtml/image/virtns.xml
+++ b/test/Docbook/rootname/slideshtml/image/virtns.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dbs:slides xmlns="http://docbook.org/ns/docbook"
+            xmlns:dbs="http://docbook.org/ns/docbook-slides"
+            xmlns:xlink="http://www.w3.org/1999/xlink">
+  <info>
+    <title>Virtuelles Kopieren</title>
+
+    <titleabbrev>Virtuelles Kopieren</titleabbrev>
+
+    <copyright>
+      <year>2007</year>
+
+      <holder>Femutec GmbH</holder>
+    </copyright>
+
+    <author>
+      <firstname>Dirk</firstname>
+
+      <surname>Baechle</surname>
+    </author>
+
+    <pubdate>09.07.2007</pubdate>
+  </info>
+
+<dbs:foilgroup>
+<title>Group</title>
+  <dbs:foil>
+    <title>sfForming</title>
+
+  </dbs:foil>
+</dbs:foilgroup>
+</dbs:slides>
+

--- a/test/Docbook/rootname/slideshtml/image/xsltver.py
+++ b/test/Docbook/rootname/slideshtml/image/xsltver.py
@@ -1,0 +1,20 @@
+import os
+import re
+
+def detectXsltVersion(fpath):
+    """ Return a tuple with the version of the Docbook XSLT stylesheets,
+        or (0, 0, 0) if no stylesheets are installed or the VERSION
+        file couldn't be found/parsed correctly.
+    """
+    with open(os.path.join(fpath, 'VERSION'), 'rb') as fin:
+        re_version = re.compile("<fm:Version>([^<]+)</fm:Version>".encode('utf-8'))
+        m = re_version.search(fin.read())
+        if m:
+            try:
+                return tuple(map(int, m.group(1).split(b'.')))
+            except Exception:
+                return (0, 0, 0)
+            
+        return (0, 0, 0)
+        
+    return (0, 0, 0)

--- a/test/Docbook/rootname/slideshtml/slideshtml.py
+++ b/test/Docbook/rootname/slideshtml/slideshtml.py
@@ -46,16 +46,11 @@ test.dir_fixture('image')
 # Normal invocation
 test.run(stderr=None)
 test.must_not_be_empty(test.workpath('manual.html'))
-test.must_not_be_empty(test.workpath('toc.html'))
-test.must_not_be_empty(test.workpath('foil01.html'))
-test.must_not_be_empty(test.workpath('foilgroup01.html'))
+test.must_contain(test.workpath('manual.html'), 'sfForming')
 
 # Cleanup
 test.run(arguments='-c')
 test.must_not_exist(test.workpath('manual.html'))
-test.must_not_exist(test.workpath('toc.html'))
-test.must_not_exist(test.workpath('foil01.html'))
-test.must_not_exist(test.workpath('foilgroup01.html'))
 
 test.pass_test()
 


### PR DESCRIPTION
Docbook changed the way that their 'slides' documents work, from version 1.77.1 to 1.78.0. This fix tries to take this into account, by looking at the version number of the docbook-xsl stylesheets installed in the system.
Based on this version, two different input files get selected (either the old format, or the new namespace-aware scheme).

The Docbook tests run fine now on my own machine with Ubuntu 19.04 LTS and in a Docker container with Ubuntu 16.04.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
