### PR TITLE
Correct some encoding problems found on Solaris & AIX

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ RELEASE 4.1.0.devyyyymmdd - Mon, 04 Jul 2020 16:06:40 -0700
 
         - Whatever John Doe did.
 
+  From Rob Boehne:
+    - Fix subprocess execution of 'lslpp' on AIX to produce text standard i/o.
+    - Re-do the fix for suncxx tool (Oracle Studio compiler) now that only Python 3 is supported,
+      to avoid decoding errors.
     
 RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000
 

--- a/SCons/Platform/aix.py
+++ b/SCons/Platform/aix.py
@@ -55,6 +55,7 @@ def get_xlc(env, xlc=None, packages=[]):
         pipe = SCons.Action._subproc(env, ['lslpp', '-fc', package],
                 stdin = 'devnull',
                 stderr = 'devnull',
+                universal_newlines=True,
                 stdout = subprocess.PIPE)
         # output of lslpp is something like this:
         #     #Path:Fileset:File

--- a/SCons/Tool/suncxx.py
+++ b/SCons/Tool/suncxx.py
@@ -55,7 +55,7 @@ def get_package_info(package_name, pkginfo, pkgchk):
         from subprocess import DEVNULL 
 
         try:
-            with open('/var/sadm/install/contents', 'r') as f:
+            with open('/var/sadm/install/contents', 'r', encoding='UTF-8') as f:
                 sadm_contents = f.read()
         except EnvironmentError:
             pass
@@ -66,16 +66,14 @@ def get_package_info(package_name, pkginfo, pkgchk):
                 pathname = os.path.dirname(sadm_match.group(1))
 
         try:
-            popen_args = {'stdout': subprocess.PIPE,
-                          'stderr': DEVNULL}
-            popen_args['universal_newlines'] = True
             p = subprocess.Popen([pkginfo, '-l', package_name],
-                                 **popen_args)
+                                 universal_newlines=True,
+                                 stdout=subprocess.PIPE,
+                                 stderr=DEVNULL)
         except EnvironmentError:
             pass
         else:
             pkginfo_contents = p.communicate()[0]
-            pkginfo_contents.decode()
             version_re = re.compile(r'^ *VERSION:\s*(.*)$', re.M)
             version_match = version_re.search(pkginfo_contents)
             if version_match:
@@ -83,16 +81,14 @@ def get_package_info(package_name, pkginfo, pkgchk):
 
         if pathname is None:
             try:
-                popen_args = {'stdout': subprocess.PIPE,
-                              'stderr': DEVNULL}
-                popen_args['universal_newlines'] = True
                 p = subprocess.Popen([pkgchk, '-l', package_name],
-                                     **popen_args)
+                                     universal_newlines=True,
+                                     stdout=subprocess.PIPE,
+                                     stderr=DEVNULL)
             except EnvironmentError:
                 pass
             else:
                 pkgchk_contents = p.communicate()[0]
-                pkgchk_contents.decode()
                 pathname_re = re.compile(r'^Pathname:\s*(.*/bin/CC)$', re.M)
                 pathname_match = pathname_re.search(pkgchk_contents)
                 if pathname_match:


### PR DESCRIPTION
Correct some encoding problems found on UNIX platforms AIX and Solaris with python 3.5+ syntax.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality. (existing tests demonstrate the issues)
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation (no updates necessary)
