### PR TITLE
Update some copyright strings and drop __revision__

### DIFF
--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -1,11 +1,34 @@
-"""SCons.Action
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-This encapsulates information about executing any sort of action that
+"""SCons Actions.
+
+Information about executing any sort of action that
 can build one or more target Nodes (typically files) from one or more
 source Nodes (also typically files) given a specific Environment.
 
 The base class here is ActionBase.  The base class supplies just a few
-OO utility methods and some generic methods for displaying information
+utility methods and some generic methods for displaying information
 about an Action in response to the various commands that control printing.
 
 A second-level base class is _ActionAction.  This extends ActionBase
@@ -60,7 +83,7 @@ this module:
     get_presig()
         Fetches the "contents" of a subclass for signature calculation.
         The varlist is added to this to produce the Action's contents.
-        TODO(?): Change this to always return ascii/bytes and not unicode (or py3 strings)
+        TODO(?): Change this to always return bytes and not str?
 
     strfunction()
         Returns a substituted string representation of the Action.
@@ -76,29 +99,6 @@ ActionFactory class that provides a __call__() method as a convenient
 way for wrapping up the functions.
 
 """
-
-# __COPYRIGHT__
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import pickle

--- a/SCons/Action.xml
+++ b/SCons/Action.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,13 +22,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-
 # Define a null function and a null class for use as builder actions.
 # Where these are defined in the file seems to affect their byte-code
 # contents, so try to minimize changes by defining them here, before we
 # even import anything.
+
 def GlobalFunc():
     pass
 

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -1,3 +1,26 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 """
 SCons.Builder
 
@@ -75,30 +98,6 @@ There are the following methods for internal use within this module:
         file names.
 
 """
-
-#
-# __COPYRIGHT__
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 from collections import UserDict, UserList
 

--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,12 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """
-CacheDir support
+"""CacheDir support
 """
 
 import atexit

--- a/SCons/CacheDirTests.py
+++ b/SCons/CacheDirTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import shutil

--- a/SCons/Conftest.py
+++ b/SCons/Conftest.py
@@ -40,14 +40,14 @@ context.Log(msg)
 
 context.BuildProg(text, ext)
     Function called to build a program, using "ext" for the file
-    extention.  Must return an empty string for success, an error
+    extension.  Must return an empty string for success, an error
     message for failure.  For reliable test results building should
     be done just like an actual program would be build, using the
     same command and arguments (including configure results so far).
 
 context.CompileProg(text, ext)
     Function called to compile a program, using "ext" for the file
-    extention.  Must return an empty string for success, an error
+    extension.  Must return an empty string for success, an error
     message for failure.  For reliable test results compiling should be
     done just like an actual source file would be compiled, using the
     same command and arguments (including configure results so far).

--- a/SCons/Conftest.py
+++ b/SCons/Conftest.py
@@ -1,9 +1,6 @@
-"""SCons.Conftest
-
-Autoconf-like configuration support; low level implementation of tests.
-"""
-
+# MIT License
 #
+# Copyright The SCons Foundation
 # Copyright (c) 2003 Stichting NLnet Labs
 # Copyright (c) 2001, 2002, 2003 Steven Knight
 #
@@ -25,80 +22,72 @@ Autoconf-like configuration support; low level implementation of tests.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-#
-# The purpose of this module is to define how a check is to be performed.
-# Use one of the Check...() functions below.
-#
+"""Autoconf-like configuration support
 
-#
-# A context class is used that defines functions for carrying out the tests,
-# logging and messages.  The following methods and members must be present:
-#
-# context.Display(msg)  Function called to print messages that are normally
-#                       displayed for the user.  Newlines are explicitly used.
-#                       The text should also be written to the logfile!
-#
-# context.Log(msg)      Function called to write to a log file.
-#
-# context.BuildProg(text, ext)
-#                       Function called to build a program, using "ext" for the
-#                       file extention.  Must return an empty string for
-#                       success, an error message for failure.
-#                       For reliable test results building should be done just
-#                       like an actual program would be build, using the same
-#                       command and arguments (including configure results so
-#                       far).
-#
-# context.CompileProg(text, ext)
-#                       Function called to compile a program, using "ext" for
-#                       the file extention.  Must return an empty string for
-#                       success, an error message for failure.
-#                       For reliable test results compiling should be done just
-#                       like an actual source file would be compiled, using the
-#                       same command and arguments (including configure results
-#                       so far).
-#
-# context.AppendLIBS(lib_name_list)
-#                       Append "lib_name_list" to the value of LIBS.
-#                       "lib_namelist" is a list of strings.
-#                       Return the value of LIBS before changing it (any type
-#                       can be used, it is passed to SetLIBS() later.)
-#
-# context.PrependLIBS(lib_name_list)
-#                       Prepend "lib_name_list" to the value of LIBS.
-#                       "lib_namelist" is a list of strings.
-#                       Return the value of LIBS before changing it (any type
-#                       can be used, it is passed to SetLIBS() later.)
-#
-# context.SetLIBS(value)
-#                       Set LIBS to "value".  The type of "value" is what
-#                       AppendLIBS() returned.
-#                       Return the value of LIBS before changing it (any type
-#                       can be used, it is passed to SetLIBS() later.)
-#
-# context.headerfilename
-#                       Name of file to append configure results to, usually
-#                       "confdefs.h".
-#                       The file must not exist or be empty when starting.
-#                       Empty or None to skip this (some tests will not work!).
-#
-# context.config_h      (may be missing). If present, must be a string, which
-#                       will be filled with the contents of a config_h file.
-#
-# context.vardict       Dictionary holding variables used for the tests and
-#                       stores results from the tests, used for the build
-#                       commands.
-#                       Normally contains "CC", "LIBS", "CPPFLAGS", etc.
-#
-# context.havedict      Dictionary holding results from the tests that are to
-#                       be used inside a program.
-#                       Names often start with "HAVE_".  These are zero
-#                       (feature not present) or one (feature present).  Other
-#                       variables may have any value, e.g., "PERLVERSION" can
-#                       be a number and "SYSTEMNAME" a string.
-#
+The purpose of this module is to define how a check is to be performed.
+
+A context class is used that defines functions for carrying out the tests,
+logging and messages.  The following methods and members must be present:
+
+context.Display(msg)
+    Function called to print messages that are normally displayed
+    for the user.  Newlines are explicitly used.  The text should
+    also be written to the logfile!
+
+context.Log(msg)
+    Function called to write to a log file.
+
+context.BuildProg(text, ext)
+    Function called to build a program, using "ext" for the file
+    extention.  Must return an empty string for success, an error
+    message for failure.  For reliable test results building should
+    be done just like an actual program would be build, using the
+    same command and arguments (including configure results so far).
+
+context.CompileProg(text, ext)
+    Function called to compile a program, using "ext" for the file
+    extention.  Must return an empty string for success, an error
+    message for failure.  For reliable test results compiling should be
+    done just like an actual source file would be compiled, using the
+    same command and arguments (including configure results so far).
+
+context.AppendLIBS(lib_name_list)
+    Append "lib_name_list" to the value of LIBS.  "lib_namelist" is
+    a list of strings.  Return the value of LIBS before changing it
+    (any type can be used, it is passed to SetLIBS() later.)
+
+context.PrependLIBS(lib_name_list)
+    Prepend "lib_name_list" to the value of LIBS.  "lib_namelist" is
+    a list of strings.  Return the value of LIBS before changing it
+    (any type can be used, it is passed to SetLIBS() later.)
+
+context.SetLIBS(value)
+    Set LIBS to "value".  The type of "value" is what AppendLIBS()
+    returned.  Return the value of LIBS before changing it (any type
+    can be used, it is passed to SetLIBS() later.)
+
+context.headerfilename
+    Name of file to append configure results to, usually "confdefs.h".
+    The file must not exist or be empty when starting.  Empty or None
+    to skip this (some tests will not work!).
+
+context.config_h  (may be missing).
+    If present, must be a string, which will be filled with the
+    contents of a config_h file.
+
+context.vardict
+    Dictionary holding variables used for the tests and stores results
+    from the tests, used for the build commands.  Normally contains
+    "CC", "LIBS", "CPPFLAGS", etc.
+
+context.havedict
+    Dictionary holding results from the tests that are to be used
+    inside a program.  Names often start with "HAVE_".  These are zero
+    (feature not present) or one (feature present).  Other variables
+    may have any value, e.g., "PERLVERSION" can be a number and
+    "SYSTEMNAME" a string.
+"""
 
 import re
 

