### PR TITLE
[WIP] Rust support

### DIFF
--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -145,6 +145,9 @@ ShCXXAction = SCons.Action.Action("$SHCXXCOM", "$SHCXXCOMSTR")
 DAction = SCons.Action.Action("$DCOM", "$DCOMSTR")
 ShDAction = SCons.Action.Action("$SHDCOM", "$SHDCOMSTR")
 
+RustAction = SCons.Action.Action("$RUSTCOM", "$RUSTCOMSTR")
+# TODO Shared
+
 ASAction = SCons.Action.Action("$ASCOM", "$ASCOMSTR")
 ASPPAction = SCons.Action.Action("$ASPPCOM", "$ASPPCOMSTR")
 

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -146,7 +146,7 @@ DAction = SCons.Action.Action("$DCOM", "$DCOMSTR")
 ShDAction = SCons.Action.Action("$SHDCOM", "$SHDCOMSTR")
 
 RustAction = SCons.Action.Action("$RUSTCOM", "$RUSTCOMSTR")
-# TODO Shared
+ShRustAction = SCons.Action.Action("$SHRUSTCOM", "$SHRUSTCOMSTR")
 
 ASAction = SCons.Action.Action("$ASCOM", "$ASCOMSTR")
 ASPPAction = SCons.Action.Action("$ASPPCOM", "$ASPPCOMSTR")

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -76,6 +76,8 @@ LaTeXSuffixes = [".tex", ".ltx", ".latex"]
 
 SWIGSuffixes = ['.i']
 
+RustSuffixes = ['.rs']
+
 for suffix in CSuffixes:
     SourceFileScanner.add_scanner(suffix, CScanner)
 

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -1278,6 +1278,8 @@ def tool_list(platform, env):
         'tar', 'zip',
         # File builders (text)
         'textfile',
+        # Rust
+        'rustc',
     ], env)
 
     tools = [

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -40,6 +40,29 @@ def _rust_library_dict_to_list(library_dict):
         for name, kind in library_dict.items()
     ]
 
+def _Crate(env, target, source, type='bin', name=None, *args, **kwargs):
+    if name is None:
+        name = target
+    return env.Command(
+        target,
+        source,
+        (
+            '$RUSTC '
+            '$_RUSTCODEGENFLAGS '
+            '$_RUSTLIBFLAGS '
+            '$_RUSTLINTFLAGS '
+            '$RUSTFLAGS '
+            '--crate-type $CRATE_TYPE '
+            '--crate-name $CRATE_NAME '
+            '-o $TARGET '
+            '$SOURCES'
+        ),
+        CRATE_TYPE=type,
+        CRATE_NAME=name,
+        *args,
+        **kwargs,
+    )
+
 def generate(env):
     static_obj, shared_obj = SCons.Tool.createObjBuilders(env)
 
@@ -90,6 +113,8 @@ def generate(env):
         '${_concat(RUSTLINTDENYPREFIX, RUSTLINTDENY, "", __env__)} '
         '${_concat(RUSTLINTFORBIDPREFIX, RUSTLINTFORBID, "", __env__)}'
     )
+
+    env.AddMethod(_Crate, "Crate")
 
 def exists(env):
     return env.Detect('rustc')

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -40,14 +40,14 @@ def generate(env):
     static_obj.add_emitter('.rs', SCons.Defaults.StaticObjectEmitter)
 
     env['RUSTC'] = env.Detect('rustc') or 'rustc'
-    env['RUSTCOM'] = '$RUSTC $_RUSTCODEGENFLAGS $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
+    env['RUSTCOM'] = '$RUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
     env['RUSTFLAGS'] = []
 
     shared_obj.add_action('.rs', SCons.Defaults.ShRustAction)
     shared_obj.add_emitter('.rs', SCons.Defaults.SharedObjectEmitter)
 
     env['SHRUSTC'] = '$RUSTC'
-    env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $SHRUSTFLAGS --crate-type cdynlib --emit obj -o $TARGET $SOURCES'
+    env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $SHRUSTFLAGS --crate-type cdynlib --emit obj -o $TARGET $SOURCES'
     env['SHRUSTFLAGS'] = []
 
     env['RUSTCODEGENPREFIX'] = '-C'
@@ -56,6 +56,12 @@ def generate(env):
         'link-args=$LINKFLAGS',
     ]
     env['_RUSTCODEGENFLAGS'] = '${_concat(RUSTCODEGENPREFIX, RUSTCODEGENFLAGS, "", __env__)}'
