### PR TITLE
Reject abbreviations of AddOption options.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Complete tests for Dictionary, env.keys() and env.values() for
       OverrideEnvironment. Enable env.setdefault() method, add tests.
+    - Raise an error if an option (not otherwise consumed) is used which
+      looks like an abbreviation of one one added by AddOption. (#3653)
 
   From Joachim Kuebart:
     - Suppress missing SConscript deprecation warning if `must_exist=False`

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -36,13 +36,13 @@ are the same as those supported by the <function>add_option</function>
 method in the standard Python library module <systemitem>optparse</systemitem>,
 with a few additional capabilities noted below.
 See the documentation for
-<emphasis>optparse</emphasis>
+<systemitem>optparse</systemitem>
 for a thorough discussion of its option-processing capabities.
 </para>
 
 <para>
 In addition to the arguments and values supported by the
-<emphasis>optparse</emphasis>
+<systemitem>optparse</systemitem>
 <function>add_option</function>
 method, &f-AddOption;
 allows setting the

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -273,8 +273,7 @@ class SConsOptionParser(optparse.OptionParser):
         """
         arg = rargs.pop(0)
 
-        # Value explicitly attached to arg?  Pretend it's the next
-        # argument.
+        # Value explicitly attached to arg?  Pretend it's the next argument.
         if "=" in arg:
             (opt, next_arg) = arg.split("=", 1)
             rargs.insert(0, next_arg)
@@ -284,7 +283,11 @@ class SConsOptionParser(optparse.OptionParser):
             had_explicit_value = False
 
         try:
-            opt = self._match_long_opt(opt)
+            if opt != self._match_long_opt(opt):
+                raise optparse.BadOptionError(
+                    "cannot use abbreviated option %s, use %s instead"
+                    % (opt, self._match_long_opt(opt))
+                )
         except optparse.BadOptionError:
             if self.preserve_unknown_options:
                 # SCons-specific:  if requested, add unknown options to
@@ -398,7 +401,7 @@ class SConsOptionParser(optparse.OptionParser):
         """
         Adds a local option to the parser.
 
-        This is initiated by a SetOption() call to add a user-defined
+        This is initiated by an AddOption() call to add a user-defined
         command-line option.  We add the option to a separate option
         group for the local options, creating the group if necessary.
         """

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -285,7 +285,7 @@ class SConsOptionParser(optparse.OptionParser):
         try:
             if opt != self._match_long_opt(opt):
                 raise optparse.BadOptionError(
-                    "cannot use abbreviated option %s, use %s instead"
+                    "'%s'. Did you mean '%s'?"
                     % (opt, self._match_long_opt(opt))
                 )
         except optparse.BadOptionError:

--- a/test/AddOption/longopts.py
+++ b/test/AddOption/longopts.py
@@ -51,6 +51,16 @@ test.run('-Q -q . --myargument=helloworld',
 test.run('-Q -q . --myarg=helloworld',
          stdout="myargument: gully\nmyarg: helloworld\n")
 
+# Issue #3653: add a check for an abbreviation which never gets AddOption'd.
+test.run('-Q -q . --myargumen=helloworld', status=2,
+         stdout="myargument: gully\nmyarg: balla\n",
+         stderr="""\
+usage: scons [OPTION] [TARGET] ...
+
+SCons Error: no such option: cannot use abbreviated option --myargumen, use --myargument instead
+""")
+
+
 test.pass_test()
 
 # Local Variables:

--- a/test/AddOption/longopts.py
+++ b/test/AddOption/longopts.py
@@ -57,7 +57,7 @@ test.run('-Q -q . --myargumen=helloworld', status=2,
          stderr="""\
 usage: scons [OPTION] [TARGET] ...
 
-SCons Error: no such option: cannot use abbreviated option --myargumen, use --myargument instead
+SCons Error: no such option: '--myargumen'. Did you mean '--myargument'?
 """)
 
 


### PR DESCRIPTION
If a cmdline option is left over, and looks like an abbreviation of an `AddOption`'d option, raise an error.

This simpler approach seems to work, so suggest adding it. The item to resolve is what the error message should be. The current message looks like this (taken from the testcase):
```
usage: scons [OPTION] [TARGET] ...

SCons Error: no such option: cannot use abbreviated option --myargumen, use --myargument instead
```
Other possibilities:
* `no such option: --myargumen appears to be an abbreviation, try --myargument`
* `no such option: --myargumen. Did you mean --myargument ?`

etc.

Note the leading part of the message `SCons Error:` is inconsistent with all other errors indicating scons failure except option errors (the rest of the code uses `scons: ***`), but this usage was not introduced with this PR. Should we update for consistency?

Replaces #3657. Fixes #3653.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
