### PR TITLE
Run autoflake on code

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -46,6 +46,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       - merging --param arguments did not work (issue #3107); 
       - passing a dict to merge where the values are strings failed (issue #2961).
     - Include previously-excluded SideEffect section in User Guide.
+    - Clean up unneeded imports (autoflake tool).
 
   From Joachim Kuebart:
     - Suppress missing SConscript deprecation warning if `must_exist=False`

--- a/SCons/DefaultsTests.py
+++ b/SCons/DefaultsTests.py
@@ -26,7 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import SCons.compat
 
 import os
-import sys
 import unittest
 
 import TestCmd

--- a/SCons/EnvironmentValues.py
+++ b/SCons/EnvironmentValues.py
@@ -72,7 +72,6 @@ class EnvironmentValue:
                 # Now we need to parse the specified string
                 result = _dollar_exps.sub(sub_match, args)
                 print(result)
-            pass
         except TypeError:
             # likely callable? either way we don't parse
             self._parsed = self.value

--- a/SCons/ErrorsTests.py
+++ b/SCons/ErrorsTests.py
@@ -24,8 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import errno
-import os
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/ExecutorTests.py
+++ b/SCons/ExecutorTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import SCons.Executor

--- a/SCons/JobTests.py
+++ b/SCons/JobTests.py
@@ -211,7 +211,7 @@ class Taskmaster:
         try:
             import threading
             self.guard = threading.Lock()
-        except:
+        except ImportError:
             self.guard = DummyLock()
 
         # keep track of the order tasks are begun in
@@ -255,7 +255,7 @@ class ParallelTestCase(unittest.TestCase):
 
         try:
             import threading
-        except:
+        except ImportError:
             raise NoThreadsException()
 
         taskmaster = Taskmaster(num_tasks, self, RandomTask)

--- a/SCons/MemoizeTests.py
+++ b/SCons/MemoizeTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import SCons.Memoize

--- a/SCons/Node/AliasTests.py
+++ b/SCons/Node/AliasTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -1694,7 +1694,6 @@ class FSTestCase(_tempdirTestCase):
             except AttributeError:
                 # could be python 3.7 or newer, make sure splitdrive can do UNC
                 assert ntpath.splitdrive(r'\\split\drive\test')[0] == r'\\split\drive'
-                pass
             path = strip_slash(path)
             return '//' + path[1:]
 

--- a/SCons/Node/NodeTests.py
+++ b/SCons/Node/NodeTests.py
@@ -25,9 +25,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import SCons.compat
 
 import collections
-import os
 import re
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -43,7 +43,6 @@ be able to depend on any other type of "thing."
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import collections
 import copy
 from itertools import chain
@@ -823,24 +822,20 @@ class Node(object, metaclass=NoSlotsPyPy):
 
     def release_target_info(self):
         """Called just after this node has been marked
-         up-to-date or was built completely.
+        up-to-date or was built completely.
 
-         This is where we try to release as many target node infos
-         as possible for clean builds and update runs, in order
-         to minimize the overall memory consumption.
+        This is where we try to release as many target node infos
+        as possible for clean builds and update runs, in order
+        to minimize the overall memory consumption.
 
-         By purging attributes that aren't needed any longer after
-         a Node (=File) got built, we don't have to care that much how
-         many KBytes a Node actually requires...as long as we free
-         the memory shortly afterwards.
+        By purging attributes that aren't needed any longer after
+        a Node (=File) got built, we don't have to care that much how
+        many KBytes a Node actually requires...as long as we free
+        the memory shortly afterwards.
 
-         @see: built() and File.release_target_info()
-         """
+        @see: built() and File.release_target_info()
+        """
         pass
-
-    #
-    #
-    #
 
     def add_to_waiting_s_e(self, node):
         self.waiting_s_e.add(node)

--- a/SCons/PathListTests.py
+++ b/SCons/PathListTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import TestUnit

--- a/SCons/Platform/aix.py
+++ b/SCons/Platform/aix.py
@@ -32,7 +32,6 @@ selection method.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import subprocess
 
 from . import posix
@@ -70,8 +69,6 @@ def get_xlc(env, xlc=None, packages=[]):
             or ('/' not in xlc and filename.endswith('/' + xlc)):
                 xlcVersion = fileset.split()[1]
                 xlcPath, sep, xlc = filename.rpartition('/')
-            pass
-        pass
     return (xlcPath, xlc, xlcVersion)
 
 def generate(env):

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -33,10 +33,7 @@ selection method.
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import errno
-import os
-import os.path
 import subprocess
-import sys
 import select
 
 import SCons.Util

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -288,7 +288,6 @@ def get_program_files_dir():
             val, tok = SCons.Util.RegQueryValueEx(k, 'ProgramFilesDir')
         except SCons.Util.RegError:
             val = ''
-            pass
 
     if val == '':
         # A reasonable default if we can't read the registry

--- a/SCons/SConsignTests.py
+++ b/SCons/SConsignTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import sys
 import unittest
 
 import TestCmd

--- a/SCons/Scanner/DirTests.py
+++ b/SCons/Scanner/DirTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
-import sys
 import unittest
 
 import TestCmd

--- a/SCons/Scanner/IDLTests.py
+++ b/SCons/Scanner/IDLTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
-import sys
 import os
 import os.path
 

--- a/SCons/Scanner/LaTeXTests.py
+++ b/SCons/Scanner/LaTeXTests.py
@@ -27,7 +27,6 @@ import SCons.compat
 
 import collections
 import os
-import sys
 import unittest
 
 import TestCmd

--- a/SCons/Scanner/ProgTests.py
+++ b/SCons/Scanner/ProgTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
-import sys
 import unittest
 
 import TestCmd

--- a/SCons/Scanner/RC.py
+++ b/SCons/Scanner/RC.py
@@ -30,7 +30,6 @@ Definition Language) files.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import re
 
 import SCons.Node.FS
 import SCons.Scanner

--- a/SCons/Scanner/RCTests.py
+++ b/SCons/Scanner/RCTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
-import sys
 import collections
 import os
 

--- a/SCons/Scanner/ScannerTests.py
+++ b/SCons/Scanner/ScannerTests.py
@@ -25,7 +25,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import SCons.compat
 
 import collections
-import sys
 import unittest
 
 import TestUnit

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -46,7 +46,6 @@ from SCons.Util import is_List, is_String, is_Dict, flatten
 from SCons.Node import SConscriptNodes
 from . import Main
 
-import collections
 import os
 import os.path
 import re

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -25,10 +25,8 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import SCons.compat
 
 import os
-import sys
 import unittest
 
-from collections import UserDict
 
 import SCons.Errors
 

--- a/SCons/Taskmaster.py
+++ b/SCons/Taskmaster.py
@@ -54,9 +54,7 @@ __doc__ = """
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import operator
 import sys
-import traceback
 from abc import ABC, abstractmethod
 from itertools import chain
 

--- a/SCons/TaskmasterTests.py
+++ b/SCons/TaskmasterTests.py
@@ -24,7 +24,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 
-import copy
 import sys
 import unittest
 
@@ -867,10 +866,9 @@ class TaskmasterTestCase(unittest.TestCase):
         except MyException as e:
             exc_caught = 1
             exc_value = e
-        except Exception as e:
-            exc_actually_caught = e
+        except Exception as exc_actually_caught:
             pass
-        assert exc_caught, "did not catch expected MyException: %s"%exc_actually_caught
+        assert exc_caught, "did not catch expected MyException: %s" % exc_actually_caught
         assert str(exc_value) == "exception value", exc_value
         assert built_text is None, built_text
 

--- a/SCons/Tool/JavaCommonTests.py
+++ b/SCons/Tool/JavaCommonTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
-import sys
 import unittest
 import fnmatch
 

--- a/SCons/Tool/MSCommon/__init__.py
+++ b/SCons/Tool/MSCommon/__init__.py
@@ -27,10 +27,6 @@ __doc__ = """
 Common functions for Microsoft Visual Studio and Visual C/C++.
 """
 
-import copy
-import os
-import re
-import subprocess
 
 import SCons.Errors
 import SCons.Platform.win32

--- a/SCons/Tool/MSCommon/arch.py
+++ b/SCons/Tool/MSCommon/arch.py
@@ -26,7 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 __doc__ = """Module to define supported Windows chip architectures.
 """
 
-import os
 
 class ArchDefinition:
     """

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -43,7 +43,6 @@ import SCons.Util
 import subprocess
 import os
 import platform
-import sys
 from string import digits as string_digits
 from subprocess import PIPE
 

--- a/SCons/Tool/ToolTests.py
+++ b/SCons/Tool/ToolTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import sys
 import unittest
 
 import TestUnit

--- a/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
+++ b/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
@@ -1,7 +1,5 @@
 # docbook.py: extension module
 # $Id: docbook.py 8353 2009-03-17 16:57:50Z mzjn $
-import sys
-import string
 import libxml2
 import libxslt
 import re

--- a/SCons/Tool/fortran.py
+++ b/SCons/Tool/fortran.py
@@ -33,7 +33,6 @@ selection method.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import re
 
 import SCons.Action
 import SCons.Defaults

--- a/SCons/Tool/gcc.py
+++ b/SCons/Tool/gcc.py
@@ -34,7 +34,6 @@ selection method.
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 from . import cc
-import os
 import re
 import subprocess
 

--- a/SCons/Tool/gxx.py
+++ b/SCons/Tool/gxx.py
@@ -33,9 +33,6 @@ selection method.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
-import re
-import subprocess
 
 import SCons.Tool
 import SCons.Util

--- a/SCons/Tool/intelc.py
+++ b/SCons/Tool/intelc.py
@@ -32,7 +32,11 @@ selection method.
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import math, sys, os.path, glob, string, re
+import glob
+import math
+import os.path
+import re
+import sys
 
 is_windows = sys.platform == 'win32'
 is_win64 = is_windows and (os.environ['PROCESSOR_ARCHITECTURE'] == 'AMD64' or

--- a/SCons/Tool/linkCommon/__init__.py
+++ b/SCons/Tool/linkCommon/__init__.py
@@ -46,7 +46,6 @@ def _call_linker_cb(env, callback, args, result=None):
     except (KeyError, TypeError):
         if Verbose:
             print('_call_linker_cb: env["LINKCALLBACKS"][%r] not found or can not be used' % callback)
-        pass
     else:
         if Verbose:
             print('_call_linker_cb: env["LINKCALLBACKS"][%r] found' % callback)

--- a/SCons/Tool/linkloc.py
+++ b/SCons/Tool/linkloc.py
@@ -34,7 +34,6 @@ selection method.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 import re
 
 import SCons.Action

--- a/SCons/Tool/msginit.py
+++ b/SCons/Tool/msginit.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.Warnings
 import SCons.Builder
-import re
 
 #############################################################################
 def _optional_no_translator_flag(env):

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -35,8 +35,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import os
-import re
-import sys
 
 import SCons.Action
 import SCons.Builder

--- a/SCons/Tool/packaging/rpm.py
+++ b/SCons/Tool/packaging/rpm.py
@@ -27,7 +27,6 @@ The rpm packager.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import SCons.Builder
 import SCons.Tool.rpmutils

--- a/SCons/Tool/qt.py
+++ b/SCons/Tool/qt.py
@@ -35,7 +35,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import re
-import glob
 
 import SCons.Action
 import SCons.Builder

--- a/SCons/Tool/textfile.py
+++ b/SCons/Tool/textfile.py
@@ -48,8 +48,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons
 
-import os
-import re
 
 from SCons.Node import Node
 from SCons.Node.Python import Value

--- a/SCons/Tool/wixTests.py
+++ b/SCons/Tool/wixTests.py
@@ -26,7 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import unittest
 import os.path
 import os
-import sys
 
 import SCons.Errors
 from SCons.Tool.wix import *

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -31,7 +31,6 @@ import sys
 import copy
 import re
 import types
-import codecs
 import pprint
 import hashlib
 from collections import UserDict, UserList, UserString, OrderedDict

--- a/SCons/Variables/BoolVariableTests.py
+++ b/SCons/Variables/BoolVariableTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/Variables/EnumVariableTests.py
+++ b/SCons/Variables/EnumVariableTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/Variables/ListVariableTests.py
+++ b/SCons/Variables/ListVariableTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import copy
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/Variables/PackageVariableTests.py
+++ b/SCons/Variables/PackageVariableTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/Variables/PathVariableTests.py
+++ b/SCons/Variables/PathVariableTests.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
-import sys
 import unittest
 
 import SCons.Errors

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import TestSCons

--- a/SCons/WarningsTests.py
+++ b/SCons/WarningsTests.py
@@ -23,7 +23,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import unittest
 
 import SCons.Warnings

--- a/SCons/compat/__init__.py
+++ b/SCons/compat/__init__.py
@@ -59,7 +59,6 @@ rest of our code will find our pre-loaded compatibility module.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 import importlib
 
@@ -81,7 +80,6 @@ def rename_module(new, old):
 # Default pickle protocol. Higher protocols are more efficient/featured
 # but incompatible with older Python versions.
 # Negative numbers choose the highest available protocol.
-import pickle
 
 # Was pickle.HIGHEST_PROTOCOL
 # Changed to 4 so that python 3.8's not incompatible with previous versions

--- a/test/AR/AR.py
+++ b/test/AR/AR.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/AR/ARFLAGS.py
+++ b/test/AR/ARFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/AS/AS.py
+++ b/test/AS/AS.py
@@ -29,8 +29,6 @@ Verify the ability to set the $AS construction variable to a different
 assembler (a wrapper we create).
 """
 
-import os
-import sys
 
 import TestSCons
 

--- a/test/AS/ASFLAGS.py
+++ b/test/AS/ASFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 
 import TestSCons

--- a/test/AS/ASPP.py
+++ b/test/AS/ASPP.py
@@ -24,8 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
-import sys
 
 import TestSCons
 

--- a/test/AS/ASPPFLAGS.py
+++ b/test/AS/ASPPFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 
 import TestSCons

--- a/test/Actions/append.py
+++ b/test/Actions/append.py
@@ -30,7 +30,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import stat
-import sys
 import TestSCons
 
 _exe = TestSCons._exe

--- a/test/Actions/pre-post.py
+++ b/test/Actions/pre-post.py
@@ -28,7 +28,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import stat
 
 import TestSCons
 

--- a/test/Builder/errors.py
+++ b/test/Builder/errors.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test the ability to catch Builder creation with poorly specified Actions.
 """
 
-import os.path
 
 import TestSCons
 

--- a/test/CC/CCVERSION.py
+++ b/test/CC/CCVERSION.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 import TestSCons
 

--- a/test/CC/SHCC.py
+++ b/test/CC/SHCC.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/CFILESUFFIX.py
+++ b/test/CFILESUFFIX.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify that we can set CFILESUFFIX to arbitrary values.
 """
 
-import os
 
 import TestSCons
 

--- a/test/CXX/CXX.py
+++ b/test/CXX/CXX.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 import TestSCons
 

--- a/test/CXX/CXXFILESUFFIX.py
+++ b/test/CXX/CXXFILESUFFIX.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/CacheDir/CacheDir_TryCompile.py
+++ b/test/CacheDir/CacheDir_TryCompile.py
@@ -32,7 +32,6 @@ could be bytes instead of a string which would fail when combining cache signatu
 which ended up a mixture of bytes and strings.
 """
 
-import os
 
 import TestSCons
 

--- a/test/CacheDir/NoCache.py
+++ b/test/CacheDir/NoCache.py
@@ -28,7 +28,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify that the NoCache environment method works.
 """
 
-import TestSCons, os.path
+import TestSCons
 
 test = TestSCons.TestSCons()
 

--- a/test/CacheDir/multiple-targets.py
+++ b/test/CacheDir/multiple-targets.py
@@ -28,8 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test that multiple target files get retrieved from a CacheDir correctly.
 """
 
-import os.path
-import shutil
 
 import TestSCons
 

--- a/test/CacheDir/option--cd.py
+++ b/test/CacheDir/option--cd.py
@@ -29,8 +29,6 @@ Test the --cache-disable option when retrieving derived files from a
 CacheDir.
 """
 
-import os.path
-import shutil
 
 import TestSCons
 

--- a/test/CacheDir/option--cr.py
+++ b/test/CacheDir/option--cr.py
@@ -29,8 +29,6 @@ Test the --cache-readonly option when retrieving derived files from a
 CacheDir. It should retrieve as normal but not update files.
 """
 
-import os.path
-import shutil
 
 import TestSCons
 

--- a/test/CacheDir/option--cs.py
+++ b/test/CacheDir/option--cs.py
@@ -29,8 +29,6 @@ Test printing build actions when using the --cache-show option and
 retrieving derived files from a CacheDir.
 """
 
-import os.path
-import shutil
 
 import TestSCons
 

--- a/test/CacheDir/readonly-cache.py
+++ b/test/CacheDir/readonly-cache.py
@@ -32,7 +32,6 @@ import glob
 import os
 import TestSCons
 import time
-from stat import *
 
 test = TestSCons.TestSCons()
 

--- a/test/CacheDir/scanner-target.py
+++ b/test/CacheDir/scanner-target.py
@@ -31,8 +31,6 @@ to push the file to the CacheDir after the build signature had already
 been cleared (as a sign that the built file should now be rescanned).
 """
 
-import os.path
-import shutil
 
 import TestSCons
 

--- a/test/Clean/Option.py
+++ b/test/Clean/Option.py
@@ -29,7 +29,6 @@ Verify that {Set,Get}Option('clean') works correctly to control
 cleaning behavior.
 """
 
-import os
 
 import TestSCons
 

--- a/test/CommandGenerator.py
+++ b/test/CommandGenerator.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/Configure/VariantDir2.py
+++ b/test/Configure/VariantDir2.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify that Configure contexts work with SConstruct/SConscript structure
 """
 
-import os
 
 import TestSCons
 

--- a/test/Configure/config-h.py
+++ b/test/Configure/config-h.py
@@ -27,7 +27,6 @@ Verify creation of a config.h file from a Configure context.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import re
 
 import TestSCons

--- a/test/Copy-Symlinks.py
+++ b/test/Copy-Symlinks.py
@@ -29,8 +29,6 @@ Verify that the Copy() Action symlink soft-copy support works.
 """
 
 import os
-import stat
-import sys
 import TestSCons
 
 import SCons.Defaults

--- a/test/D/Issues/2994/Common/D_changed_DFLAGS_not_rebuilding.py
+++ b/test/D/Issues/2994/Common/D_changed_DFLAGS_not_rebuilding.py
@@ -30,7 +30,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname
 
 import sys
 sys.path.insert(1, abspath(dirname(__file__) + '/../../../Support'))

--- a/test/D/MixedDAndC/Common/common.py
+++ b/test/D/MixedDAndC/Common/common.py
@@ -30,7 +30,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import TestSCons
 
 from os.path import abspath, dirname
-from platform import architecture
 
 import sys
 sys.path.insert(1, abspath(dirname(__file__) + '/../../Support'))

--- a/test/Decider/MD5-winonly-firstbuild.py
+++ b/test/Decider/MD5-winonly-firstbuild.py
@@ -29,8 +29,6 @@ Test but which only shows on windows when one generated file depends on another 
 In this case flex and yacc are an example.
 """
 
-import os
-import stat
 
 import TestSCons
 from TestCmd import IS_WINDOWS

--- a/test/Dir/PyPackageDir/PyPackageDir.py
+++ b/test/Dir/PyPackageDir/PyPackageDir.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/Docbook/basedir/htmlchunked/htmlchunked_cmd.py
+++ b/test/Docbook/basedir/htmlchunked/htmlchunked_cmd.py
@@ -28,7 +28,6 @@ the xsltproc executable, if it exists.
 """
 
 import os
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/Docbook/basedir/htmlhelp/htmlhelp_cmd.py
+++ b/test/Docbook/basedir/htmlhelp/htmlhelp_cmd.py
@@ -28,7 +28,6 @@ the xsltproc executable, if it exists.
 """
 
 import os
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/Docbook/basedir/slideshtml/slideshtml_cmd.py
+++ b/test/Docbook/basedir/slideshtml/slideshtml_cmd.py
@@ -28,7 +28,6 @@ the xsltproc executable, if it exists.
 """
 
 import os
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/Docbook/basic/htmlchunked/htmlchunked_cmd.py
+++ b/test/Docbook/basic/htmlchunked/htmlchunked_cmd.py
@@ -27,7 +27,6 @@ Test the chunked HTML builder while using
 the xsltproc executable, if it exists.
 """
 
-import os
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/Docbook/basic/slideshtml/slideshtml_cmd.py
+++ b/test/Docbook/basic/slideshtml/slideshtml_cmd.py
@@ -28,7 +28,6 @@ the xsltproc executable, if it exists.
 """
 
 import os
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/Errors/execute-a-directory.py
+++ b/test/Errors/execute-a-directory.py
@@ -25,7 +25,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import sys
 
 import TestSCons
 

--- a/test/Errors/non-executable-file.py
+++ b/test/Errors/non-executable-file.py
@@ -25,7 +25,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import sys
 
 import TestSCons
 

--- a/test/Fortran/F03.py
+++ b/test/Fortran/F03.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F03FILESUFFIXES.py
+++ b/test/Fortran/F03FILESUFFIXES.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F03FILESUFFIXES2.py
+++ b/test/Fortran/F03FILESUFFIXES2.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F03FLAGS.py
+++ b/test/Fortran/F03FLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F08.py
+++ b/test/Fortran/F08.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F08FILESUFFIXES.py
+++ b/test/Fortran/F08FILESUFFIXES.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F08FILESUFFIXES2.py
+++ b/test/Fortran/F08FILESUFFIXES2.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F08FLAGS.py
+++ b/test/Fortran/F08FLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F77.py
+++ b/test/Fortran/F77.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F77FILESUFFIXES.py
+++ b/test/Fortran/F77FILESUFFIXES.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F77FILESUFFIXES2.py
+++ b/test/Fortran/F77FILESUFFIXES2.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F77FLAGS.py
+++ b/test/Fortran/F77FLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F90.py
+++ b/test/Fortran/F90.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F90FILESUFFIXES.py
+++ b/test/Fortran/F90FILESUFFIXES.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F90FILESUFFIXES2.py
+++ b/test/Fortran/F90FILESUFFIXES2.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F90FLAGS.py
+++ b/test/Fortran/F90FLAGS.py
@@ -25,7 +25,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F95.py
+++ b/test/Fortran/F95.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F95FILESUFFIXES.py
+++ b/test/Fortran/F95FILESUFFIXES.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F95FILESUFFIXES2.py
+++ b/test/Fortran/F95FILESUFFIXES2.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/F95FLAGS.py
+++ b/test/Fortran/F95FLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/FORTRAN.py
+++ b/test/Fortran/FORTRAN.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/FORTRANFILESUFFIXES.py
+++ b/test/Fortran/FORTRANFILESUFFIXES.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/FORTRANFILESUFFIXES2.py
+++ b/test/Fortran/FORTRANFILESUFFIXES2.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/FORTRANFLAGS.py
+++ b/test/Fortran/FORTRANFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/FORTRANPPFILESUFFIXES.py
+++ b/test/Fortran/FORTRANPPFILESUFFIXES.py
@@ -25,9 +25,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
-import string
-import sys
 import TestSCons
 
 

--- a/test/Fortran/SHF03.py
+++ b/test/Fortran/SHF03.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHF08.py
+++ b/test/Fortran/SHF08.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHF77.py
+++ b/test/Fortran/SHF77.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHF77FLAGS.py
+++ b/test/Fortran/SHF77FLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHF90.py
+++ b/test/Fortran/SHF90.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHF90FLAGS.py
+++ b/test/Fortran/SHF90FLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHF95.py
+++ b/test/Fortran/SHF95.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHF95FLAGS.py
+++ b/test/Fortran/SHF95FLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHFORTRAN.py
+++ b/test/Fortran/SHFORTRAN.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Fortran/SHFORTRANFLAGS.py
+++ b/test/Fortran/SHFORTRANFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Install/directories.py
+++ b/test/Install/directories.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test using Install() on directories.
 """
 
-import os.path
 
 import TestSCons
 

--- a/test/Install/non-ascii-name.py
+++ b/test/Install/non-ascii-name.py
@@ -29,7 +29,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify that the Install() Builder works
 """
 
-import os.path
 
 import TestSCons
 

--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -26,7 +26,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import TestSCons
-import sys
 
 _python_ = TestSCons._python_
 

--- a/test/Java/JARCHDIR.py
+++ b/test/Java/JARCHDIR.py
@@ -33,7 +33,6 @@ Includes logic to make sure that expansions of $JARCHDIR that include
 ${TARGET} or ${SOURCE} work.
 """
 
-import os
 
 import TestSCons
 

--- a/test/Java/JARFLAGS.py
+++ b/test/Java/JARFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/Java/jar_not_in_PATH.py
+++ b/test/Java/jar_not_in_PATH.py
@@ -29,7 +29,6 @@ Ensures that the Tool gets initialized, even when jar is not directly
 found via the PATH variable (issue #2730).
 """
 
-import os
 
 import TestSCons
 

--- a/test/Java/nested-classes.py
+++ b/test/Java/nested-classes.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test Java compilation with inner and anonymous classes (Issue 2087).
 """
 
-import os
 
 import TestSCons
 

--- a/test/Java/swig-dependencies.py
+++ b/test/Java/swig-dependencies.py
@@ -143,7 +143,6 @@ except:
     # the test framework
     test.skip_test('Throwing no result for this test because of bug ' +
         'related here: https://github.com/SCons/scons/issues/2907\n')
-    pass
 #test.must_exist(['java', 'classes', 'foopack', 'foopack.class'])
 #test.must_exist(['java', 'classes', 'foopack', 'foopackJNI.class'])
 test.must_exist(['java', 'classes', 'foopack.class'])

--- a/test/LEX/LEX.py
+++ b/test/LEX/LEX.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/LEX/LEXFLAGS.py
+++ b/test/LEX/LEXFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 
 import TestSCons

--- a/test/LINK/LDMODULEVERSIONFLAGS.py
+++ b/test/LINK/LDMODULEVERSIONFLAGS.py
@@ -24,8 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
-import re
 
 import TestSCons
 import SCons.Platform

--- a/test/LINK/LINK.py
+++ b/test/LINK/LINK.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/LINK/LINKFLAGS.py
+++ b/test/LINK/LINKFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/LINK/SHLIBVERSIONFLAGS.py
+++ b/test/LINK/SHLIBVERSIONFLAGS.py
@@ -24,8 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
-import re
 
 import TestSCons
 import SCons.Platform

--- a/test/LINK/SHLINK.py
+++ b/test/LINK/SHLINK.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/LINK/SHLINKFLAGS.py
+++ b/test/LINK/SHLINKFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/LINK/VersionedLib.py
+++ b/test/LINK/VersionedLib.py
@@ -24,7 +24,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import sys
 import TestSCons
 
 import SCons.Platform

--- a/test/Libs/SharedLibrary-update-deps.py
+++ b/test/Libs/SharedLibrary-update-deps.py
@@ -30,7 +30,6 @@ This is https://github.com/SCons/scons/issues/2903
 """
 
 import sys
-import os.path
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/MSVC/PCHSTOP-errors.py
+++ b/test/MSVC/PCHSTOP-errors.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 # Test error reporting
 """
 
-import re
 
 import TestSCons
 

--- a/test/MSVC/mssdk.py
+++ b/test/MSVC/mssdk.py
@@ -27,7 +27,6 @@ Simple test to make sure mssdk works.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import time
 
 import TestSCons
 

--- a/test/MSVC/pch-basics.py
+++ b/test/MSVC/pch-basics.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify PCH works to build a simple exe and a simple dll.
 """
  
-import time
  
 import TestSCons
  

--- a/test/MSVC/pch-spaces-subdir.py
+++ b/test/MSVC/pch-spaces-subdir.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify PCH works if variant dir has spaces in its name
 """
 
-import time
 
 import TestSCons
 

--- a/test/MSVS/common-prefix.py
+++ b/test/MSVS/common-prefix.py
@@ -30,7 +30,6 @@ Test that we can generate Visual Studio 8.0 project (.vcproj) and
 solution (.sln) files that look correct.
 """
 
-import os
 import sys
 
 import TestSConsMSVS

--- a/test/MSVS/runfile.py
+++ b/test/MSVS/runfile.py
@@ -30,7 +30,6 @@ Test that we can generate Visual Studio 8.0 project (.vcproj) and
 solution (.sln) files that look correct.
 """
 
-import os
 import sys
 
 import TestSConsMSVS

--- a/test/MSVS/vs-6.0-exec.py
+++ b/test/MSVS/vs-6.0-exec.py
@@ -29,7 +29,6 @@ Test that we can actually build a simple program using our generated
 Visual Studio 6 project (.dsp) and solution (.dsw) files.
 """
 
-import os
 import sys
 
 import TestSConsMSVS

--- a/test/MSVS/vs-7.0-exec.py
+++ b/test/MSVS/vs-7.0-exec.py
@@ -29,7 +29,6 @@ Test that we can actually build a simple program using our generated
 Visual Studio 7.0 project (.vcproj) and solution (.sln) files.
 """
 
-import os
 import sys
 
 import TestSConsMSVS

--- a/test/MSVS/vs-7.0-scc-files.py
+++ b/test/MSVS/vs-7.0-scc-files.py
@@ -29,7 +29,6 @@ Test that we can generate Visual Studio 7.0 project (.vcproj) and
 solution (.sln) files that contain SCC information and look correct.
 """
 
-import os
 
 import TestSConsMSVS
 

--- a/test/MSVS/vs-7.0-scc-legacy-files.py
+++ b/test/MSVS/vs-7.0-scc-legacy-files.py
@@ -29,7 +29,6 @@ Test that we can generate Visual Studio 7.0 project (.vcproj) and
 solution (.sln) files that contain SCC information and look correct.
 """
 
-import os
 
 import TestSConsMSVS
 

--- a/test/MSVS/vs-7.1-exec.py
+++ b/test/MSVS/vs-7.1-exec.py
@@ -29,7 +29,6 @@ Test that we can actually build a simple program using our generated
 Visual Studio 7.1 project (.vcproj) and solution (.sln) files
 """
 
-import os
 import sys
 
 import TestSConsMSVS

--- a/test/MSVS/vs-7.1-scc-files.py
+++ b/test/MSVS/vs-7.1-scc-files.py
@@ -29,7 +29,6 @@ Test that we can generate Visual Studio 7.1 project (.vcproj) and
 solution (.sln) files that contain SCC information and look correct.
 """
 
-import os
 
 import TestSConsMSVS
 

--- a/test/MSVS/vs-7.1-scc-legacy-files.py
+++ b/test/MSVS/vs-7.1-scc-legacy-files.py
@@ -29,7 +29,6 @@ Test that we can generate Visual Studio 7.1 project (.vcproj) and
 solution (.sln) files that contain SCC information and look correct.
 """
 
-import os
 
 import TestSConsMSVS
 

--- a/test/MinGW/mingw_uses_comstr_issue_2799.py
+++ b/test/MinGW/mingw_uses_comstr_issue_2799.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test that mingw respects SHLINKCOMSTR, SHCCCOMSTR, and LDMODULECOMSTR
 """
 
-import sys
 import TestSCons
 
 _python_ = TestSCons._python_

--- a/test/Progress/TARGET.py
+++ b/test/Progress/TARGET.py
@@ -29,7 +29,6 @@ Verify substition of the $TARGET string in progress output, including
 overwriting it by setting the overwrite= keyword argument.
 """
 
-import os
 
 import TestSCons
 

--- a/test/Progress/spinner.py
+++ b/test/Progress/spinner.py
@@ -29,7 +29,6 @@ Verify output when a Progress() call is initialized with the list
 that represents a canonical "spinner" on the output.
 """
 
-import os
 
 import TestSCons
 

--- a/test/Repository/Install.py
+++ b/test/Repository/Install.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/Repository/InstallAs.py
+++ b/test/Repository/InstallAs.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/Repository/M4.py
+++ b/test/Repository/M4.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test that $M4 and $M4FLAGS work with repositories.
 """
 
-import os
 
 import TestSCons
 

--- a/test/SConsignFile/default.py
+++ b/test/SConsignFile/default.py
@@ -29,7 +29,6 @@ Verify the default behavior of SConsignFile(), called with no arguments.
 """
 
 import TestSCons
-import os.path
 
 _python_ = TestSCons._python_
 

--- a/test/SConsignFile/explicit-file.py
+++ b/test/SConsignFile/explicit-file.py
@@ -29,7 +29,6 @@ Verify the default behavior of SConsignFile(), called with no arguments.
 """
 
 import TestSCons
-import os.path
 
 _python_ = TestSCons._python_
 

--- a/test/SConsignFile/use-dumbdbm.py
+++ b/test/SConsignFile/use-dumbdbm.py
@@ -35,14 +35,10 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 
 try:
-    import dumbdbm
-    use_dbm = 'dumbdbm'
+    import dbm.dumb
+    use_dbm='dbm.dumb'
 except ImportError:
-    try:
-        import dbm.dumb
-        use_dbm='dbm.dumb'
-    except ImportError:
-        test.skip_test('No dumbdbm or dbm.dumb in this version of Python; skipping test.\n')
+    test.skip_test('No dbm.dumb in this version of Python; skipping test.\n')
 
 test.subdir('subdir')
 

--- a/test/SConsignFile/use-gdbm.py
+++ b/test/SConsignFile/use-gdbm.py
@@ -35,14 +35,10 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 
 try:
-    import gdbm
-    use_dbm = "gdbm"
+    import dbm.gnu
+    use_dbm = "dbm.gnu"
 except ImportError:
-    try:
-        import dbm.gnu
-        use_dbm = "dbm.gnu"
-    except ImportError:
-        test.skip_test('No GNU dbm in this version of Python; skipping test.\n')
+    test.skip_test('No GNU dbm in this version of Python; skipping test.\n')
 
 test.subdir('subdir')
 

--- a/test/SWIG/SWIGFLAGS.py
+++ b/test/SWIG/SWIGFLAGS.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify that we can use ${SOURCE} expansions in $SWIGFLAGS.
 """
 
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/SWIG/live.py
+++ b/test/SWIG/live.py
@@ -27,7 +27,6 @@ Test SWIG behavior with a live, installed SWIG.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 
 import TestSCons

--- a/test/Scanner/Scanner.py
+++ b/test/Scanner/Scanner.py
@@ -25,7 +25,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
-import os
 
 _python_ = TestSCons._python_
 

--- a/test/TEX/generated_files.py
+++ b/test/TEX/generated_files.py
@@ -33,7 +33,6 @@ Test courtesy Rob Managan.
 """
 
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 

--- a/test/TEX/synctex.py
+++ b/test/TEX/synctex.py
@@ -31,7 +31,6 @@ be aware of the created synctex.gz file.
 Test configuration contributed by Robert Managan.
 """
 
-import os
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/TempFileMunge/TEMPFILEPREFIX.py
+++ b/test/TempFileMunge/TEMPFILEPREFIX.py
@@ -25,8 +25,6 @@ it to appear at the front of name of the generated tempfile
 used for long command lines.
 """
 
-import os
-import stat
 
 import TestSCons
 

--- a/test/TempFileMunge/TEMPFILESUFFIX.py
+++ b/test/TempFileMunge/TEMPFILESUFFIX.py
@@ -25,8 +25,6 @@ it to appear at the end of name of the generated tempfile
 used for long command lines.
 """
 
-import os
-import stat
 
 import TestSCons
 

--- a/test/Variables/BoolVariable.py
+++ b/test/Variables/BoolVariable.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test the BoolVariable canned Variable type.
 """
 
-import os
 
 import TestSCons
 

--- a/test/Variables/EnumVariable.py
+++ b/test/Variables/EnumVariable.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test the EnumVariable canned Variable type.
 """
 
-import os.path
 
 import TestSCons
 

--- a/test/Variables/PackageVariable.py
+++ b/test/Variables/PackageVariable.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test the PackageVariable canned Variable type.
 """
 
-import os
 
 import TestSCons
 

--- a/test/YACC/YACCFLAGS.py
+++ b/test/YACC/YACCFLAGS.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 import sys
 
 import TestSCons

--- a/test/YACC/live.py
+++ b/test/YACC/live.py
@@ -29,8 +29,6 @@ Test YACC and YACCFLAGS with a live yacc compiler.
 """
 
 import TestSCons
-import sys
-import os
 
 _exe = TestSCons._exe
 _python_ = TestSCons._python_

--- a/test/ZIP/ZIPROOT.py
+++ b/test/ZIP/ZIPROOT.py
@@ -24,8 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
-import stat
 
 import TestSCons
 

--- a/test/emitter.py
+++ b/test/emitter.py
@@ -25,7 +25,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 

--- a/test/exitfns.py
+++ b/test/exitfns.py
@@ -25,7 +25,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
-import os
 test = TestSCons.TestSCons()
 
 # also exclude these tests since it overides the exit function which doesnt work with coverage 

--- a/test/gettext/MOFiles/UserExamples.py
+++ b/test/gettext/MOFiles/UserExamples.py
@@ -30,7 +30,6 @@ Make sure, that the examples given in user guide all work.
 """
 
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 

--- a/test/gettext/POUpdate/UserExamples.py
+++ b/test/gettext/POUpdate/UserExamples.py
@@ -29,7 +29,6 @@ Make sure, that the examples given in user guide all work.
 """
 
 import TestSCons
-import os
 
 test = TestSCons.TestSCons()
 

--- a/test/gettext/Translate/MultiCatalog.py
+++ b/test/gettext/Translate/MultiCatalog.py
@@ -42,7 +42,6 @@ files correctly.
 # replicate the bug.
 
 import TestSCons
-from os import path
 
 test = TestSCons.TestSCons()
 

--- a/test/ignore-command.py
+++ b/test/ignore-command.py
@@ -28,7 +28,6 @@ Test use of a preceding - to ignore the return value from a command.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/import.py
+++ b/test/import.py
@@ -27,7 +27,6 @@ modules directly.
 
 import os
 import re
-import sys
 
 # must do this here, since TestSCons will chdir
 tooldir = os.path.join(os.getcwd(), 'SCons', 'Tool')

--- a/test/multiline.py
+++ b/test/multiline.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/no-arguments.py
+++ b/test/no-arguments.py
@@ -30,7 +30,6 @@ is no Default() in the SConstruct file and there are no command-line
 arguments, or a null command-line argument.
 """
 
-import os.path
 
 import TestSCons
 

--- a/test/option--random.py
+++ b/test/option--random.py
@@ -27,7 +27,6 @@ Verify that we build correctly using the --random option.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/option--tree.py
+++ b/test/option--tree.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import sys
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/option-k.py
+++ b/test/option-k.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/option/debug-count.py
+++ b/test/option/debug-count.py
@@ -34,13 +34,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-try:
-    import weakref
-except ImportError:
-    x = "Python version has no 'weakref' module; skipping tests.\n"
-    test.skip_test(x)
-
-
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])