--- a/SCons/Debug.py
+++ b/SCons/Debug.py
@@ -1,15 +1,6 @@
-"""SCons.Debug
-
-Code for debugging SCons internal things.  Shouldn't be
-needed by most users. Quick shortcuts:
-
-from SCons.Debug import caller_trace
-caller_trace()
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -29,9 +20,14 @@ caller_trace()
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Code for debugging SCons internal things.
+
+Shouldn't be needed by most users. Quick shortcuts:
+
+from SCons.Debug import caller_trace
+caller_trace()
+"""
 
 import atexit
 import os

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -1,16 +1,6 @@
-"""SCons.Defaults
-
-Builders and other things for the local site.  Here's where we'll
-duplicate the functionality of autoconf until we move it into the
-installation procedure or use something like qmconf.
-
-The code that reads the registry to find MSVC components was borrowed
-from distutils.msvccompiler.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -30,9 +20,15 @@ from distutils.msvccompiler.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
+"""Builders and other things for the local site.
+
+Here's where we'll duplicate the functionality of autoconf until we
+move it into the installation procedure or use something like qmconf.
+
+The code that reads the registry to find MSVC components was borrowed
+from distutils.msvccompiler.
+"""
 
 import os
 import errno
@@ -58,9 +54,7 @@ _default_env = None
 # Lazily instantiate the default environment so the overhead of creating
 # it doesn't apply when it's not needed.
 def _fetch_DefaultEnvironment(*args, **kw):
-    """
-    Returns the already-created default construction environment.
-    """
+    """Returns the already-created default construction environment."""
     global _default_env
     return _default_env
 

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/DefaultsTests.py
+++ b/SCons/DefaultsTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1,16 +1,6 @@
-"""SCons.Environment
-
-Base class for construction Environments.  These are
-the primary objects used to communicate dependency and
-construction information to the build engine.
-
-Keyword arguments supplied when the construction Environment
-is created are construction variables used to initialize the
-Environment
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -31,8 +21,14 @@ Environment
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Base class for construction Environments.
 
+These are the primary objects used to communicate dependency and
+construction information to the build engine.
+
+Keyword arguments supplied when the construction Environment is created
+are construction variables used to initialize the Environment.
+"""
 
 import copy
 import os

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/EnvironmentValues.py
+++ b/SCons/EnvironmentValues.py
@@ -1,3 +1,26 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import re
 
 _is_valid_var = re.compile(r'[_a-zA-Z]\w*$')

--- a/SCons/EnvironmentValuesTest.py
+++ b/SCons/EnvironmentValuesTest.py
@@ -1,3 +1,26 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import unittest
 
 from  SCons.EnvironmentValues import EnvironmentValues

--- a/SCons/Errors.py
+++ b/SCons/Errors.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,16 +20,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-"""SCons.Errors
+"""SCons exception classes.
 
-This file contains the exception classes used to handle internal
-and user errors in SCons.
+Used to handle internal and user errors in SCons.
 
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import shutil
 import SCons.Util

--- a/SCons/ErrorsTests.py
+++ b/SCons/ErrorsTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import errno
 import unittest

--- a/SCons/Executor.py
+++ b/SCons/Executor.py
@@ -1,12 +1,6 @@
-"""SCons.Executor
-
-A module for executing actions with specific lists of target and source
-Nodes.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,7 +20,8 @@ Nodes.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""Execute actions with specific lists of target and source Nodes."""
 
 import collections
 

--- a/SCons/ExecutorTests.py
+++ b/SCons/ExecutorTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Job.py
+++ b/SCons/Job.py
@@ -1,13 +1,6 @@
-"""SCons.Job
-
-This module defines the Serial and Parallel classes that execute tasks to
-complete a build. The Jobs class provides a higher level interface to start,
-stop, and wait on jobs.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,9 +20,12 @@ stop, and wait on jobs.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Serial and Parallel classes to execute build tasks.
+
+The Jobs class provides a higher level interface to start,
+stop, and wait on jobs.
+"""
 
 import SCons.compat
 

--- a/SCons/JobTests.py
+++ b/SCons/JobTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 import random

--- a/SCons/Memoize.py
+++ b/SCons/Memoize.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-__doc__ = """Memoizer
+"""Decorator-based memoizer to count caching stats.
 
 A decorator-based implementation to count hits and misses of the computed
 values that various methods cache in memory.

--- a/SCons/MemoizeTests.py
+++ b/SCons/MemoizeTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Node/Alias.py
+++ b/SCons/Node/Alias.py
@@ -1,14 +1,6 @@
-
-"""scons.Node.Alias
-
-Alias nodes.
-
-This creates a hash of global Aliases (dummy targets).
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,11 @@ This creates a hash of global Aliases (dummy targets).
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Alias nodes.
+
+This creates a hash of global Aliases (dummy targets).
+"""
 
 import collections
 

--- a/SCons/Node/AliasTests.py
+++ b/SCons/Node/AliasTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -1,17 +1,6 @@
-"""scons.Node.FS
-
-File system nodes.
-
-These Nodes represent the canonical external objects that people think
-of when they think of building software: files and directories.
-
-This holds a "default_fs" variable that should be initialized with an FS
-that can be used by scripts or modules looking for the canonical default.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -31,7 +20,15 @@ that can be used by scripts or modules looking for the canonical default.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""File system nodes.
+
+These Nodes represent the canonical external objects that people think
+of when they think of building software: files and directories.
+
+This holds a "default_fs" variable that should be initialized with an FS
+that can be used by scripts or modules looking for the canonical default.
+"""
 
 import fnmatch
 import os
@@ -46,7 +43,7 @@ import importlib.util
 
 import SCons.Action
 import SCons.Debug
-from SCons.Debug import logInstanceCreation
+from SCons.Debug import logInstanceCreation, Trace
 import SCons.Errors
 import SCons.Memoize
 import SCons.Node
@@ -55,8 +52,6 @@ import SCons.Subst
 import SCons.Util
 from SCons.Util import MD5signature, MD5filesignature, MD5collect
 import SCons.Warnings
-
-from SCons.Debug import Trace
 
 print_duplicate = 0
 

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,11 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
-
 import os
 import os.path
 import sys

--- a/SCons/Node/NodeTests.py
+++ b/SCons/Node/NodeTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/Node/Python.py
+++ b/SCons/Node/Python.py
@@ -1,11 +1,6 @@
-"""scons.Node.Python
-
-Python nodes.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,9 +20,8 @@ Python nodes.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Python nodes."""
 
 import SCons.Node
 

--- a/SCons/Node/PythonTests.py
+++ b/SCons/Node/PythonTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -1,26 +1,6 @@
-"""SCons.Node
-
-The Node package for the SCons software construction utility.
-
-This is, in many ways, the heart of SCons.
-
-A Node is where we encapsulate all of the dependency information about
-any thing that SCons can build, or about any thing which SCons can use
-to build some other thing.  The canonical "thing," of course, is a file,
-but a Node can also represent something remote (like a web page) or
-something completely abstract (like an Alias).
-
-Each specific type of "thing" is specifically represented by a subclass
-of the Node base class:  Node.FS.File for files, Node.Alias for aliases,
-etc.  Dependency information is kept here in the base class, and
-information specific to files/aliases/etc. is in the subclass.  The
-goal, if we've done this correctly, is that any type of "thing" should
-be able to depend on any other type of "thing."
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -41,7 +21,24 @@ be able to depend on any other type of "thing."
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""The Node package for the SCons software construction utility.
+
+This is, in many ways, the heart of SCons.
+
+A Node is where we encapsulate all of the dependency information about
+any thing that SCons can build, or about any thing which SCons can use
+to build some other thing.  The canonical "thing," of course, is a file,
+but a Node can also represent something remote (like a web page) or
+something completely abstract (like an Alias).
+
+Each specific type of "thing" is specifically represented by a subclass
+of the Node base class:  Node.FS.File for files, Node.Alias for aliases,
+etc.  Dependency information is kept here in the base class, and
+information specific to files/aliases/etc. is in the subclass.  The
+goal, if we've done this correctly, is that any type of "thing" should
+be able to depend on any other type of "thing."
+
+"""
 
 import collections
 import copy

--- a/SCons/PathList.py
+++ b/SCons/PathList.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,17 +20,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Handle lists of directory paths.
 
-__doc__ = """SCons.PathList
-
-A module for handling lists of directory paths (the sort of things
-that get set as CPPPATH, LIBPATH, etc.) with as much caching of data and
-efficiency as we can, while still keeping the evaluation delayed so that we
-Do the Right Thing (almost) regardless of how the variable is specified.
-
+These are the path lists that get set as CPPPATH, LIBPATH,
+etc.) with as much caching of data and efficiency as we can, while
+still keeping the evaluation delayed so that we Do the Right Thing
+(almost) regardless of how the variable is specified.
 """
 
 import os

--- a/SCons/PathListTests.py
+++ b/SCons/PathListTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Platform/Platform.xml
+++ b/SCons/Platform/Platform.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/Platform/PlatformTests.py
+++ b/SCons/Platform/PlatformTests.py
@@ -1,3 +1,4 @@
+# MIT License
 #
 # Copyright The SCons Foundation
 #
@@ -19,16 +20,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-import SCons.compat
 
 import collections
 import unittest
 import os
 
+import SCons.compat
 import SCons.Errors
 import SCons.Platform
 import SCons.Environment

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -1,24 +1,4 @@
-"""SCons.Platform
-
-SCons platform selection.
-
-This looks for modules that define a callable object that can modify a
-construction environment as appropriate for a given platform.
-
-Note that we take a more simplistic view of "platform" than Python does.
-We're looking for a single string that determines a set of
-tool-independent variables with which to initialize a construction
-environment.  Consequently, we'll examine both sys.platform and os.name
-(and anything else that might come in to play) in order to return some
-specification which is unique enough for our purposes.
-
-Note that because this subsystem just *selects* a callable that can
-modify a construction environment, it's possible for people to define
-their own "platform specification" in an arbitrary callable function.
-No one needs to use or tie in to this subsystem in order to roll
-their own platform definition.
-"""
-
+# MIT License
 #
 # Copyright The SCons Foundation
 #
@@ -40,7 +20,25 @@ their own platform definition.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
+"""SCons platform selection.
+
+Looks for modules that define a callable object that can modify a
+construction environment as appropriate for a given platform.
+
+Note that we take a more simplistic view of "platform" than Python does.
+We're looking for a single string that determines a set of
+tool-independent variables with which to initialize a construction
+environment.  Consequently, we'll examine both sys.platform and os.name
+(and anything else that might come in to play) in order to return some
+specification which is unique enough for our purposes.
+
+Note that because this subsystem just *selects* a callable that can
+modify a construction environment, it's possible for people to define
+their own "platform specification" in an arbitrary callable function.
+No one needs to use or tie in to this subsystem in order to roll
+their own platform definition.
+"""
 
 import SCons.compat
 

--- a/SCons/Platform/aix.py
+++ b/SCons/Platform/aix.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.aix
-
-Platform-specific initialization for IBM AIX systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for IBM AIX systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 import subprocess
 

--- a/SCons/Platform/cygwin.py
+++ b/SCons/Platform/cygwin.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.cygwin
-
-Platform-specific initialization for Cygwin systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for Cygwin systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 import sys
 

--- a/SCons/Platform/darwin.py
+++ b/SCons/Platform/darwin.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.darwin
-
-Platform-specific initialization for Mac OS X systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for Mac OS X systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 from . import posix
 import os

--- a/SCons/Platform/hpux.py
+++ b/SCons/Platform/hpux.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.hpux
-
-Platform-specific initialization for HP-UX systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for HP-UX systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 from . import posix
 

--- a/SCons/Platform/irix.py
+++ b/SCons/Platform/irix.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.irix
-
-Platform-specific initialization for SGI IRIX systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for SGI IRIX systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 from . import posix
 

--- a/SCons/Platform/mingw.py
+++ b/SCons/Platform/mingw.py
@@ -1,11 +1,6 @@
-"""SCons.Platform.mingw
-
-Platform-specific initialization for the MinGW system.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,9 +20,8 @@ Platform-specific initialization for the MinGW system.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for the MinGW system."""
 
 import sys
 

--- a/SCons/Platform/os2.py
+++ b/SCons/Platform/os2.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.os2
-
-Platform-specific initialization for OS/2 systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,14 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for OS/2 systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
+
 from . import win32
 
 def generate(env):

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.posix
-
-Platform-specific initialization for POSIX (Linux, UNIX, etc.) systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for POSIX (Linux, UNIX, etc.) systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 import errno
 import subprocess

--- a/SCons/Platform/posix.xml
+++ b/SCons/Platform/posix.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/Platform/sunos.py
+++ b/SCons/Platform/sunos.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.sunos
-
-Platform-specific initialization for Sun systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for Sun systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 from . import posix
 

--- a/SCons/Platform/sunos.xml
+++ b/SCons/Platform/sunos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/Platform/virtualenv.py
+++ b/SCons/Platform/virtualenv.py
@@ -1,10 +1,6 @@
-"""SCons.Platform.virtualenv
-
-Support for virtualenv.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -24,9 +20,8 @@ Support for virtualenv.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""'Platform" support for a Python virtualenv."""
 
 import os
 import sys
