### PR TITLE
test: Pass a correct flag to DVIPDFFLAGS test

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Michał Górny:
+    - Fix dvipdf test failure due to passing incorrect flag to dvipdf.
+
   From Joseph Brill:
     - Internal MSVC and test updates: Rework the msvc installed versions cache so that it
       is not exposed externally and update external references accordingly.

--- a/test/DVIPDF/DVIPDFFLAGS.py
+++ b/test/DVIPDF/DVIPDFFLAGS.py
@@ -122,7 +122,7 @@ subprocess.run(cmd, shell=True)
     test.write('SConstruct', """
 import os
 ENV = {'PATH' : os.environ['PATH']}
-foo = Environment(DVIPDFFLAGS = '-N', ENV = ENV)
+foo = Environment(DVIPDFFLAGS = '-R2', ENV = ENV)
 dvipdf = foo.Dictionary('DVIPDF')
 bar = Environment(DVIPDF = r'%(_python_)s wrapper.py ' + dvipdf, ENV = ENV)
 foo.PDF(target = 'foo.pdf',


### PR DESCRIPTION
Pass '-R2' instead of '-N' as the tested flag to DVIPDFFLAGS test.
Apparently '-N' alone is not a valid flag (as of ghostscript-gpl 9.53.1)
and it causes the test to fail:

  cd . && dvipdf -N foo.dvi foo.pdf
  -N must be between 2 and 4194303
  scons: building terminated because of errors.

It is not even mentioned in the manual page (though looking
at the script, it is passed to gs).  Use '-R2' instead as an arbitrary
documented flag.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
