### PR TITLE
Update Announce.txt based on 4.0 changes in CHANGES.txt

### DIFF
--- a/Announce.txt
+++ b/Announce.txt
@@ -34,7 +34,7 @@ RELEASE VERSION/DATE TO BE FILLED IN LATER
         NOTE: If you used Python 3.8 with SCons 3.0.0 or above, you may get a pickle
         protocol error. Remove your .sconsign.dblite. You will end up with a full rebuild.
       - Added debug option "action_timestamps" which outputs to stdout the
-	    absolute start and end time for each target.
+        absolute start and end time for each target.
       - Update Command() function to accept target_scanner, source_factory, and
         target_factory arguments.
         This makes Command act more like a one-off builder.
@@ -63,16 +63,16 @@ RELEASE VERSION/DATE TO BE FILLED IN LATER
       - Remove deprecated BuildDir plus SConscript keyword build_dir
       - Remove deprecated SourceCode
       - Environment.Value() is now memoized to improve performance of repeated calls.
-	    In addition, the underlying class SCons.Node.Python.Value now supports taking
-	    a name and is allowed to be an implicit dependency of a target.
+        In addition, the underlying class SCons.Node.Python.Value now supports taking
+        a name and is allowed to be an implicit dependency of a target.
       - Added support for scanning multiple entries in an action string if
         IMPLICIT_COMMAND_DEPENDENCIES is set to 2 or 'all'. This enables more thorough
         action scanning where every item in each command line is scanned to determine
         if it is a non-source and non-target path and added to the list of implicit
         dependencies for the target.
       - Fix Github Issue #2904 - Provide useful error message when more than one 
-	    Configure Contexts are opened. Only one open is allowed. You must call
-	    conf.Finish() to complete the currently open one before creating another.
+        Configure Contexts are opened. Only one open is allowed. You must call
+        conf.Finish() to complete the currently open one before creating another.
       - Resolve Issue #3248 - Removing '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS
         NOTE: If your build depends on the above you must now add to your
         SHLIBVERSIONFLAGS
@@ -108,7 +108,7 @@ RELEASE VERSION/DATE TO BE FILLED IN LATER
         * Remove unnecessary recursion.
       - Added new module SCons.Scanner.Python to allow scanning .py files.
       - Fixed bug where changing TEXTFILESUFFIX would cause Substfile() to rebuild.
