### PR TITLE
Trivial: add a comment about options to manpage source

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -487,6 +487,11 @@ supports the same command-line options as GNU &Make;
 and many of those supported by <application>cons</application>.
 </para>
 
+<!-- The recommended approach of multiple <term> entries per <varlistentry> -->
+<!-- (if needed) is not used for Options, as the default presentation -->
+<!-- format for a varlist is changed from csv to one-per-line to improve -->
+<!-- display of Builders and Functions/Methods. Do the csv manually. -->
+
 <!-- Note: commented-out options are retained as they may be a model -->
 <!-- for future development directions. Do not remove. -->
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -488,9 +488,10 @@ and many of those supported by <application>cons</application>.
 </para>
 
 <!-- The recommended approach of multiple <term> entries per <varlistentry> -->
-<!-- (if needed) is not used for Options, as the default presentation -->
-<!-- format for a varlist is changed from csv to one-per-line to improve -->
-<!-- display of Builders and Functions/Methods. Do the csv manually. -->
+<!-- (if needed) is not used for Options, because the default docbook -->
+<!-- presentation format for a varlist has been changed in SCons from -->
+<!-- csv to one-per-line to improve the display of Builders and -->
+<!-- Functions/Methods in those sections. Do the csv manually. -->
 
 <!-- Note: commented-out options are retained as they may be a model -->
 <!-- for future development directions. Do not remove. -->


### PR DESCRIPTION
Explain for manpage editors why we don't use this form of listing options in manpage:

 ` <varlistentry><term>-A</term><term>--a-long-opt</term>...`

i.e. a term for each variant of an option. This is a comment only, no change to actual manpage.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