@@ -50,14 +45,14 @@ virtualenv_variables = ['VIRTUAL_ENV', 'PIPENV_ACTIVE']
 
 
 def _running_in_virtualenv():
-    """Returns True, if scons is executed within a virtualenv"""
+    """Returns True if scons is executed within a virtualenv"""
     # see https://stackoverflow.com/a/42580137
     return (hasattr(sys, 'real_prefix') or
             (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))
 
 
 def _is_path_in(path, base):
-    """Returns true, if **path** is located under the **base** directory."""
+    """Returns true if **path** is located under the **base** directory."""
     if not path or not base: # empty path may happen, base too
         return False
     rp = os.path.relpath(path, base)

--- a/SCons/Platform/virtualenvTests.py
+++ b/SCons/Platform/virtualenvTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,17 +20,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-import SCons.compat
 
 import collections
 import unittest
 import os
 import sys
 
+import SCons.compat
 import SCons.Platform.virtualenv
 import SCons.Util
 

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -1,14 +1,6 @@
-"""SCons.Platform.win32
-
-Platform-specific initialization for Win32 systems.
-
-There normally shouldn't be any need to import this module directly.  It
-will usually be imported through the generic SCons.Platform.Platform()
-selection method.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Platform-specific initialization for Win32 systems.
+
+There normally shouldn't be any need to import this module directly.  It
+will usually be imported through the generic SCons.Platform.Platform()
+selection method.
+"""
 
 import os
 import os.path

--- a/SCons/Platform/win32.xml
+++ b/SCons/Platform/win32.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/SConf.py
+++ b/SCons/SConf.py
@@ -1,18 +1,6 @@
-"""SCons.SConf
-
-Autoconf-like configuration support.
-
-In other words, SConf allows to run tests on the build machine to detect
-capabilities of system and do some things based on result: generate config
-files, header files for C/C++, update variables in environment.
-
-Tests on the build system can detect if compiler sees header files, if
-libraries are installed, if some command line options are supported etc.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -32,8 +20,16 @@ libraries are installed, if some command line options are supported etc.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""Autoconf-like configuration support.
+
+In other words, SConf allows to run tests on the build machine to detect
+capabilities of system and do some things based on result: generate config
+files, header files for C/C++, update variables in environment.
+
+Tests on the build system can detect if compiler sees header files, if
+libraries are installed, if some command line options are supported etc.
+"""
 
 import SCons.compat
 

--- a/SCons/SConfTests.py
+++ b/SCons/SConfTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/SConsign.py
+++ b/SCons/SConsign.py
@@ -1,11 +1,6 @@
-"""SCons.SConsign
-
-Writing and reading information to the .sconsign file or files.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,8 +20,8 @@ Writing and reading information to the .sconsign file or files.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""Operations on signature database files (.sconsign). """
 
 import SCons.compat
 

