### PR TITLE
Reduce the number of "false negative" test failures for test/Interactive/configure.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       when msvc debug output is enabled (GH Issue #3699).
     - MSVS test updates: Tests for building a program using generated MSVS project and
       solution files using MSVS 2015 and later now work as expected on x86 hosts.
+    - Test update: Reduce the number of "false negative" test failures for the interactive
+      configuration test (test/interactive/configure.py).
  
   From William Deegan:
     - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to


### PR DESCRIPTION
The interactive configuration test (test/Interactive/configure.py) can return a "false negative" test failure caused by an unreliable ordering in the actual stdout output.

This likely contributes to the failure frequency of test/Interactive/configure.py in the AppVeyor builds.

On a vintage Windows 7 x86 test computer, the following sequences of statements in the actual stdout output have been observed:

* Case 1
  ```
  scons>>> D:\WPy32-3771\python-3.7.7\python.exe mycc.py foo.obj foo.cpp
  scons>>> scons: `foo.obj' is up to date.
  scons>>> D:\WPy32-3771\python-3.7.7\python.exe mycc.py foo.obj foo.cpp
  scons>>> scons: `foo.obj' is up to date.
  scons>>> 
  ```

* Case 2
  ```
  scons>>> D:\WPy32-3771\python-3.7.7\python.exe mycc.py foo.obj foo.cpp
  scons>>> D:\WPy32-3771\python-3.7.7\python.exe mycc.py foo.obj foo.cpp
  scons>>> scons: `foo.obj' is up to date.
  scons>>> scons: `foo.obj' is up to date.
  scons>>> 
  ```

* Case 3
  ```
  scons>>> D:\WPy32-3771\python-3.7.7\python.exe mycc.py foo.obj foo.cpp
  scons>>> D:\WPy32-3771\python-3.7.7\python.exe mycc.py foo.obj foo.cpp
  scons>>> D:\WPy32-3771\python-3.7.7\python.exe mycc.py foo.obj foo.cpp
  scons>>> scons: `foo.obj' is up to date.
  scons>>>
  ```

"Case 3" results in a test failure.  It is bizarre and almost seems like a low level bug.  There were 2 occurrences in the last 350+ tests.

The implementation was changed to use a custom match function that evaluates the counts for each of 3 regular expressions (see the diff for details) regardless of the order of lines of text in stdout.  The actual match counts are then compared to the expected match counts.  For example, in both Case 1 and Case 2 above, the expected match counts are the same: [2,2,1].  Case 3 would be [3,1,1].

## Contributor Checklist:

- [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
- [x] I have updated `CHANGES.txt` (and read the `README.rst`)
- [ ] I have updated the appropriate documentation
