### PR TITLE
Rework and eliminate external references to the runtime caching of installed MSVC instances

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Joseph Brill:
+    - MSVC and test updates: Rework the msvc installed versions cache so that it is not
+      exposed externally and update external references accordingly.
+
   From William Deegan:
     - Fix yacc tool, not respecting YACC set at time of tool initialization.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,8 +9,8 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Joseph Brill:
-    - MSVC and test updates: Rework the msvc installed versions cache so that it is not
-      exposed externally and update external references accordingly.
+    - Internal MSVC and test updates: Rework the msvc installed versions cache so that it
+      is not exposed externally and update external references accordingly.
 
   From William Deegan:
     - Fix yacc tool, not respecting YACC set at time of tool initialization.

--- a/test/MSVC/MSVC_UWP_APP.py
+++ b/test/MSVC/MSVC_UWP_APP.py
@@ -82,7 +82,7 @@ test = TestSCons.TestSCons()
 
 test.skip_if_not_msvc()
 
-installed_msvc_versions = msvc.cached_get_installed_vcs()
+installed_msvc_versions = msvc.get_installed_vcs()
 # MSVC guaranteed to be at least one version on the system or else
 # skip_if_not_msvc() function would have skipped the test
 


### PR DESCRIPTION
The cache_get_installed_vcs function was eliminated and the functionality was moved into the get_installed_vcs function.  All invocations of cache_get_installed_vcs were renamed in vc.py and in test/MSVC/MSVC_UWP_APP.py.

The runtime caching of installed vcs is not externally visible outside of vc.py.  The runtime caching of installed vcs can still be reset via the function call to reset_installed_vcs.  Note: prior to #3701 (June 2020), the installed vcs were not correctly reset.

Moving the cache functionality inside the get_installed_vcs function, allows the functionality to be internalized to the vc.py module and provides a consistent interface for the tests.

This PR was spawned from #3723 to isolate the two issues originally identified in separate PRs.

There is discussion in #3723 indicating that the consequences of this PR would need to be investigated further.

## Contributor Checklist:

- [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
- [x] I have updated `CHANGES.txt` (and read the `README.rst`)
- [ ] I have updated the appropriate documentation