--- a/SCons/SConsignTests.py
+++ b/SCons/SConsignTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import unittest

--- a/SCons/Scanner/C.py
+++ b/SCons/Scanner/C.py
@@ -1,11 +1,6 @@
-"""SCons.Scanner.C
-
-This module implements the dependency scanner for C/C++ code.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,9 +20,8 @@ This module implements the dependency scanner for C/C++ code.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for C/C++ code."""
 
 import SCons.Node.FS
 import SCons.Scanner
@@ -36,8 +30,7 @@ import SCons.Util
 import SCons.cpp
 
 class SConsCPPScanner(SCons.cpp.PreProcessor):
-    """
-    SCons-specific subclass of the cpp.py module's processing.
+    """SCons-specific subclass of the cpp.py module's processing.
 
     We subclass this so that: 1) we can deal with files represented
     by Nodes, not strings; 2) we can keep track of the files that are
@@ -81,8 +74,7 @@ def dictify_CPPDEFINES(env):
     return cppdefines
 
 class SConsCPPScannerWrapper:
-    """
-    The SCons wrapper around a cpp.py scanner.
+    """The SCons wrapper around a cpp.py scanner.
 
     This is the actual glue between the calling conventions of generic
     SCons scanners, and the (subclass of) cpp.py class that knows how
@@ -116,12 +108,14 @@ def CScanner():
     # knows how to evaluate #if/#ifdef/#else/#elif lines when searching
     # for #includes.  This is commented out for now until we add the
     # right configurability to let users pick between the scanners.
-    #return SConsCPPScannerWrapper("CScanner", "CPPPATH")
+    # return SConsCPPScannerWrapper("CScanner", "CPPPATH")
 
-    cs = SCons.Scanner.ClassicCPP("CScanner",
-                                  "$CPPSUFFIXES",
-                                  "CPPPATH",
-                                  '^[ \t]*#[ \t]*(?:include|import)[ \t]*(<|")([^>"]+)(>|")')
+    cs = SCons.Scanner.ClassicCPP(
+        "CScanner",
+        "$CPPSUFFIXES",
+        "CPPPATH",
+        r'^[ \t]*#[ \t]*(?:include|import)[ \t]*(<|")([^>"]+)(>|")',
+    )
     return cs
 
 
@@ -131,8 +125,7 @@ def CScanner():
 
 
 class SConsCPPConditionalScanner(SCons.cpp.PreProcessor):
-    """
-    SCons-specific subclass of the cpp.py module's processing.
+    """SCons-specific subclass of the cpp.py module's processing.
 
     We subclass this so that: 1) we can deal with files represented
     by Nodes, not strings; 2) we can keep track of the files that are

--- a/SCons/Scanner/CTests.py
+++ b/SCons/Scanner/CTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,11 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-import SCons.compat
 
 import collections
 import os
@@ -32,6 +28,7 @@ import unittest
 import TestCmd
 import TestUnit
 
+import SCons.compat
 import SCons.Node.FS
 import SCons.Warnings
 

--- a/SCons/Scanner/D.py
+++ b/SCons/Scanner/D.py
@@ -1,14 +1,6 @@
-"""SCons.Scanner.D
-
-Scanner for the Digital Mars "D" programming language.
-
-Coded by Andy Friesen
-17 Nov 2003
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,9 +20,11 @@ Coded by Andy Friesen
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Scanner for the Digital Mars "D" programming language.
+
+Coded by Andy Friesen, 17 Nov 2003
+"""
 
 import SCons.Scanner
 

--- a/SCons/Scanner/DTests.py
+++ b/SCons/Scanner/DTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +20,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
+import collections
+import os
 import unittest
 
 import TestCmd
@@ -31,8 +31,6 @@ import SCons.Scanner.D
 
 test = TestCmd.TestCmd(workdir = '')
 
-import collections
-import os
 
 class DummyEnvironment(collections.UserDict):
     def __init__(self, **kw):

--- a/SCons/Scanner/Dir.py
+++ b/SCons/Scanner/Dir.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.Node.FS
 import SCons.Scanner

--- a/SCons/Scanner/DirTests.py
+++ b/SCons/Scanner/DirTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import unittest

--- a/SCons/Scanner/Fortran.py
+++ b/SCons/Scanner/Fortran.py
@@ -1,11 +1,6 @@
-"""SCons.Scanner.Fortran
-
-This module implements the dependency scanner for Fortran code.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,7 +21,7 @@ This module implements the dependency scanner for Fortran code.
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for Fortran code."""
 
 import re
 

--- a/SCons/Scanner/FortranTests.py
+++ b/SCons/Scanner/FortranTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,12 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
-import os.path
 import unittest
 
 import SCons.Scanner.Fortran

--- a/SCons/Scanner/IDL.py
+++ b/SCons/Scanner/IDL.py
@@ -1,12 +1,6 @@
-"""SCons.Scanner.IDL
-
-This module implements the dependency scanner for IDL (Interface
-Definition Language) files.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,19 +20,20 @@ Definition Language) files.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for IDL (Interface Definition Language) files."""
 
 import SCons.Node.FS
 import SCons.Scanner
 
 def IDLScan():
     """Return a prototype Scanner instance for scanning IDL source files"""
-    cs = SCons.Scanner.ClassicCPP("IDLScan",
-                                  "$IDLSUFFIXES",
-                                  "CPPPATH",
-                                  '^[ \t]*(?:#[ \t]*include|[ \t]*import)[ \t]+(<|")([^>"]+)(>|")')
+    cs = SCons.Scanner.ClassicCPP(
+        "IDLScan",
+        "$IDLSUFFIXES",
+        "CPPPATH",
+        r'^[ \t]*(?:#[ \t]*include|[ \t]*import)[ \t]+(<|")([^>"]+)(>|")',
+    )
     return cs
 
 # Local Variables:

--- a/SCons/Scanner/IDLTests.py
+++ b/SCons/Scanner/IDLTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 import os

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -1,11 +1,6 @@
-"""SCons.Scanner.LaTeX
-
-This module implements the dependency scanner for LaTeX code.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,9 +20,8 @@ This module implements the dependency scanner for LaTeX code.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for LaTeX code."""
 
 import os.path
 import re
@@ -96,7 +90,6 @@ class FindENVPathDirs:
         return tuple(dir.Rfindalldirs(path))
 
 
-
 def LaTeXScanner():
     """
     Return a prototype Scanner instance for scanning LaTeX source files
@@ -108,6 +101,7 @@ def LaTeXScanner():
                graphics_extensions = TexGraphics,
                recursive = 0)
     return ds
+
 
 def PDFLaTeXScanner():
     """
@@ -121,9 +115,9 @@ def PDFLaTeXScanner():
                recursive = 0)
     return ds
 
+
 class LaTeX(SCons.Scanner.Base):
-    """
-    Class for scanning LaTeX files for included files.
+    """Class for scanning LaTeX files for included files.
 
     Unlike most scanners, which use regular expressions that just
     return the included file name, this returns a tuple consisting

--- a/SCons/Scanner/LaTeXTests.py
+++ b/SCons/Scanner/LaTeXTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,11 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-import SCons.compat
 
 import collections
 import os
@@ -31,6 +27,7 @@ import unittest
 
 import TestCmd
 
+import SCons.compat
 import SCons.Node.FS
 import SCons.Scanner.LaTeX
 

--- a/SCons/Scanner/Prog.py
+++ b/SCons/Scanner/Prog.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for program files."""
 
 import SCons.Node
 import SCons.Node.FS
@@ -39,9 +39,7 @@ def ProgramScanner(**kw):
     return ps
 
 def _subst_libs(env, libs):
-    """
-    Substitute environment variables and split into list.
-    """
+    """Substitute environment variables and split into list."""
     if SCons.Util.is_String(libs):
         libs = env.subst(libs)
         if SCons.Util.is_String(libs):
@@ -57,9 +55,9 @@ def _subst_libs(env, libs):
     return libs
 
 def scan(node, env, libpath = ()):
-    """
-    This scanner scans program files for static-library
-    dependencies.  It will search the LIBPATH environment variable
+    """Scans program files for static-library dependencies.
+
+    It will search the LIBPATH environment variable
     for libraries specified in the LIBS variable, returning any
     files it finds as dependencies.
     """

