### PR TITLE
Update docs on argument passing to Environment, etc.

### DIFF
--- a/doc/generated/examples/builders_override_ex1_1.xml
+++ b/doc/generated/examples/builders_override_ex1_1.xml
@@ -1,0 +1,5 @@
+<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
+cc -o foo1.o -c -DFOO foo.c
+cc -o foo2.o -c -DBAR foo.c
+cc -o foo3.o -c -DBAR -DFOO foo.c
+</screen>

--- a/doc/generated/examples/builders_override_ex2_1.xml
+++ b/doc/generated/examples/builders_override_ex2_1.xml
@@ -1,0 +1,4 @@
+<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
+cc -o hello.o -c -DEBUG -Iinclude hello.c
+cc -o hello hello.o -lm
+</screen>

--- a/doc/generated/examples/parse_flags_ex1_1.xml
+++ b/doc/generated/examples/parse_flags_ex1_1.xml
@@ -1,5 +1,7 @@
 <screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
-CC is: cc
-LATEX is: None
-scons: `.' is up to date.
+CPPPATH: ['/opt/include']
+LIBPATH: ['/opt/lib']
+LIBS: ['foo']
+cc -o f1.o -c -I/opt/include f1.c
+cc -o f1 f1.o -L/opt/lib -lfoo
 </screen>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2126,31 +2126,20 @@ version of Microsoft Visual C++ you wish to use,
 but setting it after the &consenv; is constructed has no effect.
 </para>
 
-<para>
-An existing &consenv; can be duplicated by calling the &f-link-env-Clone;
-method. Without arguments, it will be a copy with the same
-settings. Otherwise, &f-env-Clone; takes the same arguments as &f-Environment;,
-and uses the arguments to create a modified copy.
-</para>
-
-<para>
-&SCons; also provides a special &consenv; called the
-<firstterm>&DefEnv;</firstterm>.
-The &defenv; is used only for global functions, that is,
-construction activities called without the context of a regular &consenv;.
-See &f-link-DefaultEnvironment; for more information.
-</para>
-
 <para>As a convenience,
 &consvars; may also be set or modified by the
 <parameter>parse_flags</parameter>
-keyword argument, which causes the
+keyword argument during object creation, 
+which has the effect of the
 &f-link-env-MergeFlags;
-method to be applied to the argument value
+method being applied to the argument value
 after all other processing is completed.
 This is useful either if the exact content of the flags is unknown
 (for example, read from a control file)
-or if the flags need to be distributed to a number of &consvars;.</para>
+or if the flags need to be distributed to a number of &consvars;.
+&f-link-env-ParseFlags; describes how these arguments
+are distributed to &consvars;.
+</para>
 
 <programlisting language="python">
 env = Environment(parse_flags='-Iinclude -DEBUG -lm')
@@ -2162,8 +2151,21 @@ the <envar>CPPPATH</envar> &consvar;,
 <envar>CPPDEFINES</envar>,
 and 'm' to
 <envar>LIBS</envar>.
-&f-link-env-ParseFlags; describes how these arguments
-are distributed to &consvars;.
+</para>
+
+<para>
+An existing &consenv; can be duplicated by calling the &f-link-env-Clone;
+method. Without arguments, it will be a copy with the same
+settings. Otherwise, &f-env-Clone; takes the same arguments as &f-Environment;,
+and uses the arguments to create a modified copy.
+</para>
+
+<para>
+&SCons; provides a special &consenv; called the
+<firstterm>&DefEnv;</firstterm>.
+The &defenv; is used only for global functions, that is,
+construction activities called without the context of a regular &consenv;.
+See &f-link-DefaultEnvironment; for more information.
 </para>
 
 <para>By default, a new &consenv; is
@@ -2622,12 +2624,14 @@ and
 env.Program('build/prog', ['f1.c', 'f2.c'], srcdir='src')
 </programlisting>
 
-<para>It is possible to <firstterm>override</firstterm> (replace or add)
-&consvars; when calling a
-builder method by passing them as keyword arguments.
+<para>Keyword arguments that are not specifically
+recognized are treated as &consvar;
+<firstterm>overrides</firstterm>,
+which replace or add those variables on a limited basis.
 These overrides
-will only be in effect when building that target, and will not
-affect other parts of the build. For example, if you want to specify
+will only be in effect when building the target of the builder call,
+and will not affect other parts of the build.
+For example, if you want to specify
 some libraries needed by just one program:</para>
 
 <programlisting language="python">
@@ -2637,9 +2641,12 @@ env.Program('hello', 'hello.c', LIBS=['gl', 'glut'])
 <para>or generate a shared library with a non-standard suffix:</para>
 
 <programlisting language="python">
-env.SharedLibrary('word', 'word.cpp',
-                  SHLIBSUFFIX='.ocx',
-                  LIBSUFFIXES=['.ocx'])
+env.SharedLibrary(
+    target='word',
+    source='word.cpp',
+    SHLIBSUFFIX='.ocx',
+    LIBSUFFIXES=['.ocx'],
+)
 </programlisting>
 
 <para>Note that both the &cv-link-SHLIBSUFFIX;
@@ -2648,12 +2655,12 @@ variables must be set if you want &scons; to search automatically
 for dependencies on the non-standard library names;
 see the descriptions below of these variables for more information.</para>
 
-<para>It is also possible to use the
+<para>The optional
 <parameter>parse_flags</parameter>
-keyword argument in an override,
-to merge command-line style arguments
-into the appropriate &consvars;
-(see &f-link-env-MergeFlags;).
+keyword argument is recognized by builders.
+This works similarly to the 
+&f-link-env-MergeFlags; method, where the argument value is
+broken into individual settings and merged into the appropriate &consvars;.
 </para>
 
 <programlisting language="python">
@@ -2671,21 +2678,22 @@ and 'm' to
 &scons;
 are, in fact,
 methods of a &consenv; object,
-they may also be called without an explicit environment:</para>
+many may also be called without an explicit environment:</para>
 
 <programlisting language="python">
 Program('hello', 'hello.c')
 SharedLibrary('word', 'word.cpp')
 </programlisting>
 
-<para>In this case,
-the methods are called internally using a default construction
-environment that consists of the tools and values that
+<para>If called this way, methods will internally use the
+&defenv; that consists of the tools and values that
 &scons;
 has determined are appropriate for the local system.</para>
 
 <para>Builder methods that can be called without an explicit
-environment may be called from custom Python modules that you
+environment (indicated in the listing of builders without
+a leading <literal><replaceable>env</replaceable>.</literal>)
+may be called from custom Python modules that you
 import into an SConscript file by adding the following
 to the Python module:</para>
 
@@ -2698,7 +2706,8 @@ containing Nodes that will be built.
 A <firstterm>Node</firstterm>
 is an internal SCons object
 which represents
-build targets or sources.</para>
+build targets or sources.
+See <xref linkend="node_objects"> for more information.</para>
 
 <para>The returned Node-list object
 can be passed to other builder methods as source(s)
@@ -4641,7 +4650,7 @@ vars.AddVariables(
 
 </refsect2>
 
-<refsect2 id='file_and_directory_nodes'>
+<refsect2 id='node_objects'>
 <title>File and Directory Nodes</title>
 
 <para>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2707,7 +2707,7 @@ A <firstterm>Node</firstterm>
 is an internal SCons object
 which represents
 build targets or sources.
-See <xref linkend="node_objects"> for more information.</para>
+See <xref linkend="node_objects"/> for more information.</para>
 
 <para>The returned Node-list object
 can be passed to other builder methods as source(s)

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -125,7 +125,7 @@ method form, or both, exist. If all four exist you will get:
 *f-link-foobar*
     which is a link to the description of the global Function
 
-*f-env-link-foobar*
+*f-link-env-foobar*
     which is a link to the description of the environment method
 
 

--- a/doc/user/MANIFEST
+++ b/doc/user/MANIFEST
@@ -36,6 +36,7 @@ nodes.xml
 output.xml
 parseconfig.xml
 parseflags.xml
+parse_flags_arg.xml
 preface.xml
 python.xml
 repositories.xml

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -468,6 +468,64 @@ environment, of directory names, suffixes, etc.
 
   </para>
 
+  <sidebar>
+    <title>Sidebar: Python Dictionaries</title>
+
+    <para>
+
+    If you're not familiar with the &Python; programming language,
+    we need to talk a little bit about the &Python; dictionary data type.
+    A dictionary (also known by terms such as mapping, associative array
+    and key-value store) associates keys with values, such
+    that accessing the dict by key gives you back the associated value;
+    setting by key creates the association (and replaces any
+    previous association for that key).
+    Accessing can be done by using <literal>[]</literal>
+    indexing notation, and dictionaries also provide a
+    method named <methodname>get</methodname> which responds
+    with a default value (<constant>None</constant> or a default
+    you supply) if the key is not in the dictionary, which
+    avoids failing in that case.  The syntax
+    for a dictionary itself uses curly braces (<literal>{}</literal>).
+    Here are some simple examples using syntax that indicates
+    interacting with the &Python; interpreter
+    (<prompt>&gt;&gt;&gt;</prompt> is the interpreter prompt) -
+    you can try these out:
+
+    </para>
+
+    <screen>
+<prompt>&gt;&gt;&gt;</prompt> <userinput>tel = {'jack': 4098, 'sape': 4139}</userinput>
+<prompt>&gt;&gt;&gt;</prompt> <userinput>tel['guido'] = 4098</userinput>
+<prompt>&gt;&gt;&gt;</prompt> <userinput>tel['jack']</userinput>
+4098
+<prompt>&gt;&gt;&gt;</prompt> <userinput>del tel['sape']</userinput>
+<prompt>&gt;&gt;&gt;</prompt> <userinput>tel['irv'] = 4127</userinput>
+<prompt>&gt;&gt;&gt;</prompt> <userinput>print(tel)</userinput>
+{'jack': 4098, 'guido': 4127, 'irv': 4127}
+<prompt>&gt;&gt;&gt;</prompt> <userinput>'guido' in tel</userinput>
+True
+<prompt>&gt;&gt;&gt;</prompt> <userinput>print(tel['jack'])</userinput>
+Traceback (most recent call last):
+  File "&lt;stdin&gt;", line 1, in &lt;module&gt;
+KeyError: 'jack'
+<prompt>&gt;&gt;&gt;</prompt> <userinput>print(tel.get('jack'))</userinput>
+None
+    </screen>
+
+    <para>
+
+    The &consenv; is written to behave like a &Python;
+    dictionary, and the &cv-ENV; construction variable in
+    a &consenv; <emphasis>is</emphasis> a &Python; dictionary.
+    The <varname>os.environ</varname> value that &Python; uses
+    to make available the external environment is also a
+    dictionary.  We will need these concepts in this chapter.
+
+    </para>
+
+  </sidebar>
+
   <section id="sect-external-environments">
   <title>Using Values From the External Environment</title>
 
@@ -477,7 +535,7 @@ environment, of directory names, suffixes, etc.
   variable settings that
   the user has in force
   when executing &SCons;
-  are available in the Python
+  are available in the &Python;
   <varname>os.environ</varname>
   dictionary.
   This means that you must add an
@@ -495,7 +553,7 @@ import os
 print("Shell is", os.environ['SHELL'])
      </file>
      <file name="foo.c">
-int main() { }
+void main() { }
      </file>
    </scons_example>
 
@@ -506,9 +564,7 @@ int main() { }
   dictionary in your &SConscript;
   files to initialize &consenvs;
   with values from the user's external environment.
-  See the next section,
-  <xref linkend="sect-construction-environments"></xref>,
-  for information on how to do this.
+  Read on to the next section for information on how to do this.
 
   </para>
 
@@ -520,7 +576,7 @@ int main() { }
     <para>
 
       It is rare that all of the software in a large,
-      complicated system needs to be built the same way.
+      complicated system needs to be built exactly the same way.
       For example, different source files may need different options
       enabled on the command line,
       or different executable programs need to be linked
@@ -581,10 +637,8 @@ env = Environment()
 
        <scons_example name="environments_ex1">
          <file name="SConstruct" printme="1">
- env = Environment(CC = 'gcc',
-                   CCFLAGS = '-O2')
-
- env.Program('foo.c')
+env = Environment(CC='gcc', CCFLAGS='-O2')
+env.Program('foo.c')
          </file>
          <file name="foo.c">
 int main() { }
@@ -623,7 +677,7 @@ int main() { }
       You can fetch individual values, known as
       <firstterm>Construction Variables</firstterm>,
       using the same syntax used
-      for accessing individual named items in a Python dictionary:
+      for accessing individual named items in a &Python; dictionary:
 
       </para>
 
@@ -639,10 +693,10 @@ print("LATEX is: %s" % env.get('LATEX', None))
 
       This example &SConstruct; file doesn't contain instructions
       for building any targets, but because it's still a valid
-      &SConstruct; it will be evaulated and the Python
+      &SConstruct; it will be evaulated and the &Python;
       <function>print</function> calls will output the values
-      of &cv-link-CC; and &cv-link-LATEX; for us (using the
-      <function>.get()</function> method for fetching means
+      of &cv-link-CC; and &cv-link-LATEX; for us (remember using the
+      <methodname>.get()</methodname> method for fetching means
       we get a default value back, rather than a failure,
       if the variable is not set):
 
@@ -655,11 +709,10 @@ print("LATEX is: %s" % env.get('LATEX', None))
       <para>
 
       A &consenv;
-      is actually an object with associated methods and
-      attributes.
+      is actually an object with associated methods and attributes.
       If you want to have direct access to only the
       dictionary of &consvars;
-      you can fetch this using the &Dictionary; method
+      you can fetch this using the &f-link-env-Dictionary; method
       (although it's rarely necessary to use this method):
 
       </para>
@@ -699,7 +752,7 @@ for key in ['OBJSUFFIX', 'LIBSUFFIX', 'PROGSUFFIX']:
 
       If you want to loop and print the values of
       all of the &consvars; in a &consenv;,
-      the Python code to do that in sorted order might look something like:
+      the &Python; code to do that in sorted order might look something like:
 
       </para>
 
@@ -742,7 +795,7 @@ print(env.Dump())
 
       <sconstruct>
 env = Environment()
-print("CC is: %s"%env.subst('$CC'))
+print("CC is: %s" % env.subst('$CC'))
       </sconstruct>
 
       <para>
@@ -758,8 +811,8 @@ print("CC is: %s"%env.subst('$CC'))
       </para>
 
       <sconstruct>
-env = Environment(CCFLAGS = '-DFOO')
-print("CCCOM is: %s"%env['CCCOM'])
+env = Environment(CCFLAGS='-DFOO')
+print("CCCOM is: %s" % env['CCCOM'])
       </sconstruct>
 
       <para>
@@ -784,8 +837,8 @@ scons: `.' is up to date.
       </para>
 
       <sconstruct>