-	    (Github Issue #3540)
+        (Github Issue #3540)
       - Rebase forked copy of shutil.copytree to Python 3.7 stlib version.
       - Significant rework of documentation: API docs are now generated
         using Sphinx; manpage and user guide now use more "standard"
@@ -119,13 +119,13 @@ RELEASE VERSION/DATE TO BE FILLED IN LATER
       - SubstitutionEnvironment and OverrideEnvironment now have keys()
         and values() methods to better emulate a dict (already had items()).
       - MSVC updates:
-	    * When there are multiple product installations (e.g, Community and
+        * When there are multiple product installations (e.g, Community and
           Build Tools) of MSVC 2017 or MSVC 2019, an Enterprise, Professional, 
           or Community installation will be selected before a Build Tools installation when
           "14.1" or "14.2" is requested, respectively. (GH Issue #3699).
         * When there are multiple product installations of MSVC 2017 (e.g.,
           Community and Express), 2017 Express is no longer returned when "14.1" is
-          requested.  Only 2017 Express will be returned when "14.1Exp" is requested.
+          requested. Only 2017 Express will be returned when "14.1Exp" is requested.
           (GH Issue #3699).
         * Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to
           propagate'VCINSTALLDIR' and 'VCToolsInstallDir' which clang tools use to locate
@@ -148,7 +148,7 @@ RELEASE VERSION/DATE TO BE FILLED IN LATER
         * switch to using uuid module to generate GUIDs rather than hand rolled
           method using md5 directly.
           NOTE: This change affects the following builders' output. If your build
-		  depends on the output of these builders you will likely see a rebuild:
+          depends on the output of these builders you will likely see a rebuild:
             1. Package() (with PACKAGETYPE='msi')
             2. MSVSSolution()
             3. MSVSProject()

--- a/Announce.txt
+++ b/Announce.txt
@@ -25,11 +25,18 @@ RELEASE VERSION/DATE TO BE FILLED IN LATER
   since last release.  This announcement highlights only the important
   changes.
 
-  NOTE: The 4.0.0 Release of SCons will drop Python 2.7 Support
-
   Please note the following important changes since release 3.1.1:
-      - Added debug option "action_timestamps" which outputs to stdout the absolute start and end time for each target.
-      - Update Command() function to accept target_scanner, source_factory, and target_factory arguments.
+      - Python 2.7 is not longer supported. SCons now requires Python 3.5 or later.
+        Initial support for Python 3.9 is also included in this release.
+      - Fixed Github Issue 3628 - Hardcoding pickle protocol to 4 (supports python 3.4+)
+        and skipping Python 3.8's new pickle protocol 5 whose main advantage is for
+        out-of-band data buffers.
+        NOTE: If you used Python 3.8 with SCons 3.0.0 or above, you may get a pickle
+        protocol error. Remove your .sconsign.dblite. You will end up with a full rebuild.
+      - Added debug option "action_timestamps" which outputs to stdout the
+	    absolute start and end time for each target.
+      - Update Command() function to accept target_scanner, source_factory, and
+        target_factory arguments.
         This makes Command act more like a one-off builder.
       - Added support for "-imacros" to ParseFlags	
       - Avoid crash with UnicodeDecodeError on Python 3 when a Latex log file in
@@ -54,6 +61,102 @@ RELEASE VERSION/DATE TO BE FILLED IN LATER
       - Remove deprecated Builder keywords: overrides and scanner
       - Remove deprecated env.Copy
       - Remove deprecated BuildDir plus SConscript keyword build_dir
+      - Remove deprecated SourceCode
+      - Environment.Value() is now memoized to improve performance of repeated calls.
+	    In addition, the underlying class SCons.Node.Python.Value now supports taking
+	    a name and is allowed to be an implicit dependency of a target.
+      - Added support for scanning multiple entries in an action string if
+        IMPLICIT_COMMAND_DEPENDENCIES is set to 2 or 'all'. This enables more thorough
+        action scanning where every item in each command line is scanned to determine
+        if it is a non-source and non-target path and added to the list of implicit
+        dependencies for the target.
+      - Fix Github Issue #2904 - Provide useful error message when more than one 
+	    Configure Contexts are opened. Only one open is allowed. You must call
+	    conf.Finish() to complete the currently open one before creating another.
+      - Resolve Issue #3248 - Removing '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS
+        NOTE: If your build depends on the above you must now add to your
+        SHLIBVERSIONFLAGS
+      - Renamed as.py to asm.py and left redirecting tool.  'as' is a reserved word and so
+        changing the name was required as we wanted to import symbols for use in
+        compilation_db tool.
+      - Add CompilationDatabase() builder in compilation_db tool. Contributed by MongoDB.
+        Setting COMPILATIONDB_USE_ABSPATH to True|False controls whether the files are
+        absolute or relative paths. Address Issue #3693 and #3694 found during development.
+      - Extended `Environment.Dump()` to select a format to serialize construction
+        variables (pretty, json).
+      - New conditional C Scanner (`SCons.Scanner.C.CConditionalScanner()`)
+        which interprets C/C Preprocessor conditional syntax (#ifdef, #if, #else,
+        #elif, #define, etc.)
+      - Improvements for virtual C Pre-Processor:
+        * Handle UNSIGNED LONG and LONG numeric constants in DEC (keep support for HEX)
+        * Skip unrecognized directives, such as `#if( defined ...)`
+        * Ignore `#include DYNAMIC_INCLUDE` directive that depends on a dynamic
+          macro which is not located in a state TABLE.
+        * Cleanup CPP expressions before evaluating (strip comments, carriage returns)
+      - Add no_progress (-Q) option as a set-able option. However, setting it in the 
+        SConstruct/SConscript will still cause "scons: Reading SConscript files ..." to be
+        printed, since the option is not set when the build scripts first get read.
+      - Added check for SONAME in environment to setup symlinks correctly (Github Issue #3246)
+      - Added storage of SConstructs and SConscripts nodes into global set for checking
+        if a given node is a SConstruct/SConscript. 
+        Added new node function SCons.Node.is_sconscript(self) (Github Issue #3625)
+      - Several improvements to the performance of Subst:
+        * Prevent unnecessary frame allocations by no longer defining the *Subber
+          classes inside of their respective function calls.
+        * Prevent unnecessary calls to eval when a token is surrounded in braces
+          but is not a function call.
+        * Remove unnecessary recursion.
+      - Added new module SCons.Scanner.Python to allow scanning .py files.
+      - Fixed bug where changing TEXTFILESUFFIX would cause Substfile() to rebuild.
+	    (Github Issue #3540)
+      - Rebase forked copy of shutil.copytree to Python 3.7 stlib version.
+      - Significant rework of documentation: API docs are now generated
+        using Sphinx; manpage and user guide now use more "standard"
+        markup elements (which could facilitate later conversion to a
+        different doc format, should that choice be made); significant
+        rewordings in manpage.  Manpage Examples moved to an external
+        repository / website (scons-cookbook.readthedocs.io).
+      - SubstitutionEnvironment and OverrideEnvironment now have keys()
+        and values() methods to better emulate a dict (already had items()).
+      - MSVC updates:
+	    * When there are multiple product installations (e.g, Community and
+          Build Tools) of MSVC 2017 or MSVC 2019, an Enterprise, Professional, 
+          or Community installation will be selected before a Build Tools installation when
+          "14.1" or "14.2" is requested, respectively. (GH Issue #3699).
+        * When there are multiple product installations of MSVC 2017 (e.g.,
+          Community and Express), 2017 Express is no longer returned when "14.1" is
+          requested.  Only 2017 Express will be returned when "14.1Exp" is requested.
+          (GH Issue #3699).
+        * Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to
+          propagate'VCINSTALLDIR' and 'VCToolsInstallDir' which clang tools use to locate
+          header files and libraries from MSVC install. (Fixes GH Issue #3480)
+        * Improve Visual Studio solution/project generation code to add support
+          for a per-variant cppflags. Intellisense can be affected by cppflags,
+          this is especially important when it comes to /std:c++* which specifies
+          what C++ standard version to target. SCons will append /Zc:__cplusplus
+          to the project's cppflags when a /std:c++* flag is found as this is
+          required for intellisense to use the C++ standard version from cppflags.
+        * Accommodate VS 2017 Express - it's got a more liberal license then VS
+          Community, so some people prefer it (from 2019, no more Express)
+        * vswhere call should also now work even if programs aren't on the C: drive.
+        * Add an alternate warning message if cl.exe is not found and msvc config
+          cache is in use (SCONS_CACHE_MSVC_CONFIG was given) - config cache
+          may be out of date.
+        * MSVC updates: pass on VSCMD_DEBUG and VSCMD_SKIP_SENDTELEMETRY to msvc
+          tool setup if set in environment. Add Powershell to default env
+          (used to call telemetry script).
+        * switch to using uuid module to generate GUIDs rather than hand rolled
+          method using md5 directly.
+          NOTE: This change affects the following builders' output. If your build
+		  depends on the output of these builders you will likely see a rebuild:
+            1. Package() (with PACKAGETYPE='msi')
+            2. MSVSSolution()
+            3. MSVSProject()
+        * Allow user specified location for vswhere.exe specified by VSWHERE. 
+          NOTE: This must be set at the time the 'msvc' 'msvs' and/or 'mslink'
+          tool(s) are initialized to have any effect.
+        * Fix CheckFunc detection code for Visual 2019. Some functions
+          (e.g. memmove) were incorrectly recognized as not available.
 
     Please note the following important changes since release 3.0.4:
       - Change the default for AppendENVPath to delete_existing=0, so path


### PR DESCRIPTION
This change includes the parts of CHANGES.txt that stood out to me that are included between 3.1.2 and 4.0. Also adds the python scanner from 3.1.2 because otherwise some subsequent fixes may not make sense.

Because the removal of Python 2 support is the most important, I put that first in the list of changes.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
