### PR TITLE
[WIP] Enforcing HTML output encoding to UTF-8.

### DIFF
--- a/doc/design/html.xsl
+++ b/doc/design/html.xsl
@@ -24,11 +24,14 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	version="1.0">
 
-<xsl:import href="../../SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/> 
+<xsl:import href="../../SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/>
+
+<xsl:output method="html"
+            encoding="UTF-8"
+            indent="no"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +55,97 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
+<xsl:template match="function">
+  <xsl:call-template name="inline.boldmonoseq"/>
+</xsl:template>
+<xsl:template match="methodname">
+  <xsl:call-template name="inline.boldmonoseq"/>
+</xsl:template>
+<!-- Prevent our EPUB cover image from getting included -->
+<xsl:template match="mediaobject[@role = 'cover']">
+</xsl:template>
+
+
+
+<xsl:template name="head.content">
+  <xsl:param name="node" select="."/>
+  <xsl:param name="title">
+    <xsl:apply-templates select="$node" mode="object.title.markup.textonly"/>
+  </xsl:param>
+
+  <title>
+    <xsl:copy-of select="$title"/>
+  </title>
+
+  <xsl:if test="$html.base != ''">
+    <base href="{$html.base}"/>
+  </xsl:if>
+
+  <!-- Insert links to CSS files or insert literal style elements -->
+  <xsl:call-template name="generate.css"/>
+
+  <xsl:if test="$html.stylesheet != ''">
+    <xsl:call-template name="output.html.stylesheets">
+      <xsl:with-param name="stylesheets" select="normalize-space($html.stylesheet)"/>
+    </xsl:call-template>
+  </xsl:if>
+
+  <xsl:if test="$link.mailto.url != ''">
+    <link rev="made"
+          href="{$link.mailto.url}"/>
+  </xsl:if>
+
+  <meta name="generator" content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+
+  <xsl:if test="$generate.meta.abstract != 0">
+    <xsl:variable name="info" select="(articleinfo
+                                      |bookinfo
+                                      |prefaceinfo
+                                      |chapterinfo
+                                      |appendixinfo
+                                      |sectioninfo
+                                      |sect1info
+                                      |sect2info
+                                      |sect3info
+                                      |sect4info
+                                      |sect5info
+                                      |referenceinfo
+                                      |refentryinfo
+                                      |partinfo
+                                      |info
+                                      |docinfo)[1]"/>
+    <xsl:if test="$info and $info/abstract">
+      <meta name="description">
+        <xsl:attribute name="content">
+          <xsl:for-each select="$info/abstract[1]/*">
+            <xsl:value-of select="normalize-space(.)"/>
+            <xsl:if test="position() &lt; last()">
+              <xsl:text> </xsl:text>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:attribute>
+      </meta>
+    </xsl:if>
+  </xsl:if>
+
+  <xsl:if test="($draft.mode = 'yes' or
+                ($draft.mode = 'maybe' and
+                ancestor-or-self::*[@status][1]/@status = 'draft'))
+                and $draft.watermark.image != ''">
+    <style type="text/css"><xsl:text>
+body { background-image: url('</xsl:text>
+<xsl:value-of select="$draft.watermark.image"/><xsl:text>');
+       background-repeat: no-repeat;
+       background-position: top left;
+       /* The following properties make the watermark "fixed" on the page. */
+       /* I think that's just a bit too distracting for the reader... */
+       /* background-attachment: fixed; */
+       /* background-position: center center; */
+     }</xsl:text>
+    </style>
+  </xsl:if>
+  <xsl:apply-templates select="." mode="head.keywords.content"/>
+</xsl:template>
+
+</xsl:stylesheet>
 

--- a/doc/man/html.xsl
+++ b/doc/man/html.xsl
@@ -25,10 +25,13 @@
 -->
 <xsl:stylesheet
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:fo="http://www.w3.org/1999/XSL/Format"
 	version="1.0">
 
 <xsl:import href="../../SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/>
+
+<xsl:output method="html"
+            encoding="UTF-8"
+            indent="no"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -62,6 +65,88 @@ set       toc,title
 </xsl:template>
 <!-- Prevent our EPUB cover image from getting included -->
 <xsl:template match="mediaobject[@role = 'cover']">
+</xsl:template>
+
+
+
+<xsl:template name="head.content">
+  <xsl:param name="node" select="."/>
+  <xsl:param name="title">
+    <xsl:apply-templates select="$node" mode="object.title.markup.textonly"/>
+  </xsl:param>
+
+  <title>
+    <xsl:copy-of select="$title"/>
+  </title>
+
+  <xsl:if test="$html.base != ''">
+    <base href="{$html.base}"/>
+  </xsl:if>
+
+  <!-- Insert links to CSS files or insert literal style elements -->
+  <xsl:call-template name="generate.css"/>
+
+  <xsl:if test="$html.stylesheet != ''">
+    <xsl:call-template name="output.html.stylesheets">
+      <xsl:with-param name="stylesheets" select="normalize-space($html.stylesheet)"/>
+    </xsl:call-template>
+  </xsl:if>
+
+  <xsl:if test="$link.mailto.url != ''">
+    <link rev="made"
+          href="{$link.mailto.url}"/>
+  </xsl:if>
+
+  <meta name="generator" content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+
+  <xsl:if test="$generate.meta.abstract != 0">
+    <xsl:variable name="info" select="(articleinfo
+                                      |bookinfo
+                                      |prefaceinfo
+                                      |chapterinfo
+                                      |appendixinfo
+                                      |sectioninfo
+                                      |sect1info
+                                      |sect2info
+                                      |sect3info
+                                      |sect4info
+                                      |sect5info
+                                      |referenceinfo
+                                      |refentryinfo
+                                      |partinfo
+                                      |info
+                                      |docinfo)[1]"/>
+    <xsl:if test="$info and $info/abstract">
+      <meta name="description">
+        <xsl:attribute name="content">
+          <xsl:for-each select="$info/abstract[1]/*">
+            <xsl:value-of select="normalize-space(.)"/>
+            <xsl:if test="position() &lt; last()">
+              <xsl:text> </xsl:text>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:attribute>
+      </meta>
+    </xsl:if>
+  </xsl:if>
+
+  <xsl:if test="($draft.mode = 'yes' or
+                ($draft.mode = 'maybe' and
+                ancestor-or-self::*[@status][1]/@status = 'draft'))
+                and $draft.watermark.image != ''">
+    <style type="text/css"><xsl:text>
+body { background-image: url('</xsl:text>
+<xsl:value-of select="$draft.watermark.image"/><xsl:text>');
+       background-repeat: no-repeat;
+       background-position: top left;
+       /* The following properties make the watermark "fixed" on the page. */
+       /* I think that's just a bit too distracting for the reader... */
+       /* background-attachment: fixed; */
+       /* background-position: center center; */
+     }</xsl:text>
+    </style>
+  </xsl:if>
+  <xsl:apply-templates select="." mode="head.keywords.content"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/doc/reference/html.xsl
+++ b/doc/reference/html.xsl
@@ -24,11 +24,14 @@
 
 -->
 <xsl:stylesheet
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-	version="1.0"> 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	version="1.0">
 
-<xsl:import href="../../SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/> 
+<xsl:import href="../../SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/>
+
+<xsl:output method="html"
+            encoding="UTF-8"
+            indent="no"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -52,5 +55,97 @@ reference toc,title
 set       toc,title
 </xsl:param>
 
-</xsl:stylesheet> 
+<xsl:template match="function">
+  <xsl:call-template name="inline.boldmonoseq"/>
+</xsl:template>
+<xsl:template match="methodname">
+  <xsl:call-template name="inline.boldmonoseq"/>
+</xsl:template>
+<!-- Prevent our EPUB cover image from getting included -->
+<xsl:template match="mediaobject[@role = 'cover']">
+</xsl:template>
+
+
+
+<xsl:template name="head.content">
+  <xsl:param name="node" select="."/>
+  <xsl:param name="title">
+    <xsl:apply-templates select="$node" mode="object.title.markup.textonly"/>
+  </xsl:param>
+
+  <title>
+    <xsl:copy-of select="$title"/>
+  </title>
+
+  <xsl:if test="$html.base != ''">
+    <base href="{$html.base}"/>
+  </xsl:if>
+
+  <!-- Insert links to CSS files or insert literal style elements -->
+  <xsl:call-template name="generate.css"/>
+
+  <xsl:if test="$html.stylesheet != ''">
+    <xsl:call-template name="output.html.stylesheets">
+      <xsl:with-param name="stylesheets" select="normalize-space($html.stylesheet)"/>
+    </xsl:call-template>
+  </xsl:if>
+
+  <xsl:if test="$link.mailto.url != ''">
+    <link rev="made"
+          href="{$link.mailto.url}"/>
+  </xsl:if>
+
+  <meta name="generator" content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+
+  <xsl:if test="$generate.meta.abstract != 0">
+    <xsl:variable name="info" select="(articleinfo
+                                      |bookinfo
+                                      |prefaceinfo
+                                      |chapterinfo
+                                      |appendixinfo
+                                      |sectioninfo
+                                      |sect1info
+                                      |sect2info
+                                      |sect3info
+                                      |sect4info
+                                      |sect5info
+                                      |referenceinfo
+                                      |refentryinfo
+                                      |partinfo
+                                      |info
+                                      |docinfo)[1]"/>
+    <xsl:if test="$info and $info/abstract">
+      <meta name="description">
+        <xsl:attribute name="content">
+          <xsl:for-each select="$info/abstract[1]/*">
+            <xsl:value-of select="normalize-space(.)"/>
+            <xsl:if test="position() &lt; last()">
+              <xsl:text> </xsl:text>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:attribute>
+      </meta>
+    </xsl:if>
+  </xsl:if>
+
+  <xsl:if test="($draft.mode = 'yes' or
+                ($draft.mode = 'maybe' and
+                ancestor-or-self::*[@status][1]/@status = 'draft'))
+                and $draft.watermark.image != ''">
+    <style type="text/css"><xsl:text>
+body { background-image: url('</xsl:text>
+<xsl:value-of select="$draft.watermark.image"/><xsl:text>');
+       background-repeat: no-repeat;
+       background-position: top left;
+       /* The following properties make the watermark "fixed" on the page. */
+       /* I think that's just a bit too distracting for the reader... */
+       /* background-attachment: fixed; */
+       /* background-position: center center; */
+     }</xsl:text>
+    </style>
+  </xsl:if>
+  <xsl:apply-templates select="." mode="head.keywords.content"/>
+</xsl:template>
+
+</xsl:stylesheet>
 

--- a/doc/user/html.xsl
+++ b/doc/user/html.xsl
@@ -25,10 +25,13 @@
 -->
 <xsl:stylesheet
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:fo="http://www.w3.org/1999/XSL/Format"
 	version="1.0">
 
 <xsl:import href="../../SCons/Tool/docbook/docbook-xsl-1.76.1/html/docbook.xsl"/>
+
+<xsl:output method="html"
+            encoding="UTF-8"
+            indent="no"/>
 
 <xsl:param name="l10n.gentext.default.language" select="'en'"/>
 <xsl:param name="section.autolabel" select="1"/>
@@ -64,4 +67,87 @@ set       toc,title
 <xsl:template match="mediaobject[@role = 'cover']">
 </xsl:template>
 
+
+
+<xsl:template name="head.content">
+  <xsl:param name="node" select="."/>
+  <xsl:param name="title">
+    <xsl:apply-templates select="$node" mode="object.title.markup.textonly"/>
+  </xsl:param>
+
+  <title>
+    <xsl:copy-of select="$title"/>
+  </title>
+
+  <xsl:if test="$html.base != ''">
+    <base href="{$html.base}"/>
+  </xsl:if>
+
+  <!-- Insert links to CSS files or insert literal style elements -->
+  <xsl:call-template name="generate.css"/>
+
+  <xsl:if test="$html.stylesheet != ''">
+    <xsl:call-template name="output.html.stylesheets">
+      <xsl:with-param name="stylesheets" select="normalize-space($html.stylesheet)"/>
+    </xsl:call-template>
+  </xsl:if>
+
+  <xsl:if test="$link.mailto.url != ''">
+    <link rev="made"
+          href="{$link.mailto.url}"/>
+  </xsl:if>
+
+  <meta name="generator" content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+
+  <xsl:if test="$generate.meta.abstract != 0">
+    <xsl:variable name="info" select="(articleinfo
+                                      |bookinfo
+                                      |prefaceinfo
+                                      |chapterinfo
+                                      |appendixinfo
+                                      |sectioninfo
+                                      |sect1info
+                                      |sect2info
+                                      |sect3info
+                                      |sect4info
+                                      |sect5info
+                                      |referenceinfo
+                                      |refentryinfo
+                                      |partinfo
+                                      |info
+                                      |docinfo)[1]"/>
+    <xsl:if test="$info and $info/abstract">
+      <meta name="description">
+        <xsl:attribute name="content">
+          <xsl:for-each select="$info/abstract[1]/*">
+            <xsl:value-of select="normalize-space(.)"/>
+            <xsl:if test="position() &lt; last()">
+              <xsl:text> </xsl:text>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:attribute>
+      </meta>
+    </xsl:if>
+  </xsl:if>
+
+  <xsl:if test="($draft.mode = 'yes' or
+                ($draft.mode = 'maybe' and
+                ancestor-or-self::*[@status][1]/@status = 'draft'))
+                and $draft.watermark.image != ''">
+    <style type="text/css"><xsl:text>
+body { background-image: url('</xsl:text>
+<xsl:value-of select="$draft.watermark.image"/><xsl:text>');
+       background-repeat: no-repeat;
+       background-position: top left;
+       /* The following properties make the watermark "fixed" on the page. */
+       /* I think that's just a bit too distracting for the reader... */
+       /* background-attachment: fixed; */
+       /* background-position: center center; */
+     }</xsl:text>
+    </style>
+  </xsl:if>
+  <xsl:apply-templates select="." mode="head.keywords.content"/>
+</xsl:template>
+
 </xsl:stylesheet>
+


### PR DESCRIPTION
The stylesheet for the single HTML outputs (not chunked) get adapted,
such that UTF-8 is always used as output encoding for all chunks.
In addition, the HTML header now contains a corresponding
"content" tag, displaying the used charset=UTF-8.

## Contributor Checklist:

* [ n/a ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ n/a ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ n/a ] I have updated the appropriate documentation
