### PR TITLE
Change Warning to SConsWarning

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -213,6 +213,8 @@ RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000
       dir_fixture.
     - SubstitutionEnvironment and OverrideEnvironment now have keys()
       and values() methods to better emulate a dict (already had items()).
+    - Rename internal Warning base class to SConsWarning to avoid any
+      possible confusion with Python's own Warning class.
 
 
 RELEASE 3.1.2 - Mon, 17 Dec 2019 02:06:27 +0000

--- a/SCons/SConf.py
+++ b/SCons/SConf.py
@@ -136,7 +136,7 @@ def CreateConfigHBuilder(env):
         env.SConfigHBuilder(k, env.Value(v))
 
 
-class SConfWarning(SCons.Warnings.Warning):
+class SConfWarning(SCons.Warnings.SConsWarning):
     pass
 SCons.Warnings.enableWarningClass(SConfWarning)
 

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -69,7 +69,7 @@ if "--debug=memoizer" in _args:
     import SCons.Warnings
     try:
         SCons.Memoize.EnableMemoization()
-    except SCons.Warnings.Warning:
+    except SCons.Warnings.SConsWarning:
         # Some warning was thrown.  Arrange for it to be displayed
         # or not after warnings are configured.
         from . import Main

--- a/SCons/Tool/GettextCommon.py
+++ b/SCons/Tool/GettextCommon.py
@@ -31,25 +31,25 @@ import re
 
 
 #############################################################################
-class XgettextToolWarning(SCons.Warnings.Warning): pass
+class XgettextToolWarning(SCons.Warnings.SConsWarning): pass
 
 
 class XgettextNotFound(XgettextToolWarning): pass
 
 
-class MsginitToolWarning(SCons.Warnings.Warning): pass
+class MsginitToolWarning(SCons.Warnings.SConsWarning): pass
 
 
 class MsginitNotFound(MsginitToolWarning): pass
 
 
-class MsgmergeToolWarning(SCons.Warnings.Warning): pass
+class MsgmergeToolWarning(SCons.Warnings.SConsWarning): pass
 
 
 class MsgmergeNotFound(MsgmergeToolWarning): pass
 
 
-class MsgfmtToolWarning(SCons.Warnings.Warning): pass
+class MsgfmtToolWarning(SCons.Warnings.SConsWarning): pass
 
 
 class MsgfmtNotFound(MsgfmtToolWarning): pass

--- a/SCons/Tool/gettext_tool.py
+++ b/SCons/Tool/gettext_tool.py
@@ -42,7 +42,7 @@ def generate(env,**kw):
             tool_bin_dir = os.path.dirname(tool)
             env.AppendENVPath('PATH', tool_bin_dir)
         else:
-            SCons.Warnings.Warning(t + ' tool requested, but binary not found in ENV PATH')
+            SCons.Warnings.SConsWarning(t + ' tool requested, but binary not found in ENV PATH')
     env.Tool(t)
   env.AddMethod(_translate, 'Translate')
 #############################################################################

--- a/SCons/Tool/intelc.py
+++ b/SCons/Tool/intelc.py
@@ -448,7 +448,7 @@ def generate(env, version=None, abi=None, topdir=None, verbose=0):
     if not topdir:
         # Normally this is an error, but it might not be if the compiler is
         # on $PATH and the user is importing their env.
-        class ICLTopDirWarning(SCons.Warnings.Warning):
+        class ICLTopDirWarning(SCons.Warnings.SConsWarning):
             pass
         if (is_mac or is_linux) and not env.Detect('icc') or \
            is_windows and not env.Detect('icl'):
@@ -569,7 +569,7 @@ def generate(env, version=None, abi=None, topdir=None, verbose=0):
         if not licdir:
             licdir = defaultlicdir
             if not os.path.exists(licdir):
