### PR TITLE
Convert test runner to use argparse

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -71,6 +71,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       MethodWrapper to set up the method the same way env.AddMethod does.
       MethodWrapper moved to Util to avoid a circular import. Fixes #3028.
     - Some Python 2 compatibility code dropped
+    - Rework runtest.py to use argparse for arg handling (was a mix
+      of hand-coded and optparse, with a stated intent to "gradually port")
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/runtest.py
+++ b/runtest.py
@@ -15,7 +15,6 @@ performs test discovery and processes tests according to options.
 """
 
 import argparse
-import functools
 import glob
 import os
 import re
@@ -162,7 +161,6 @@ if args.excludelistfile:
             args.testlistfile = p.resolve()
         else:
             args.testlistfile = p.resolve(strict=True)
-        args.excludelistfile = p.myresolve()
     except FileNotFoundError:
         sys.stderr.write(
             parser.format_usage()

--- a/runtest.py
+++ b/runtest.py
@@ -141,6 +141,7 @@ if args.testlist and (args.testlistfile or args.all):
     sys.exit(1)
 
 if args.testlistfile:
+    # args.testlistfile changes from a string to a pathlib Path object
     try:
         p = Path(args.testlistfile)
         if sys.version_info.major == 3 and sys.version_info.minor < 6:
@@ -155,12 +156,13 @@ if args.testlistfile:
         sys.exit(1)
 
 if args.excludelistfile:
+    # args.excludelistfile changes from a string to a pathlib Path object
     try:
         p = Path(args.excludelistfile)
         if sys.version_info.major == 3 and sys.version_info.minor < 6:
-            args.testlistfile = p.resolve()
+            args.excludelistfile = p.resolve()
         else:
-            args.testlistfile = p.resolve(strict=True)
+            args.excludelistfile = p.resolve(strict=True)
     except FileNotFoundError:
         sys.stderr.write(
             parser.format_usage()

--- a/runtest.py
+++ b/runtest.py
@@ -15,6 +15,7 @@ performs test discovery and processes tests according to options.
 """
 
 import argparse
+import functools
 import glob
 import os
 import re
@@ -143,7 +144,10 @@ if args.testlist and (args.testlistfile or args.all):
 if args.testlistfile:
     try:
         p = Path(args.testlistfile)
-        args.testlistfile = p.resolve(strict=True)
+        if sys.version_info.major == 3 and sys.version_info.minor < 6:
+            args.testlistfile = p.resolve()
+        else:
+            args.testlistfile = p.resolve(strict=True)
     except FileNotFoundError:
         sys.stderr.write(
             parser.format_usage()
@@ -154,7 +158,11 @@ if args.testlistfile:
 if args.excludelistfile:
     try:
         p = Path(args.excludelistfile)
-        args.excludelistfile = p.resolve(strict=True)
+        if sys.version_info.major == 3 and sys.version_info.minor < 6:
+            args.testlistfile = p.resolve()
+        else:
+            args.testlistfile = p.resolve(strict=True)
+        args.excludelistfile = p.myresolve()
     except FileNotFoundError:
         sys.stderr.write(
             parser.format_usage()


### PR DESCRIPTION
Formerly used optparse + homegrown, with a comment stating migration should be done (argprse now has superseded optparse).

Cleaned up a few stray bits that weren't used any longer.

Collects the changes intended for os.environ into a local dict, which is then used to make a single update.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
