### PR TITLE
Suppress missing SConscript deprecation message when must_exist is used.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,8 +29,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       OverrideEnvironment. Enable env.setdefault() method, add tests.
 
   From Joachim Kuebart:
-    - Suppress missing SConscript deprecation warning if `must_exist` is
-      used.
+    - Suppress missing SConscript deprecation warning if `must_exist=False`
+      is used.
 
 
 RELEASE 4.0.1 - Mon, 16 Jul 2020 16:06:40 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Complete tests for Dictionary, env.keys() and env.values() for
       OverrideEnvironment. Enable env.setdefault() method, add tests.
 
+  From Joachim Kuebart:
+    - Suppress missing SConscript deprecation warning if `must_exist` is
+      used.
+
 
 RELEASE 4.0.1 - Mon, 16 Jul 2020 16:06:40 -0700
 

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -172,7 +172,7 @@ def handle_missing_SConscript(f, must_exist=None):
         msg = "Fatal: missing SConscript '%s'" % f.get_internal_path()
         raise SCons.Errors.UserError(msg)
 
-    if SCons.Script._warn_missing_sconscript_deprecated:
+    if SCons.Script._warn_missing_sconscript_deprecated and must_exist is None:
         msg = "Calling missing SConscript without error is deprecated.\n" + \
               "Transition by adding must_exist=0 to SConscript calls.\n" + \
               "Missing SConscript '%s'" % f.get_internal_path()

--- a/test/SConscript/fixture/SConstruct
+++ b/test/SConscript/fixture/SConstruct
@@ -1,0 +1,17 @@
+import SCons
+from SCons.Warnings import _warningOut
+import sys
+
+DefaultEnvironment(tools=[])
+# 1. call should succeed without deprecation warning
+try:
+    SConscript('missing/SConscript', must_exist=False)
+except SCons.Errors.UserError as e:
+    if _warningOut:
+        _warningOut(e)
+# 2. call should succeed with deprecation warning
+try:
+    SConscript('missing/SConscript')
+except SCons.Errors.UserError as e:
+    if _warningOut:
+        _warningOut(e)

--- a/test/SConscript/must_exist_deprecation.py
+++ b/test/SConscript/must_exist_deprecation.py
@@ -36,25 +36,7 @@ test = TestSCons.TestSCons()
 # catch the exception if is raised, send it on as a warning
 # this gives us traceability of the line responsible
 SConstruct_path = test.workpath('SConstruct')
-test.write(SConstruct_path, """\
-import SCons
-from SCons.Warnings import _warningOut
-import sys
-
-DefaultEnvironment(tools=[])
-# 1. call should succeed without deprecation warning
-try:
-    SConscript('missing/SConscript', must_exist=False)
-except SCons.Errors.UserError as e:
-    if _warningOut:
-        _warningOut(e)
-# 2. call should succeed with deprecation warning
-try:
-    SConscript('missing/SConscript')
-except SCons.Errors.UserError as e:
-    if _warningOut:
-        _warningOut(e)
-""")
+test.file_fixture("fixture/SConstruct")
 
 # we should see two warnings, the second being the deprecation message.
 # need to build the path in the expected msg in an OS-agnostic way

--- a/test/SConscript/must_exist_deprecation.py
+++ b/test/SConscript/must_exist_deprecation.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+'''
+Test deprecation warning if must_exist flag is used in a SConscript call
+'''
+
+import os
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+# catch the exception if is raised, send it on as a warning
+# this gives us traceability of the line responsible
+SConstruct_path = test.workpath('SConstruct')
+test.write(SConstruct_path, """\
+import SCons
+from SCons.Warnings import _warningOut
+import sys
+
+DefaultEnvironment(tools=[])
+# 1. call should succeed without deprecation warning
+try:
+    SConscript('missing/SConscript', must_exist=False)
+except SCons.Errors.UserError as e:
+    if _warningOut:
+        _warningOut(e)
+# 2. call should succeed with deprecation warning
+try:
+    SConscript('missing/SConscript')
+except SCons.Errors.UserError as e:
+    if _warningOut:
+        _warningOut(e)
+""")
+
+# we should see two warnings, the second being the deprecation message.
+# need to build the path in the expected msg in an OS-agnostic way
+missing = os.path.normpath('missing/SConscript')
+warn1 = """
+scons: warning: Ignoring missing SConscript '{}'
+""".format(missing) + test.python_file_line(SConstruct_path, 8)
+warn2 = """
+scons: warning: Calling missing SConscript without error is deprecated.
+Transition by adding must_exist=0 to SConscript calls.
+Missing SConscript '{}'
+""".format(missing) + test.python_file_line(SConstruct_path, 14)
+
+expect_stderr = warn1 + warn2
+test.run(arguments = ".", stderr = expect_stderr)
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
## Steps to reproduce

When running a line like the following:
```
conan = SConscript("SConscript_conan", must_exist=False)
```

SCons produces the output:
```
scons: warning: Calling missing SConscript without error is deprecated.
Transition by adding must_exist=0 to SConscript calls.
Missing SConscript 'SConscript_conan'
```
in spite of the `must_exist` option being given.

## Expected behaviour

The deprecation warning message should only be shown if the `must_exist` option is not used.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation

I added a new test rather than adding tests to `must_exist.py` because the deprecation warning is shown at most once in each run.

I didn't update the documentation because to me it already explains the behaviour I have implemented.
