### PR TITLE
Remove using pywin32 to retrieve peak memory usage for --debug=memory

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From William Deegan:
     - Fix yacc tool, not respecting YACC set at time of tool initialization.
     - Refactor SCons.Tool to move all common shared and loadable module linking logic to SCons.Tool.linkCommon
+    - Remove using pywin32 to retrieve peak memory usage on Win32 for `--debug=memory`
 
   From Michał Górny:
     - Fix dvipdf test failure due to passing incorrect flag to dvipdf.

--- a/SCons/Debug.py
+++ b/SCons/Debug.py
@@ -90,7 +90,6 @@ def dumpLoggedInstances(classes, file=sys.stdout):
                     file.write('        %20s : %s\n' % (key, value))
 
 
-
 if sys.platform[:5] == "linux":
     # Linux doesn't actually support memory usage stats from getrusage().
     def memory():
@@ -102,28 +101,23 @@ elif sys.platform[:6] == 'darwin':
     #TODO really get memory stats for OS X
     def memory():
         return 0
+elif sys.platform == 'win32':
+    from SCons.compat.win32 import get_peak_memory_usage
+    memory = get_peak_memory_usage
 else:
     try:
         import resource
     except ImportError:
-        try:
-            import win32process
-            import win32api
-        except ImportError:
-            def memory():
-                return 0
-        else:
-            def memory():
-                process_handle = win32api.GetCurrentProcess()
-                memory_info = win32process.GetProcessMemoryInfo( process_handle )
-                return memory_info['PeakWorkingSetSize']
+        def memory():
+            return 0
     else:
         def memory():
             res = resource.getrusage(resource.RUSAGE_SELF)
             return res[4]
 
-# returns caller's stack
+
 def caller_stack():
+    """return caller's stack"""
     import traceback
     tb = traceback.extract_stack()
     # strip itself and the caller from the output

--- a/SCons/compat/win32.py
+++ b/SCons/compat/win32.py
@@ -1,0 +1,101 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""Logic to replicate parts of pywin32 SCons uses."""
+
+__all__ = ['get_current_process', 'get_memory_info', 'get_memory_usage', 'get_peak_memory_usage']
+
+import ctypes
+from ctypes import wintypes
+
+#
+# From Activestate Recipe
+# https://code.activestate.com/recipes/578513-get-memory-usage-of-windows-processes-using-getpro/
+# MIT licensed
+#
+GetCurrentProcess = ctypes.windll.kernel32.GetCurrentProcess
+GetCurrentProcess.argtypes = []
+GetCurrentProcess.restype = wintypes.HANDLE
+
+SIZE_T = ctypes.c_size_t
+
+
+class PROCESS_MEMORY_COUNTERS_EX(ctypes.Structure):
+    _fields_ = [
+        ('cb', wintypes.DWORD),
+        ('PageFaultCount', wintypes.DWORD),
+        ('PeakWorkingSetSize', SIZE_T),
+        ('WorkingSetSize', SIZE_T),
+        ('QuotaPeakPagedPoolUsage', SIZE_T),
+        ('QuotaPagedPoolUsage', SIZE_T),
+        ('QuotaPeakNonPagedPoolUsage', SIZE_T),
+        ('QuotaNonPagedPoolUsage', SIZE_T),
+        ('PagefileUsage', SIZE_T),
+        ('PeakPagefileUsage', SIZE_T),
+        ('PrivateUsage', SIZE_T),
+    ]
+
+
+GetProcessMemoryInfo = ctypes.windll.psapi.GetProcessMemoryInfo
+GetProcessMemoryInfo.argtypes = [
+    wintypes.HANDLE,
+    ctypes.POINTER(PROCESS_MEMORY_COUNTERS_EX),
+    wintypes.DWORD,
+]
+GetProcessMemoryInfo.restype = wintypes.BOOL
+
+
+def get_current_process():
+    """Return handle to current process."""
+    return GetCurrentProcess()
+
+
+def get_memory_info(process=None):
+    """Return Win32 process memory counters structure as a dict."""
+    if process is None:
+        process = get_current_process()
+    counters = PROCESS_MEMORY_COUNTERS_EX()
+    ret = GetProcessMemoryInfo(process, ctypes.byref(counters),
+                               ctypes.sizeof(counters))
+    if not ret:
+        raise ctypes.WinError()
+    info = dict((name, getattr(counters, name))
+                for name, _ in counters._fields_)
+    return info
+
+
+def get_memory_usage(process=None):
+    """Return this process's memory usage in bytes."""
+    info = get_memory_info(process=process)
+    return info['PrivateUsage']
+
+
+def get_peak_memory_usage(process=None):
+    """Return this process's memory usage in bytes."""
+    info = get_memory_info(process=process)
+    return info['PeakWorkingSetSize']
+
+
+if __name__ == '__main__':
+    import pprint
+
+    pprint.pprint(get_memory_info())


### PR DESCRIPTION
Reduce dependency on pywin32 package for Windows platforms.


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
