### PR TITLE
Drop some more Py2 compat things

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Make sure cProfile is used if profiling - SCons was expecting
       the Util module to monkeypatch in cProfile as profile if available,
       but this is no longer being done.
+    - Some Python 2 compat dropped
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,7 +63,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Make sure cProfile is used if profiling - SCons was expecting
       the Util module to monkeypatch in cProfile as profile if available,
       but this is no longer being done.
-    - Some Python 2 compat dropped
+    - Some Python 2 compatibility code dropped
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -434,7 +434,7 @@ class EntryProxy(SCons.Util.Proxy):
 
     # In PY3 if a class defines __eq__, then it must explicitly provide
     # __hash__.  Since SCons.Util.Proxy provides __eq__ we need the following
-    # see: https://docs.python.org/3.1/reference/datamodel.html#object.__hash__
+    # see: https://docs.python.org/3/reference/datamodel.html#object.__hash__
     __hash__ = SCons.Util.Delegate('__hash__')
 
     def __get_abspath(self):

--- a/SCons/Node/Python.py
+++ b/SCons/Node/Python.py
@@ -129,7 +129,7 @@ class Value(SCons.Node.Node):
             self.built_value = self.value
         return self.built_value
 
-    def get_text_contents(self):
+    def get_text_contents(self) -> str:
         """By the assumption that the node.built_value is a
         deterministic product of the sources, the contents of a Value
         are the concatenation of all the contents of its sources.  As
@@ -141,16 +141,13 @@ class Value(SCons.Node.Node):
             contents = contents + kid.get_contents().decode()
         return contents
 
-    def get_contents(self):
-        """
-        Get contents for signature calculations.
-        :return: bytes
-        """
+    def get_contents(self) -> bytes:
+        """Get contents for signature calculations."""
         text_contents = self.get_text_contents()
         try:
             return text_contents.encode()
-        except UnicodeDecodeError:
-            # Already encoded as python2 str are bytes
+        except AttributeError:
+            # Should not happen, as get_text_contents returns str
             return text_contents
 
     def changed_since_last_build(self, target, prev_ni):

--- a/SCons/Node/Python.py
+++ b/SCons/Node/Python.py
@@ -143,19 +143,14 @@ class Value(SCons.Node.Node):
 
     def get_contents(self) -> bytes:
         """Get contents for signature calculations."""
-        text_contents = self.get_text_contents()
-        try:
-            return text_contents.encode()
-        except AttributeError:
-            # Should not happen, as get_text_contents returns str
-            return text_contents
+        return self.get_text_contents().encode()
 
     def changed_since_last_build(self, target, prev_ni):
         cur_csig = self.get_csig()
         try:
             return cur_csig != prev_ni.csig
         except AttributeError:
-            return 1
+            return True
 
     def get_csig(self, calc=None):
         """Because we're a Python value node and don't have a real

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -36,11 +36,7 @@ start_time = time.time()
 
 import collections
 import os
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 import sys
 

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -541,9 +541,7 @@ class scons_subst_TestCase(SubstTestCase):
             scons_subst('$foo.bar.3.0', env)
         except SCons.Errors.UserError as e:
             expect = [
-                # Python 2.3, 2.4
-                "SyntaxError `invalid syntax (line 1)' trying to evaluate `$foo.bar.3.0'",
-                # Python 2.5
+                # Python 2.5 and later
                 "SyntaxError `invalid syntax (<string>, line 1)' trying to evaluate `$foo.bar.3.0'",
             ]
             assert str(e) in expect, e

--- a/SCons/Tool/clang.py
+++ b/SCons/Tool/clang.py
@@ -84,8 +84,7 @@ def generate(env):
         # clang -dumpversion is of no use
         with pipe.stdout:
             line = pipe.stdout.readline()
-        if sys.version_info[0] > 2:
-            line = line.decode()
+        line = line.decode()
         match = re.search(r'clang +version +([0-9]+(?:\.[0-9]+)+)', line)
         if match:
             env['CCVERSION'] = match.group(1)

--- a/SCons/Tool/clangxx.py
+++ b/SCons/Tool/clangxx.py
@@ -92,8 +92,7 @@ def generate(env):
         # clang -dumpversion is of no use
         with pipe.stdout:
             line = pipe.stdout.readline()
-        if sys.version_info[0] > 2:
-            line = line.decode()
+        line = line.decode()
         match = re.search(r'clang +version +([0-9]+(?:\.[0-9]+)+)', line)
         if match:
             env['CXXVERSION'] = match.group(1)

