### PR TITLE
Add COMPILATIONDB_USE_PATH_FILTER for filtering compilation database.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -74,6 +74,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Could yield a single tempfile with the first TEMPFILE's contents, used by both steps
       in the action list.
 
+  From James Benton:
+    - Add COMPILATIONDB_USE_PATH_FILTER env option for CompilationDatabase() builder which allows
+      filtering of entries based on the output file paths using fnmatch (issue #3742).
+
 
 
 

--- a/SCons/Tool/compilation_db.xml
+++ b/SCons/Tool/compilation_db.xml
@@ -38,6 +38,7 @@ See its __doc__ string for a discussion of the format.
             <item>__COMPILATIONDB_ENV</item>
 -->            
             <item>COMPILATIONDB_USE_ABSPATH</item>
+            <item>COMPILATIONDB_USE_PATH_FILTER</item>
         </sets>
     </tool>
 
@@ -86,11 +87,24 @@ env.CompilationDatabase('my_output.json')
         <summary>
             <para>
                 This is a boolean flag to instruct &b-link-CompilationDatabase; to
-                write the <literal>file</literal> and <literal>target</literal> members
+                write the <literal>file</literal> and <literal>output</literal> members
                 in the compilation database with absolute or relative paths.
             </para>
             <para>
                 The default value is False (use relative paths)
+            </para>
+        </summary>
+    </cvar>
+
+    <cvar name="COMPILATIONDB_USE_PATH_FILTER">
+        <summary>
+            <para>
+                This is a string which instructs &b-link-CompilationDatabase; to
+                only include entries where the <literal>output</literal> member
+                matches the pattern in the filter string using fnmatch.
+            </para>
+            <para>
+                The default value is an empty string '', which means no entries will be filtered.
             </para>
         </summary>
     </cvar>

--- a/doc/user/external.xml
+++ b/doc/user/external.xml
@@ -100,17 +100,26 @@
     <para>
 
     The compilation database can be populated with
-    source and target files either with paths relative
+    source and output files either with paths relative
     to the top of the build, or using absolute paths.
     This is controlled by
     <envar>COMPILATIONDB_USE_ABSPATH=(True|False)</envar>
     which defaults to <constant>False</constant>.
+    The entries in this file can be filtered by using
+    <envar>COMPILATIONDB_USE_PATH_FILTER='fnmatch pattern'</envar>
+    where the filter string is a
+    <ulink url="https://docs.python.org/3/library/fnmatch.html">
+      <citetitle>fnmatch</citetitle>
+    </ulink>
+    based pattern which is a typical file glob syntax.
+    This filtering can be used for outputting different
+    build variants to different compilation database files.
 
     </para>
 
     <para>
 
-    Example of absolute paths for target and source:
+    Example of absolute paths for output and source:
 
     </para>
 
@@ -126,14 +135,14 @@ env.CompilationDatabase('compile_commands.json')
         "command": "gcc -o test_main.o -c test_main.c",
         "directory": "/home/user/sandbox",
         "file": "/home/user/sandbox/test_main.c",
-        "target": "/home/user/sandbox/test_main.o"
+        "output": "/home/user/sandbox/test_main.o"
     }
 ]
     </programlisting>
 
     <para>
 
-    Example of relative paths for target and source:
+    Example of relative paths for output and source:
 
     </para>
 
@@ -148,7 +157,46 @@ env.CompilationDatabase('compile_commands.json')
         "command": "gcc -o test_main.o -c test_main.c",
         "directory": "/home/user/sandbox",
         "file": "test_main.c",
