### PR TITLE
Remove pywin32 from SCons.Util where it was used for reading registry

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From William Deegan:
     - Fix yacc tool, not respecting YACC set at time of tool initialization.
     - Refactor SCons.Tool to move all common shared and loadable module linking logic to SCons.Tool.linkCommon
+    - Remove pywin32 usage from SCons.Util where it was used for accessing the registry. Python native winreg
+      library already includes this functionality.
 
   From Michał Górny:
     - Fix dvipdf test failure due to passing incorrect flag to dvipdf.

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -648,22 +648,9 @@ try:
     RegError        = winreg.error
 
 except ImportError:
-    try:
-        import win32api
-        import win32con
-        can_read_reg = 1
-        hkey_mod = win32con
-
-        RegOpenKeyEx    = win32api.RegOpenKeyEx
-        RegEnumKey      = win32api.RegEnumKey
-        RegEnumValue    = win32api.RegEnumValue
-        RegQueryValueEx = win32api.RegQueryValueEx
-        RegError        = win32api.error
-
-    except ImportError:
-        class _NoError(Exception):
-            pass
-        RegError = _NoError
+    class _NoError(Exception):
+        pass
+    RegError = _NoError
 
 
 # Make sure we have a definition of WindowsError so we can


### PR DESCRIPTION
Remove pywin32 from SCons.Util where it was used for reading registry if not available via Python's winreg package. It's (long been) part of Python's standard library so using pywin32 as a backup is not necessary

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
