### PR TITLE
MSVS 2015+ generated project/solution tests fail for x86 targets

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       (GH Issue #3699).
     - MSVC updates: An MSVC 6.0 installation now appears in the installed versions list
       when msvc debug output is enabled (GH Issue #3699).
+    - MSVS test updates: Tests for building a program using generated MSVS project and
+      solution files using MSVS 2015 and later now work as expected on x86 hosts.
  
   From William Deegan:
     - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to

--- a/test/MSVS/vs-14.0-exec.py
+++ b/test/MSVS/vs-14.0-exec.py
@@ -81,6 +81,7 @@ env.Program('foo.c')
 """ % locals())
 
 test.write(['sub dir', 'foo.c'], r"""
+#include <stdio.h>
 int
 main(int argc, char *argv)
 {

--- a/test/MSVS/vs-14.0Exp-exec.py
+++ b/test/MSVS/vs-14.0Exp-exec.py
@@ -77,6 +77,7 @@ env.Program('foo.c')
 """ % locals())
 
 test.write(['sub dir', 'foo.c'], r"""
+#include <stdio.h>
 int
 main(int argc, char *argv)
 {

--- a/test/MSVS/vs-14.1-exec.py
+++ b/test/MSVS/vs-14.1-exec.py
@@ -81,6 +81,7 @@ env.Program('foo.c')
 """ % locals())
 
 test.write(['sub dir', 'foo.c'], r"""
+#include <stdio.h>
 int
 main(int argc, char *argv)
 {

--- a/test/MSVS/vs-14.2-exec.py
+++ b/test/MSVS/vs-14.2-exec.py
@@ -81,6 +81,7 @@ env.Program('foo.c')
 """ % locals())
 
 test.write(['sub dir', 'foo.c'], r"""
+#include <stdio.h>
 int
 main(int argc, char *argv)
 {

--- a/test/fixture/no_msvc/no_msvcs_sconstruct.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct.py
@@ -1,7 +1,7 @@
 import SCons
 import SCons.Tool.MSCommon
 
-def DummyVsWhere(env, msvc_version):
+def DummyVsWhere(msvc_version, env):
     # not testing versions with vswhere, so return none
     return None
 


### PR DESCRIPTION
The generated project/solution tests for MSVS 2015, MSVS 2015 Express, MSVS 2017, and MSVS 2019 fail for x86 targets which is effectively on x86 hosts.

The link fails on x86 targets with an unresolved symbol error:
```
foo.obj : error LNK2019: unresolved external symbol _printf referenced in function _main
```
This does behavior does not manifest itself for amd64 targets.

Including stdio.h in the generated code seems to appease msvc for x86 targets:
```
#include <stdio.h>
int
main(int argc, char *argv)
{
    printf("foo.c\n");
    exit (0);
}
```

The output logs for tests outside of SCons using the same build flags as SCons for the generated code with and without including stdio.h for  the 14.2, 14.1, 14.1Exp, 14.0, and 12.0 compilers on both x86 and amd64 host and for both x86 and amd64 targets are:
- x86: [x86_log.txt](https://github.com/SCons/scons/files/4841265/x86_log.txt)
- amd64: [amd64_log.txt](https://github.com/SCons/scons/files/4841267/amd64_log.txt)

In the interest of full disclosure, I did not test 14.0Exp as I do not have it installed.

There was also a minor change to one of the DummyVsWhere functions: the order of the arguments was reversed from the function it was replacing.  There is no effect, but it was confusing.

## Contributor Checklist:

- [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
- [x] I have updated `CHANGES.txt` (and read the `README.rst`)
- [ ] I have updated the appropriate documentation