-env = Environment(CCFLAGS = '-DFOO')
-print("CCCOM is: %s"%env.subst('$CCCOM'))
+env = Environment(CCFLAGS='-DFOO')
+print("CCCOM is: %s" % env.subst('$CCCOM'))
       </sconstruct>
 
       <para>
@@ -827,7 +880,7 @@ scons: `.' is up to date.
        <scons_example name="environments_missing1">
          <file name="SConstruct" printme="1">
 env = Environment()
-print("value is: %s"%env.subst( '->$MISSING&lt;-' ))
+print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
         </file>
       </scons_example>
 
@@ -855,7 +908,7 @@ print("value is: %s"%env.subst( '->$MISSING&lt;-' ))
          <file name="SConstruct" printme="1">
 AllowSubstExceptions()
 env = Environment()
-print("value is: %s"%env.subst( '->$MISSING&lt;-' ))
+print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
         </file>
       </scons_example>
 
@@ -875,7 +928,7 @@ print("value is: %s"%env.subst( '->$MISSING&lt;-' ))
          <file name="SConstruct" printme="1">
 AllowSubstExceptions(IndexError, NameError, ZeroDivisionError)
 env = Environment()
-print("value is: %s"%env.subst( '->${1 / 0}&lt;-' ))
+print("value is: %s"%env.subst( '-&gt;${1 / 0}&lt;-' ))
         </file>
       </scons_example>
 
@@ -996,7 +1049,8 @@ env = DefaultEnvironment(tools=['gcc', 'gnulink'],
 
     </section>
 
-    <section>
+    <section id='multiple_construction_envs'>
+
     <title>Multiple &ConsEnvs;</title>
 
       <para>
@@ -1135,15 +1189,15 @@ int main() { }
       to share the same values for one or more variables.
       Rather than always having to repeat all of the common
       variables when you create each construction environment,
-      you can use the &Clone; method
+      you can use the &f-link-env-Clone; method
       to create a copy of a construction environment.
 
       </para>
 
       <para>
 
-      Like the &Environment; call that creates a construction environment,
-      the &Clone; method takes &consvar; assignment keyword arguments,
+      Like the &f-link-Environment; call that creates a construction environment,
+      the &Clone; method takes &consvar; assignments,
       which will override the values in the copied construction environment.
       For example, suppose we want to use &gcc;
       to create three versions of a program,
@@ -1193,7 +1247,7 @@ int main() { }
       <para>
 
       You can replace existing construction variable values
-      using the &Replace; method:
+      using the &f-link-env-Replace; method:
 
       </para>
 
@@ -1323,9 +1377,9 @@ int main() { }
       that a construction variable should be
       set to a value only if the construction environment
       does not already have that variable defined
-      You can do this with the &SetDefault; method,
+      You can do this with the &f-link-env-SetDefault; method,
       which behaves similarly to the <function>set_default</function>
-      method of Python dictionary objects:
+      method of &Python; dictionary objects:
 
       </para>
 
@@ -1355,7 +1409,7 @@ env.SetDefault(SPECIAL_FLAG='-extra-option')
 
       You can append a value to
       an existing construction variable
-      using the &Append; method:
+      using the &f-link-env-Append; method:
 
       </para>
 
@@ -1429,7 +1483,7 @@ print("NEW_VARIABLE = %s"%env['NEW_VARIABLE'])
       Some times it's useful to add a new value
       only if the existing construction variable
       doesn't already contain the value.
-      This can be done using the &AppendUnique; method:
+      This can be done using the &f-link-env-AppendUnique; method:
 
       </para>
 
@@ -1455,14 +1509,14 @@ env.AppendUnique(CCFLAGS=['-g'])
 
       You can append a value to the beginning of
       an existing construction variable
-      using the &Prepend; method:
+      using the &f-link-env-Prepend; method:
 
       </para>
 
       <scons_example name="environments_ex9">
         <file name="SConstruct" printme="1">
-env = Environment(CCFLAGS = ['-DMY_VALUE'])
-env.Prepend(CCFLAGS = ['-DFIRST'])
+env = Environment(CCFLAGS=['-DMY_VALUE'])
+env.Prepend(CCFLAGS=['-DFIRST'])
 env.Program('foo.c')
         </file>
         <file name="foo.c">
@@ -1491,8 +1545,8 @@ int main() { }
       <scons_example name="environments_Prepend-nonexistent">
         <file name="SConstruct" printme="1">
 env = Environment()
-env.Prepend(NEW_VARIABLE = 'added')
-print("NEW_VARIABLE = %s"%env['NEW_VARIABLE'])
+env.Prepend(NEW_VARIABLE='added')
+print("NEW_VARIABLE = %s" % env['NEW_VARIABLE'])
         </file>
       </scons_example>
 
@@ -1531,7 +1585,7 @@ print("NEW_VARIABLE = %s"%env['NEW_VARIABLE'])
       to the beginning of a construction variable
       only if the existing value
       doesn't already contain the to-be-added value.
-      This can be done using the &PrependUnique; method:
+      This can be done using the &f-link-env-PrependUnique; method:
 
       </para>
 
@@ -1550,7 +1604,7 @@ env.PrependUnique(CCFLAGS=['-g'])
 
       </section>
 
-      <section>
+      <section id="builder_overrides">
       <title>Overriding Construction Variable Settings</title>
 
       <para>
@@ -1586,11 +1640,38 @@ env.SharedLibrary(
 
       <para>
 
-      When overriding this way, the Python-style keyword arguments
-      mean "set to this value".  If you want your override to augment
-      an existing value, you have to take some extra steps. XXX
+      When overriding this way, the &Python; keyword arguments in
+      the builder call mean "set to this value".
+      If you want your override to augment an existing value,
+      you have to take some extra steps.
+      Inside the builder call,
+      it is possible to substitute in the existing value by using
+      a string containing the variable name prefaced by a
+      dollar sign (<literal>$</literal>).
 
       </para>
+
+      <scons_example name="builders_override_ex1">
+        <file name="SConstruct" printme="1">
+env = Environment(CPPDEFINES="FOO")
+env.Object(target="foo1.o", source="foo.c")
+env.Object(target="foo2.o", source="foo.c", CPPDEFINES="BAR")
+env.Object(target="foo3.o", source="foo.c", CPPDEFINES=["BAR", "$CPPDEFINES"])
+        </file>
+        <file name="foo.c">
+void main() { }
+        </file>
+      </scons_example>
+
+      <para>
+
+      Which yields:
+
+      </para>
+
+      <scons_output example="builders_override_ex1" suffix="1">
+         <scons_output_command>scons -Q</scons_output_command>
+      </scons_output>
 
       <para>
 
@@ -1598,7 +1679,7 @@ env.SharedLibrary(
       keyword argument in an override to merge command-line
       style arguments into the appropriate construction
       variables. This works like the &f-link-env-MergeFlags; method,
-      which will be described later.
+      which will be fully described in the next chapter.
 
       </para>
 
@@ -1609,15 +1690,41 @@ env.SharedLibrary(
 
       </para>
 
-      <programlisting>
+      <scons_example name="builders_override_ex2">
+        <file name="SConstruct" printme="1">
 env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
-      </programlisting>
+        </file>
+        <file name="hello.c">
+#include &lt;stdio.h&gt;
+void main() {
+        printf("Hello, world\n");
+}
+        </file>
+      </scons_example>
+
+      <para>
+
+      So when executed:
+
+      </para>
+
+      <scons_output example="builders_override_ex2" suffix="1">
+         <scons_output_command>scons -Q</scons_output_command>
+      </scons_output>
 
       <para>
 
       Using temporary overrides this way is lighter weight than making
       a full construction environment, so it can help performance in
       large projects which have lots of special case values to set.
+      However, keep in mind that this only works well when the
+      targets are unique.  Using builder overrides to try to build
+      the same target with different sets of flags or other construction
+      variables will lead to the
+      <computeroutput>scons: *** Two environments with different actions...</computeroutput>
+      error described in <xref linkend="multiple_construction_envs"/>
+      above. In this case you will actually want to create separate
+      environments.
 
       </para>
 
@@ -1632,12 +1739,11 @@ env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
 
       When &SCons; builds a target file,
       it does not execute the commands with
-      the same external environment
+      the external environment
       that you used to execute &SCons;.
-      Instead, it uses the dictionary
-      stored in the &cv-link-ENV; construction variable
-      as the external environment
-      for executing commands.
+      Instead, it builds an exection environment from the values
+      stored in the &cv-link-ENV; &consvar;
+      and uses that for executing commands.
 
     </para>
 
@@ -1647,11 +1753,11 @@ env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
       is that the &PATH; environment variable,
       which controls where the operating system
       will look for commands and utilities,
-      is not the same as in the external environment
+      will almost certainly not be the same as in the external environment
       from which you called &SCons;.
-      This means that &SCons; will not, by default,
+      This means that &SCons; might not
       necessarily find all of the tools
-      that you can execute from the command line.
+      that you can successfully execute from the command line yourself.
 
     </para>
 
@@ -1681,21 +1787,21 @@ env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
 
     <sconstruct>
 path = ['/usr/local/bin', '/bin', '/usr/bin']
-env = Environment(ENV = {'PATH' : path})
+env = Environment(ENV={'PATH': path})
     </sconstruct>
 
     <para>
 
-    Assign a dictionary to the &cv-ENV;
+    Assigning a dictionary to the &cv-ENV;
     construction variable in this way
-    completely resets the external environment
+    completely resets the execution environment,
     so that the only variable that will be
     set when external commands are executed
     will be the &PATH; value.
     If you want to use the rest of
     the values in &cv-ENV; and only
-    set the value of &PATH;,
-    the most straightforward way is probably:
+    set the value of &PATH;, you can assign a value only
+    to that variable:
 
     </para>
 
@@ -1706,11 +1812,10 @@ env['ENV']['PATH'] = ['/usr/local/bin', '/bin', '/usr/bin']
     <para>
 
     Note that &SCons; does allow you to define
-    the directories in the &PATH; in a string,
+    the directories in the &PATH; in a string with paths
     separated by the pathname-separator character
-    for your system (':' on POSIX systems, ';' on Windows
-    or use <literal>os.pathsep</literal> for portability).
-
+    for your system (<literal>':'</literal> on POSIX systems,
+    <literal>';'</literal> on Windows).
 
     </para>
 
@@ -1721,10 +1826,18 @@ env['ENV']['PATH'] = '/usr/local/bin:/bin:/usr/bin'
     <para>
 
     But doing so makes your &SConscript; file less portable,
-    (although in this case that may not be a huge concern
-    since the directories you list are likely system-specific, anyway).
+    since it will be correct only for the system type that
+    matches the separator. You can use the &Python;
+    <varname>os.pathsep</varname> for for greater portability -
+    don't worry too much if this &Python; syntax doesn't make sense
+    since there are other ways available:
 
     </para>
+
+    <sconstruct>
+import os
+env['ENV']['PATH'] = os.pathsep.join(['/usr/local/bin', '/bin', '/usr/bin'])
+    </sconstruct>
 
     <!--
 
@@ -1761,20 +1874,20 @@ for key in keys:
 
       <para>
 
-      You may want to propagate the external &PATH;
+      You may want to propagate the external environment &PATH;
       to the execution environment for commands.
       You do this by initializing the &PATH;
       variable with the &PATH; value from
-      the <literal>os.environ</literal>
+      the <varname>os.environ</varname>
       dictionary,
-      which is Python's way of letting you
+      which is &Python;'s way of letting you
       get at the external environment:
 
       </para>
 
       <sconstruct>
 import os
-env = Environment(ENV = {'PATH' : os.environ['PATH']})
+env = Environment(ENV={'PATH': os.environ['PATH']})
       </sconstruct>
 
       <para>
@@ -1790,7 +1903,7 @@ env = Environment(ENV = {'PATH' : os.environ['PATH']})
 
       <sconstruct>
 import os
-env = Environment(ENV = os.environ)
+env = Environment(ENV=os.environ)
       </sconstruct>
 
       <para>
@@ -1819,12 +1932,13 @@ env = Environment(ENV = os.environ)
 
       One of the most common requirements
       for manipulating a variable in the execution environment
-      is to add one or more custom directories to a search
-      like the <envar>PATH</envar> variable on Linux or POSIX systems,
-      or the <envar>%PATH%</envar> variable on Windows,
+      is to add one or more custom directories to a path search variable
+      like <envar>PATH</envar> on Linux or POSIX systems,
+      or <envar>%PATH%</envar> on Windows,
       so that a locally-installed compiler or other utility
       can be found when &SCons; tries to execute it to update a target.
-      &SCons; provides &PrependENVPath; and &AppendENVPath; functions
+      &SCons; provides &f-link-env-PrependENVPath;
+      and &f-link-env-AppendENVPath; functions
       to make adding things to execution variables convenient.
       You call these functions by specifying the variable
       to which you want the value added,
@@ -1836,7 +1950,7 @@ env = Environment(ENV = os.environ)
       </para>
 
       <sconstruct>
-env = Environment(ENV = os.environ)
+env = Environment(ENV=os.environ)
 env.PrependENVPath('PATH', '/usr/local/bin')
 env.AppendENVPath('LIB', '/usr/local/lib')
       </sconstruct>
@@ -1869,13 +1983,14 @@ env.AppendENVPath('LIB', '/usr/local/lib')
       Normally when using a tool from the construction environment,
       several different search locations are checked by default.
       This includes the <filename>Scons/Tools/</filename> directory
-      inbuilt to scons and the directory <filename>site_scons/site_tools</filename>
+      in the &SCons; distribution and the 
+      directory <filename>site_scons/site_tools</filename>
       relative to the root SConstruct file.
       </para>
 
       <sconstruct>
 # Builtin tool or tool located within site_tools
-env = Environment(tools = ['SomeTool'])
+env = Environment(tools=['SomeTool'])
 env.SomeTool(targets, sources)
 
 # The search locations would include by default
@@ -1892,13 +2007,17 @@ SCons/Tool/SomeTool/__init__.py
 
       <para>
       In some cases you may want to specify a different location to search for tools.
-      The Environment constructor contains an option for this called toolpath
+      The &f-link-Environment; function contains an option for this called
+      <parameter>toolpath</parameter>
       This can be used to add additional search directories.
       </para>
 
       <sconstruct>
 # Tool located within the toolpath directory option
-env = Environment(tools = ['SomeTool'], toolpath = ['/opt/SomeToolPath', '/opt/SomeToolPath2'])
+env = Environment(
+    tools=['SomeTool'],
+    toolpath=['/opt/SomeToolPath', '/opt/SomeToolPath2']
+)
 env.SomeTool(targets, sources)
 
 # The search locations in this example would include:
@@ -1918,16 +2037,22 @@ SCons/Tool/SomeTool/__init__.py
     <title>Nested Tools within a toolpath</title>
 
       <para>
-      &SCons; 3.0 now supports the ability for a Builder to be located
-	  within a sub-directory / sub-package of the toolpath.
-	  This is similar to namespacing within python.
-	  With nested or namespaced tools we can use the dot notation
-	  to specify a sub-directory that the tool is located under.
+
+      Since &SCons; 3.0, a Builder may be located
+      within a sub-directory / sub-package of the toolpath.
+      This is similar to namespacing within &Python;.
+      <!-- TODO: that was an advanced topic!!! -->
+      With nested or namespaced tools we can use the dot notation
+      to specify a sub-directory that the tool is located under.
+
       </para>
 
       <sconstruct>
 # namespaced target
-env = Environment(tools = ['SubDir1.SubDir2.SomeTool'], toolpath = ['/opt/SomeToolPath'])
+env = Environment(
+    tools=['SubDir1.SubDir2.SomeTool'],
+    toolpath=['/opt/SomeToolPath']
+)
 env.SomeTool(targets, sources)
 
 # With this example the search locations would include
@@ -1939,26 +2064,23 @@ SCons/Tool/SubDir1/SubDir2/SomeTool/__init__.py
 ./site_scons/site_tools/SubDir1/SubDir2/SomeTool/__init__.py
       </sconstruct>
 
-      <para>
-      For python2 It's important to note when creating tools within sub-directories,
-      there needs to be a __init__.py file within each directory.
-      This file can just be empty.
-      This is the same constraint used by python when loading modules
-      from within sub-directories (packages).
-      For python3 this appears to be no longer a requirement.
-      </para>
     </section>
 
 	<section>
     <title>Using sys.path within the toolpath</title>
 
       <para>
-      If we want to access tools externally to scons on the sys.path
-      (one example would be tools installed via the pip package manager)
-      One way to do this is to use sys.path with the toolpath.
+      If we want to access tools externally to scons on the
+      <varname>sys.path</varname>
+      (one example would be tools installed via the &Python;
+      <command>pip</command> package manager)
+      One way to do this is to use
+      <varname>sys.path</varname> with the toolpath.
 
-      One thing to watch out for with this approach is that sys.path
-      can sometimes contains paths to .egg files instead of directories.
+      One thing to watch out for with this approach is that
+      <varname>sys.path</varname>
+      can sometimes contains paths to <filename>.egg</filename>
+      files instead of directories.
       So we need to filter those out with this approach.
       </para>
 
@@ -1967,16 +2089,20 @@ SCons/Tool/SubDir1/SubDir2/SomeTool/__init__.py
 
 searchpaths = []
 for item in sys.path:
-    if os.path.isdir(item): searchpaths.append(item)
+    if os.path.isdir(item):
+        searchpaths.append(item)
 
-env = Environment(tools = ['someinstalledpackage.SomeTool'], toolpath = searchpaths)
+env = Environment(
+    tools=['someinstalledpackage.SomeTool'],
+    toolpath=searchpaths
+)
 env.SomeTool(targets, sources)
       </sconstruct>
 
       <para>
-      By using sys.path with the toolpath argument
+      By using <varname>sys.path</varname> with the toolpath argument
       and by using the nested syntax we can have scons search
-      packages installed via pip for Tools.
+      packages installed via <command>pip</command> for Tools.
       </para>
 
 <sconstruct>
@@ -1997,29 +2123,40 @@ C:\Python35\Lib\site-packages\someinstalledpackage\SomeTool\__init__.py
       <para>
       In some cases you may want to use a tool
       located within a installed external pip package.
-      This is possible by the use of sys.path with the toolpath.
+      This is possible by the use of
+      <varname>sys.path</varname> with the toolpath.
       However in that situation you need to provide a prefix to the toolname
-      to indicate where it is located within sys.path
+      to indicate where it is located within <varname>sys.path</varname>.
       </para>
 
       <sconstruct>
 searchpaths = []
 for item in sys.path:
-    if os.path.isdir(item): searchpaths.append(item)
-env = Environment(tools = ['tools_example.subdir1.subdir2.SomeTool'], toolpath = searchpaths)
+    if os.path.isdir(item):
+        searchpaths.append(item)
+env = Environment(
+    tools=['tools_example.subdir1.subdir2.SomeTool'],
+    toolpath=searchpaths
+)
 env.SomeTool(targets, sources)
       </sconstruct>
 
       <para>
-      To avoid the use of a prefix within the name of the tool or filtering sys.path for directories,
-      we can use the <function>PyPackageDir(modulename)</function> function to locate the directory of the python package.
-      <function>PyPackageDir</function> returns a Dir object which represents the path of the directory
+      To avoid the use of a prefix within the name of the tool or filtering
+      <varname>sys.path</varname> for directories,
+      we can use &f-link-PyPackageDir; function to locate the directory of
+      the python package.
+      &f-PyPackageDir; returns a Dir object which represents the path of the
+      directory
       for the python package / module specified as a parameter.
       </para>
 
       <sconstruct>
 # namespaced target using sys.path
-env = Environment(tools = ['SomeTool'], toolpath = [PyPackageDir('tools_example.subdir1.subdir2')])
+env = Environment(
+    tools=['SomeTool'],
+    toolpath=[PyPackageDir('tools_example.subdir1.subdir2')]
+)
 env.SomeTool(targets, sources)
       </sconstruct>
 

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -367,11 +367,11 @@ environment, of directory names, suffixes, etc.
     <listitem>
     <para>
 
-    The <firstterm>external environment</firstterm>
+    The <firstterm>External Environment</firstterm>
     is the set of variables in the user's environment
-    at the time the user runs &SCons;.
-    These variables are available within the &SConscript; files
-    through the Python <literal>os.environ</literal> dictionary.
+    at the time the user runs &SCons;. These variables are not
+    automatically part of an &SCons; build
+    but are available to be examined if needed.
     See <xref linkend="sect-external-environments"></xref>, below.
 
     </para>
@@ -384,7 +384,7 @@ environment, of directory names, suffixes, etc.
     <listitem>
     <para>
 
-    A <firstterm>&consenv;</firstterm>
+    A <firstterm>&ConsEnv;</firstterm>
     is a distinct object created within
     a &SConscript; file and
     which contains values that
@@ -408,7 +408,7 @@ environment, of directory names, suffixes, etc.
     <listitem>
     <para>
 
-    An <firstterm>execution environment</firstterm>
+    An <firstterm>Execution Environment</firstterm>
     is the values that &SCons; sets
     when executing an external
     command (such as a compiler or linker)
@@ -429,7 +429,7 @@ environment, of directory names, suffixes, etc.
   Unlike &Make;,  &SCons; does not automatically
   copy or import values between different environments
   (with the exception of explicit clones of &consenvs;,
-  which inherit values from their parent).
+  which inherit the values from their parent).
   This is a deliberate design choice
   to make sure that builds are,
   by default, repeatable regardless of
@@ -477,8 +477,8 @@ environment, of directory names, suffixes, etc.
   variable settings that
   the user has in force
   when executing &SCons;
-  are available through the normal Python
-  <envar>os.environ</envar>
+  are available in the Python
+  <varname>os.environ</varname>
   dictionary.
   This means that you must add an
   <literal>import os</literal> statement
@@ -491,6 +491,8 @@ environment, of directory names, suffixes, etc.
    <scons_example name="environments_ex1">
      <file name="SConstruct" printme="1">
 import os
+
+print("Shell is", os.environ['SHELL'])
      </file>
      <file name="foo.c">
 int main() { }
@@ -500,7 +502,7 @@ int main() { }
   <para>
 
   More usefully, you can use the
-  <envar>os.environ</envar>
+  <varname>os.environ</varname>
   dictionary in your &SConscript;
   files to initialize &consenvs;
   with values from the user's external environment.
@@ -618,8 +620,9 @@ int main() { }
 
       <para>
 
-      You can fetch individual &consvars;
-      using the normal syntax
+      You can fetch individual values, known as
+      <firstterm>Construction Variables</firstterm>,
+      using the same syntax used
       for accessing individual named items in a Python dictionary:
 
       </para>
@@ -628,14 +631,20 @@ int main() { }
         <file name="SConstruct" printme="1">
 env = Environment()
 print("CC is: %s" % env['CC'])
+print("LATEX is: %s" % env.get('LATEX', None))
         </file>
       </scons_example>
 
       <para>
 
-      This example &SConstruct; file doesn't build anything,
-      but because it's actually a Python script,
-      it will print the value of &cv-link-CC; for us:
+      This example &SConstruct; file doesn't contain instructions
+      for building any targets, but because it's still a valid
+      &SConstruct; it will be evaulated and the Python
+      <function>print</function> calls will output the values
+      of &cv-link-CC; and &cv-link-LATEX; for us (using the
+      <function>.get()</function> method for fetching means
+      we get a default value back, rather than a failure,
+      if the variable is not set):
 
       </para>
 
@@ -650,7 +659,8 @@ print("CC is: %s" % env['CC'])
       attributes.
       If you want to have direct access to only the
       dictionary of &consvars;
-      you can fetch this using the &Dictionary; method:
+      you can fetch this using the &Dictionary; method
+      (although it's rarely necessary to use this method):
 
       </para>
 
@@ -1004,8 +1014,8 @@ env = DefaultEnvironment(tools=['gcc', 'gnulink'],
 
       <scons_example name="environments_ex2">
         <file name="SConstruct" printme="1">
-opt = Environment(CCFLAGS = '-O2')
-dbg = Environment(CCFLAGS = '-g')
+opt = Environment(CCFLAGS='-O2')
+dbg = Environment(CCFLAGS='-g')
 
 opt.Program('foo', 'foo.c')
 
@@ -1035,8 +1045,8 @@ int main() { }
 
       <scons_example name="environments_ex3">
         <file name="SConstruct" printme="1">
-opt = Environment(CCFLAGS = '-O2')
-dbg = Environment(CCFLAGS = '-g')
+opt = Environment(CCFLAGS='-O2')
+dbg = Environment(CCFLAGS='-g')
 
 opt.Program('foo', 'foo.c')
 
@@ -1133,7 +1143,7 @@ int main() { }
       <para>
 
       Like the &Environment; call that creates a construction environment,
-      the &Clone; method takes &consvar; assignments,
+      the &Clone; method takes &consvar; assignment keyword arguments,
       which will override the values in the copied construction environment.
       For example, suppose we want to use &gcc;
       to create three versions of a program,
@@ -1148,9 +1158,9 @@ int main() { }
 
       <scons_example name="environments_ex5">
         <file name="SConstruct" printme="1">
-env = Environment(CC = 'gcc')
-opt = env.Clone(CCFLAGS = '-O2')
-dbg = env.Clone(CCFLAGS = '-g')
+env = Environment(CC='gcc')
+opt = env.Clone(CCFLAGS='-O2')
+dbg = env.Clone(CCFLAGS='-g')
 
 env.Program('foo', 'foo.c')
 
@@ -1189,8 +1199,8 @@ int main() { }
 
       <scons_example name="environments_Replace1">
         <file name="SConstruct" printme="1">
-env = Environment(CCFLAGS = '-DDEFINE1')
-env.Replace(CCFLAGS = '-DDEFINE2')
+env = Environment(CCFLAGS='-DDEFINE1')
+env.Replace(CCFLAGS='-DDEFINE2')
 env.Program('foo.c')
         </file>
         <file name="foo.c">
@@ -1222,8 +1232,8 @@ int main() { }
       <scons_example name="environments_Replace-nonexistent">
         <file name="SConstruct" printme="1">
 env = Environment()
-env.Replace(NEW_VARIABLE = 'xyzzy')
-print("NEW_VARIABLE = %s"%env['NEW_VARIABLE'])
+env.Replace(NEW_VARIABLE='xyzzy')
+print("NEW_VARIABLE = %s" % env['NEW_VARIABLE'])
         </file>
       </scons_example>
 
@@ -1257,12 +1267,12 @@ print("NEW_VARIABLE = %s"%env['NEW_VARIABLE'])
 
       <scons_example name="environments_Replace2">
         <file name="SConstruct" printme="1">
-env = Environment(CCFLAGS = '-DDEFINE1')
-print("CCFLAGS = %s"%env['CCFLAGS'])
+env = Environment(CCFLAGS='-DDEFINE1')
+print("CCFLAGS = %s" % env['CCFLAGS'])
 env.Program('foo.c')
 
-env.Replace(CCFLAGS = '-DDEFINE2')
-print("CCFLAGS = %s"%env['CCFLAGS'])
+env.Replace(CCFLAGS='-DDEFINE2')
+print("CCFLAGS = %s" % env['CCFLAGS'])
 env.Program('bar.c')
         </file>
         <file name="foo.c">
@@ -1320,7 +1330,7 @@ int main() { }
       </para>
 
       <sconstruct>
-env.SetDefault(SPECIAL_FLAG = '-extra-option')
+env.SetDefault(SPECIAL_FLAG='-extra-option')
       </sconstruct>
 
       <para>
@@ -1538,6 +1548,79 @@ env.PrependUnique(CCFLAGS=['-g'])
 
       </para>
 
+      </section>
+
+      <section>
+      <title>Overriding Construction Variable Settings</title>
+
+      <para>
+
+      Rather than creating a cloned environmant for specific tasks,
+      you can <firstterm>override</firstterm> or add construction variables
+      when calling a builder method by passing them as keyword arguments.
+      The values of these overridden or added variables will only be in
+      effect when building that target, and will not affect other parts
+      of the build.
+      For example, if you want to add additional libraries for just one program:
+
+      </para>
+
+      <programlisting>
+env.Program('hello', 'hello.c', LIBS=['gl', 'glut'])
+      </programlisting>
+
+      <para>
+
+      or generate a shared library with a non-standard suffix:
+
+      </para>
+
+      <programlisting>
+env.SharedLibrary(
+    target='word',
+    source='word.cpp',
+    SHLIBSUFFIX='.ocx',
+    LIBSUFFIXES=['.ocx'],
+)
+      </programlisting>
+
+      <para>
+
+      When overriding this way, the Python-style keyword arguments
+      mean "set to this value".  If you want your override to augment
+      an existing value, you have to take some extra steps. XXX
+
+      </para>
+
+      <para>
+
+      It is also possible to use the <parameter>parse_flags</parameter>
+      keyword argument in an override to merge command-line
+      style arguments into the appropriate construction
+      variables. This works like the &f-link-env-MergeFlags; method,
+      which will be described later.
+
+      </para>
+
+      <para>
+
+      This example adds 'include' to &cv-link-CPPPATH;,
+      'EBUG' to &cv-link-CPPDEFINES;, and 'm' to &cv-link-LIBS;:
+
+      </para>
+
+      <programlisting>
+env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
+      </programlisting>
+
+      <para>
+
+      Using temporary overrides this way is lighter weight than making
+      a full construction environment, so it can help performance in
+      large projects which have lots of special case values to set.
+
+      </para>
+
     </section>
 
   </section>
@@ -1737,7 +1820,7 @@ env = Environment(ENV = os.environ)
       One of the most common requirements
       for manipulating a variable in the execution environment
       is to add one or more custom directories to a search
-      like the <envar>$PATH</envar> variable on Linux or POSIX systems,
+      like the <envar>PATH</envar> variable on Linux or POSIX systems,
       or the <envar>%PATH%</envar> variable on Windows,
       so that a locally-installed compiler or other utility
       can be found when &SCons; tries to execute it to update a target.

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -477,9 +477,10 @@ environment, of directory names, suffixes, etc.
     we need to talk a little bit about the &Python; dictionary data type.
     A dictionary (also known by terms such as mapping, associative array
     and key-value store) associates keys with values, such
-    that accessing the dict by key gives you back the associated value;
-    setting by key creates the association (and replaces any
-    previous association for that key).
+    that asking the dict about a key gives you back the associated value
+    and assigning to a key creates the association - either a new
+    setting if the key was unknown, or replacing the previous
+    previous association if the key was already in the dict.
     Accessing can be done by using <literal>[]</literal>
     indexing notation, and dictionaries also provide a
     method named <methodname>get</methodname> which responds
@@ -487,7 +488,8 @@ environment, of directory names, suffixes, etc.
     you supply) if the key is not in the dictionary, which
     avoids failing in that case.  The syntax
     for a dictionary itself uses curly braces (<literal>{}</literal>).
-    Here are some simple examples using syntax that indicates
+    Here are some simple examples (inspired by those in the official
+    Python tutorial) using syntax that indicates
     interacting with the &Python; interpreter
     (<prompt>&gt;&gt;&gt;</prompt> is the interpreter prompt) -
     you can try these out:
@@ -515,7 +517,7 @@ None
 
     <para>
 
-    The &consenv; is written to behave like a &Python;
+    &Consenvs; are written to behave like a &Python;
     dictionary, and the &cv-ENV; construction variable in
     a &consenv; <emphasis>is</emphasis> a &Python; dictionary.
     The <varname>os.environ</varname> value that &Python; uses
@@ -537,8 +539,10 @@ None
   when executing &SCons;
   are available in the &Python;
   <varname>os.environ</varname>
-  dictionary.
-  This means that you must add an
+  dictionary. That syntax means the <varname>environ</varname>
+  attribute of the <systemitem>os</systemitem> module.
+  In Python, to access contents of a module you must first
+  <literal>import</literal> it - so you would include the
   <literal>import os</literal> statement
   to any &SConscript; file
   in which you want to use
@@ -587,7 +591,7 @@ void main() { }
       that control how the software is built.
       A &consenv; is an object
       that has a number of associated
-      &consvars;, each with a name and a value.
+      &consvars;, each with a name and a value, just like a dictionary.
       (A construction environment also has an attached
       set of &Builder; methods,
       about which we'll learn more later.)
@@ -652,7 +656,7 @@ int main() { }
         construction variable values,
         except that the user has explicitly specified use of the
         GNU C compiler &gcc;,
-        and further specifies that the <option>-O2</option>
+        and that the <option>-O2</option>
         (optimization level two)
         flag should be used when compiling the object file.
         In other words, the explicit initializations of
@@ -1144,8 +1148,8 @@ int main() { }
 
       <scons_example name="environments_ex4">
         <file name="SConstruct" printme="1">
-opt = Environment(CCFLAGS = '-O2')
-dbg = Environment(CCFLAGS = '-g')
+opt = Environment(CCFLAGS='-O2')
+dbg = Environment(CCFLAGS='-g')
 
 o = opt.Object('foo-opt', 'foo.c')
 opt.Program(o)

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -697,7 +697,7 @@ print("LATEX is: %s" % env.get('LATEX', None))
 
       This example &SConstruct; file doesn't contain instructions
       for building any targets, but because it's still a valid
-      &SConstruct; it will be evaulated and the &Python;
+      &SConstruct; it will be evaluated and the &Python;
       <function>print</function> calls will output the values
       of &cv-link-CC; and &cv-link-LATEX; for us (remember using the
       <methodname>.get()</methodname> method for fetching means
@@ -1761,7 +1761,7 @@ void main() {
       from which you called &SCons;.
       This means that &SCons; might not
       necessarily find all of the tools
-      that you can successfully execute from the command line yourself.
+      that you can successfully execute from the command line.
 
     </para>
 

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -1741,7 +1741,7 @@ void main() {
       it does not execute the commands with
       the external environment
       that you used to execute &SCons;.
-      Instead, it builds an exection environment from the values
+      Instead, it builds an execution environment from the values
       stored in the &cv-link-ENV; &consvar;
       and uses that for executing commands.
 

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -878,7 +878,7 @@ scons: `.' is up to date.
 
       If a problem occurs when expanding a construction variable,
       by default it is expanded to <literal>''</literal>