--- a/SCons/Scanner/ProgTests.py
+++ b/SCons/Scanner/ProgTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import unittest

--- a/SCons/Scanner/Python.py
+++ b/SCons/Scanner/Python.py
@@ -1,18 +1,6 @@
-"""SCons.Scanner.Python
-
-This module implements the dependency scanner for Python code.
-
-One important note about the design is that this does not take any dependencies
-upon packages or binaries in the Python installation unless they are listed in
-PYTHONPATH. To do otherwise would have required code to determine where the
-Python installation is, which is outside of the scope of a scanner like this.
-If consumers want to pick up dependencies upon these packages, they must put
-those directories in PYTHONPATH.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -32,9 +20,17 @@ those directories in PYTHONPATH.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for Python code.
+
+One important note about the design is that this does not take any dependencies
+upon packages or binaries in the Python installation unless they are listed in
+PYTHONPATH. To do otherwise would have required code to determine where the
+Python installation is, which is outside of the scope of a scanner like this.
+If consumers want to pick up dependencies upon these packages, they must put
+those directories in PYTHONPATH.
+
+"""
 
 import itertools
 import os
@@ -55,8 +51,7 @@ def path_function(env, dir=None, target=None, source=None, argument=None):
 
 
 def find_include_names(node):
-    """
-    Scans the node for all imports.
+    """Scans the node for all imports.
 
     Returns a list of tuples. Each tuple has two elements:
         1. The main import (e.g. module, module.file, module.module2)

--- a/SCons/Scanner/PythonTests.py
+++ b/SCons/Scanner/PythonTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/Scanner/RC.py
+++ b/SCons/Scanner/RC.py
@@ -1,12 +1,6 @@
-"""SCons.Scanner.RC
-
-This module implements the dependency scanner for RC (Interface
-Definition Language) files.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,9 +20,8 @@ Definition Language) files.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for RC (Interface Definition Language) files."""
 
 
 import SCons.Node.FS
@@ -36,9 +29,8 @@ import SCons.Scanner
 
 
 def no_tlb(nodes):
-    """
-    Filter out .tlb files as they are binary and shouldn't be scanned
-    """
+    """Filter out .tlb files as they are binary and shouldn't be scanned."""
+
     # print("Nodes:%s"%[str(n) for n in nodes])
     return [n for n in nodes if str(n)[-4:] != '.tlb']
 
@@ -46,16 +38,16 @@ def no_tlb(nodes):
 def RCScan():
     """Return a prototype Scanner instance for scanning RC source files"""
 
-    res_re= r'^(?:\s*#\s*(?:include)|' \
-            r'.*?\s+(?:ICON|BITMAP|CURSOR|HTML|FONT|MESSAGETABLE|TYPELIB|REGISTRY|D3DFX)' \
-            r'\s*.*?)' \
-            r'\s*(<|"| )([^>"\s]+)(?:[>"\s])*$'
-    resScanner = SCons.Scanner.ClassicCPP("ResourceScanner",
-                                          "$RCSUFFIXES",
-                                          "CPPPATH",
-                                          res_re,
-                                          recursive=no_tlb)
-    
+    res_re = (
+        r'^(?:\s*#\s*(?:include)|'
+        r'.*?\s+(?:ICON|BITMAP|CURSOR|HTML|FONT|MESSAGETABLE|TYPELIB|REGISTRY|D3DFX)'
+        r'\s*.*?)'
+        r'\s*(<|"| )([^>"\s]+)(?:[>"\s])*$'
+    )
+    resScanner = SCons.Scanner.ClassicCPP(
+        "ResourceScanner", "$RCSUFFIXES", "CPPPATH", res_re, recursive=no_tlb
+    )
+
     return resScanner
 
 # Local Variables:

--- a/SCons/Scanner/RCTests.py
+++ b/SCons/Scanner/RCTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 import collections

--- a/SCons/Scanner/SWIG.py
+++ b/SCons/Scanner/SWIG.py
@@ -1,11 +1,6 @@
-"""SCons.Scanner.SWIG
-
-This module implements the dependency scanner for SWIG code. 
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,9 +20,8 @@ This module implements the dependency scanner for SWIG code.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Dependency scanner for SWIG code."""
 
 import SCons.Scanner
 

--- a/SCons/Scanner/Scanner.xml
+++ b/SCons/Scanner/Scanner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/Scanner/ScannerTests.py
+++ b/SCons/Scanner/ScannerTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,15 +21,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-import SCons.compat
-
 import collections
 import unittest
 
 import TestUnit
 
+import SCons.compat
 import SCons.Scanner
 
 class DummyFS:

--- a/SCons/Scanner/__init__.py
+++ b/SCons/Scanner/__init__.py
@@ -1,11 +1,6 @@
-"""SCons.Scanner
-
-The Scanner package for the SCons software construction utility.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,9 +20,8 @@ The Scanner package for the SCons software construction utility.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""The Scanner package for the SCons software construction utility."""
 
 import re
 
@@ -43,16 +37,16 @@ class _Null:
 _null = _Null
 
 def Scanner(function, *args, **kw):
-    """
-    Public interface factory function for creating different types
-    of Scanners based on the different types of "functions" that may
-    be supplied.
+    """Factory function to create a Scanner Object.
+
+    Creates the appropriate Scanner based on the type of "function".
 
     TODO:  Deprecate this some day.  We've moved the functionality
     inside the Base class and really don't need this factory function
     any more.  It was, however, used by some of our Tool modules, so
     the call probably ended up in various people's custom modules
     patterned on SCons code.
+
     """
     if SCons.Util.is_Dict(function):
         return Selector(function, *args, **kw)
@@ -60,10 +54,8 @@ def Scanner(function, *args, **kw):
         return Base(function, *args, **kw)
 
 
-
 class FindPathDirs:
-    """
-    A class to bind a specific E{*}PATH variable name to a function that
+    """Class to bind a specific E{*}PATH variable name to a function that
     will return all of the E{*}path directories.
     """
     def __init__(self, variable):
@@ -82,66 +74,25 @@ class FindPathDirs:
 
 
 class Base:
+    """Base class for dependency scanners.
+
+    This implements straightforward, single-pass scanning of a single file.
     """
