### PR TITLE
added SOVERSION for symlinked library generation from just a version number

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,7 +32,7 @@ RELEASE 4.0.1 - Mon, 16 Jul 2020 16:06:40 -0700
 
   From Daniel Moody:
     - Added method on Node to test if its node used in SConf. (Github Issue #3626)
-
+    - Added SOVERSION to configure the SONAME just by version number (Github Issue #3247)
 
 
 RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,8 @@ RELEASE 4.0.1 - Mon, 16 Jul 2020 16:06:40 -0700
     - Added Environment() variable TEMPFILEDIR which allows setting the directory which temp
       files createdby TEMPFILEMUNGE are created in.
 
+  From Daniel Moody:
+    - Added SOVERSION to configure the SONAME just by version number (Github Issue #3247)
 
 
 RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000
@@ -53,7 +55,7 @@ RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000
 
   From Joseph Brill:
     - MSVC updates: When there are multiple product installations (e.g, Community and
-      Build Tools) of MSVC 2017 or MSVC 2019, an Enterprise, Professional, 
+      Build Tools) of MSVC 2017 or MSVC 2019, an Enterprise, Professional,
       or Community installation will be selected before a Build Tools installation when
       "14.1" or "14.2" is requested, respectively. (GH Issue #3699).
     - MSVC updates: When there are multiple product installations of MSVC 2017 (e.g.,
@@ -67,7 +69,7 @@ RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000
     - Test update: Reduce the number of "false negative" test failures for the interactive
       configuration test (test/interactive/configure.py).
     - MSVS update: Fix the development environment path for MSVS 7.0.
- 
+
   From William Deegan:
     - Fix broken clang + MSVC 2019 combination by using MSVC configuration logic to
       propagate'VCINSTALLDIR' and 'VCToolsInstallDir' which clang tools use to locate
@@ -84,9 +86,9 @@ RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000
     - Add msys2 installed mingw default path to PATH for mingw tool.
       - C:\msys64\mingw64\bin
     - Purge obsolete internal build and tooling scripts
-    - Allow user specified location for vswhere.exe specified by VSWHERE. 
+    - Allow user specified location for vswhere.exe specified by VSWHERE.
       NOTE: This must be set at the time the 'msvc' 'msvs' and/or 'mslink' tool(s) are initialized to have any effect.
-    - Resolve Issue #3451 and Issue #3450 - Rewrite SCons setup.py and packaging. Move script logic to entry points so 
+    - Resolve Issue #3451 and Issue #3450 - Rewrite SCons setup.py and packaging. Move script logic to entry points so
       package can create scripts which use the correct version of Python.
     - Resolve Issue #3248 - Removing '-Wl,-Bsymbolic' from SHLIBVERSIONFLAGS
       NOTE: If your build depends on the above you must now add to your SHLIBVERSIONFLAGS
@@ -140,16 +142,16 @@ RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000
       that instructs scons to use single line drawing characters to draw the dependency tree.
 
   From Daniel Moody:
-    - Add no_progress (-Q) option as a set-able option. However, setting it in the 
+    - Add no_progress (-Q) option as a set-able option. However, setting it in the
       SConstruct/SConscript will still cause "scons: Reading SConscript files ..." to be
       printed, since the option is not set when the build scripts first get read.
     - Added check for SONAME in environment to setup symlinks correctly (Github Issue #3246)
-    - User callable's called during substition expansion could possibly throw a TypeError 
-      exception, however SCons was using TypeError to detect if the callable had a different 
-      signature than expected, and would silently fail to report user's exceptions. Fixed to 
+    - User callable's called during substition expansion could possibly throw a TypeError
+      exception, however SCons was using TypeError to detect if the callable had a different
+      signature than expected, and would silently fail to report user's exceptions. Fixed to
       use signature module to detect function signature instead of TypeError. (Github Issue #3654)
     - Added storage of SConstructs and SConscripts nodes into global set for checking
-      if a given node is a SConstruct/SConscript. 
+      if a given node is a SConstruct/SConscript.
       Added new node function SCons.Node.is_sconscript(self) (Github Issue #3625)
 
   From Andrew Morrow:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,11 +28,11 @@ RELEASE 4.0.1 - Mon, 16 Jul 2020 16:06:40 -0700
 
   From William Deegan:
     - Added Environment() variable TEMPFILEDIR which allows setting the directory which temp
-      files createdby TEMPFILEMUNGE are created in.
+      files created by TEMPFILEMUNGE are created in.
 
   From Daniel Moody:
     - Added method on Node to test if its node used in SConf. (Github Issue #3626)
-
+    - Added SOVERSION to configure the SONAME just by version number (Github Issue #3247)
 
 
 RELEASE 4.0.0 - Sat, 04 Jul 2020 12:00:27 +0000

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -448,7 +448,7 @@ class _ImpLibInfoSupport:
 
 class _LibInfoGeneratorBase:
     """Generator base class for library-related info such as suffixes for
-    versioned libraries, symlink maps, sonames etc. It handles commonalties
+    versioned libraries, symlink maps, sonames etc. It handles commonalities
     of SharedLibrary and LoadableModule
     """
     _support_classes = {'ShLib': _ShLibInfoSupport,

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -673,14 +673,10 @@ class _LibSonameGenerator(_LibInfoGeneratorBase):
     """Library soname generator. Returns library soname (e.g. libfoo.so.0) for
     a given node (e.g. /foo/bar/libfoo.so.0.1.2)"""
 
-    def __init__(self, libtype=None):
+    def __init__(self, libtype):
         super(_LibSonameGenerator, self).__init__(libtype, 'Soname')
 
-    def __call__(self, env, libnode, *args, **kw):
-        # we can differentiate the type of this generator at the call time
-        # allowing us to decide this information during subst expansion
-        self.libtype = kw.get('libtype', self.libtype)
-
+    def __call__(self, env, libnode, **kw):
         """Returns a SONAME based on a shared library's node path"""
         Verbose = False
 

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -676,7 +676,7 @@ class _LibSonameGenerator(_LibInfoGeneratorBase):
     def __init__(self, libtype):
         super(_LibSonameGenerator, self).__init__(libtype, 'Soname')
 
-    def __call__(self, env, libnode, **kw):
+    def __call__(self, env, libnode, *args, **kw):
         """Returns a SONAME based on a shared library's node path"""
         Verbose = False
 

--- a/SCons/Tool/applelink.py
+++ b/SCons/Tool/applelink.py
@@ -39,8 +39,6 @@ import SCons.Util
 # the -rpath option, so we use the "link" tool instead of "gnulink".
 from . import link
 
-from SCons.Tool import ShLibSonameGenerator
-
 class AppleLinkInvalidCurrentVersionException(Exception):
     pass
 
@@ -71,12 +69,7 @@ def _applelib_versioned_lib_soname(env, libnode, version, prefix, suffix, name_f
         print("_applelib_versioned_lib_soname: name={!r}".format(name))
     major = version.split('.')[0]
     (libname,_suffix) = name.split('.')
-    # if a desired SONAME was supplied, use that, otherwise create 
-    # a default from the major version
-    if env.get('SONAME'):
-        soname = ShLibSonameGenerator(env, libnode)
-    else:
-        soname = '.'.join([libname, major, _suffix])
+    soname = '.'.join([libname, major, _suffix])
     if Verbose:
         print("_applelib_versioned_lib_soname: soname={!r}".format(soname))
     return soname
@@ -192,7 +185,7 @@ def generate(env):
 
 
     # see: http://docstore.mik.ua/orelly/unix3/mac/ch05_04.htm  for proper naming
-    link._setup_versioned_lib_variables(env, tool = 'applelink')#, use_soname = use_soname)
+    link._setup_versioned_lib_variables(env, tool = 'applelink', use_soname = True)
     env['LINKCALLBACKS'] = link._versioned_lib_callbacks()
     env['LINKCALLBACKS']['VersionedShLibSuffix'] = _applelib_versioned_lib_suffix
     env['LINKCALLBACKS']['VersionedShLibSoname'] = _applelib_versioned_shlib_soname
@@ -205,8 +198,8 @@ def generate(env):
     # override the default for loadable modules, which are different
     # on OS X than dynamic shared libs.  echoing what XCode does for
     # pre/suffixes:
-    env['LDMODULEPREFIX'] = '' 
-    env['LDMODULESUFFIX'] = '' 
+    env['LDMODULEPREFIX'] = ''
+    env['LDMODULESUFFIX'] = ''
     env['LDMODULEFLAGS'] = SCons.Util.CLVar('$LINKFLAGS -bundle')
     env['LDMODULECOM'] = '$LDMODULE -o ${TARGET} $LDMODULEFLAGS $SOURCES $_LIBDIRFLAGS $_LIBFLAGS $_FRAMEWORKPATH $_FRAMEWORKS $FRAMEWORKSFLAGS'
 

--- a/SCons/Tool/applelink.py
+++ b/SCons/Tool/applelink.py
@@ -74,12 +74,15 @@ def _applelib_versioned_lib_soname(env, libnode, version, prefix, suffix, name_f
         print("_applelib_versioned_lib_soname: soname={!r}".format(soname))
     return soname
 
+
 def _applelib_versioned_shlib_soname(env, libnode, version, prefix, suffix):
     return _applelib_versioned_lib_soname(env, libnode, version, prefix, suffix, link._versioned_shlib_name)
 
 
 # User programmatically describes how SHLIBVERSION maps to values for compat/current.
 _applelib_max_version_values = (65535, 255, 255)
+
+
 def _applelib_check_valid_version(version_string):
     """
     Check that the version # is valid.

--- a/SCons/Tool/link.py
+++ b/SCons/Tool/link.py
@@ -46,8 +46,6 @@ from SCons.Tool.DCommon import isD
 
 from SCons.Tool.cxx import iscplusplus
 
-from SCons.Tool import ShLibSonameGenerator
-
 issued_mixed_link_warning = False
 
 
@@ -175,13 +173,7 @@ def _versioned_lib_soname(env, libnode, version, prefix, suffix, name_func):
     if Verbose:
         print("_versioned_lib_soname: name={!r}".format(name))
     major = version.split('.')[0]
-
-    # if a desired SONAME was supplied, use that, otherwise create 
-    # a default from the major version
-    if env.get('SONAME'):
-        soname = ShLibSonameGenerator(env, libnode)
-    else:
-        soname = name + '.' + major
+    soname = name + '.' + major
     if Verbose:
         print("_versioned_lib_soname: soname={!r}".format(soname))
     return soname
@@ -243,17 +235,14 @@ def _versioned_lib_symlinks(env, libnode, version, prefix, suffix, name_func, so
 
 def _versioned_shlib_symlinks(env, libnode, version, prefix, suffix):
     name_func = env['LINKCALLBACKS']['VersionedShLibName']
-    soname_func = env['LINKCALLBACKS']['VersionedShLibSoname']
+    soname_func = env['ShLibSonameGenerator']
 
     return _versioned_lib_symlinks(env, libnode, version, prefix, suffix, name_func, soname_func)
 
 
 def _versioned_ldmod_symlinks(env, libnode, version, prefix, suffix):
-    name_func = _versioned_ldmod_name
-    soname_func = _versioned_ldmod_soname
-
     name_func = env['LINKCALLBACKS']['VersionedLdModName']
-    soname_func = env['LINKCALLBACKS']['VersionedLdModSoname']
+    soname_func = env['LdModSonameGenerator']
 
     return _versioned_lib_symlinks(env, libnode, version, prefix, suffix, name_func, soname_func)
 

--- a/SCons/Tool/link.xml
+++ b/SCons/Tool/link.xml
@@ -396,8 +396,10 @@ The variable is used by linker tools which use the &t-link-link; tool such as &t
 <para>
 Simlar to &cv-link-SONAME; but only modifies the version number, and not the name, suffix or prefix of a versioned shared library/loadable module.  This can not be used in the same environment as &cv-link-SONAME; because it would be ambiguous as to what the SONAME should be.
 <example_commands>
-env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SOVERSION='2')
+env.SharedLibrary('test', 'test.c', SHLIBVERSION='3.4.1', SOVERSION='4')
 </example_commands>
+The previous example on linux for instance, will create a library named 'libtest.so.3.4.1' and a symlink to that library called 'libtest.so.4'. It will only make major version number symlinks. For example setting SOVERSION to '4.2' in the previous example command does not give symliked library 'litest.so.4.2', just 'libtest.so.4'.
+
 The variable is used by linker tools which use the &t-link-link; tool such as &t-link-gnulink; or &t-link-applelink;.
 </para>
 </summary>

--- a/SCons/Tool/link.xml
+++ b/SCons/Tool/link.xml
@@ -152,7 +152,7 @@ to <literal>'.dll'</literal>.
 <cvar name="IMPLIBNOVERSIONSYMLINKS">
 <summary>
 <para>
-Used to override &cv-link-SHLIBNOVERSIONSYMLINKS;/&cv-link-LDMODULENOVERSIONSYMLINKS; when 
+Used to override &cv-link-SHLIBNOVERSIONSYMLINKS;/&cv-link-LDMODULENOVERSIONSYMLINKS; when
 creating versioned import library for a shared library/loadable module. If not defined,
 then &cv-link-SHLIBNOVERSIONSYMLINKS;/&cv-link-LDMODULENOVERSIONSYMLINKS; is used to determine
 whether to disable symlink generation or not.
@@ -378,11 +378,27 @@ See also &cv-link-LINKFLAGS;  for linking static objects.
 <cvar name="SONAME">
 <summary>
 <para>
-Variable used to hard-code SONAME for versioned shared library/loadable module.
+Variable used to hard-code SONAME for versioned shared library/loadable module. This can not be used in the same environment as &cv-link-SOVERSION; because it would be ambiguous as to what the SONAME should be.
 <example_commands>
-env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SONAME='libtest.so.2')
+env.SharedLibrary(
+  'test',
+  'test.c',
+  SHLIBVERSION='0.1.2',
+  SONAME='libtest.so.2')
 </example_commands>
-The variable is used, for example, by &t-link-gnulink; linker tool.
+The variable is used by linker tools which use the &t-link-link; tool such as &t-link-gnulink; or &t-link-applelink;.
+</para>
+</summary>
+</cvar>
+
+<cvar name="SOVERSION">
+<summary>
+<para>
+Simlar to &cv-link-SONAME; but only modifies the version number, and not the name, suffix or prefix of a versioned shared library/loadable module.  This can not be used in the same environment as &cv-link-SONAME; because it would be ambiguous as to what the SONAME should be.
+<example_commands>
+env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SOVERSION='2')
+</example_commands>
+The variable is used by linker tools which use the &t-link-link; tool such as &t-link-gnulink; or &t-link-applelink;.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/link.xml
+++ b/SCons/Tool/link.xml
@@ -394,10 +394,12 @@ The variable is used by linker tools which use the &t-link-link; tool such as &t
 <cvar name="SOVERSION">
 <summary>
 <para>
-Simlar to &cv-link-SONAME; but only modifies the version number, and not the name, suffix or prefix of a versioned shared library/loadable module.  This can not be used in the same environment as &cv-link-SONAME; because it would be ambiguous as to what the SONAME should be.
+Simlar to &cv-link-SONAME; but only modifies the version number, not the name, suffix or prefix of a versioned shared library/loadable module.  This can not be used in the same environment as &cv-link-SONAME; because it would be ambiguous as to what the SONAME should be.
 <example_commands>
-env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SOVERSION='2')
+env.SharedLibrary('test', 'test.c', SHLIBVERSION='3.4.1', SOVERSION='4')
 </example_commands>
+The previous example on linux for instance, will create a library named 'libtest.so.3.4.1' and a symlink to that library called 'libtest.so.4'. It will only make major version number symlinks. For example setting SOVERSION to '4.2' in the previous example command does not give symlinked library 'litest.so.4.2', just 'libtest.so.4'.
+
 The variable is used by linker tools which use the &t-link-link; tool such as &t-link-gnulink; or &t-link-applelink;.
 </para>
 </summary>

--- a/SCons/Tool/link.xml
+++ b/SCons/Tool/link.xml
@@ -394,11 +394,11 @@ The variable is used by linker tools which use the &t-link-link; tool such as &t
 <cvar name="SOVERSION">
 <summary>
 <para>
-Simlar to &cv-link-SONAME; but only modifies the version number, and not the name, suffix or prefix of a versioned shared library/loadable module.  This can not be used in the same environment as &cv-link-SONAME; because it would be ambiguous as to what the SONAME should be.
+Simlar to &cv-link-SONAME; but only modifies the version number, not the name, suffix or prefix of a versioned shared library/loadable module.  This can not be used in the same environment as &cv-link-SONAME; because it would be ambiguous as to what the SONAME should be.
 <example_commands>
 env.SharedLibrary('test', 'test.c', SHLIBVERSION='3.4.1', SOVERSION='4')
 </example_commands>
-The previous example on linux for instance, will create a library named 'libtest.so.3.4.1' and a symlink to that library called 'libtest.so.4'. It will only make major version number symlinks. For example setting SOVERSION to '4.2' in the previous example command does not give symliked library 'litest.so.4.2', just 'libtest.so.4'.
+The previous example on linux for instance, will create a library named 'libtest.so.3.4.1' and a symlink to that library called 'libtest.so.4'. It will only make major version number symlinks. For example setting SOVERSION to '4.2' in the previous example command does not give symlinked library 'litest.so.4.2', just 'libtest.so.4'.
 
 The variable is used by linker tools which use the &t-link-link; tool such as &t-link-gnulink; or &t-link-applelink;.
 </para>

--- a/test/LINK/SHLIBVERSIONFLAGS.py
+++ b/test/LINK/SHLIBVERSIONFLAGS.py
@@ -69,14 +69,34 @@ test.write('SConstruct', "SharedLibrary('foo','foo.c',SHLIBVERSION='1.2.3')\n")
 test.run(stdout = versionflags, match = TestSCons.match_re_dotall)
 test.run(arguments = ['-c'])
 
-# stdout must contain SHLIBVERSIONFLAGS if there is SHLIBVERSION provided
+# stdout must contain SONAME if there is SONAME provided
 test = TestSCons.TestSCons()
 test.write('foo.c', foo_c_src)
 test.write('SConstruct', """
 SharedLibrary('foo','foo.c',SHLIBVERSION='1.2.3',SONAME='%s')
 """ % soname)
 test.run(stdout = sonameVersionFlags, match = TestSCons.match_re_dotall)
+test.must_exist(test.workpath(soname))
 test.run(arguments = ['-c'])
+
+# stdout must contain SOVERSION if there is SOVERSION provided
+test = TestSCons.TestSCons()
+test.write('foo.c', foo_c_src)
+test.write('SConstruct', """
+SharedLibrary('foo','foo.c',SHLIBVERSION='1.2.3',SOVERSION='4')
+""")
+test.run(stdout = sonameVersionFlags, match = TestSCons.match_re_dotall)
+test.must_exist(test.workpath(soname))
+test.run(arguments = ['-c'])
+
+# test if both SONAME and SOVERSION are used
+test = TestSCons.TestSCons()
+test.write('foo.c', foo_c_src)
+test.write('SConstruct', """
+SharedLibrary('foo','foo.c',SHLIBVERSION='1.2.3',SONAME='%s',SOVERSION='4')
+""" % soname)
+test.run(status=2,stderr=None)
+test.must_contain_all_lines(test.stderr(), ['Ambiguous library .so naming'])
 
 test.pass_test()
 


### PR DESCRIPTION
This PR covers just the SOVERSION updates from https://github.com/SCons/scons/pull/3661

The SOVERSION is a new environment variable which works very similar to the SONAME environment variable, except instead of providing the full library name as you do with SONAME, you just provide an number which will generally be the major version number in the symlinked library. 

The SHLIBVERSION environment variable is also very similar to this, except that the SHLIBVERSION is generally the specific version number of the library, and used on the actual output library, instead of the symlinked library.

Please review https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html for more information on the standard conventions for library versioning in linux.

Also note that macOS uses a similar convention for versioning libraries, so this PR also adds the variable to apple linker.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