--- a/test/option/debug-objects.py
+++ b/test/option/debug-objects.py
@@ -32,13 +32,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-try:
-    import weakref
-except ImportError:
-    x = "Python version has no 'weakref' module; skipping tests.\n"
-    test.skip_test(x)
-
-
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])

--- a/test/packaging/place-files-in-subdirectory.py
+++ b/test/packaging/place-files-in-subdirectory.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test the requirement to place files in a given subdirectory before archiving.
 """
 
-import os
 import subprocess
 
 import TestSCons

--- a/test/python-version.py
+++ b/test/python-version.py
@@ -29,7 +29,6 @@ Verify the behavior of our check for unsupported or deprecated versions
 of Python.
 """
 
-import os
 import re
 
 import TestCmd

--- a/test/runtest/testlistfile.py
+++ b/test/runtest/testlistfile.py
@@ -29,7 +29,6 @@ Test a list of tests to run in a file specified with the -f option.
 """
 
 import os.path
-import re
 
 import TestRuntest
 

--- a/test/scons-time/func/prefix.py
+++ b/test/scons-time/func/prefix.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Verify that the func -p and --prefix options specify what log files to use.
 """
 
-import os.path
 
 import TestSCons_time
 

--- a/test/scons-time/run/archive/zip.py
+++ b/test/scons-time/run/archive/zip.py
@@ -29,7 +29,6 @@ Verify basic generation of timing information from an input fake-project
 .zip file.
 """
 
-import sys
 
 import TestSCons_time
 

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -29,7 +29,6 @@ Verify that the sconsign script works with files generated when
 using the signatures in an SConsignFile().
 """
 