-        "target": "test_main.o"
+        "output": "test_main.o"
+    }
+]
+    </programlisting>
+
+    <para>
+
+    Example of using filtering for build variants:
+
+    </para>
+
+    <sconstruct>
+env = Environment()
+env.Tool('compilation_db')
+
+env1 = env.Clone()
+env1['COMPILATIONDB_USE_PATH_FILTER'] = 'build/linux32/*'
+env1.CompilationDatabase('compile_commands-linux32.json')
+
+env2 = env.Clone()
+env2['COMPILATIONDB_USE_PATH_FILTER'] = 'build/linux64/*'
+env2.CompilationDatabase('compile_commands-linux64.json')
+    </sconstruct>
+    <programlisting language="json">
+[
+    {
+        "command": "gcc -m32 -o build/linux32/test_main.o -c test_main.c",
+        "directory": "/home/user/sandbox",
+        "file": "test_main.c",
+        "output": "build/linux32/test_main.o"
+    }
+]
+    </programlisting>
+    <programlisting language="json">
+[
+    {
+        "command": "gcc -m64 -o build/linux64/test_main.o -c test_main.c",
+        "directory": "/home/user/sandbox",
+        "file": "test_main.c",
+        "output": "build/linux64/test_main.o"
     }
 ]
     </programlisting>

--- a/test/CompilationDatabase/fixture/SConstruct_variant
+++ b/test/CompilationDatabase/fixture/SConstruct_variant
@@ -32,6 +32,10 @@ env.CompilationDatabase('compile_commands_over_rel.json', COMPILATIONDB_USE_ABSP
 env.CompilationDatabase('compile_commands_over_abs_1.json', COMPILATIONDB_USE_ABSPATH=1)
 env.CompilationDatabase('compile_commands_over_abs_0.json', COMPILATIONDB_USE_ABSPATH=0)
 
+# Try filter for build and build2 output
+env.CompilationDatabase('compile_commands_filter_build.json', COMPILATIONDB_USE_PATH_FILTER='build/*')
+env.CompilationDatabase('compile_commands_filter_build2.json', COMPILATIONDB_USE_PATH_FILTER='build2/*')
+
 env.VariantDir('build','src')
 env.Program('build/main', 'build/test_main.c')
 

--- a/test/CompilationDatabase/variant_dir.py
+++ b/test/CompilationDatabase/variant_dir.py
@@ -56,6 +56,14 @@ abs_files = [
     'compile_commands_over_abs_1.json',
 ]
 
+filter_build_files = [
+    'compile_commands_filter_build.json',
+]
+
+filter_build2_files = [
+    'compile_commands_filter_build2.json',
+]
+
 example_rel_file = """[
     {
         "command": "%(exe)s mygcc.py cc -o %(output_file)s -c %(variant_src_file)s",
@@ -114,5 +122,46 @@ if sys.platform == 'win32':
 for f in abs_files:
     test.must_exist(f)
     test.must_match(f, example_abs_file, mode='r')
+
+example_filter_build_file = """[
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output_file)s -c %(variant_src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(src_file)s",
+        "output": "%(output_file)s"
+    }
+]""" % {'exe': sys.executable,
+        'workdir': test.workdir,
+        'src_file': os.path.join('src', 'test_main.c'),
+        'output_file': os.path.join('build', 'test_main.o'),
+        'variant_src_file': os.path.join('build', 'test_main.c')
+        }
+
+if sys.platform == 'win32':
+    example_filter_build_file = example_filter_build_file.replace('\\', '\\\\')
+
+for f in filter_build_files:
+    test.must_exist(f)
+    test.must_match(f, example_filter_build_file, mode='r')
+
+example_filter_build2_file = """[
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output2_file)s -c %(src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(src_file)s",
+        "output": "%(output2_file)s"
+    }
+]""" % {'exe': sys.executable,
+        'workdir': test.workdir,
+        'src_file': os.path.join('src', 'test_main.c'),
+        'output2_file': os.path.join('build2', 'test_main.o'),
+        }
+
+if sys.platform == 'win32':
+    example_filter_build2_file = example_filter_build2_file.replace('\\', '\\\\')
+
+for f in filter_build2_files:
+    test.must_exist(f)
+    test.must_match(f, example_filter_build2_file, mode='r')
 
 test.pass_test()


### PR DESCRIPTION
The filter is a fnmatch pattern matched against output file.

Also rename target->output in docs to match the output of compilation_db.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
