### PR TITLE
Fix SCons.Node.FS.File.get_csig() usage of md5_chunksize (Issue #3726)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
         - Whatever John Doe did.
 
+  From Adam Gross:
+    - Fix minor bug affecting SCons.Node.FS.File.get_csig()'s usage of the MD5 chunksize.
+      User-facing behavior does not change with this fix (GH Issue #3726).
+
   From Mats Wichmann:
     - Complete tests for Dictionary, env.keys() and env.values() for
       OverrideEnvironment. Enable env.setdefault() method, add tests.

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -3222,7 +3222,7 @@ class File(Base):
         if csig is None:
 
             try:
-                if self.get_size() < File.md5_chunksize:
+                if self.get_size() < File.md5_chunksize * 1024:
                     contents = self.get_contents()
                 else:
                     csig = self.get_content_hash()

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -2634,7 +2634,8 @@ class File(Base):
     NodeInfo = FileNodeInfo
     BuildInfo = FileBuildInfo
 
-    md5_chunksize = 64
+    # Although the command-line argument is in kilobytes, this is in bytes.
+    md5_chunksize = 65536
 
     def diskcheck_match(self):
         diskcheck_match(self, self.isdir,
@@ -2736,7 +2737,7 @@ class File(Base):
             return MD5signature('')
         fname = self.rfile().get_abspath()
         try:
-            cs = MD5filesignature(fname, chunksize=File.md5_chunksize * 1024)
+            cs = MD5filesignature(fname, chunksize=File.md5_chunksize)
         except EnvironmentError as e:
             if not e.filename:
                 e.filename = fname
@@ -3222,7 +3223,7 @@ class File(Base):
         if csig is None:
 
             try:
-                if self.get_size() < File.md5_chunksize * 1024:
+                if self.get_size() < File.md5_chunksize:
                     contents = self.get_contents()
                 else:
                     csig = self.get_content_hash()
@@ -3623,7 +3624,7 @@ class File(Base):
 
         cachedir, cachefile = self.get_build_env().get_CacheDir().cachepath(self)
         if not self.exists() and cachefile and os.path.exists(cachefile):
-            self.cachedir_csig = MD5filesignature(cachefile, File.md5_chunksize * 1024)
+            self.cachedir_csig = MD5filesignature(cachefile, File.md5_chunksize)
         else:
             self.cachedir_csig = self.get_csig()
         return self.cachedir_csig

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -2097,8 +2097,8 @@ class DirTestCase(_tempdirTestCase):
             None, SCons.Node.FS)
 
         # Call get_csig() to test get_contents() usage. The actual results of
-        # the calls to get_csig() are not relevant for this test. If any
-        # exceptions are raised, we must first reset the get_contents function
+        # the calls to get_csig() are not relevant for this test. If an
+        # exception is raised, we must first reset the get_contents function
         # before reraising it or other tests will fail too.
         exception = None
         try:

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -2066,13 +2066,13 @@ class DirTestCase(_tempdirTestCase):
         get_contents() is called; otherwise, it verifies that get_contents()
         is not called.
         """
-        chunksize = SCons.Node.FS.File.md5_chunksize
+        chunksize_bytes = SCons.Node.FS.File.md5_chunksize
         test = self.test
 
         test.subdir('chunksize_dir')
-        test.write(['chunksize_dir', 'f1'], 'a' * (chunksize - 1))
-        test.write(['chunksize_dir', 'f2'], 'a' * chunksize)
-        test.write(['chunksize_dir', 'f3'], 'a' * (chunksize * 1024 + 1))
+        test.write(['chunksize_dir', 'f1'], 'a' * (chunksize_bytes // 1024 - 1))
+        test.write(['chunksize_dir', 'f2'], 'a' * (chunksize_bytes // 1024))
+        test.write(['chunksize_dir', 'f3'], 'a' * (chunksize_bytes + 1))
 
         dir = self.fs.Dir('chunksize_dir')
         f1 = dir.File('f1')

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -2072,7 +2072,7 @@ class DirTestCase(_tempdirTestCase):
         test.subdir('chunksize_dir')
         test.write(['chunksize_dir', 'f1'], 'a' * (chunksize - 1))
         test.write(['chunksize_dir', 'f2'], 'a' * chunksize)
-        test.write(['chunksize_dir', 'f3'], 'a' * (chunksize * 1024))
+        test.write(['chunksize_dir', 'f3'], 'a' * (chunksize * 1024 + 1))
 
         dir = self.fs.Dir('chunksize_dir')
         f1 = dir.File('f1')
@@ -2080,7 +2080,7 @@ class DirTestCase(_tempdirTestCase):
         f3 = dir.File('f3')
 
         # Expect f1 and f2 to call get_contents(), while f3 will not because it
-        # will do reads of chunksize bytes at a time.
+        # should do reads of chunksize kilobytes at a time.
         expected_get_contents_calls = {f1, f2}
         self.actual_get_contents_calls = 0
 

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -2058,6 +2058,62 @@ class DirTestCase(_tempdirTestCase):
         assert g.get_csig() + " g" == files[2], files
         assert s.get_csig() + " sub" == files[3], files
 
+    def test_md5_chunksize(self):
+        """
+        Test verifying that File.get_csig() correctly uses md5_chunksize. This
+        variable is documented as the md5 chunksize in kilobytes. This test
+        verifies that if the file size is less than the md5 chunksize,
+        get_contents() is called; otherwise, it verifies that get_contents()
+        is not called.
+        """
+        chunksize = SCons.Node.FS.File.md5_chunksize
+        test = self.test
+
+        test.subdir('chunksize_dir')
+        test.write(['chunksize_dir', 'f1'], 'a' * (chunksize - 1))
+        test.write(['chunksize_dir', 'f2'], 'a' * chunksize)
+        test.write(['chunksize_dir', 'f3'], 'a' * (chunksize * 1024))
+
+        dir = self.fs.Dir('chunksize_dir')
+        f1 = dir.File('f1')
+        f2 = dir.File('f2')
+        f3 = dir.File('f3')
+
+        # Expect f1 and f2 to call get_contents(), while f3 will not because it
+        # will do reads of chunksize bytes at a time.
+        expected_get_contents_calls = {f1, f2}
+        self.actual_get_contents_calls = 0
+
+        def get_contents_override(file_object):
+            self.actual_get_contents_calls += 1
+            if file_object in expected_get_contents_calls:
+                return file_object._old_get_contents()
+            else:
+                raise Exception('get_contents was unexpectedly called on node '
+                                '%s' % file_object)
+
+        SCons.Node.FS.File._old_get_contents = SCons.Node.FS.File.get_contents
+        SCons.Node.FS.File.get_contents = get_contents_override.__get__(
+            None, SCons.Node.FS)
+
+        exception = None
+        try:
+            f1.get_csig()
+            f2.get_csig()
+            f3.get_csig()
+        except Exception as e:
+            exception = e
+            print('exception %s' % e)
+
+        SCons.Node.FS.File.get_contents = SCons.Node.FS.File._old_get_contents
+        delattr(SCons.Node.FS.File, '_old_get_contents')
+
+        if exception:
+            raise exception
+
+        assert self.actual_get_contents_calls == len(expected_get_contents_calls), \
+            self.actual_get_contents_calls
+
     def test_implicit_re_scans(self):
         """Test that adding entries causes a directory to be re-scanned
         """

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -2096,6 +2096,10 @@ class DirTestCase(_tempdirTestCase):
         SCons.Node.FS.File.get_contents = get_contents_override.__get__(
             None, SCons.Node.FS)
 
+        # Call get_csig() to test get_contents() usage. The actual results of
+        # the calls to get_csig() are not relevant for this test. If any
+        # exceptions are raised, we must first reset the get_contents function
+        # before reraising it or other tests will fail too.
         exception = None
         try:
             f1.get_csig()
@@ -2103,7 +2107,6 @@ class DirTestCase(_tempdirTestCase):
             f3.get_csig()
         except Exception as e:
             exception = e
-            print('exception %s' % e)
 
         SCons.Node.FS.File.get_contents = SCons.Node.FS.File._old_get_contents
         delattr(SCons.Node.FS.File, '_old_get_contents')

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1112,7 +1112,7 @@ def _main(parser):
     SCons.Job.explicit_stack_size = options.stack_size
 
     if options.md5_chunksize:
-        SCons.Node.FS.File.md5_chunksize = options.md5_chunksize
+        SCons.Node.FS.File.md5_chunksize = options.md5_chunksize * 1024
 
     platform = SCons.Platform.platform_module()
 


### PR DESCRIPTION
md5_chunksize is documented to be in kilobytes, but this function was using it as though it is in bytes. This change fixes that, adding a test to confirm the correct behavior for a few different cases.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