-import re
 import TestSCons
 import TestSConsign
 

--- a/test/silent-command.py
+++ b/test/silent-command.py
@@ -28,7 +28,6 @@ Test the use of a preceding @ to suppress printing a command.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os
 
 import TestSCons
 

--- a/test/srcchange.py
+++ b/test/srcchange.py
@@ -32,7 +32,6 @@ of Decider('content').
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/subdir.py
+++ b/test/subdir.py
@@ -25,7 +25,6 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
-import os.path
 
 _python_ = TestSCons._python_
 

--- a/test/symlink/dangling-include.py
+++ b/test/symlink/dangling-include.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test how we handle #includes of dangling symlinks.
 """
 
-import os
 
 import TestSCons
 

--- a/test/symlink/dangling-source.py
+++ b/test/symlink/dangling-source.py
@@ -28,7 +28,6 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 Test how we handle dangling symlinks as source files.
 """
 
-import os
 
 import TestSCons
 

--- a/test/timestamp-fallback.py
+++ b/test/timestamp-fallback.py
@@ -32,7 +32,6 @@ rare no-md5 Pythons comes into play (some entities ban the use
 of md5 as unsafe, although SCons does not use it in a security context.
 """
 
-import sys
 import os
 
 import TestSCons

--- a/test/tool_args.py
+++ b/test/tool_args.py
@@ -29,7 +29,6 @@ Test the ability to pass a dictionary of keyword arguments to
 a Tool specification's generate() method.
 """
 
-import os.path
 
 import TestSCons
 

--- a/test/toolpath/basic.py
+++ b/test/toolpath/basic.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 
 import TestSCons
 

--- a/test/toolpath/nested/nested.py
+++ b/test/toolpath/nested/nested.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/toolpath/relative_import/relative_import.py
+++ b/test/toolpath/relative_import/relative_import.py
@@ -24,7 +24,6 @@
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os.path
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/update-release-info/update-release-info.py
+++ b/test/update-release-info/update-release-info.py
@@ -27,7 +27,8 @@ have the appropriate triggers to cause the modifications.
 
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-import os, sys, time
+import os
+import time
 
 import TestRuntest
 

--- a/test/virtualenv/activated/option/enable-virtualenv.py
+++ b/test/virtualenv/activated/option/enable-virtualenv.py
@@ -30,7 +30,6 @@ Ensure that the --enable-virtualenv flag works.
 
 import TestSCons
 import SCons.Platform.virtualenv
-import sys
 import os
 import re
 

--- a/test/virtualenv/activated/option/ignore-virtualenv.py
+++ b/test/virtualenv/activated/option/ignore-virtualenv.py
@@ -30,7 +30,6 @@ Ensure that the --ignore-virtualenv flag works.
 
 import TestSCons
 import SCons.Platform.virtualenv
-import sys
 import os
 import re
 

--- a/test/virtualenv/activated/virtualenv_activated_python.py
+++ b/test/virtualenv/activated/virtualenv_activated_python.py
@@ -33,7 +33,6 @@ environment or in unactivated virtualenv.
 
 import TestSCons
 import SCons.Platform.virtualenv
-import sys
 import os
 import re
 

--- a/test/virtualenv/activated/virtualenv_detect_virtualenv.py
+++ b/test/virtualenv/activated/virtualenv_detect_virtualenv.py
@@ -30,7 +30,6 @@ Check if SCons.Platform.virtualenv.Virtualenv() works in SConscripts.
 
 import TestSCons
 import SCons.Platform.virtualenv
-import sys
 
 test = TestSCons.TestSCons()
 

--- a/test/virtualenv/regularenv/virtualenv_detect_regularenv.py
+++ b/test/virtualenv/regularenv/virtualenv_detect_regularenv.py
@@ -30,7 +30,6 @@ Check if SCons.Platform.virtualenv.Virtualenv() works in SConscript.
 
 import TestSCons
 import SCons.Platform.virtualenv
-import sys
 
 test = TestSCons.TestSCons()
 

--- a/test/virtualenv/unactivated/virtualenv_unactivated_python.py
+++ b/test/virtualenv/unactivated/virtualenv_unactivated_python.py
@@ -33,7 +33,6 @@ a regular environment or in an activated virtualenv.
 
 import TestSCons
 import SCons.Platform.virtualenv
-import sys
 import os
 import re
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -309,7 +309,6 @@ import tempfile
 import threading
 import time
 import traceback
-import types
 from collections import UserList, UserString
 from subprocess import PIPE, STDOUT
 

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -24,13 +24,11 @@ __revision__ = "TestCmdTests.py 1.3.D001 2010/06/03 12:58:27 knight"
 
 import os
 import shutil
-import signal
 import stat
 import subprocess
 import sys
 import tempfile
 import time
-import types
 import unittest
 from io import StringIO
 from contextlib import closing

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -99,7 +99,6 @@ __author__ = "Steven Knight <knight at baldmt dot com>"
 __revision__ = "TestCommon.py 1.3.D001 2010/06/03 12:58:27 knight"
 __version__ = "1.3"
 
-import copy
 import glob
 import os
 import stat

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -22,11 +22,9 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 __author__ = "Steven Knight <knight at baldmt dot com>"
 __revision__ = "TestCommonTests.py 1.3.D001 2010/06/03 12:58:27 knight"
 
-import difflib
 import os
 import re
 import signal
-import stat
 import sys
 import unittest
 

--- a/testing/framework/TestSConsign.py
+++ b/testing/framework/TestSConsign.py
@@ -19,7 +19,6 @@ in this subclass.
 
 import os
 import os.path
-import sys
 
 from TestSCons import *
 from TestSCons import __all__


### PR DESCRIPTION
Eliminate unneeded imports, and a few unneeded statements - usually `pass` where it is not syntactically needed.

A couple of import try blocks were eliminated or changed when they're "cannot happen" due to current floor Python version.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
