### PR TITLE
User Guide: don't link to tigris any more

### DIFF
--- a/doc/user/troubleshoot.xml
+++ b/doc/user/troubleshoot.xml
@@ -69,8 +69,8 @@
   odds are pretty good that someone else will run into
   the same problem, too.
   If so, please let the SCons development team know
-  (preferably by filing a bug report
-  or feature request at our project pages at tigris.org)
+  using the contact information at
+  <ulink url="https://scons.org/contact.html"/>
   so that we can use your feedback
   to try to come up with a better way to help you,
   and others, get the necessary insight into &SCons; behavior


### PR DESCRIPTION
Troubleshooting section had a remaining link to tigris.org. Now points to scons website - not to github, because we don't
encourage directly filing a bug before first discussing.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
