### PR TITLE
[WIP] Use spawner processes to speed up spawning

### DIFF
--- a/SCons/Job.py
+++ b/SCons/Job.py
@@ -278,7 +278,11 @@ else:
         def run(self, args, env):
             pickle.dump({"args": args, "env": env}, self._spawner.stdin)
             self._spawner.stdin.flush()
-            return pickle.load(self._spawner.stdout)
+            ret = pickle.load(self._spawner.stdout)
+            if isinstance(ret, Exception):
+                raise ret
+            else:
+                return ret
 
         def stop(self):
             self._spawner.stdin.close()

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -54,9 +54,10 @@ import SCons.Errors
 import SCons.Subst
 import SCons.Tool
 
-# Gets set to True in Main._main() when the '--process-spawner'
+# Set to True in Main._main() when the '--process-spawner'
 # option was given on the command-line for speeding up process spawning.
-process_spawner = False
+# Set to False otherwise.
+process_spawner = None
 
 
 def platform_default():

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -54,6 +54,10 @@ import SCons.Errors
 import SCons.Subst
 import SCons.Tool
 
+# Gets set to True in Main._main() when the '--process-spawner'
+# option was given on the command-line for speeding up process spawning.
+process_spawner = False
+
 
 def platform_default():
     """Return the platform string for our execution environment.

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -65,11 +65,11 @@ def escape(arg):
 if process_spawner:
     from SCons.Job import spawner_tls
 
-    def exec_subprocess(l, env):
-        return spawner_tls.spawner.run(l, env)
+    def exec_subprocess(args, env):
+        return spawner_tls.spawner.run(args, env)
 else:
-    def exec_subprocess(l, env):
-        proc = subprocess.Popen(l, env = env, close_fds = True)
+    def exec_subprocess(args, env):
+        proc = subprocess.Popen(args, env = env, close_fds = True)
         return proc.wait()
 
 def subprocess_spawn(sh, escape, cmd, args, env):

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -43,6 +43,7 @@ import SCons.Util
 from SCons.Platform import TempFileMunge
 from SCons.Platform.virtualenv import ImportVirtualenv
 from SCons.Platform.virtualenv import ignore_virtualenv, enable_virtualenv
+from SCons.Job import spawner_tls
 
 exitvalmap = {
     2 : 127,
@@ -63,8 +64,7 @@ def escape(arg):
 
 
 def exec_subprocess(l, env):
-    proc = subprocess.Popen(l, env = env, close_fds = True)
-    return proc.wait()
+    return spawner_tls.spawner.run(l, env)
 
 def subprocess_spawn(sh, escape, cmd, args, env):
     return exec_subprocess([sh, '-c', ' '.join(args)], env)

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -62,6 +62,8 @@ def escape(arg):
     return '"' + arg + '"'
 
 
+assert process_spawner is not None  # must be set before
+
 if process_spawner:
     from SCons.Job import spawner_tls
 

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -40,10 +40,9 @@ import sys
 import select
 
 import SCons.Util
-from SCons.Platform import TempFileMunge
+from SCons.Platform import TempFileMunge, process_spawner
 from SCons.Platform.virtualenv import ImportVirtualenv
 from SCons.Platform.virtualenv import ignore_virtualenv, enable_virtualenv
-from SCons.Job import spawner_tls
 
 exitvalmap = {
     2 : 127,
@@ -63,8 +62,15 @@ def escape(arg):
     return '"' + arg + '"'
 
 
-def exec_subprocess(l, env):
-    return spawner_tls.spawner.run(l, env)
+if process_spawner:
+    from SCons.Job import spawner_tls
+
+    def exec_subprocess(l, env):
+        return spawner_tls.spawner.run(l, env)
+else:
+    def exec_subprocess(l, env):
+        proc = subprocess.Popen(l, env = env, close_fds = True)
+        return proc.wait()
 
 def subprocess_spawn(sh, escape, cmd, args, env):
     return exec_subprocess([sh, '-c', ' '.join(args)], env)

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -988,6 +988,9 @@ def _main(parser):
     if options.interactive:
         SCons.Node.interactive = True
 
+    if options.process_spawner:
+        SCons.Platform.process_spawner = True
+
     # That should cover (most of) the options.  Next, set up the variables
     # that hold command-line arguments, so the SConscript files that we
     # read and execute have access to them.

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -988,8 +988,7 @@ def _main(parser):
     if options.interactive:
         SCons.Node.interactive = True
 
-    if options.process_spawner:
-        SCons.Platform.process_spawner = True
+    SCons.Platform.process_spawner = options.process_spawner
 
     # That should cover (most of) the options.  Next, set up the variables
     # that hold command-line arguments, so the SConscript files that we

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -836,6 +836,12 @@ def Parser(version):
                   help="Trace Node evaluation to FILE.",
                   metavar="FILE")
 
+    # TODO allow only on posix? it doesn't affect other systems anyway.
+    op.add_option('--process-spawner',
+                  dest='process_spawner', default=False,
+                  action="store_true",
+                  help="Use a spawner process to speed up spawning")
+
     tree_options = ["all", "derived", "prune", "status", "linedraw"]
 
     def opt_tree(option, opt, value, parser, tree_options=tree_options):

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -38,6 +38,7 @@ except ImportError:
 _ = gettext
 
 import SCons.Node.FS
+import SCons.Platform
 import SCons.Platform.virtualenv
 import SCons.Warnings
 
@@ -836,11 +837,11 @@ def Parser(version):
                   help="Trace Node evaluation to FILE.",
                   metavar="FILE")
 
-    # TODO allow only on posix? it doesn't affect other systems anyway.
-    op.add_option('--process-spawner',
-                  dest='process_spawner', default=False,
-                  action="store_true",
-                  help="Use a spawner process to speed up spawning")
+    if SCons.Platform.platform_default() == "posix":
+        op.add_option('--process-spawner',
+                      dest='process_spawner', default=False,
+                      action="store_true",
+                      help="Use a spawner process to speed up spawning.")
 
     tree_options = ["all", "derived", "prune", "status", "linedraw"]
 

--- a/SCons/spawner.py
+++ b/SCons/spawner.py
@@ -2,22 +2,16 @@
 import sys
 import pickle
 import subprocess
-import struct
-
-
-INT_STRUCT = struct.Struct("L")
 
 
 def main():
     while True:
-        size_buf = sys.stdin.buffer.read(INT_STRUCT.size)
-        if len(size_buf) == 0:
+        try:
+            params = pickle.load(sys.stdin.buffer)
+        except EOFError:
             break
-
-        msg_size, = INT_STRUCT.unpack(size_buf)
-        params = pickle.loads(sys.stdin.buffer.read(msg_size))
         proc = subprocess.Popen(params["args"], env=params["env"], close_fds=True)
-        sys.stdout.buffer.write(INT_STRUCT.pack(proc.wait()))
+        pickle.dump(proc.wait(), sys.stdout.buffer)
         sys.stdout.buffer.flush()
 
 

--- a/SCons/spawner.py
+++ b/SCons/spawner.py
@@ -10,8 +10,14 @@ def main():
             params = pickle.load(sys.stdin.buffer)
         except EOFError:
             break
-        proc = subprocess.Popen(params["args"], env=params["env"], close_fds=True)
-        pickle.dump(proc.wait(), sys.stdout.buffer)
+
+        try:
+            proc = subprocess.Popen(params["args"], env=params["env"], close_fds=True)
+            ret = proc.wait()
+        except Exception as e:
+            ret = e
+
+        pickle.dump(ret, sys.stdout.buffer)
         sys.stdout.buffer.flush()
 
 

--- a/SCons/spawner.py
+++ b/SCons/spawner.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import sys
+import pickle
+import subprocess
+import struct
+
+
+INT_STRUCT = struct.Struct("L")
+
+
+def main():
+    while True:
+        size_buf = sys.stdin.buffer.read(INT_STRUCT.size)
+        if len(size_buf) == 0:
+            break
+
+        msg_size, = INT_STRUCT.unpack(size_buf)
+        params = pickle.loads(sys.stdin.buffer.read(msg_size))
+        proc = subprocess.Popen(params["args"], env=params["env"], close_fds=True)
+        sys.stdout.buffer.write(INT_STRUCT.pack(proc.wait()))
+        sys.stdout.buffer.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
SCons tends to grow large in RAM usage. It's expensive for large processes to `fork()`.
The best solution would be `vfork()`, but CPython doesn't support it properly (see [this issue](https://bugs.python.org/issue35823) for latest status).

Until CPython has it (and in order to support older versions as well), I added the `--process-spawner` SCons options, which lets each `Worker` create its private "spawner" process. Further `exec_subprocess()` calls by that `Worker` will send the `Popen` requests to the spawner via simple IPC (pickle messages over stdin/stdout), and the spawner will `Popen` the requested process, `wait` for its result and send it back to the `Worker`.

Overall it's quite simple, yet for RAM-heavy SCons it adds a huge speedup.

Discussed (with some performance benching) in https://pairlist4.pair.net/pipermail/scons-users/2020-June/008286.html and https://github.com/SCons/scons/pull/3703 (specifically [this comment](https://github.com/SCons/scons/pull/3703#issuecomment-650636998), [this one](https://github.com/SCons/scons/pull/3703#issuecomment-650715727) and [this](https://github.com/SCons/scons/pull/3703#issuecomment-650824696))

### Tasks:
* [x] Take a look at replacing the IPC with `mutltiprocessing` module
* [x] Pipe back exceptions raised in the spawner (and add a test for that)
* [x] Run a full-build benchmark, on a real project (and not partial builds of MongoDB / SCons artificial benchmarks)
* [ ] Write tests (or: modify some existing tests to use `--process-wrapper`)
* [x] Make sure all spawner extra code is only executed if on POSIX

## Contributor Checklist:

I still have to finish these (I just want an ack from one of you the maintainers that this looks okay)

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
