### PR TITLE
runtest now writes a log of fails

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,7 +72,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       MethodWrapper moved to Util to avoid a circular import. Fixes #3028.
     - Some Python 2 compatibility code dropped
     - Rework runtest.py to use argparse for arg handling (was a mix
-      of hand-coded and optparse, with a stated intent to "gradually port")
+      of hand-coded and optparse, with a stated intent to "gradually port").
+    - Add options to runtest to generate/not generate a log of failed tests,
+      and to rerun such tests. Useful when an error cascades through several
+      tests, can quickly try if a change improves all the fails.
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -75,7 +75,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       of hand-coded and optparse, with a stated intent to "gradually port").
     - Add options to runtest to generate/not generate a log of failed tests,
       and to rerun such tests. Useful when an error cascades through several
-      tests, can quickly try if a change improves all the fails.
+      tests, can quickly try if a change improves all the fails. Dropped
+      runtest test for fallback from qmtest, not needed; added new tests.
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/runtest.py
+++ b/runtest.py
@@ -140,13 +140,13 @@ logctl.add_argument('--xml', metavar='XML', help="Save results to XML in SCons X
 # process args and handle a few specific cases:
 args = parser.parse_args()
 
-# we can't do this check with an argparse exclusive group,
-# since the cmdline tests (args.testlist) are not optional args,
-# exclusive only works with optional args.
+# we can't do this check with an argparse exclusive group, since those
+# only work with optional args, and the cmdline tests (args.testlist)
+# are not optional args,
 if args.testlist and (args.testlistfile or args.all or args.retry):
     sys.stderr.write(
         parser.format_usage()
-        + "error: command line tests cannot be combined with -f/--filei -a/--all or --retry\n"
+        + "error: command line tests cannot be combined with -f/--file, -a/--all or --retry\n"
     )
     sys.exit(1)
 

--- a/test/runtest/no_faillog.py
+++ b/test/runtest/no_faillog.py
@@ -25,60 +25,54 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Test that by default tests are invoked directly via Python, not
-using qmtest.
+Test a list of tests in failed_tests.log to run with the --retry option
 """
 
-import os
+import os.path
 
 import TestRuntest
 
 pythonstring = TestRuntest.pythonstring
 pythonflags = TestRuntest.pythonflags
+test_fail_py = os.path.join('test', 'fail.py')
+test_pass_py = os.path.join('test', 'pass.py')
 
 test = TestRuntest.TestRuntest()
-
 test.subdir('test')
-
-test_fail_py      = os.path.join('test', 'fail.py')
-test_no_result_py = os.path.join('test', 'no_result.py')
-test_pass_py      = os.path.join('test', 'pass.py')
-
 test.write_failing_test(test_fail_py)
-test.write_no_result_test(test_no_result_py)
 test.write_passing_test(test_pass_py)
+
+test.write('failed_tests.log', """\
+%(test_fail_py)s
+""" % locals())
 
 expect_stdout = """\
 %(pythonstring)s%(pythonflags)s %(test_fail_py)s
 FAILING TEST STDOUT
-%(pythonstring)s%(pythonflags)s %(test_no_result_py)s
-NO RESULT TEST STDOUT
 %(pythonstring)s%(pythonflags)s %(test_pass_py)s
 PASSING TEST STDOUT
 
 Failed the following test:
 \t%(test_fail_py)s
-
-NO RESULT from the following test:
-\t%(test_no_result_py)s
 """ % locals()
 
 expect_stderr = """\
 FAILING TEST STDERR
-NO RESULT TEST STDERR
 PASSING TEST STDERR
 """
 
 testlist = [
     test_fail_py,
-    test_no_result_py,
     test_pass_py,
 ]
 
-test.run(arguments = '-k %s' % ' '.join(testlist),
-         status = 1,
-         stdout = expect_stdout,
-         stderr = expect_stderr)
+test.run(
+    arguments='-k --no-faillog %s' % ' '.join(testlist),
+    status=1,
+    stdout=expect_stdout,
+    stderr=expect_stderr,
+)
+test.must_not_exist('failing_tests.log')
 
 test.pass_test()
 

--- a/test/runtest/print_time.py
+++ b/test/runtest/print_time.py
@@ -42,13 +42,9 @@ test_no_result_py = re.escape(os.path.join('test', 'no_result.py'))
 test_pass_py = re.escape(os.path.join('test', 'pass.py'))
 
 test = TestRuntest.TestRuntest(match = TestCmd.match_re)
-
 test.subdir('test')
-
 test.write_failing_test(['test', 'fail.py'])
-
 test.write_no_result_test(['test', 'no_result.py'])
-
 test.write_passing_test(['test', 'pass.py'])
 
 expect_stdout = """\

--- a/test/runtest/python.py
+++ b/test/runtest/python.py
@@ -37,9 +37,7 @@ if not hasattr(os.path, 'pardir'):
 import TestRuntest
 
 test = TestRuntest.TestRuntest()
-
 test_pass_py = os.path.join('test', 'pass.py')
-
 head, python = os.path.split(TestRuntest.python)
 head, dir = os.path.split(head)
 

--- a/test/runtest/simple/combined.py
+++ b/test/runtest/simple/combined.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 #
 # __COPYRIGHT__
@@ -34,21 +33,17 @@ import os
 
 import TestRuntest
 
-test = TestRuntest.TestRuntest()
-
 pythonstring = TestRuntest.pythonstring
 pythonflags = TestRuntest.pythonflags
 test_fail_py = os.path.join('test', 'fail.py')
 test_no_result_py = os.path.join('test', 'no_result.py')
 test_pass_py = os.path.join('test', 'pass.py')
 
+test = TestRuntest.TestRuntest()
 test.subdir('test')
-
-test.write_failing_test(['test', 'fail.py'])
-
-test.write_no_result_test(['test', 'no_result.py'])
-
-test.write_passing_test(['test', 'pass.py'])
+test.write_failing_test(test_fail_py)
+test.write_no_result_test(test_no_result_py)
+test.write_passing_test(test_pass_py)
 
 expect_stdout = """\
 %(pythonstring)s%(pythonflags)s %(test_fail_py)s
@@ -71,10 +66,14 @@ NO RESULT TEST STDERR
 PASSING TEST STDERR
 """
 
-test.run(arguments='-k test',
-         status=1,
-         stdout=expect_stdout,
-         stderr=expect_stderr)
+test.run(
+    arguments='-k test',
+    status=1,
+    stdout=expect_stdout,
+    stderr=expect_stderr
+)
+test.must_exist('failed_tests.log')
+test.must_contain('failed_tests.log', test_fail_py)
 
 test.pass_test()
 

--- a/test/runtest/testlistfile.py
+++ b/test/runtest/testlistfile.py
@@ -26,6 +26,7 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test a list of tests to run in a file specified with the -f option.
+The commented-out test should not run.
 """
 
 import os.path
@@ -41,11 +42,8 @@ test_pass_py = os.path.join('test', 'pass.py')
 test = TestRuntest.TestRuntest()
 
 test.subdir('test')
-
 test.write_failing_test(['test', 'fail.py'])
-
 test.write_no_result_test(['test', 'no_result.py'])
-
 test.write_passing_test(['test', 'pass.py'])
 
 test.write('t.txt', """\


### PR DESCRIPTION
`failed_tests.log` is created if there are any fails (on by default).  `--retry` option added to rerun tests from that file, or use `-f listfile` to use a file of a different name. `--faillog=FILE` allows saving the fails to a non-default name (in case don't want to overwrite the existing one, perhaps); `--no-faillog` disables the writing of the log.

Two unneeded tests relating to qmtest were dropped: `fallback.py` didn't really test anything, and `noqmtest.py` was a duplicate of `simple/combined.py` after the qmtest specifics had been stripped out.  Added tests for the added three options (git thinks two were renames).

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