--- a/SCons/Tool/textfile.py
+++ b/SCons/Tool/textfile.py
@@ -74,8 +74,8 @@ def _do_subst(node, subs):
     if 'b' in TEXTFILE_FILE_WRITE_MODE:
         try:
             contents = bytearray(contents, 'utf-8')
-        except UnicodeDecodeError:
-            # contents is already utf-8 encoded python 2 str i.e. a byte array
+        except TypeError:
+            # TODO: this should not happen, get_text_contents returns text
             contents = bytearray(contents)
 
     return contents

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -193,11 +193,7 @@ class UtilTestCase(unittest.TestCase):
         try:
             node, expect, withtags = self.tree_case_1()
 
-            if sys.version_info.major < 3:
-                IOStream = io.BytesIO
-            else:
-                IOStream = io.StringIO
-
+            IOStream = io.StringIO
             sys.stdout = IOStream()
             print_tree(node, get_children)
             actual = sys.stdout.getvalue()
@@ -249,11 +245,6 @@ class UtilTestCase(unittest.TestCase):
     def test_is_Dict(self):
         assert is_Dict({})
         assert is_Dict(UserDict())
-
-        # os.environ is not a dictionary in python 3
-        if sys.version_info < (3, 0):
-            assert is_Dict(os.environ)
-
         try:
             class mydict(dict):
                 pass

--- a/SCons/Utilities/sconsign.py
+++ b/SCons/Utilities/sconsign.py
@@ -98,11 +98,6 @@ def default_mapper(entry, name):
         val = eval("entry." + name)
     except AttributeError:
         val = None
-    if sys.version_info.major >= 3 and isinstance(val, bytes):
-        # This is a dirty hack for py 2/3 compatibility. csig is a bytes object
-        # in Python3 while Python2 bytes are str. Hence, we decode the csig to a
-        # Python3 string
-        val = val.decode()
     return str(val)
 
 
@@ -327,8 +322,8 @@ class Do_SConsignDB:
             sys.stderr.write("sconsign: ignoring invalid `%s' file `%s': %s\n"
                              % (self.dbm_name, fname, e))
             exc_type, _, _ = sys.exc_info()
-            if exc_type.__name__ == "ValueError" and sys.version_info < (3,0,0):
-                sys.stderr.write("Python 2 only supports pickle protocols 0-2.\n")
+            if exc_type.__name__ == "ValueError":
+                sys.stderr.write("unrecognized pickle protocol.\n")
             return
 
         if Print_Directories:

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -344,13 +344,13 @@ def is_List(e):
 
 
 def to_bytes(s):
-    if isinstance(s, bytes) or bytes is str:
+    if isinstance(s, bytes):
         return s
     return bytes(s, 'utf-8')
 
 
 def to_str(s):
-    if bytes is str or is_String(s):
+    if is_String(s):
         return s
     return str(s, 'utf-8')
 
@@ -469,7 +469,7 @@ def match_exact(lines=None, matches=None, newline=os.sep):
     :returns: an object (1) on match, else None, like re.match
 
     """
-    if isinstance(lines, bytes) or bytes is str:
+    if isinstance(lines, bytes):
         newline = to_bytes(newline)
 
     if not is_List(lines):

--- a/testing/framework/TestRuntest.py
+++ b/testing/framework/TestRuntest.py
@@ -36,8 +36,6 @@ else:
     pythonstring = python
 pythonstring = pythonstring.replace('\\', '\\\\')
 pythonflags = ''
-if sys.version_info[0] < 3:
-    pythonflags = ' -tt'
 
 failing_test_template = """\
 import sys

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1491,12 +1491,9 @@ SConscript(sconscript)
             self.run(program=python, stdin="""\
 import sysconfig, sys, os.path
 py_ver = 'python%d%d' % sys.version_info[:2]
-# use distutils to help find include and lib path
-# TODO: PY3 fine to use sysconfig.get_config_var("INCLUDEPY")
 try:
-    import distutils.sysconfig
-    exec_prefix = distutils.sysconfig.EXEC_PREFIX
-    include = distutils.sysconfig.get_python_inc()
+    exec_prefix = sysconfig.get_config_var("exec_prefix")
+    include = sysconfig.get_config_var("INCLUDEPY")
     print(include)
     lib_path = os.path.join(exec_prefix, 'libs')
     if not os.path.exists(lib_path):


### PR DESCRIPTION
- Change exception type in a a couple of try block to what could go wrong, Py3 would not raise UniCodeDecodeError for these cases
- One try-import of StringIO module
- sconsign does not need a decode that was claimed as compat hack
- Remove some sys.version_info checks
- Use more modern way to get Python details in test frawmework
- AddMethod updated and RenameFunction dropped - it had become a one-liner  and had no clients other than AddMethod (never exposed as public)

No doc impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