-                class ICLLicenseDirWarning(SCons.Warnings.Warning):
+                class ICLLicenseDirWarning(SCons.Warnings.SConsWarning):
                     pass
                 SCons.Warnings.enableWarningClass(ICLLicenseDirWarning)
                 SCons.Warnings.warn(ICLLicenseDirWarning,

--- a/SCons/Tool/jar.py
+++ b/SCons/Tool/jar.py
@@ -101,7 +101,7 @@ def Jar(env, target = None, source = [], *args, **kw):
     # no target and want implicit target to be made and the arg
     # was actaully the list of sources
     if SCons.Util.is_List(target) and source == []:
-        SCons.Warnings.Warning("Making implicit target jar file, " +
+        SCons.Warnings.SConsWarning("Making implicit target jar file, " +
                               "and treating the list as sources")
         source = target
         target = None
@@ -123,7 +123,7 @@ def Jar(env, target = None, source = [], *args, **kw):
             target = os.path.splitext(str(source[0]))[0] + env.subst('$JARSUFFIX')
         except:
             # something strange is happening but attempt anyways
-            SCons.Warnings.Warning("Could not make implicit target from sources, using directory")
+            SCons.Warnings.SConsWarning("Could not make implicit target from sources, using directory")
             target = os.path.basename(str(env.Dir('.'))) + env.subst('$JARSUFFIX')
 
     # make lists out of our target and sources
@@ -192,7 +192,7 @@ def Jar(env, target = None, source = [], *args, **kw):
             except:
                 pass
 
-            SCons.Warnings.Warning("File: " + str(s) + " could not be identified as File or Directory, skipping.")
+            SCons.Warnings.SConsWarning("File: " + str(s) + " could not be identified as File or Directory, skipping.")
 
     # at this point all our sources have been converted to classes or directories of class
     # so pass it to the Jar builder

--- a/SCons/Tool/lex.py
+++ b/SCons/Tool/lex.py
@@ -93,7 +93,7 @@ def get_lex_path(env, append_paths=False):
             if append_paths:
                 env.AppendENVPath('PATH', os.path.dirname(bin_path))
             return bin_path
-    SCons.Warnings.Warning('lex tool requested, but lex or flex binary not found in ENV PATH')
+    SCons.Warnings.SConsWarning('lex tool requested, but lex or flex binary not found in ENV PATH')
 
 
 def generate(env):

--- a/SCons/Tool/msgfmt.py
+++ b/SCons/Tool/msgfmt.py
@@ -89,7 +89,7 @@ def generate(env,**kw):
           msgfmt_bin_dir = os.path.dirname(msgfmt)
           env.AppendENVPath('PATH', msgfmt_bin_dir)
       else:
-          SCons.Warnings.Warning('msgfmt tool requested, but binary not found in ENV PATH')
+          SCons.Warnings.SConsWarning('msgfmt tool requested, but binary not found in ENV PATH')
 
   try:
     env['MSGFMT'] = _detect_msgfmt(env)

--- a/SCons/Tool/msginit.py
+++ b/SCons/Tool/msginit.py
@@ -91,7 +91,7 @@ def generate(env,**kw):
           msginit_bin_dir = os.path.dirname(msginit)
           env.AppendENVPath('PATH', msginit_bin_dir)
       else:
-          SCons.Warnings.Warning('msginit tool requested, but binary not found in ENV PATH')
+          SCons.Warnings.SConsWarning('msginit tool requested, but binary not found in ENV PATH')
 
   try:
     env['MSGINIT'] = _detect_msginit(env)

--- a/SCons/Tool/msgmerge.py
+++ b/SCons/Tool/msgmerge.py
@@ -82,7 +82,7 @@ def generate(env,**kw):
           msgmerge_bin_dir = os.path.dirname(msgmerge)
           env.AppendENVPath('PATH', msgmerge_bin_dir)
       else:
-          SCons.Warnings.Warning('msgmerge tool requested, but binary not found in ENV PATH')
+          SCons.Warnings.SConsWarning('msgmerge tool requested, but binary not found in ENV PATH')
   try:
     env['MSGMERGE'] = _detect_msgmerge(env)
   except:

--- a/SCons/Tool/packaging/__init__.py
+++ b/SCons/Tool/packaging/__init__.py
@@ -36,7 +36,7 @@ from SCons.Errors import UserError, SConsEnvironmentError
 from SCons.Script import AddOption, GetOption
 from SCons.Util import is_List, make_path_relative
 from SCons.Variables import *
-from SCons.Warnings import warn, Warning
+from SCons.Warnings import warn, SConsWarning
 
 
 __all__ = [
@@ -306,7 +306,7 @@ def stripinstallbuilder(target, source, env):
                     and file.builder.name in ["InstallBuilder", "InstallAsBuilder"])
 
     if len([src for src in source if has_no_install_location(src)]):
-        warn(Warning, "there are files to package which have no\
+        warn(SConsWarning, "there are files to package which have no\
         InstallBuilder attached, this might lead to irreproducible packages")
 
     n_source = []

--- a/SCons/Tool/qt.py
+++ b/SCons/Tool/qt.py
@@ -46,7 +46,7 @@ import SCons.Util
 import SCons.Tool.cxx
 cplusplus = SCons.Tool.cxx
 
-class ToolQtWarning(SCons.Warnings.Warning):
+class ToolQtWarning(SCons.Warnings.SConsWarning):
     pass
 
 class GeneratedMocFileNotIncluded(ToolQtWarning):

--- a/SCons/Tool/swig.py
+++ b/SCons/Tool/swig.py
@@ -190,7 +190,7 @@ def generate(env):
             swig_bin_dir = os.path.dirname(swig)
             env.AppendENVPath('PATH', swig_bin_dir)
         else:
-            SCons.Warnings.Warning('swig tool requested, but binary not found in ENV PATH')
+            SCons.Warnings.SConsWarning('swig tool requested, but binary not found in ENV PATH')
 
     if 'SWIG' not in env:
         env['SWIG'] = env.Detect(swigs) or swigs[0]

--- a/SCons/Tool/xgettext.py
+++ b/SCons/Tool/xgettext.py
@@ -286,7 +286,7 @@ def generate(env, **kw):
             xgettext_bin_dir = os.path.dirname(xgettext)
             env.AppendENVPath('PATH', xgettext_bin_dir)
         else:
-            SCons.Warnings.Warning('xgettext tool requested, but binary not found in ENV PATH')
+            SCons.Warnings.SConsWarning('xgettext tool requested, but binary not found in ENV PATH')
     try:
         env['XGETTEXT'] = _detect_xgettext(env)
     except:

--- a/SCons/Tool/yacc.py
+++ b/SCons/Tool/yacc.py
@@ -123,7 +123,7 @@ def get_yacc_path(env, append_paths=False):
             if append_paths:
                 env.AppendENVPath('PATH', os.path.dirname(bin_path))
             return bin_path
-    SCons.Warnings.Warning('yacc tool requested, but yacc or bison binary not found in ENV PATH')
+    SCons.Warnings.SConsWarning('yacc tool requested, but yacc or bison binary not found in ENV PATH')
 
 
 def generate(env):

--- a/SCons/Warnings.py
+++ b/SCons/Warnings.py
@@ -140,31 +140,41 @@ class DeprecatedMissingSConscriptWarning(DeprecatedWarning):
 _enabled = []
 
 # If set, raise the warning as an exception
-_warningAsException = 0
+_warningAsException = False
 
 # If not None, a function to call with the warning
 _warningOut = None
 
 def suppressWarningClass(clazz):
-    """Suppresses all warnings that are of type clazz or
-    derived from clazz."""
-    _enabled.insert(0, (clazz, 0))
+    """Suppresses all warnings of type clazz or derived from clazz."""
+    _enabled.insert(0, (clazz, False))
 
 def enableWarningClass(clazz):
-    """Enables all warnings that are of type clazz or
-    derived from clazz."""
-    _enabled.insert(0, (clazz, 1))
+    """Enables all warnings of type clazz or derived from clazz."""
+    _enabled.insert(0, (clazz, True))
 
-def warningAsException(flag=1):
-    """Turn warnings into exceptions.  Returns the old value of the flag."""
+def warningAsException(flag=True):
+    """Set global _warningAsExeption flag.
+
+    Args:
+        flag: value to set warnings-as-exceptions to [default: True]
+
+    Returns:
+        The previous value.
+    """
     global _warningAsException
     old = _warningAsException
     _warningAsException = flag
     return old
 
 def warn(clazz, *args):
-    global _enabled, _warningAsException, _warningOut
+    """Issue a warning, accounting for SCons rules.
 
+    Check if warnings for this class are enabled.
+    If warnings are treated as exceptions, raise exception.
+    Use the global warning-emitter _warningOut, which allows selecting
+    different ways of presenting a traceback (see Script/Main.py)
+    """
     warning = clazz(args)
     for cls, flag in _enabled:
         if isinstance(warning, cls):
@@ -182,39 +192,36 @@ def process_warn_strings(arguments):
     The requests are strings passed to the --warn option or the
     SetOption('warn') function.
 
-    An argument to this option should be of the form <warning-class>
-    or no-<warning-class>.  The warning class is munged in order
-    to get an actual class name from the classes above, which we
-    need to pass to the {enable,disable}WarningClass() functions.
-    The supplied <warning-class> is split on hyphens, each element
-    is capitalized, then smushed back together.  Then the string
-    "SConsWarning" is appended to get the class name.
+    An argument to this option should be of the form "warning-class"
+    or "no-warning-class".  The warning class is munged and has
+    the suffix "Warning" added in order to get an actual class name
+    from the classes above, which we need to pass to the
+    {enable,disable}WarningClass() functions.
 
-    For example, 'deprecated' will enable the DeprecatedWarning
-    class.  'no-dependency' will disable the DependencyWarning class.
+    For example, "deprecated" will enable the DeprecatedWarning class.
+    "no-dependency" will disable the DependencyWarning class.
 
     As a special case, --warn=all and --warn=no-all will enable or
-    disable (respectively) the base SConsWarning class of all warnings.
+    disable (respectively) the base class of all SCons warnings.
     """
 
-    def _capitalize(s):
-        if s[:5] == "scons":
-            return "SCons" + s[5:]
-        else:
-            return s.capitalize()
+    def _classmunge(s):
+        """Convert a warning argument to SConsCase.
+
+        The result is CamelCase, except "Scons" is changed to "SCons"
+        """
+        s = s.replace("-", " ").title().replace(" ", "")
+        return s.replace("Scons", "SCons")
 
     for arg in arguments:
-
-        elems = arg.lower().split('-')
-        enable = 1
-        if elems[0] == 'no':
-            enable = 0
-            del elems[0]
-
-        if len(elems) == 1 and elems[0] == 'all':
+        enable = True
+        if arg.startswith("no-"):
+            enable = False
+            arg = arg[len("no-") :]
+        if arg == 'all':
             class_name = "SConsWarning"
         else:
-            class_name = ''.join(map(_capitalize, elems)) + "SConsWarning"
+            class_name = _classmunge(arg) + 'Warning'
         try:
             clazz = globals()[class_name]
         except KeyError:

--- a/SCons/Warnings.py
+++ b/SCons/Warnings.py
@@ -33,27 +33,29 @@ import sys
 
 import SCons.Errors
 
-class Warning(SCons.Errors.UserError):
+class SConsWarning(SCons.Errors.UserError):
     pass
 
-class WarningOnByDefault(Warning):
+class WarningOnByDefault(SConsWarning):
     pass
 
 
 # NOTE:  If you add a new warning class, add it to the man page, too!
-class TargetNotBuiltWarning(Warning): # Should go to OnByDefault
+# Not all warnings are defined here, some are defined in the location of use
+
+class TargetNotBuiltWarning(SConsWarning): # Should go to OnByDefault
     pass
 
 class CacheVersionWarning(WarningOnByDefault):
     pass
 
-class CacheWriteErrorWarning(Warning):
+class CacheWriteErrorWarning(SConsWarning):
     pass
 
 class CorruptSConsignWarning(WarningOnByDefault):
     pass
 
-class DependencyWarning(Warning):
+class DependencyWarning(SConsWarning):
     pass
 
 class DevelopmentVersionWarning(WarningOnByDefault):
@@ -94,7 +96,7 @@ class VisualCMissingWarning(WarningOnByDefault):
 class VisualVersionMismatch(WarningOnByDefault):
     pass
 
-class VisualStudioMissingWarning(Warning):
+class VisualStudioMissingWarning(SConsWarning):
     pass
 
 class FortranCxxMixWarning(LinkWarning):
@@ -103,10 +105,10 @@ class FortranCxxMixWarning(LinkWarning):
 
 # Deprecation warnings
 
-class FutureDeprecatedWarning(Warning):
+class FutureDeprecatedWarning(SConsWarning):
     pass
 
-class DeprecatedWarning(Warning):
+class DeprecatedWarning(SConsWarning):
     pass
 
 class MandatoryDeprecatedWarning(DeprecatedWarning):
@@ -186,13 +188,13 @@ def process_warn_strings(arguments):
     need to pass to the {enable,disable}WarningClass() functions.
     The supplied <warning-class> is split on hyphens, each element
     is capitalized, then smushed back together.  Then the string
-    "Warning" is appended to get the class name.
+    "SConsWarning" is appended to get the class name.
 
     For example, 'deprecated' will enable the DeprecatedWarning
     class.  'no-dependency' will disable the DependencyWarning class.
 
     As a special case, --warn=all and --warn=no-all will enable or
-    disable (respectively) the base Warning class of all warnings.
+    disable (respectively) the base SConsWarning class of all warnings.
     """
 
     def _capitalize(s):
@@ -210,9 +212,9 @@ def process_warn_strings(arguments):
             del elems[0]
 
         if len(elems) == 1 and elems[0] == 'all':
-            class_name = "Warning"
+            class_name = "SConsWarning"
         else:
-            class_name = ''.join(map(_capitalize, elems)) + "Warning"
+            class_name = ''.join(map(_capitalize, elems)) + "SConsWarning"
         try:
             clazz = globals()[class_name]
         except KeyError:

--- a/SCons/WarningsTests.py
+++ b/SCons/WarningsTests.py
@@ -45,7 +45,7 @@ class WarningsTestCase(unittest.TestCase):
         
         to = TestOutput()
         SCons.Warnings._warningOut=to
-        SCons.Warnings.enableWarningClass(SCons.Warnings.Warning)
+        SCons.Warnings.enableWarningClass(SCons.Warnings.SConsWarning)
         SCons.Warnings.warn(SCons.Warnings.DeprecatedWarning,
                             "Foo")
         assert to.out == "Foo", to.out
@@ -60,12 +60,12 @@ class WarningsTestCase(unittest.TestCase):
         SCons.Warnings._enabled = []
         SCons.Warnings._warningAsException = 0
 
-        SCons.Warnings.enableWarningClass(SCons.Warnings.Warning)
+        SCons.Warnings.enableWarningClass(SCons.Warnings.SConsWarning)
         old = SCons.Warnings.warningAsException()
         assert old == 0, old
         exc_caught = 0
         try:
-            SCons.Warnings.warn(SCons.Warnings.Warning, "Foo")
+            SCons.Warnings.warn(SCons.Warnings.SConsWarning, "Foo")
         except:
             exc_caught = 1
         assert exc_caught == 1
@@ -74,7 +74,7 @@ class WarningsTestCase(unittest.TestCase):
         assert old == 1, old
         exc_caught = 0
         try:
-            SCons.Warnings.warn(SCons.Warnings.Warning, "Foo")
+            SCons.Warnings.warn(SCons.Warnings.SConsWarning, "Foo")
         except:
             exc_caught = 1
         assert exc_caught == 0
@@ -95,7 +95,7 @@ class WarningsTestCase(unittest.TestCase):
                             "Foo")
         assert to.out is None, to.out
 
-        SCons.Warnings.enableWarningClass(SCons.Warnings.Warning)
+        SCons.Warnings.enableWarningClass(SCons.Warnings.SConsWarning)
         SCons.Warnings.warn(SCons.Warnings.DeprecatedWarning,
                             "Foo")
         assert to.out == "Foo", to.out
@@ -111,15 +111,15 @@ class WarningsTestCase(unittest.TestCase):
         assert to.out is None, to.out
 
         # Dependency warnings should still be enabled though
-        SCons.Warnings.enableWarningClass(SCons.Warnings.Warning)
+        SCons.Warnings.enableWarningClass(SCons.Warnings.SConsWarning)
         SCons.Warnings.warn(SCons.Warnings.DependencyWarning,
                             "Foo")
         assert to.out == "Foo", to.out
 
         # Try reenabling all warnings...
-        SCons.Warnings.enableWarningClass(SCons.Warnings.Warning)
+        SCons.Warnings.enableWarningClass(SCons.Warnings.SConsWarning)
 
-        SCons.Warnings.enableWarningClass(SCons.Warnings.Warning)
+        SCons.Warnings.enableWarningClass(SCons.Warnings.SConsWarning)
         SCons.Warnings.warn(SCons.Warnings.DeprecatedWarning,
                             "Foo")
         assert to.out == "Foo", to.out

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -188,7 +188,7 @@ def initialize_sconsflags(ignore_python_version):
     # support the --warn=no-visual-c-missing warning.)
     visual_c = os.environ.get('TESTSCONS_SCONSFLAGS',
                               '--warn=no-visual-c-missing')
-    if visual_c:
+    if visual_c and visual_c not in sconsflags:
         sconsflags.append(visual_c)
     os.environ['SCONSFLAGS'] = ' '.join(sconsflags)
     return save_sconsflags


### PR DESCRIPTION
avoid potential overlap with Python's own Warnng class.

Review questions relating to the Warnings module in general, maybe not specific to this PR, but maybe this will flush out some discussion:

* [ ] the question of whether `SConsWarning` should subclass `SCons.Errors.UserError` or Python's own `Warning` class remains unanswered for the PR author.
* [ ] SCons warnings (and exceptions) are not explicitly called out in the manpage. Should they be?
* [ ] some warnings are defined in their local use location, some are defined in the Warnings module  This is not broken, but the inconsistency means it's hard to know what to advise, say, a Tool writer who might want to know where to define a specific warning.  Perhaps the rule is that: scons-wide warnings should be in the Warnings module, tool-specific warnings in the tool definition module?
* [ ] Some usage of warnings is of the form `FooWarning("message")`, some is to call the `SCons.Warnings.warn()` method. The former bypasses the enable/disable/one-time logic and seems less desirable?  Is this worth worrying about?

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