-      (an empty string), and will not cause scons to fail.
+      (an empty string), and will not cause &scons; to fail.
       </para>
 
        <scons_example name="environments_missing1">
@@ -900,9 +900,9 @@ print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
       which of these exceptions are actually fatal and which are
       allowed to occur safely.   By default, &NameError; and &IndexError;
       are the two exceptions that are allowed to occur: so instead of
-      causing scons to fail, these are caught, the variable expanded to
+      causing &scons; to fail, these are caught, the variable expanded to
       <literal>''</literal>
-      and scons execution continues.
+      and &scons; execution continues.
       To require that all construction variable names exist, and that
       indexes out of range are not allowed, call &AllowSubstExceptions;
       with no extra arguments.
@@ -1054,7 +1054,6 @@ env = DefaultEnvironment(tools=['gcc', 'gnulink'],
     </section>
 
     <section id='multiple_construction_envs'>
-
     <title>Multiple &ConsEnvs;</title>
 
       <para>
@@ -1986,10 +1985,10 @@ env.AppendENVPath('LIB', '/usr/local/lib')
       <para>
       Normally when using a tool from the construction environment,
       several different search locations are checked by default.
-      This includes the <filename>Scons/Tools/</filename> directory
-      in the &SCons; distribution and the 
-      directory <filename>site_scons/site_tools</filename>
-      relative to the root SConstruct file.
+      This includes the <filename>SCons/Tools/</filename> directory
+      that is part of the &scons; distribution
+      and the directory <filename>site_scons/site_tools</filename>
+      relative to the root &SConstruct; file.
       </para>
 
       <sconstruct>
@@ -2037,7 +2036,7 @@ SCons/Tool/SomeTool/__init__.py
 
     </section>
 
-	<section>
+    <section>
     <title>Nested Tools within a toolpath</title>
 
       <para>
@@ -2070,16 +2069,14 @@ SCons/Tool/SubDir1/SubDir2/SomeTool/__init__.py
 
     </section>
 
-	<section>
+    <section>
     <title>Using sys.path within the toolpath</title>
 
       <para>
-      If we want to access tools externally to scons on the
-      <varname>sys.path</varname>
-      (one example would be tools installed via the &Python;
-      <command>pip</command> package manager)
-      One way to do this is to use
-      <varname>sys.path</varname> with the toolpath.
+      If we want to access tools external to &scons; which are findable
+      via <varname>sys.path</varname>
+      (for example, tools installed via Python's <command>pip</command> package manager),
+      it is possible to use <varname>sys.path</varname> with the toolpath.
 
       One thing to watch out for with this approach is that
       <varname>sys.path</varname>
@@ -2105,7 +2102,7 @@ env.SomeTool(targets, sources)
 
       <para>
       By using <varname>sys.path</varname> with the toolpath argument
-      and by using the nested syntax we can have scons search
+      and by using the nested syntax we can have &scons; search
       packages installed via <command>pip</command> for Tools.
       </para>
 

--- a/doc/user/less-simple.xml
+++ b/doc/user/less-simple.xml
@@ -189,7 +189,7 @@ void file2() { printf("file2.c\n"); }
     (&SCons; puts the output file name to the left
     of the source file names
     so that the order mimics that of an
-    assignment statement:  "program = source files".)
+    assignment statement:  <literal>program = source files</literal>.)
     This makes our example:
 
     </para>
@@ -462,10 +462,8 @@ Program('program', src_files)
 
     &SCons; also allows you to identify
     the output file and input source files
-    using Python keyword arguments.
-    The output file keyword is
-    <parameter>target</parameter>,
-    and the source file(s) keyword is (logically enough)
+    using Python keyword arguments
+    <parameter>target</parameter> and
     <parameter>source</parameter>.
     The Python syntax for this is:
 

--- a/doc/user/less-simple.xml
+++ b/doc/user/less-simple.xml
@@ -463,30 +463,30 @@ Program('program', src_files)
     &SCons; also allows you to identify
     the output file and input source files
     using Python keyword arguments.
-    The output file is known as the
-    <emphasis>target</emphasis>,
-    and the source file(s) are known (logically enough) as the
-    <emphasis>source</emphasis>.
+    The output file keyword is
+    <parameter>target</parameter>,
+    and the source file(s) keyword is (logically enough)
+    <parameter>source</parameter>.
     The Python syntax for this is:
 
     </para>
 
     <programlisting>
 src_files = Split('main.c file1.c file2.c')
-Program(target = 'program', source = src_files)
+Program(target='program', source=src_files)
     </programlisting>
 
     <para>
 
     Because the keywords explicitly identify
-    what each argument is,
-    you can actually reverse the order if you prefer:
+    what each argument is, the order does
+    not matter and you can reverse it if you prefer:
 
     </para>
 
     <programlisting>
 src_files = Split('main.c file1.c file2.c')
-Program(source = src_files, target = 'program')
+Program(source=src_files, target='program')
     </programlisting>
 
     <para>
@@ -641,65 +641,6 @@ Program('bar', bar_files)
     <para>
 
     This is functionally equivalent to the previous example.
-
-    </para>
-
-  </section>
-
-  <section>
-  <title>Overriding construction variables when calling a Builder</title>
-
-    <para>
-
-    It is possible to override or add construction variables
-    when calling a builder method by passing additional keyword arguments.
-    These overridden or added variables will only be in effect when
-    building the target, so they will not affect other parts of the build.
-    For example, if you want to add additional libraries for just one program:
-
-    </para>
-
-    <programlisting>
-env.Program('hello', 'hello.c', LIBS=['gl', 'glut'])
-    </programlisting>
-
-    <para>
-
-    or generate a shared library with a non-standard suffix:
-
-    </para>
-
-    <programlisting>
-env.SharedLibrary('word', 'word.cpp',
-                  SHLIBSUFFIX='.ocx',
-                  LIBSUFFIXES=['.ocx'])
-    </programlisting>
-
-    <para>
-
-    It is also possible to use the <literal>parse_flags</literal>
-    keyword argument in an override to merge command-line
-    style arguments into the appropriate construction
-    variables (see &f-link-env-MergeFlags;).
-
-    </para>
-
-    <para>
-
-    This example adds 'include' to &cv-link-CPPPATH;,
-    'EBUG' to &cv-link-CPPDEFINES;, and 'm' to &cv-link-LIBS;.
-
-    </para>
-
-    <programlisting>
-env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
-    </programlisting>
-
-    <para>
-
-    Within the call to the builder action the environment is not cloned,
-    instead an OverrideEnvironment() is created which is more
-    light weight than a whole Environment()
 
     </para>
 

--- a/doc/user/main.xml
+++ b/doc/user/main.xml
@@ -87,14 +87,14 @@
     (brief) overview of *what* these functions do to decide if this
     chapter is where they should read in more detail.  -->
     <para>
-    This chapter describes the &MergeFlags;, &ParseFlags;, and &ParseConfig; methods of a &consenv;.
+    This chapter describes the &MergeFlags;, &ParseFlags;, and &ParseConfig;
+    methods of a &consenv;, as well as the <parameter>parse_flags</parameter>
+    keyword argument to methods that construct environments.
     </para>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="mergeflags.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="parse_flags_arg.xml"/>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="parseflags.xml"/>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="parseconfig.xml"/>
-    <!--
-    XXX parse_flags= option of Environment()
-    -->
   </chapter>
 
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="output.xml"/>

--- a/doc/user/mergeflags.xml
+++ b/doc/user/mergeflags.xml
@@ -46,21 +46,26 @@
 
  <para>
 
- &SCons; construction environments have a &MergeFlags; method
- that merges a dictionary of values into the construction environment.
+ &SCons; &consenvs; have an &f-link-env-MergeFlags; method
+ that merges values from a passed-in argument into the &consenv;
+ If the argument is a dictionary,
  &MergeFlags; treats each value in the dictionary
  as a list of options such as one might pass to a command
  (such as a compiler or linker).
  &MergeFlags; will not duplicate an option
  if it already exists in the construction environment variable.
+ If the argument is a string, &MergeFlags; calls the
+ &f-link-env-ParseFlags; method to burst it out into a 
+ dictionary first, then acts on the result.
 
  </para>
 
  <para>
 
- &MergeFlags; tries to be intelligent about merging options.
+ &MergeFlags; tries to be intelligent about merging options,
+ knowing that different &consvars; may have different needs.
  When merging options to any variable
- whose name ends in <varname>PATH</varname>,
+ whose name ends in <literal>PATH</literal>,
  &MergeFlags; keeps the leftmost occurrence of the option,
  because in typical lists of directory paths,
  the first occurrence "wins."
@@ -74,8 +79,8 @@
  <scons_example name="mergeflags_MergeFlags1">
    <file name="SConstruct" printme="1">
 env = Environment()
-env.Append(CCFLAGS = '-option -O3 -O1')
-flags = { 'CCFLAGS' : '-whatever -O3' }
+env.Append(CCFLAGS='-option -O3 -O1')
+flags = {'CCFLAGS': '-whatever -O3'}
 env.MergeFlags(flags)
 print(env['CCFLAGS'])
    </file>
@@ -101,8 +106,8 @@ print(env['CCFLAGS'])
  <scons_example name="mergeflags_MergeFlags2">
    <file name="SConstruct" printme="1">
 env = Environment()
-env.Append(CPPPATH = ['/include', '/usr/local/include', '/usr/include'])
-flags = { 'CPPPATH' : ['/usr/opt/include', '/usr/local/include'] }
+env.Append(CPPPATH=['/include', '/usr/local/include', '/usr/include'])
+flags = {'CPPPATH': ['/usr/opt/include', '/usr/local/include']}
 env.MergeFlags(flags)
 print(env['CPPPATH'])
    </file>
@@ -135,8 +140,8 @@ print(env['CPPPATH'])
  <scons_example name="mergeflags_MergeFlags3">
    <file name="SConstruct" printme="1">
 env = Environment()
-env.Append(CCFLAGS = '-option -O3 -O1')
-env.Append(CPPPATH = ['/include', '/usr/local/include', '/usr/include'])
+env.Append(CCFLAGS='-option -O3 -O1')
+env.Append(CPPPATH=['/include', '/usr/local/include', '/usr/include'])
 env.MergeFlags('-whatever -I/usr/opt/include -O3 -I/usr/local/include')
 print(env['CCFLAGS'])
 print(env['CPPPATH'])

--- a/doc/user/parse_flags_arg.xml
+++ b/doc/user/parse_flags_arg.xml
@@ -17,7 +17,7 @@
          xmlns="http://www.scons.org/dbxsd/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
-<title>Merging Options the Environment: the <parameter>merge_flags</parameter> Parameter</title>
+<title>Merging Options into the Environment: the <parameter>merge_flags</parameter> Parameter</title>
 
 <!--
 
@@ -52,7 +52,9 @@
  is given, its value is distributed to &consvars; in the
  new environment in the same way as
  described for the &MergeFlags; method.
- This also works when calling &f-link-env-Clone;.
+ This also works when calling &f-link-env-Clone;,
+ as well as in overrides to builder methods
+ (see <xref linkend="builder_overrides"/>).
 
  </para>
 

--- a/doc/user/parse_flags_arg.xml
+++ b/doc/user/parse_flags_arg.xml
@@ -1,0 +1,75 @@
+<?xml version='1.0'?>
+<!DOCTYPE sconsdoc [
+    <!ENTITY % scons SYSTEM "../scons.mod">
+    %scons;
+
+    <!ENTITY % builders-mod SYSTEM "../generated/builders.mod">
+    %builders-mod;
+    <!ENTITY % functions-mod SYSTEM "../generated/functions.mod">
+    %functions-mod;
+    <!ENTITY % tools-mod SYSTEM "../generated/tools.mod">
+    %tools-mod;
+    <!ENTITY % variables-mod SYSTEM "../generated/variables.mod">
+    %variables-mod;
+]>
+
+<section id="sect-parse_flags_"
+         xmlns="http://www.scons.org/dbxsd/v1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+<title>Merging Options the Environment: the <parameter>merge_flags</parameter> Parameter</title>
+
+<!--
+
+  __COPYRIGHT__
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-->
+
+ <para>
+
+ It is also possible to merge &consvar; values from arguments
+ given to the &f-link-Environment; call itself.
+ If the <parameter>parse_flags</parameter> keyword argument
+ is given, its value is distributed to &consvars; in the
+ new environment in the same way as
+ described for the &MergeFlags; method.
+ This also works when calling &f-link-env-Clone;.
+
+ </para>
+
+ <scons_example name="parse_flags_ex1">
+   <file name="SConstruct" printme="1">
+env = Environment(parse_flags="-I/opt/include -L/opt/lib -lfoo")
+for k in ('CPPPATH', 'LIBPATH', 'LIBS'):
+    print("%s:" % k, env.get(k))
+env.Program("f1.c")
+   </file>
+   <file name="f1.c">
+int main() { return 0; }
+   </file>
+ </scons_example>
+
+ <scons_output example="parse_flags_ex1" os="posix" suffix="1">
+    <scons_output_command>scons -Q</scons_output_command>
+ </scons_output>
+
+</section>

--- a/doc/user/parseflags.xml
+++ b/doc/user/parseflags.xml
@@ -46,7 +46,7 @@
 
  <para>
 
- &SCons; has a bewildering array of construction variables
+ &SCons; has a bewildering array of &consvars;
  for different types of options when building programs.
  Sometimes you may not know exactly which variable
  should be used for a particular option.
@@ -55,10 +55,10 @@
 
  <para>
 
- &SCons; construction environments have a &ParseFlags; method
+ &SCons; &consenvs; have a &f-link-env-ParseFlags; method
  that takes a set of typical command-line options
  and distributes them into the appropriate construction variables.
- Historically, it was created to support the &ParseConfig; method,
+ Historically, it was created to support the &f-link-env-ParseConfig; method,
  so it focuses on options used by the GNU Compiler Collection (GCC)
  for the C and C++ toolchains.
 
@@ -68,7 +68,7 @@
 
  &ParseFlags; returns a dictionary containing the options
  distributed into their respective construction variables.
- Normally, this dictionary would be passed to &MergeFlags;
+ Normally, this dictionary would then be passed to &MergeFlags;
  to merge the options into a &consenv;,
  but the dictionary can be edited if desired to provide
  additional functionality.
@@ -128,7 +128,7 @@ env.MergeFlags(d)
 env.Program("f1.c")
    </file>
    <file name="f1.c">
- int main() { return 0; }
+void main() { return 0; }
    </file>
  </scons_example>
 
@@ -154,7 +154,7 @@ env.MergeFlags(d)
 env.Program("f1.c")
    </file>
    <file name="f1.c">
-int main() { return 0; }
+void main() { return 0; }
    </file>
  </scons_example>
 
@@ -164,7 +164,8 @@ int main() { return 0; }
 
  <para>
 
- If a string begins with a "!" (an exclamation mark, often called a bang),
+ If a string begins with a an exclamation mark (<literal>!</literal>,
+ sometimes also called a bang),
  the string is passed to the shell for execution.
  The output of the command is then parsed:
 
@@ -181,7 +182,7 @@ env.MergeFlags(d)
 env.Program("f1.c")
    </file>
    <file name="f1.c">
-int main() { return 0; }
+void main() { return 0; }
    </file>
  </scons_example>
 


### PR DESCRIPTION
Adds a new uguide Ch 7 section on using the `parse_flags` kwarg (with Example)

Moves the section on overrides in calls to Builders to Chap 7   it was using concepts not introduced yet where it was placed. Markup changes and wording tweaks.  A lightning intro to Python dictionaries is now included.

Does the manpage need to mention this in more detail than currently?

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