+
+    env['RUSTLIBPATHPREFIX'] = '-L'
+    env['RUSTLIBPATH'] = []
+    env['RUSTLIBSPREFIX'] = '-l'
+    env['RUSTLIBS'] = []
+    env['_RUSTLIBFLAGS'] = '${_concat(RUSTLIBPATHPREFIX, RUSTLIBPATH, "", __env__)} ${_concat(RUSTLIBSPREFIX, RUSTLIBS, "", __env__)}'
 
 def exists(env):
     return env.Detect('rustc')

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -30,18 +30,18 @@ selection method.
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-import SCons.Action
-import SCons.Builder
-import SCons.Util
-
-_rustc_builder = SCons.Builder.Builder(
-        action = 'rustc -o $TARGET $SOURCES',
-        src_suffix = '.rs',)
+import SCons.Defaults
+import SCons.Tool
 
 def generate(env):
-    """Add Builders and construction variables to the Environment."""
+    static_obj, shared_obj = SCons.Tool.createObjBuilders(env)
 
-    env['BUILDERS']['RUSTC'] = _rustc_builder
+    static_obj.add_action('.rs', SCons.Defaults.RustAction)
+    static_obj.add_emitter('.rs', SCons.Defaults.StaticObjectEmitter)
+
+    env['RUSTC'] = env.Detect('rustc') or 'rustc'
+    env['RUSTCOM'] = '$RUSTC $RUSTFLAGS --emit obj -o $TARGET $SOURCES'
+    env['RUSTFLAGS'] = []
 
 def exists(env):
     return env.Detect('rustc')

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -51,11 +51,11 @@ def generate(env):
     env['SHRUSTFLAGS'] = []
 
     env['RUSTCODEGENPREFIX'] = '-C'
-    env['RUSTCODEGENFLAGS'] = [  # TODO: This should be a dictionary
-        'linker=$LINK',
-        'link-args=$LINKFLAGS',
-    ]
-    env['_RUSTCODEGENFLAGS'] = '${_concat(RUSTCODEGENPREFIX, RUSTCODEGENFLAGS, "", __env__)}'
+    env['RUSTCODEGENFLAGS'] = {
+        'linker': '$LINK',
+        'link-args': '$LINKFLAGS',
+    }
+    env['_RUSTCODEGENFLAGS'] = '${_defines(RUSTCODEGENPREFIX, RUSTCODEGENFLAGS, "", __env__)}'
 
     env['RUSTLIBPATHPREFIX'] = '-L'
     env['RUSTLIBPATH'] = []

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -32,6 +32,8 @@ selection method.
 
 import SCons.Defaults
 import SCons.Tool
+import subprocess
+import shlex
 
 
 def _rust_library_dict_to_list(library_dict):
@@ -98,6 +100,11 @@ def generate(env):
         '${_concat(RUSTLIBSPREFIX, _rust_library_dict_to_list(RUSTLIBS), "", __env__)}'
     )
 
+    # Automatically append stdlib
+    # TODO: Evaluate lazily
+    libdir_command = env.subst('$RUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $_RUSTLINTFLAGS $RUSTFLAGS --print=target-libdir')
+    libdir = subprocess.run(shlex.split(libdir_command), stdout=subprocess.PIPE).stdout.decode().strip('\n')
+    env.Append(LIBS=env.Glob(libdir + "/libstd-*$SHLIBSUFFIX"))
 
     env['RUSTLINTWARNPREFIX'] = '-W'
     env['RUSTLINTWARN'] = []

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -40,14 +40,14 @@ def generate(env):
     static_obj.add_emitter('.rs', SCons.Defaults.StaticObjectEmitter)
 
     env['RUSTC'] = env.Detect('rustc') or 'rustc'
-    env['RUSTCOM'] = '$RUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
+    env['RUSTCOM'] = '$RUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $_RUSTLINTFLAGS $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
     env['RUSTFLAGS'] = []
 
     shared_obj.add_action('.rs', SCons.Defaults.ShRustAction)
     shared_obj.add_emitter('.rs', SCons.Defaults.SharedObjectEmitter)
 
     env['SHRUSTC'] = '$RUSTC'
-    env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $SHRUSTFLAGS --crate-type cdylib --emit obj -o $TARGET $SOURCES'
+    env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $_RUSTLINTFLAGS $SHRUSTFLAGS --crate-type cdylib --emit obj -o $TARGET $SOURCES'
     env['SHRUSTFLAGS'] = []
 
     env['RUSTCODEGENPREFIX'] = '-C'
@@ -62,6 +62,21 @@ def generate(env):
     env['RUSTLIBSPREFIX'] = '-l'
     env['RUSTLIBS'] = []
     env['_RUSTLIBFLAGS'] = '${_concat(RUSTLIBPATHPREFIX, RUSTLIBPATH, "", __env__)} ${_concat(RUSTLIBSPREFIX, RUSTLIBS, "", __env__)}'