-    The base class for dependency scanners.  This implements
-    straightforward, single-pass scanning of a single file.
-    """
-
-    def __init__(self,
-                 function,
-                 name = "NONE",
-                 argument = _null,
-                 skeys = _null,
-                 path_function = None,
-                 # Node.FS.Base so that, by default, it's okay for a
-                 # scanner to return a Dir, File or Entry.
-                 node_class = SCons.Node.FS.Base,
-                 node_factory = None,
-                 scan_check = None,
-                 recursive = None):
-        """
-        Construct a new scanner object given a scanner function.
-
-        'function' - a scanner function taking two or three
-        arguments and returning a list of strings.
-
-        'name' - a name for identifying this scanner object.
-
-        'argument' - an optional argument that, if specified, will be
-        passed to both the scanner function and the path_function.
-
-        'skeys' - an optional list argument that can be used to determine
-        which scanner should be used for a given Node. In the case of File
-        nodes, for example, the 'skeys' would be file suffixes.
-
-        'path_function' - a function that takes four or five arguments
-        (a construction environment, Node for the directory containing
-        the SConscript file that defined the primary target, list of
-        target nodes, list of source nodes, and optional argument for
-        this instance) and returns a tuple of the directories that can
-        be searched for implicit dependency files.  May also return a
-        callable() which is called with no args and returns the tuple
-        (supporting Bindable class).
-
-        'node_class' - the class of Nodes which this scan will return.
-        If node_class is None, then this scanner will not enforce any
-        Node conversion and will return the raw results from the
-        underlying scanner function.
-
-        'node_factory' - the factory function to be called to translate
-        the raw results returned by the scanner function into the
-        expected node_class objects.
-
-        'scan_check' - a function to be called to first check whether
-        this node really needs to be scanned.
-
-        'recursive' - specifies that this scanner should be invoked
-        recursively on all of the implicit dependencies it returns
-        (the canonical example being #include lines in C source files).
-        May be a callable, which will be called to filter the list
-        of nodes found to select a subset for recursive scanning
-        (the canonical example being only recursively scanning
-        subdirectories within a directory).
+    def __init__(
+        self,
+        function,
+        name="NONE",
+        argument=_null,
+        skeys=_null,
+        path_function=None,
+        # Node.FS.Base so that, by default, it's okay for a
+        # scanner to return a Dir, File or Entry.
+        node_class=SCons.Node.FS.Base,
+        node_factory=None,
+        scan_check=None,
+        recursive=None,
+    ):
+        """Construct a new scanner object given a scanner function.
 
         The scanner function's first argument will be a Node that should
         be scanned for dependencies, the second argument will be an
@@ -152,14 +103,55 @@ class Base:
 
         Examples:
 
-        s = Scanner(my_scanner_function)
+          s = Scanner(my_scanner_function)
+          s = Scanner(function = my_scanner_function)
+          s = Scanner(function = my_scanner_function, argument = 'foo')
 
-        s = Scanner(function = my_scanner_function)
+        Args:
+            function: a scanner function taking two or three arguments
+              and returning a list of strings.
 
-        s = Scanner(function = my_scanner_function, argument = 'foo')
+            name: a name for identifying this scanner object.
+
+            argument: an optional argument that, if specified, will be
+              passed to both the scanner function and the path_function.
+
+            skeys: an optional list argument that can be used
+              to determine which scanner should be used for a given
+              Node. In the case of File nodes, for example, the 'skeys'
+              would be file suffixes.
+
+            path_function: a function that takes four or five arguments
+              (a construction environment, Node for the directory
+              containing the SConscript file that defined the primary
+              target, list of target nodes, list of source nodes, and
+              optional argument for this instance) and returns a tuple
+              of the directories that can be searched for implicit
+              dependency files.  May also return a callable() which
+              is called with no args and returns the tuple (supporting
+              Bindable class).
+
+            node_class: the class of Nodes which this scan will return.
+              If node_class is None, then this scanner will not enforce
+              any Node conversion and will return the raw results from
+              the underlying scanner function.
+
+            node_factory: the factory function to be called to
+              translate the raw results returned by the scanner function
+              into the expected node_class objects.
+
+            scan_check: a function to be called to first check whether
+              this node really needs to be scanned.
+
+            recursive: specifies that this scanner should be invoked
+              recursively on all of the implicit dependencies it returns
+              (the canonical example being #include lines in C source
+              files).  May be a callable, which will be called to filter
+              the list of nodes found to select a subset for recursive
+              scanning (the canonical example being only recursively
+              scanning subdirectories within a directory).
 
         """
-
         # Note: this class could easily work with scanner functions that take
         # something other than a filename as an argument (e.g. a database
         # node) and a dependencies list that aren't file names. All that
@@ -196,11 +188,15 @@ class Base:
             return self.path_function(env, dir, target, source)
 
     def __call__(self, node, env, path=()):
-        """
-        This method scans a single object. 'node' is the node
-        that will be passed to the scanner function, and 'env' is the
-        environment that will be passed to the scanner function. A list of
-        direct dependency nodes for the specified node will be returned.
+        """Scans a single object.
+
+        Args:
+          node: the node that will be passed to the scanner function
+          env: the environment that will be passed to the scanner function.
+
+        Returns:
+          A list of direct dependency nodes for the specified node.
+
         """
         if self.scan_check and not self.scan_check(node, env):
             return []

--- a/SCons/Script/Interactive.py
+++ b/SCons/Script/Interactive.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,11 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
-__doc__ = """
-SCons interactive mode
-"""
+"""SCons interactive mode. """
 
 # TODO:
 #

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1,20 +1,6 @@
-"""SCons.Script
-
-This file implements the main() function used by the scons script.
-
-Architecturally, this *is* the scons script, and will likely only be
-called from the external "scons" wrapper.  Consequently, anything here
-should not be, or be considered, part of the build engine.  If it's
-something that we expect other software to want to use, it should go in
-some other module.  If it's specific to the "scons" script invocation,
-it goes here.
-"""
-
-unsupported_python_version = (3, 4, 0)
-deprecated_python_version = (3, 4, 0)
-
-
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -35,8 +21,19 @@ deprecated_python_version = (3, 4, 0)
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""The main() function used by the scons script.
 
+Architecturally, this *is* the scons script, and will likely only be
+called from the external "scons" wrapper.  Consequently, anything here
+should not be, or be considered, part of the build engine.  If it's
+something that we expect other software to want to use, it should go in
+some other module.  If it's specific to the "scons" script invocation,
+it goes here.
+"""
+
+# these define the range of versions SCons supports
+unsupported_python_version = (3, 4, 0)
+deprecated_python_version = (3, 4, 0)
 
 import SCons.compat
 

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/Script/MainTests.py
+++ b/SCons/Script/MainTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import optparse
 import re

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -1,12 +1,6 @@
-"""SCons.Script.SConscript
-
-This module defines the Python API provided to SConscript and SConstruct
-files.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,7 +21,7 @@ files.
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""This module defines the Python API provided to SConscript files."""
 
 import SCons
 import SCons.Action

--- a/SCons/Script/SConscript.xml
+++ b/SCons/Script/SConscript.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/Script/SConscriptTests.py
+++ b/SCons/Script/SConscriptTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.Script.SConscript
 

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -1,18 +1,6 @@
-"""SCons.Script
-
-This file implements the main() function used by the scons script.
-
-Architecturally, this *is* the scons script, and will likely only be
-called from the external "scons" wrapper.  Consequently, anything here
-should not be, or be considered, part of the build engine.  If it's
-something that we expect other software to want to use, it should go in
-some other module.  If it's specific to the "scons" script invocation,
-it goes here.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -32,9 +20,16 @@ it goes here.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""The main() function used by the scons script.
+
+Architecturally, this *is* the scons script, and will likely only be
+called from the external "scons" wrapper.  Consequently, anything here
+should not be, or be considered, part of the build engine.  If it's
+something that we expect other software to want to use, it should go in
+some other module.  If it's specific to the "scons" script invocation,
+it goes here.
+"""
 
 import time
 start_time = time.time()
@@ -134,7 +129,6 @@ GetBuildFailures        = Main.GetBuildFailures
 #profiling               = Main.profiling
 #repositories            = Main.repositories
 
-#
 from . import SConscript
 _SConscript = SConscript
 
@@ -282,7 +276,11 @@ _no_missing_sconscript = False
 _warn_missing_sconscript_deprecated = True
 
 def set_missing_sconscript_error(flag=1):
-    """Set behavior on missing file in SConscript() call. Returns previous value"""
+    """Set behavior on missing file in SConscript() call.
+
+    Returns:
+        previous value
+    """
     global _no_missing_sconscript
     old = _no_missing_sconscript
     _no_missing_sconscript = flag

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -1,11 +1,6 @@
-"""SCons.Subst
-
-SCons string substitution.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,7 +21,7 @@ SCons string substitution.
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""SCons string substitution."""
 
 import collections
 import re
@@ -36,17 +31,19 @@ import SCons.Errors
 from SCons.Util import is_String, is_Sequence
 
 # Indexed by the SUBST_* constants below.
-_strconv = [SCons.Util.to_String_for_subst,
-            SCons.Util.to_String_for_subst,
-            SCons.Util.to_String_for_signature]
-
-
+_strconv = [
+    SCons.Util.to_String_for_subst,
+    SCons.Util.to_String_for_subst,
+    SCons.Util.to_String_for_signature,
+]
 
 AllowableExceptions = (IndexError, NameError)
+
 
 def SetAllowableExceptions(*excepts):
     global AllowableExceptions
     AllowableExceptions = [_f for _f in excepts if _f]
+
 
 def raise_exception(exception, target, s):
     name = exception.__class__.__name__
@@ -55,7 +52,6 @@ def raise_exception(exception, target, s):
         raise SCons.Errors.BuildError(target[0], msg)
     else:
         raise SCons.Errors.UserError(msg)
-
 
 
 class Literal:

--- a/SCons/Subst.xml
+++ b/SCons/Subst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/Taskmaster.py
+++ b/SCons/Taskmaster.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,39 +21,31 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import sys
+"""Generic Taskmaster module for the SCons build engine.
 
-__doc__ = """
-    Generic Taskmaster module for the SCons build engine.
-    =====================================================
+This module contains the primary interface(s) between a wrapping user
+interface and the SCons build engine.  There are two key classes here:
 
-    This module contains the primary interface(s) between a wrapping user
-    interface and the SCons build engine.  There are two key classes here:
+Taskmaster
+    This is the main engine for walking the dependency graph and
+    calling things to decide what does or doesn't need to be built.
 
-    Taskmaster
-    ----------
-        This is the main engine for walking the dependency graph and
-        calling things to decide what does or doesn't need to be built.
+Task
+    This is the base class for allowing a wrapping interface to
+    decide what does or doesn't actually need to be done.  The
+    intention is for a wrapping interface to subclass this as
+    appropriate for different types of behavior it may need.
 
-    Task
-    ----
-        This is the base class for allowing a wrapping interface to
-        decide what does or doesn't actually need to be done.  The
-        intention is for a wrapping interface to subclass this as
-        appropriate for different types of behavior it may need.
+    The canonical example is the SCons native Python interface,
+    which has Task subclasses that handle its specific behavior,
+    like printing "'foo' is up to date" when a top-level target
+    doesn't need to be built, and handling the -c option by removing
+    targets as its "build" action.  There is also a separate subclass
+    for suppressing this output when the -q option is used.
 
-        The canonical example is the SCons native Python interface,
-        which has Task subclasses that handle its specific behavior,
-        like printing "'foo' is up to date" when a top-level target
-        doesn't need to be built, and handling the -c option by removing
-        targets as its "build" action.  There is also a separate subclass
-        for suppressing this output when the -q option is used.
-
-        The Taskmaster instantiates a Task object for each (set of)
-        target(s) that it decides need to be evaluated and/or built.
+    The Taskmaster instantiates a Task object for each (set of)
+    target(s) that it decides need to be evaluated and/or built.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 from abc import ABC, abstractmethod

--- a/SCons/TaskmasterTests.py
+++ b/SCons/TaskmasterTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1,9 +1,6 @@
-"""SCons.Util
-
-Various utility functions go here.
-"""
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -24,7 +21,7 @@ Various utility functions go here.
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Various SCons utility functions."""
 
 import os
 import sys
@@ -1579,9 +1576,6 @@ class NullSeq(Null):
         return self
     def __setitem__(self, i, v):
         return self
-
-
-del __revision__
 
 
 def to_bytes(s):

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import SCons.compat
 

--- a/SCons/Utilities/ConfigureCache.py
+++ b/SCons/Utilities/ConfigureCache.py
@@ -2,7 +2,9 @@
 #
 # SCons - a Software Constructor
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/SCons/Utilities/sconsign.py
+++ b/SCons/Utilities/sconsign.py
@@ -2,7 +2,9 @@
 #
 # SCons - a Software Constructor
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -22,6 +24,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Utility script to dump information from SCons signature database."""
 
 import getopt
 import os

--- a/SCons/Variables/BoolVariable.py
+++ b/SCons/Variables/BoolVariable.py
@@ -1,18 +1,6 @@
-"""SCons.Variables.BoolVariable
-
-This file defines the option type for SCons implementing true/false values.
-
-Usage example::
-
-    opts = Variables()
-    opts.Add(BoolVariable('embedded', 'build for an embedded system', 0))
-    ...
-    if env['embedded'] == 1:
-    ...
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -32,9 +20,17 @@ Usage example::
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Option type for true/false Variables.
+
+Usage example::
+
+    opts = Variables()
+    opts.Add(BoolVariable('embedded', 'build for an embedded system', 0))
+    ...
+    if env['embedded'] == 1:
+    ...
+"""
 
 __all__ = ['BoolVariable',]
 

--- a/SCons/Variables/BoolVariableTests.py
+++ b/SCons/Variables/BoolVariableTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Variables/EnumVariable.py
+++ b/SCons/Variables/EnumVariable.py
@@ -1,21 +1,6 @@
-"""SCons.Variables.EnumVariable
-
-This file defines the option type for SCons allowing only specified
-input-values.
-
-Usage example::
-
-    opts = Variables()
-    opts.Add(EnumVariable('debug', 'debug output and symbols', 'no',
-                      allowed_values=('yes', 'no', 'full'),
-                      map={}, ignorecase=2))
-    ...
-    if env['debug'] == 'full':
-    ...
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -35,9 +20,30 @@ Usage example::
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Option type for enumeration Variables.
+
+This file defines the option type for SCons allowing only specified
+input-values.
+
+Usage example::
+
+    opts = Variables()
+    opts.Add(
+        EnumVariable(
+            'debug',
+            'debug output and symbols',
+            'no',
+            allowed_values=('yes', 'no', 'full'),
+            map={},
+            ignorecase=2,
+        )
+    )
+    ...
+    if env['debug'] == 'full':
+    ...
+"""
+
 
 __all__ = ['EnumVariable',]
 

--- a/SCons/Variables/EnumVariableTests.py
+++ b/SCons/Variables/EnumVariableTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Variables/ListVariable.py
+++ b/SCons/Variables/ListVariable.py
@@ -1,31 +1,6 @@
-"""SCons.Variables.ListVariable
-
-This file defines the option type for SCons implementing 'lists'.
-
-A 'list' option may either be 'all', 'none' or a list of names
-separated by comma. After the option has been processed, the option
-value holds either the named list elements, all list elements or no
-list elements at all.
-
-Usage example::
-
-    list_of_libs = Split('x11 gl qt ical')
-
-    opts = Variables()
-    opts.Add(ListVariable('shared',
-                      'libraries to build as shared libraries',
-                      'all',
-                      elems = list_of_libs))
-    ...
-    for lib in list_of_libs:
-     if lib in env['shared']:
-         env.SharedObject(...)
-     else:
-         env.Object(...)
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -46,7 +21,35 @@ Usage example::
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Option type for list Variables.
+
+This file defines the option type for SCons implementing 'lists'.
+
+A 'list' option may either be 'all', 'none' or a list of names
+separated by comma. After the option has been processed, the option
+value holds either the named list elements, all list elements or no
+list elements at all.
+
+Usage example::
+
+    list_of_libs = Split('x11 gl qt ical')
+
+    opts = Variables()
+    opts.Add(
+        ListVariable(
+            'shared',
+            'libraries to build as shared libraries',
+            'all',
+            elems=list_of_libs,
+        )
+    )
+    ...
+    for lib in list_of_libs:
+        if lib in env['shared']:
+            env.SharedObject(...)
+        else:
+            env.Object(...)
+"""
 
 # Known Bug: This should behave like a Set-Type, but does not really,
 # since elements can occur twice.

--- a/SCons/Variables/ListVariableTests.py
+++ b/SCons/Variables/ListVariableTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import copy
 import unittest

--- a/SCons/Variables/PackageVariable.py
+++ b/SCons/Variables/PackageVariable.py
@@ -1,34 +1,6 @@
-"""SCons.Variables.PackageVariable
-
-This file defines the option type for SCons implementing 'package
-activation'.
-
-To be used whenever a 'package' may be enabled/disabled and the
-package path may be specified.
-
-Usage example:
-
-  Examples:
-      x11=no   (disables X11 support)
-      x11=yes  (will search for the package installation dir)
-      x11=/usr/local/X11 (will check this path for existence)
-
-  To replace autoconf's --with-xxx=yyy ::
-
-      opts = Variables()
-      opts.Add(PackageVariable('x11',
-                             'use X11 installed here (yes = search some places',
-                             'yes'))
-      ...
-      if env['x11'] == True:
-          dir = ... search X11 in some standard places ...
-          env['x11'] = dir
-      if env['x11']:
-          ... build with x11 ...
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -48,9 +20,35 @@ Usage example:
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Option type for package Variables.
+
+This file defines the option type for SCons implementing 'package activation'.
+
+To be used whenever a 'package' may be enabled/disabled and the
+package path may be specified.
+
+Usage example:
+
+  Examples:
+      x11=no   (disables X11 support)
+      x11=yes  (will search for the package installation dir)
+      x11=/usr/local/X11 (will check this path for existence)
+
+  To replace autoconf's --with-xxx=yyy ::
+
+
+      opts = Variables()
+      opts.Add(PackageVariable('x11',
+                             'use X11 installed here (yes = search some places',
+                             'yes'))
+      ...
+      if env['x11'] == True:
+          dir = ... search X11 in some standard places ...
+          env['x11'] = dir
+      if env['x11']:
+          ... build with x11 ...
+"""
 
 __all__ = ['PackageVariable',]
 

--- a/SCons/Variables/PackageVariableTests.py
+++ b/SCons/Variables/PackageVariableTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Variables/PathVariable.py
+++ b/SCons/Variables/PathVariable.py
@@ -1,51 +1,6 @@
-"""SCons.Variables.PathVariable
-
-This file defines an option type for SCons implementing path settings.
-
-To be used whenever a user-specified path override should be allowed.
-
-Arguments to PathVariable are:
-  option-name  = name of this option on the command line (e.g. "prefix")
-  option-help  = help string for option
-  option-dflt  = default value for this option
-  validator    = [optional] validator for option value.  Predefined validators are:
-
-                     PathAccept -- accepts any path setting; no validation
-                     PathIsDir  -- path must be an existing directory
-                     PathIsDirCreate -- path must be a dir; will create
-                     PathIsFile -- path must be a file
-                     PathExists -- path must exist (any type) [default]
-
-                 The validator is a function that is called and which
-                 should return True or False to indicate if the path
-                 is valid.  The arguments to the validator function
-                 are: (key, val, env).  The key is the name of the
-                 option, the val is the path specified for the option,
-                 and the env is the env to which the Options have been
-                 added.
-
-Usage example::
-
-  Examples:
-      prefix=/usr/local
-
-  opts = Variables()
-
-  opts = Variables()
-  opts.Add(PathVariable('qtdir',
-                        'where the root of Qt is installed',
-                        qtdir, PathIsDir))
-  opts.Add(PathVariable('qt_includes',
-                      'where the Qt includes are installed',
-                      '$qtdir/includes', PathIsDirCreate))
-  opts.Add(PathVariable('qt_libraries',
-                      'where the Qt library is installed',
-                      '$qtdir/lib'))
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -65,9 +20,48 @@ Usage example::
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Option type for path Variables.
+
+This file defines an option type for SCons implementing path settings.
+
+To be used whenever a user-specified path override should be allowed.
+
+Arguments to PathVariable are:
+  option-name  = name of this option on the command line (e.g. "prefix")
+  option-help  = help string for option
+  option-dflt  = default value for this option
+  validator    = [optional] validator for option value.  Predefined are:
+    PathAccept -- accepts any path setting; no validation
+    PathIsDir  -- path must be an existing directory
+    PathIsDirCreate -- path must be a dir; will create
+    PathIsFile -- path must be a file
+    PathExists -- path must exist (any type) [default]
+
+  The validator is a function that is called and which should return
+  True or False to indicate if the path is valid.  The arguments
+  to the validator function are: (key, val, env).  The key is the
+  name of the option, the val is the path specified for the option,
+  and the env is the env to which the Options have been added.
+
+Usage example::
+
+  Examples:
+      prefix=/usr/local
+
+  opts = Variables()
+
+  opts = Variables()
+  opts.Add(PathVariable('qtdir',
+                        'where the root of Qt is installed',
+                        qtdir, PathIsDir))
+  opts.Add(PathVariable('qt_includes',
+                      'where the Qt includes are installed',
+                      '$qtdir/includes', PathIsDirCreate))
+  opts.Add(PathVariable('qt_libraries',
+                      'where the Qt library is installed',
+                      '$qtdir/lib'))
+"""
 
 __all__ = ['PathVariable',]
 

--- a/SCons/Variables/PathVariableTests.py
+++ b/SCons/Variables/PathVariableTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import unittest

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -1,11 +1,6 @@
-"""SCons.Variables
-
-This file defines the Variables class that is used to add user-friendly
-customizable variables to an SCons build.
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,7 +21,7 @@ customizable variables to an SCons build.
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Add user-friendly customizable variables to an SCons build. """
 
 import os.path
 import sys

--- a/SCons/Warnings.py
+++ b/SCons/Warnings.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,15 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-"""SCons.Warnings
-
-This file implements the warnings framework for SCons.
-
-"""
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""The SCons warnings framework."""
 
 import sys
 

--- a/SCons/WarningsTests.py
+++ b/SCons/WarningsTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import unittest
 

--- a/SCons/__main__.py
+++ b/SCons/__main__.py
@@ -1,3 +1,26 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import SCons.Script
 # this does all the work, and calls sys.exit
 # with the proper exit status when done.

--- a/SCons/compat/__init__.py
+++ b/SCons/compat/__init__.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,21 +20,21 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__doc__ = """
-SCons compatibility package for old Python versions
+"""SCons compatibility package for old Python versions
 
 This subpackage holds modules that provide backwards-compatible
-implementations of various things that we'd like to use in SCons but which
-only show up in later versions of Python than the early, old version(s)
-we still support.
+implementations of various things from newer Python versions
+that we cannot count on because SCons still supported older Pythons.
 
 Other code will not generally reference things in this package through
 the SCons.compat namespace.  The modules included here add things to
 the builtins namespace or the global module list so that the rest
 of our code can use the objects and names imported here regardless of
-Python version.
+Python version. As a result, if this module is used, it should violate
+the normal convention for imports (standard library imports first,
+then program-specific imports, each ordered aplhabetically)
+and needs to be listed first.
 
 The rest of the things here will be in individual compatibility modules
 that are either: 1) suitably modified copies of the future modules that
@@ -56,8 +57,6 @@ function defined below loads the module as the "real" name (without the
 '_scons'), after which all of the "import {module}" statements in the
 rest of our code will find our pre-loaded compatibility module.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 import importlib

--- a/SCons/compat/_scons_dbm.py
+++ b/SCons/compat/_scons_dbm.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,18 +20,14 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__doc__ = """
-dbm compatibility module for Python versions that don't have dbm.
+"""dbm compatibility module for Python versions that don't have dbm.
 
 This does not not NOT (repeat, *NOT*) provide complete dbm functionality.
 It's just a stub on which to hang just enough pieces of dbm functionality
 that the whichdb.whichdb() implementstation in the various 2.X versions of
 Python won't blow up even if dbm wasn't compiled in.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 class error(Exception):
     pass

--- a/SCons/cpp.py
+++ b/SCons/cpp.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,13 +20,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""SCons C Pre-Processor module"""
 
-__doc__ = """
-SCons C Pre-Processor module
-"""
 import SCons.compat
 
 import os
@@ -650,8 +647,6 @@ class DumbPreProcessor(PreProcessor):
         d = self.default_table
         for func in ['if', 'elif', 'else', 'endif', 'ifdef', 'ifndef']:
             d[func] = d[func] = self.do_nothing
-
-del __revision__
 
 # Local Variables:
 # tab-width:4

--- a/SCons/cppTests.py
+++ b/SCons/cppTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,8 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import atexit
 import unittest
@@ -28,7 +27,6 @@ import unittest
 import TestUnit
 
 import cpp
-
 
 
 basic_input = """

--- a/SCons/dblite.py
+++ b/SCons/dblite.py
@@ -1,3 +1,26 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 """
 dblite.py module contributed by Ralf W. Grosse-Kunstleve.
 Extended for Unicode by Steven Knight.

--- a/SCons/exitfuncs.py
+++ b/SCons/exitfuncs.py
@@ -1,11 +1,6 @@
-"""SCons.exitfuncs
-
-Register functions which are executed when SCons exits for any reason.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,10 +20,10 @@ Register functions which are executed when SCons exits for any reason.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Register functions which are executed when SCons exits for any reason."""
 
+# This is obsolete now
 
 import atexit
 


### PR DESCRIPTION
Touches the first and second levels of `SCons/` (except `SCons/Tool`), not tests or docs which remain TODO.

Make sure docstring is first non-comment content, eliminate cases where docstring is set elsewhere but assigns to `__doc__` - this approach of course worked inside Python, but confuses various tools.

Some module-level docstrings modified a bit, in particular the convention of having the name of the module as the first line
is dropped, replaced by a summary description going there instead - this improves the look in the API Docs, which otherwise display something like:

    SCons.Foo - SCons.Foo

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
