### PR TITLE
Fix invalid cache state when using SCons interactive mode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -35,6 +35,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       User-facing behavior does not change with this fix (GH Issue #3726).
     - Fix occasional test failures caused by not being able to find a file or directory fixture
       when running multiple tests with multiple jobs.
+    - Fix incorrect cache hits and/or misses when running in interactive mode by having
+      SCons.Node.Node.clear() clear out all caching-related state.
 
   From Joachim Kuebart:
     - Suppress missing SConscript deprecation warning if `must_exist=False`

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -3722,6 +3722,14 @@ class clearTestCase(unittest.TestCase):
         assert not f.exists()
         assert not f.rexists()
         assert str(f) == test.workpath('f'), str(f)
+        # Now verify clear() resets optional File-specific attributes
+        optional_attrs = ['cachedir_csig', 'cachesig', 'contentsig']
+        for attr in optional_attrs:
+            setattr(f, attr, 'xyz')
+        f.clear()
+        for attr in optional_attrs:
+            assert not hasattr(f, attr), attr
+        assert not f.cached, f.cached
 
 
 class disambiguateTestCase(unittest.TestCase):

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -3729,7 +3729,6 @@ class clearTestCase(unittest.TestCase):
         f.clear()
         for attr in optional_attrs:
             assert not hasattr(f, attr), attr
-        assert not f.cached, f.cached
 
 
 class disambiguateTestCase(unittest.TestCase):

--- a/SCons/Node/NodeTests.py
+++ b/SCons/Node/NodeTests.py
@@ -1297,6 +1297,7 @@ class NodeTestCase(unittest.TestCase):
         n.includes = 'testincludes'
         n.Tag('found_includes', {'testkey':'testvalue'})
         n.implicit = 'testimplicit'
+        n.cached = 1
 
         x = MyExecutor()
         n.set_executor(x)
@@ -1304,6 +1305,7 @@ class NodeTestCase(unittest.TestCase):
         n.clear()
 
         assert n.includes is None, n.includes
+        assert n.cached == 0, n.cached
         assert x.cleaned_up
 
     def test_get_subst_proxy(self):

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -869,10 +869,12 @@ class Node(object, metaclass=NoSlotsPyPy):
         self.clear_memoized_values()
         self.ninfo = self.new_ninfo()
         self.executor_cleanup()
-        try:
-            delattr(self, '_calculated_sig')
-        except AttributeError:
-            pass
+        for attr in ['cachedir_csig', 'cachesig', 'contentsig']:
+            try:
+                delattr(self, attr)
+            except AttributeError:
+                pass
+        self.cached = 0
         self.includes = None
 
     def clear_memoized_values(self):


### PR DESCRIPTION
SCons.Node.Node.clear() had code to clear cache-related state but it was only clearing a non-unused variable _calculated_sig. Fix this by clearing the three variables now used in practice by get_cachedir_bsig() and the functions that it calls: `cachedir_csig`, `cachesig`, and `contentsig`. Also reset `cached` to 0 because the task scheduler depends on it but doesn't reset it.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