+
+    env['RUSTLINTWARNPREFIX'] = '-W'
+    env['RUSTLINTWARN'] = []
+    env['RUSTLINTALLOWPREFIX'] = '-A'
+    env['RUSTLINTALLOW'] = []
+    env['RUSTLINTDENYPREFIX'] = '-D'
+    env['RUSTLINTDENY'] = []
+    env['RUSTLINTFORBIDPREFIX'] = '-F'
+    env['RUSTLINTFORBID'] = []
+    env['_RUSTLINTFLAGS'] = (
+        '${_concat(RUSTLINTWARNPREFIX, RUSTLINTWARN, "", __env__)} '
+        '${_concat(RUSTLINTALLOWPREFIX, RUSTLINTALLOW, "", __env__)} '
+        '${_concat(RUSTLINTDENYPREFIX, RUSTLINTDENY, "", __env__)} '
+        '${_concat(RUSTLINTFORBIDPREFIX, RUSTLINTFORBID, "", __env__)}'
+    )
 
 def exists(env):
     return env.Detect('rustc')

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -36,15 +36,16 @@ import SCons.Tool
 def generate(env):
     static_obj, shared_obj = SCons.Tool.createObjBuilders(env)
 
-    static_obj.add_action('.rs', SCons.Defaults.RustAction)
-    static_obj.add_emitter('.rs', SCons.Defaults.StaticObjectEmitter)
+    for suffix in SCons.Tool.RustSuffixes:
+        static_obj.add_action(suffix, SCons.Defaults.RustAction)
+        static_obj.add_emitter(suffix, SCons.Defaults.StaticObjectEmitter)
+
+        shared_obj.add_action(suffix, SCons.Defaults.ShRustAction)
+        shared_obj.add_emitter(suffix, SCons.Defaults.SharedObjectEmitter)
 
     env['RUSTC'] = env.Detect('rustc') or 'rustc'
     env['RUSTCOM'] = '$RUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $_RUSTLINTFLAGS $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
     env['RUSTFLAGS'] = []
-
-    shared_obj.add_action('.rs', SCons.Defaults.ShRustAction)
-    shared_obj.add_emitter('.rs', SCons.Defaults.SharedObjectEmitter)
 
     env['SHRUSTC'] = '$RUSTC'
     env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $_RUSTLINTFLAGS $SHRUSTFLAGS --crate-type cdylib --emit obj -o $TARGET $SOURCES'

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -33,6 +33,13 @@ selection method.
 import SCons.Defaults
 import SCons.Tool
 
+
+def _rust_library_dict_to_list(library_dict):
+    return [
+        name if kind is None else '{}={}'.format(kind, name)
+        for name, kind in library_dict.items()
+    ]
+
 def generate(env):
     static_obj, shared_obj = SCons.Tool.createObjBuilders(env)
 
@@ -58,11 +65,16 @@ def generate(env):
     }
     env['_RUSTCODEGENFLAGS'] = '${_defines(RUSTCODEGENPREFIX, RUSTCODEGENFLAGS, "", __env__)}'
 
+    env['_rust_library_dict_to_list'] = _rust_library_dict_to_list
     env['RUSTLIBPATHPREFIX'] = '-L'
-    env['RUSTLIBPATH'] = []
+    env['RUSTLIBPATH'] = dict()
     env['RUSTLIBSPREFIX'] = '-l'
-    env['RUSTLIBS'] = []
-    env['_RUSTLIBFLAGS'] = '${_concat(RUSTLIBPATHPREFIX, RUSTLIBPATH, "", __env__)} ${_concat(RUSTLIBSPREFIX, RUSTLIBS, "", __env__)}'
+    env['RUSTLIBS'] = dict()
+    env['_RUSTLIBFLAGS'] = (
+        '${_concat(RUSTLIBPATHPREFIX, _rust_library_dict_to_list(RUSTLIBPATH), "", __env__)} '
+        '${_concat(RUSTLIBSPREFIX, _rust_library_dict_to_list(RUSTLIBS), "", __env__)}'
+    )
+
 
     env['RUSTLINTWARNPREFIX'] = '-W'
     env['RUSTLINTWARN'] = []

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -47,7 +47,7 @@ def generate(env):
     shared_obj.add_emitter('.rs', SCons.Defaults.SharedObjectEmitter)
 
     env['SHRUSTC'] = '$RUSTC'
-    env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $SHRUSTFLAGS --crate-type cdynlib --emit obj -o $TARGET $SOURCES'
+    env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $_RUSTLIBFLAGS $SHRUSTFLAGS --crate-type cdylib --emit obj -o $TARGET $SOURCES'
     env['SHRUSTFLAGS'] = []
 
     env['RUSTCODEGENPREFIX'] = '-C'

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -43,5 +43,12 @@ def generate(env):
     env['RUSTCOM'] = '$RUSTC $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
     env['RUSTFLAGS'] = []
 
