### PR TITLE
Fix fortran tools to set SHFORTRAN variables to $FORTRAN

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,12 @@ NOTE: The 4.0.0 Release of SCons will drops Python 2.7 Support
 RELEASE 4.1.0.devyyyymmdd - Mon, 04 Jul 2020 16:06:40 -0700
 
   From Rob Boehne:
+    - Fix fortran tools to set SHFORTRAN variables to $FORTRAN, similarly SHF77, SHF90, SHF95,
+      SHF03 and SHF08 will default to the variables $F77, $F90, $F95, $F03 and $F08 respectively.
+      If you were depending on changing the value of FORTRAN (or $F[0-9][0-9]) having no effect
+      on the value of SHFORTRAN, this change will break that.   The values of FORTRAN, F77, F90,
+      F95, F03, F08 and SHFORTRAN, SHF77 (etc.) now are not overridden in generate if alredy set
+      by the user.
     - Fix subprocess execution of 'lslpp' on AIX to produce text standard i/o.
     - Re-do the fix for suncxx tool (Oracle Studio compiler) now that only Python 3 is supported,
       to avoid decoding errors.

--- a/SCons/Tool/f03.py
+++ b/SCons/Tool/f03.py
@@ -46,11 +46,15 @@ def generate(env):
     add_f03_to_env(env)
 
     fcomp = env.Detect(compilers) or 'f03'
-    env['F03']  = fcomp
-    env['SHF03']  = fcomp
+    if 'F03' not in env:
+        env['F03']  = fcomp
+    if 'SHF03' not in env:
+        env['SHF03']  = '$F03'
 
-    env['FORTRAN']  = fcomp
-    env['SHFORTRAN']  = fcomp
+    if 'FORTRAN' not in env:
+        env['FORTRAN']  = fcomp
+    if 'SHFORTRAN' not in env:
+        env['SHFORTRAN']  = '$FORTRAN'
 
 
 def exists(env):

--- a/SCons/Tool/f08.py
+++ b/SCons/Tool/f08.py
@@ -46,11 +46,15 @@ def generate(env):
     add_f08_to_env(env)
 
     fcomp = env.Detect(compilers) or 'f08'
-    env['F08']  = fcomp
-    env['SHF08']  = fcomp
+    if 'F08' not in env:
+        env['F08']  = fcomp
+    if 'SHF08' not in env:
+        env['SHF08']  = '$F08'
 
-    env['FORTRAN']  = fcomp
-    env['SHFORTRAN']  = fcomp
+    if 'FORTRAN' not in env:
+        env['FORTRAN']  = fcomp
+    if 'SHFORTRAN' not in env:
+        env['SHFORTRAN']  = '$FORTRAN'
 
 
 def exists(env):

--- a/SCons/Tool/f77.py
+++ b/SCons/Tool/f77.py
@@ -46,11 +46,15 @@ def generate(env):
     add_f77_to_env(env)
 
     fcomp = env.Detect(compilers) or 'f77'
-    env['F77']  = fcomp
-    env['SHF77']  = fcomp
+    if 'F77' not in env:
+        env['F77'] = fcomp
+    if 'SHF77' not in env:
+        env['SHF77']  = '$F77'
 
-    env['FORTRAN']  = fcomp
-    env['SHFORTRAN']  = fcomp
+    if 'FORTRAN' not in env:
+        env['FORTRAN']  = fcomp
+    if 'SHFORTRAN' not in env:
+        env['SHFORTRAN']  = '$FORTRAN'
 
 def exists(env):
     return env.Detect(compilers)

--- a/SCons/Tool/f90.py
+++ b/SCons/Tool/f90.py
@@ -46,11 +46,15 @@ def generate(env):
     add_f90_to_env(env)
 
     fc = env.Detect(compilers) or 'f90'
-    env['F90']  = fc
-    env['SHF90']  = fc
+    if 'F90' not in env:
+        env['F90']  = fc
+    if 'SHF90' not in env:
+        env['SHF90']  = '$F90'
 
-    env['FORTRAN']  = fc
-    env['SHFORTRAN']  = fc
+    if 'FORTRAN' not in env:
+        env['FORTRAN']  = fc
+    if 'SHFORTRAN' not in env:
+        env['SHFORTRAN']  = '$FORTRAN'
 
 def exists(env):
     return env.Detect(compilers)

--- a/SCons/Tool/f95.py
+++ b/SCons/Tool/f95.py
@@ -46,11 +46,15 @@ def generate(env):
     add_f95_to_env(env)
 
     fcomp = env.Detect(compilers) or 'f95'
-    env['F95']  = fcomp
-    env['SHF95']  = fcomp
+    if 'F95' not in env:
+        env['F95']  = fcomp
+    if 'SHF95' not in env:
+        env['SHF95']  = '$F95'
 
-    env['FORTRAN']  = fcomp
-    env['SHFORTRAN']  = fcomp
+    if 'FORTRAN' not in env:
+        env['FORTRAN']  = fcomp
+    if 'SHFORTRAN' not in env:
+        env['SHFORTRAN']  = '$FORTRAN'
 
 
 def exists(env):

--- a/SCons/Tool/fortran.py
+++ b/SCons/Tool/fortran.py
@@ -48,9 +48,10 @@ def generate(env):
     add_all_to_env(env)
     add_fortran_to_env(env)
 
-    fc = env.Detect(compilers) or 'f77'
-    env['SHFORTRAN'] = fc
-    env['FORTRAN'] = fc
+    if 'FORTRAN' not in env:
+        env['FORTRAN'] = env.Detect(compilers) or 'f77'
+    if 'SHFORTRAN' not in env:
+        env['SHFORTRAN'] = '$FORTRAN'
 
 def exists(env):
     return env.Detect(compilers)


### PR DESCRIPTION
Fix fortran tools to set SHvariable to $variable (i.e. SHF77 to $F77 )
These changes address the problem noticed in issue #3740 with test CPPFLAGS.py.  This test assumed that changing the FORTRAN variable in an Environment would be inherited by SHFORTRAN.  That *should* be a valid assumption, but was not true for many of the fortran tools.  This PR corrects that, by setting SHFORTRAN to $FORTRAN much the way it is done in the C language tool.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality. 
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
