### PR TITLE
Simplify more tests to use unittest.main

### DIFF
--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -1617,16 +1617,7 @@ class CompositeBuilderTestCase(unittest.TestCase):
         assert str(err) == expect, err
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        BuilderTestCase,
-        CompositeBuilderTestCase
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -1376,7 +1376,7 @@ def generate(env, **kw):
         env[k] = v
 
 def exists(env):
-    return 1
+    return True
 """)
 
         env = self.TestEnvironment(tools = [('faketool', {'a':1, 'b':2, 'c':3})],
@@ -1856,14 +1856,14 @@ def exists(env):
 
         test.write('xxx.py', """\
 def exists(env):
-    1
+    return True
 def generate(env):
     env['XXX'] = 'one'
 """)
 
         test.write('yyy.py', """\
 def exists(env):
-    1
+    return True
 def generate(env):
     env['YYY'] = 'two'
 """)
@@ -2481,14 +2481,14 @@ f5: \
 
         test.write('xxx.py', """\
 def exists(env):
-    1
+    return True
 def generate(env):
     env['XXX'] = 'one'
 """)
 
         test.write('yyy.py', """\
 def exists(env):
-    1
+    return True
 def generate(env):
     env['YYY'] = 'two'
 """)
@@ -3951,16 +3951,7 @@ class EnvironmentVariableTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [ SubstitutionTestCase,
-                 BaseTestCase,
-                 OverrideEnvironmentTestCase,
-                 NoSubstitutionProxyTestCase,
-                 EnvironmentVariableTestCase ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/SCons/PathListTests.py
+++ b/SCons/PathListTests.py
@@ -189,16 +189,7 @@ class PathListTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        subst_pathTestCase,
-        PathListCacheTestCase,
-        PathListTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/SCons/SConsignTests.py
+++ b/SCons/SConsignTests.py
@@ -382,18 +382,7 @@ class writeTestCase(SConsignTestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    tclasses = [
-        BaseTestCase,
-        SConsignDBTestCase,
-        SConsignDirFileTestCase,
-        SConsignFileTestCase,
-        writeTestCase,
-    ]
-    for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
-        suite.addTests(list(map(tclass, names)))
-    TestUnit.run(suite)
+    unittest.main()
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Scanner/RCTests.py
+++ b/SCons/Scanner/RCTests.py
@@ -158,13 +158,6 @@ class RCScannerTestCase3(unittest.TestCase):
         deps_match(self, deps, headers)
         
 
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(RCScannerTestCase1())
-    suite.addTest(RCScannerTestCase2())
-    suite.addTest(RCScannerTestCase3())
-    return suite
-
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
For issue #3113, but does not complete it - there are still uses of `TestSuite` where the "simple fix" from the issue requires more thought.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