+    shared_obj.add_action('.rs', SCons.Defaults.ShRustAction)
+    shared_obj.add_emitter('.rs', SCons.Defaults.SharedObjectEmitter)
+
+    env['SHRUSTC'] = '$RUSTC'
+    env['SHRUSTCOM'] = '$SHRUSTC $SHRUSTFLAGS --crate-type cdynlib --emit obj -o $TARGET $SOURCES'
+    env['SHRUSTFLAGS'] = []
+
 def exists(env):
     return env.Detect('rustc')

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -1,0 +1,47 @@
+"""SCons.Tool.rustc
+
+Tool-specific initialization for the rustc compiler.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+"""
+
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import SCons.Action
+import SCons.Builder
+import SCons.Util
+
+_rustc_builder = SCons.Builder.Builder(
+        action = 'rustc -o $TARGET $SOURCES',
+        src_suffix = '.rs',)
+
+def generate(env):
+    """Add Builders and construction variables to the Environment."""
+
+    env['BUILDERS']['RUSTC'] = _rustc_builder
+
+def exists(env):
+    return 1

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -40,7 +40,7 @@ def generate(env):
     static_obj.add_emitter('.rs', SCons.Defaults.StaticObjectEmitter)
 
     env['RUSTC'] = env.Detect('rustc') or 'rustc'
-    env['RUSTCOM'] = '$RUSTC $RUSTFLAGS --emit obj -o $TARGET $SOURCES'
+    env['RUSTCOM'] = '$RUSTC $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
     env['RUSTFLAGS'] = []
 
 def exists(env):

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -40,15 +40,22 @@ def generate(env):
     static_obj.add_emitter('.rs', SCons.Defaults.StaticObjectEmitter)
 
     env['RUSTC'] = env.Detect('rustc') or 'rustc'
-    env['RUSTCOM'] = '$RUSTC $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
+    env['RUSTCOM'] = '$RUSTC $_RUSTCODEGENFLAGS $RUSTFLAGS --crate-type staticlib --emit obj -o $TARGET $SOURCES'
     env['RUSTFLAGS'] = []
 
     shared_obj.add_action('.rs', SCons.Defaults.ShRustAction)
     shared_obj.add_emitter('.rs', SCons.Defaults.SharedObjectEmitter)
 
     env['SHRUSTC'] = '$RUSTC'
-    env['SHRUSTCOM'] = '$SHRUSTC $SHRUSTFLAGS --crate-type cdynlib --emit obj -o $TARGET $SOURCES'
+    env['SHRUSTCOM'] = '$SHRUSTC $_RUSTCODEGENFLAGS $SHRUSTFLAGS --crate-type cdynlib --emit obj -o $TARGET $SOURCES'
     env['SHRUSTFLAGS'] = []
+
+    env['RUSTCODEGENPREFIX'] = '-C'
+    env['RUSTCODEGENFLAGS'] = [  # TODO: This should be a dictionary
+        'linker=$LINK',
+        'link-args=$LINKFLAGS',
+    ]
+    env['_RUSTCODEGENFLAGS'] = '${_concat(RUSTCODEGENPREFIX, RUSTCODEGENFLAGS, "", __env__)}'
 
 def exists(env):
     return env.Detect('rustc')

--- a/SCons/Tool/rustc.py
+++ b/SCons/Tool/rustc.py
@@ -44,4 +44,4 @@ def generate(env):
     env['BUILDERS']['RUSTC'] = _rustc_builder
 
 def exists(env):
-    return 1
+    return env.Detect('rustc')

--- a/test/Rust/rustc.py
+++ b/test/Rust/rustc.py
@@ -31,7 +31,7 @@ fn main() {
 """)
 test.write('SConstruct', r"""
 env = Environment()
-env.Program("hello", "hello.rs")
+env.Crate("hello", "hello.rs")
 """)
 test.run("hello")
 # TODO: Check the output of hello world

--- a/test/Rust/rustc.py
+++ b/test/Rust/rustc.py
@@ -1,0 +1,37 @@
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+test.write("hello.rs", r"""
+fn main() {
+    println!("{}", "Hello world!");
+}
+""")
+test.write('SConstruct', r"""
+env = Environment()
+env.Program("hello", "hello.rs")
+""")
+test.run("hello")
+# TODO: Check the output of hello world


### PR DESCRIPTION
# Add support for the rustc compiler.

I'm adding rust support to scons.
My goal is to add the ability to convert c/cxx projects using scons to rust, by converting one module (obj) at a time.


## Tasks
* [x] Add rustc
* [x] Detect rustc
* [x] Omit obj files from the rust compiler.
* [x] Add support for compilation flags
* [x] Create a crate method
* [x] Add the rust standard library to the library path
* [ ] Add a scanner for rust
* [ ] Add more tests
* [ ] Add documentation
* [ ] Handle the main function (In rust there is a difference between a `bin` crate and a `lib` crate)
* [ ] Run rust tests (`#[test]` in the `.rs` files)

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
