### PR TITLE
Fix yacc tool to respect yacc

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,9 +8,9 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
+  From William Deegan:
+    - Fix yaccc tool, not respecting YACC set at time of tool initialization.
 
-        - Whatever John Doe did.
 
   From Adam Gross:
     - Fix minor bug affecting SCons.Node.FS.File.get_csig()'s usage of the MD5 chunksize.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From William Deegan:
-    - Fix yaccc tool, not respecting YACC set at time of tool initialization.
+    - Fix yacc tool, not respecting YACC set at time of tool initialization.
 
 
   From Adam Gross:

--- a/SCons/Tool/yacc.py
+++ b/SCons/Tool/yacc.py
@@ -50,14 +50,14 @@ if sys.platform == 'win32':
 else:
     BINS = ["bison", "yacc"]
 
+
 def _yaccEmitter(target, source, env, ysuf, hsuf):
     yaccflags = env.subst("$YACCFLAGS", target=target, source=source)
     flags = SCons.Util.CLVar(yaccflags)
     targetBase, targetExt = os.path.splitext(SCons.Util.to_String(target[0]))
 
-    if '.ym' in ysuf:                # If using Objective-C
-        target = [targetBase + ".m"] # the extension is ".m".
-
+    if '.ym' in ysuf:  # If using Objective-C
+        target = [targetBase + ".m"]  # the extension is ".m".
 
     # If -d is specified on the command line, yacc will emit a .h
     # or .hpp file with the same name as the .c or .cpp output file.
@@ -75,10 +75,8 @@ def _yaccEmitter(target, source, env, ysuf, hsuf):
     # be noted and also be cleaned
     # Bug #2558
     if "-v" in flags:
-        env.SideEffect(targetBase+'.output',target[0])
-        env.Clean(target[0],targetBase+'.output')
-
-
+        env.SideEffect(targetBase + '.output', target[0])
+        env.Clean(target[0], targetBase + '.output')
 
     # With --defines and --graph, the name of the file is totally defined
     # in the options.
@@ -94,14 +92,18 @@ def _yaccEmitter(target, source, env, ysuf, hsuf):
 
     return (target, source)
 
+
 def yEmitter(target, source, env):
     return _yaccEmitter(target, source, env, ['.y', '.yacc'], '$YACCHFILESUFFIX')
+
 
 def ymEmitter(target, source, env):
     return _yaccEmitter(target, source, env, ['.ym'], '$YACCHFILESUFFIX')
 
+
 def yyEmitter(target, source, env):
     return _yaccEmitter(target, source, env, ['.yy'], '$YACCHXXFILESUFFIX')
+
 
 def get_yacc_path(env, append_paths=False):
     """
@@ -118,7 +120,7 @@ def get_yacc_path(env, append_paths=False):
         bin_path = SCons.Tool.find_program_path(
             env,
             prog,
-            default_paths=CHOCO_DEFAULT_PATH + MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
+            default_paths=CHOCO_DEFAULT_PATH + MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS)
         if bin_path:
             if append_paths:
                 env.AppendENVPath('PATH', os.path.dirname(bin_path))
@@ -149,12 +151,15 @@ def generate(env):
         # ignore the return, all we need is for the path to be added
         _ = get_yacc_path(env, append_paths=True)
 
-    env["YACC"] = env.Detect(BINS)
+    if 'YACC' not in env:
+        env["YACC"] = env.Detect(BINS)
+
     env['YACCFLAGS'] = SCons.Util.CLVar('')
-    env['YACCCOM']   = '$YACC $YACCFLAGS -o $TARGET $SOURCES'
+    env['YACCCOM'] = '$YACC $YACCFLAGS -o $TARGET $SOURCES'
     env['YACCHFILESUFFIX'] = '.h'
     env['YACCHXXFILESUFFIX'] = '.hpp'
     env['YACCVCGFILESUFFIX'] = '.vcg'
+
 
 def exists(env):
     if sys.platform == 'win32':

--- a/test/YACC/YACC-fixture/SConstruct_YACC_before
+++ b/test/YACC/YACC-fixture/SConstruct_YACC_before
@@ -1,0 +1,4 @@
+env=Environment(tools=[])
+env2=env.Clone(YACC="SOMETHING_DUMB")
+env2.Tool('yacc')
+env2.CFile('aaa.y')

--- a/test/YACC/YACC.py
+++ b/test/YACC/YACC.py
@@ -58,8 +58,8 @@ test.must_match('bbb.c',        "bbb.yacc" + os.linesep + "myyacc.py" + os.lines
 test.must_match('ccc.cc',       "ccc.yacc" + os.linesep + "myyacc.py" + os.linesep)
 test.must_match('ddd.m',        "ddd.yacc" + os.linesep + "myyacc.py" + os.linesep)
 
-
-
+test.run(arguments="-n -f SConstruct_YACC_before")
+test.fail_test('SOMETHING_DUMB' not in  test.stdout(), "YACC is not overridden to be SOMETHING_DUMB")
 
 test.pass_test()
 


### PR DESCRIPTION
Fix yacc tool, not respecting YACC set at time of tool initialization.



## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
