### PR TITLE
Fix the module-relative filename produced in the internal-use only debug log record for the MSVC tools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-﻿
+
 
                  SCons - a software construction tool
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Joseph Brill:
+    - Modify the MSCommon internal-use only debug logging records to contain the correct relative
+      file path when the debug function is called from outside the MSCommon module.
+
   From William Deegan:
     - Fix yacc tool, not respecting YACC set at time of tool initialization.
 


### PR DESCRIPTION
A filter was added to the existing debug logging (i.e., SCONS_MSCOMMON_DEBUG=*filename*) to product the correct relative module path for a debug invocation.  

Previously, "MSCommon/" was hard-coded into the record format.  This results in an incorrect module path when debug is called from a script "above" the MSCommon module (e.g., msvsTests.py).

* Prior to the change:
    ```
    01456ms:MSCommon/msvsTests.py:setUp#593:THIS TYPE :test_config_generation (__main__.msvs6aTestCase): 
    03250ms:MSCommon/msvsTests.py:setUp#593:THIS TYPE :test_get_default_version (__main__.msvs6aTestCase): 
    03255ms:MSCommon/msvsTests.py:test_get_default_version#607:Testing for default version 6.0: 
    03256ms:MSCommon/vs.py:get_installed_visual_studios#423:trying to find VS 14.2: 
    ```
* After the change:
    ```
    01139ms:Tool/msvsTests.py:setUp#593:THIS TYPE :test_config_generation (__main__.msvs6aTestCase): 
    02982ms:Tool/msvsTests.py:setUp#593:THIS TYPE :test_get_default_version (__main__.msvs6aTestCase): 
    03015ms:Tool/msvsTests.py:test_get_default_version#607:Testing for default version 6.0: 
    03032ms:MSCommon/vs.py:get_installed_visual_studios#423:trying to find VS 14.2: 
    ```

The fix was taken from #3743 and reworked to be consistent with the current code in MSCommon/common.py.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation

