### PR TITLE
Add selection options to test runner

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -6,22 +6,17 @@
 #
 # The SCons test suite consists of:
 #
-#  - unit tests        - included in *Tests.py files from src/ dir
+#  - unit tests        - included in *Tests.py files from SCons/ dir
 #  - end-to-end tests  - these are *.py files in test/ directory that
 #                        require custom SCons framework from testing/
 #
 # This script adds SCons/ and testing/ directories to PYTHONPATH,
 # performs test discovery and processes them according to options.
-#
-# With -p (--package) option, script tests specified package from
-# build directory and sets PYTHONPATH to reference modules unpacked
-# during build process for testing purposes (build/test-*).
 
 """
 Options:
   -a --all                 Run all tests.
   -b --baseline BASE       Run test scripts against baseline BASE.
-     --builddir DIR        Directory in which packages were built.
   -d --debug               Run test scripts under the Python debugger.
   -D --devmode             Run tests in Python's development mode (3.7+ only)
      --e2e-only            Run only the end-to-end tests
@@ -38,15 +33,6 @@ Options:
                            chars! You might run into some deadlocks else.
   -o --output FILE         Save the output from a test run to the log file.
   -P PYTHON                Use the specified Python interpreter.
-  -p --package PACKAGE     Test against the specified PACKAGE:
-                             deb           Debian
-                             local-tar-gz  .tar.gz standalone package
-                             local-zip     .zip standalone package
-                             rpm           Red Hat
-                             src-tar-gz    .tar.gz source package
-                             src-zip       .zip source package
-                             tar-gz        .tar.gz distribution
-                             zip           .zip distribution
      --passed              Summarize which tests passed.
   -q --quiet               Don't print the test being executed.
      --quit-on-failure     Quit on any test failure.
@@ -89,7 +75,6 @@ from queue import Queue
 cwd = os.getcwd()
 
 baseline = None
-builddir = os.path.join(cwd, 'build')
 external = 0
 devmode = False
 debug = ''
@@ -97,7 +82,6 @@ execute_tests = True
 jobs = 1
 list_only = False
 printcommand = True
-package = None
 print_passed_summary = False
 scons = None
 scons_exec = False
@@ -105,7 +89,6 @@ testlistfile = None
 version = ''
 print_times = False
 python = None
-sp = []
 print_progress = True
 catch_output = False
 suppress_output = False
@@ -156,7 +139,6 @@ opts, args = getopt.getopt(
     "b:dDef:hj:klnP:p:qsv:Xx:t",
     [
         "baseline=",
-        "builddir=",
         "debug",
         "devmode", 
         "external",
@@ -167,7 +149,6 @@ opts, args = getopt.getopt(
         "list",
         "no-exec",
         "nopipefiles",
-        "package=",
         "passed",
         "python=",
         "quiet",
@@ -186,10 +167,6 @@ opts, args = getopt.getopt(
 for o, a in opts:
     if o in ['-b', '--baseline']:
         baseline = a
-    elif o in ['--builddir']:
-        builddir = a
-        if not os.path.isabs(builddir):
-            builddir = os.path.normpath(os.path.join(cwd, builddir))
     elif o in ['-d', '--debug']:
         for d in sys.path:
             pdb = os.path.join(d, 'pdb.py')
@@ -220,8 +197,6 @@ for o, a in opts:
         execute_tests = False
     elif o in ['--nopipefiles']:
         allow_pipe_files = False
-    elif o in ['-p', '--package']:
-        package = a
     elif o in ['--passed']:
         print_passed_summary = True
     elif o in ['-P', '--python']:
@@ -252,7 +227,7 @@ for o, a in opts:
         unit_only = True
 
 
-class Unbuffered():
+class Unbuffered:
     """ class to arrange for stdout/stderr to be unbuffered """
     def __init__(self, file):
         self.file = file
@@ -270,7 +245,7 @@ sys.stderr = Unbuffered(sys.stderr)
 
 if options.output:
     logfile = open(options.output, 'w')
-    class Tee():
+    class Tee:
         def __init__(self, openfile, stream):
             self.file = openfile
             self.stream = stream
@@ -305,12 +280,8 @@ else:
                     return f
         return None
 
-sp.append(builddir)
-sp.append(cwd)
 
-#
 _ws = re.compile(r'\s')
-
 
 def escape(s):
     if _ws.search(s):
@@ -423,7 +394,7 @@ class PopenExecutor(RuntestBase):
     by calling subprocess.run (behind the covers uses Popen.
     Very similar to SystemExecutor, but uses command_str
     instead of command_args, and doesn't allow for not catching
-    the output.
+    the output).
     """
     # For an explanation of the following 'if ... else'
     # and the 'allow_pipe_files' option, please check out the
@@ -571,23 +542,27 @@ if old_pythonpath:
 #
 # Each test path, whichever of the three sources it comes from,
 # specifies either a test file or a directory to search for
-# SCons tests. SCons code layout assumes that any file under the 'src'
+# SCons tests. SCons code layout assumes that any file under the 'SCons'
 # subdirectory that ends with 'Tests.py' is a unit test, and any Python
 # script (*.py) under the 'test' subdirectory is an end-to-end test.
 # We need to track these because they are invoked differently.
 # find_unit_tests and find_e2e_tests are used for this searching.
 #
-# Note that there are some tests under 'src' that *begin* with
+# Note that there are some tests under 'SCons' that *begin* with
 # 'test_', but they're packaging and installation tests, not
 # functional tests, so we don't execute them by default.  (They can
 # still be executed by hand, though).
 #
 # Test exclusions, if specified, are then applied.
 
-tests = []
-excludetests = []
 unittests = []
 endtests = []
+
+
+def scanlist(testlist):
+    """Process a testlist file"""
+    tests = [t.strip() for t in testlist if not t.startswith('#')]
+    return [t for t in tests if t]
 
 
 def find_unit_tests(directory):
@@ -613,7 +588,7 @@ def find_e2e_tests(directory):
             continue
         try:
             with open(os.path.join(dirpath, ".exclude_tests")) as f:
-                excludes = [e.split("#", 1)[0].strip() for e in f.readlines()]
+                excludes = scanlist(f)
         except EnvironmentError:
             excludes = []
         for fname in filenames:
@@ -622,10 +597,10 @@ def find_e2e_tests(directory):
     return sorted(result)
 
 
+# initial selection:
 if testlistfile:
     with open(testlistfile, 'r') as f:
-        tests = [x[:-1].strip() for x in f if not x.startswith('#')]
-    tests = [x for x in tests if x]
+        tests = scanlist(f)
 else:
     testpaths = []
     if options.all:
@@ -644,41 +619,37 @@ else:
         # sys.stderr.write("to:%s\n"%tp)
         for path in glob.glob(tp):
             if os.path.isdir(path):
-                if path.startswith(('SCons', 'testing')) and not e2e_only:
-                    for p in find_unit_tests(path):
-                        unittests.append(p)
-                elif path.startswith('test') and not unit_only:
-                    for p in find_e2e_tests(path):
-                        endtests.append(p)
+                if path.startswith(('SCons', 'testing')):
+                    unittests.extend(find_unit_tests(path))
+                elif path.startswith('test'):
+                    endtests.extend(find_e2e_tests(path))
             else:
-                if path.endswith("Tests.py") and not e2e_only:
+                if path.endswith("Tests.py"):
                     unittests.append(path)
-                else:
-                    if not unit_only:
-                        endtests.append(path)
+                elif path.endswith(".py"):
+                    endtests.append(path)
+    tests = unittests + endtests
 
-    tests.extend(unittests)
-    tests.extend(endtests)
-    tests.sort()
+# Remove exclusions:
+if e2e_only:
+    tests = [t for t in tests if not t.endswith("Tests.py")]
+if unit_only:
+    tests = [t for t in tests if t.endswith("Tests.py")]
+if excludelistfile:
+    with open(excludelistfile, 'r') as f:
+        excludetests = scanlist(f)
+    tests = [t for t in tests if t not in excludetests]
 
 if not tests:
     sys.stderr.write(usagestr + """
-runtest.py:  No tests were found.
-             Tests can be specified on the command line, read from file
-             with -f option, or discovered with -a to run all tests.
+runtest: no tests were found.
+         Tests can be specified on the command line, read from a file with
+         the -f/--file option, or discovered with -a/--all to run all tests.
 """)
     sys.exit(1)
 
-if excludelistfile:
-    with open(excludelistfile, 'r') as f:
-        excludetests = f.readlines()
-    excludetests = [x for x in excludetests if x[0] != '#']
-    excludetests = [x[:-1] for x in excludetests]
-    excludetests = [x.strip() for x in excludetests]
-    excludetests = [x for x in excludetests if x]
 
 # ---[ test processing ]-----------------------------------
-tests = [t for t in tests if t not in excludetests]
 tests = [Test(t, n + 1) for n, t in enumerate(tests)]
 
 if list_only:


### PR DESCRIPTION
`runtest.py` can now take `--unit-only` and `--e2e-only` selection options to limit a test run to tests from one or other category.

* Docstrings updated, a comment block moved and expanded.
* Drop unused package and builddir options.
* Extract the reading of a list of tests to a common routine.
* Exclude processing combined into one area.


Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
