### PR TITLE
Remove some "star imports"

### DIFF
--- a/SCons/DefaultsTests.py
+++ b/SCons/DefaultsTests.py
@@ -30,7 +30,7 @@ import TestCmd
 
 import SCons.Errors
 
-from SCons.Defaults import *
+from SCons.Defaults import mkdir_func
 
 class DefaultsTestCase(unittest.TestCase):
     def test_mkdir_func0(self):

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -53,9 +53,27 @@ import SCons.SConf
 import SCons.SConsign
 import SCons.Subst
 import SCons.Tool
-import SCons.Util
-from SCons.Util import MethodWrapper
 import SCons.Warnings
+from SCons.Util import (
+    AppendPath,
+    CLVar,
+    LogicalLines,
+    MethodWrapper,
+    PrependPath,
+    Split,
+    WhereIs,
+    flatten,
+    is_Dict,
+    is_List,
+    is_Sequence,
+    is_String,
+    is_Tuple,
+    md5,
+    semi_deepcopy,
+    semi_deepcopy_dict,
+    to_String_for_subst,
+    uniquer_hashables,
+)
 
 class _Null:
     pass
@@ -69,18 +87,17 @@ _warn_target_signatures_deprecated = True
 CleanTargets = {}
 CalculatorArgs = {}
 
-semi_deepcopy = SCons.Util.semi_deepcopy
-semi_deepcopy_dict = SCons.Util.semi_deepcopy_dict
-
 def alias_builder(env, target, source):
     pass
 
-AliasBuilder = SCons.Builder.Builder(action = alias_builder,
-                                     target_factory = SCons.Node.Alias.default_ans.Alias,
-                                     source_factory = SCons.Node.FS.Entry,
-                                     multi = 1,
-                                     is_explicit = None,
-                                     name='AliasBuilder')
+AliasBuilder = SCons.Builder.Builder(
+    action=alias_builder,
+    target_factory=SCons.Node.Alias.default_ans.Alias,
+    source_factory=SCons.Node.FS.Entry,
+    multi=True,
+    is_explicit=None,
+    name='AliasBuilder',
+)
 
 def apply_tools(env, tools, toolpath):
     # Store the toolpath in the Environment.
@@ -91,7 +108,7 @@ def apply_tools(env, tools, toolpath):
         return
     # Filter out null tools from the list.
     for tool in [_f for _f in tools if _f]:
-        if SCons.Util.is_List(tool) or isinstance(tool, tuple):
+        if is_List(tool) or isinstance(tool, tuple):
             toolname = tool[0]
             toolargs = tool[1] # should be a dict of kw args
             tool = env.Tool(toolname, **toolargs)
@@ -191,7 +208,7 @@ def _delete_duplicates(l, keep_last):
 # Note: MethodWrapper moved to SCons.Util as it was needed there
 # and otherwise we had a circular import problem.
 
-class BuilderWrapper(SCons.Util.MethodWrapper):
+class BuilderWrapper(MethodWrapper):
     """
     A MethodWrapper subclass that that associates an environment with
     a Builder.
@@ -214,9 +231,9 @@ class BuilderWrapper(SCons.Util.MethodWrapper):
         if source is _null:
             source = target
             target = None
-        if target is not None and not SCons.Util.is_List(target):
+        if target is not None and not is_List(target):
             target = [target]
-        if source is not None and not SCons.Util.is_List(source):
+        if source is not None and not is_List(source):
             source = [source]
         return super().__call__(target, source, *args, **kw)
 
@@ -431,24 +448,24 @@ class SubstitutionEnvironment:
         if not args:
             return []
 
-        args = SCons.Util.flatten(args)
+        args = flatten(args)
 
         nodes = []
         for v in args:
-            if SCons.Util.is_String(v):
+            if is_String(v):
                 n = None
                 for l in lookup_list:
                     n = l(v)
                     if n is not None:
                         break
                 if n is not None:
-                    if SCons.Util.is_String(n):
+                    if is_String(n):
                         # n = self.subst(n, raw=1, **kw)
                         kw['raw'] = 1
                         n = self.subst(n, **kw)
                         if node_factory:
                             n = node_factory(n)
-                    if SCons.Util.is_List(n):
+                    if is_List(n):
                         nodes.extend(n)
                     else:
                         nodes.append(n)
@@ -456,7 +473,7 @@ class SubstitutionEnvironment:
                     # v = node_factory(self.subst(v, raw=1, **kw))
                     kw['raw'] = 1
                     v = node_factory(self.subst(v, **kw))
-                    if SCons.Util.is_List(v):
+                    if is_List(v):
                         nodes.extend(v)
                     else:
                         nodes.append(v)
@@ -492,7 +509,7 @@ class SubstitutionEnvironment:
         nkw = {}
         for k, v in kw.items():
             k = self.subst(k, raw, target, source)
-            if SCons.Util.is_String(v):
+            if is_String(v):
                 v = self.subst(v, raw, target, source)
             nkw[k] = v
         return nkw
@@ -511,7 +528,7 @@ class SubstitutionEnvironment:
         """Substitute a path list, turning EntryProxies into Nodes
         and leaving Nodes (and other objects) as-is."""
 
-        if not SCons.Util.is_List(path):
+        if not is_List(path):
             path = [path]
 
         def s(obj):
@@ -524,23 +541,23 @@ class SubstitutionEnvironment:
             try:
                 get = obj.get
             except AttributeError:
-                obj = SCons.Util.to_String_for_subst(obj)
+                obj = to_String_for_subst(obj)
             else:
                 obj = get()
             return obj
 
         r = []
         for p in path:
-            if SCons.Util.is_String(p):
+            if is_String(p):
                 p = self.subst(p, target=target, source=source, conv=s)
-                if SCons.Util.is_List(p):
+                if is_List(p):
                     if len(p) == 1:
                         p = p[0]
                     else:
                         # We have an object plus a string, or multiple
                         # objects that we need to smush together.  No choice
                         # but to make them into a string.
-                        p = ''.join(map(SCons.Util.to_String_for_subst, p))
+                        p = ''.join(map(to_String_for_subst, p))
             else:
                 p = s(p)
             r.append(p)
@@ -558,7 +575,7 @@ class SubstitutionEnvironment:
              }
         # if the command is a list, assume it's been quoted
         # othewise force a shell
-        if not SCons.Util.is_List(command): kw['shell'] = True
+        if not is_List(command): kw['shell'] = True
         # run constructed command
         p = SCons.Action._subproc(self, command, **kw)
         out,err = p.communicate()
@@ -628,18 +645,18 @@ class SubstitutionEnvironment:
         the result of that evaluation is then added to the dict.
         """
         dict = {
-            'ASFLAGS'       : SCons.Util.CLVar(''),
-            'CFLAGS'        : SCons.Util.CLVar(''),
-            'CCFLAGS'       : SCons.Util.CLVar(''),
-            'CXXFLAGS'      : SCons.Util.CLVar(''),
+            'ASFLAGS'       : CLVar(''),
+            'CFLAGS'        : CLVar(''),
+            'CCFLAGS'       : CLVar(''),
+            'CXXFLAGS'      : CLVar(''),
             'CPPDEFINES'    : [],
-            'CPPFLAGS'      : SCons.Util.CLVar(''),
+            'CPPFLAGS'      : CLVar(''),
             'CPPPATH'       : [],
-            'FRAMEWORKPATH' : SCons.Util.CLVar(''),
-            'FRAMEWORKS'    : SCons.Util.CLVar(''),
+            'FRAMEWORKPATH' : CLVar(''),
+            'FRAMEWORKS'    : CLVar(''),
             'LIBPATH'       : [],
             'LIBS'          : [],
-            'LINKFLAGS'     : SCons.Util.CLVar(''),
+            'LINKFLAGS'     : CLVar(''),
             'RPATH'         : [],
         }
 
@@ -648,7 +665,7 @@ class SubstitutionEnvironment:
             if not arg:
                 return
 
-            if not SCons.Util.is_String(arg):
+            if not is_String(arg):
                 for t in arg: do_parse(t)
                 return
 
@@ -818,7 +835,7 @@ class SubstitutionEnvironment:
             unique: merge flags rather than appending (default: True)
 
         """
-        if not SCons.Util.is_Dict(args):
+        if not is_Dict(args):
             args = self.ParseFlags(args)
 
         if not unique:
@@ -828,7 +845,7 @@ class SubstitutionEnvironment:
         for key, value in args.items():
             if not value:
                 continue
-            value = SCons.Util.Split(value)
+            value = Split(value)
             try:
                 orig = self[key]
             except KeyError:
@@ -952,7 +969,7 @@ class Base(SubstitutionEnvironment):
             platform = self._dict.get('PLATFORM', None)
             if platform is None:
                 platform = SCons.Platform.Platform()
-        if SCons.Util.is_String(platform):
+        if is_String(platform):
             platform = SCons.Platform.Platform(platform)
         self._dict['PLATFORM'] = str(platform)
         platform(self)
@@ -1081,7 +1098,7 @@ class Base(SubstitutionEnvironment):
             # claim they can scan the same suffix, earlier scanners
             # in the list will overwrite later scanners, so that
             # the result looks like a "first match" to the user.
-            if not SCons.Util.is_List(scanners):
+            if not is_List(scanners):
                 scanners = [scanners]
             else:
                 scanners = scanners[:] # copy so reverse() doesn't mod original
@@ -1164,13 +1181,13 @@ class Base(SubstitutionEnvironment):
             # but Python 1.5.2 apparently doesn't let you use "continue"
             # within try:-except: blocks, so we have to nest our code.
             try:
-                if key == 'CPPDEFINES' and SCons.Util.is_String(self._dict[key]):
+                if key == 'CPPDEFINES' and is_String(self._dict[key]):
                     self._dict[key] = [self._dict[key]]
                 orig = self._dict[key]
             except KeyError:
                 # No existing variable in the environment, so just set
                 # it to the new value.
-                if key == 'CPPDEFINES' and SCons.Util.is_String(val):
+                if key == 'CPPDEFINES' and is_String(val):
                     self._dict[key] = [val]
                 else:
                     self._dict[key] = val
@@ -1209,7 +1226,7 @@ class Base(SubstitutionEnvironment):
                 else:
                     # The original looks like a dictionary, so update it
                     # based on what we think the value looks like.
-                    if SCons.Util.is_List(val):
+                    if is_List(val):
                         if key == 'CPPDEFINES':
                             tmp = []
                             for (k, v) in orig.items():
@@ -1227,7 +1244,7 @@ class Base(SubstitutionEnvironment):
                         try:
                             update_dict(val)
                         except (AttributeError, TypeError, ValueError):
-                            if SCons.Util.is_Dict(val):
+                            if is_Dict(val):
                                 for k, v in val.items():
                                     orig[k] = v
                             else:
@@ -1237,7 +1254,7 @@ class Base(SubstitutionEnvironment):
     # allow Dirs and strings beginning with # for top-relative
     # Note this uses the current env's fs (in self).
     def _canonicalize(self, path):
-        if not SCons.Util.is_String(path): # typically a Dir
+        if not is_String(path): # typically a Dir
             path = str(path)
         if path and path[0] == '#':
             path = str(self.fs.Dir(path))
@@ -1259,8 +1276,7 @@ class Base(SubstitutionEnvironment):
         if envname in self._dict and name in self._dict[envname]:
             orig = self._dict[envname][name]
 
-        nv = SCons.Util.AppendPath(orig, newpath, sep, delete_existing,
-                                   canonicalize=self._canonicalize)
+        nv = AppendPath(orig, newpath, sep, delete_existing, canonicalize=self._canonicalize)
 
         if envname not in self._dict:
             self._dict[envname] = {}
@@ -1275,30 +1291,30 @@ class Base(SubstitutionEnvironment):
         """
         kw = copy_non_reserved_keywords(kw)
         for key, val in kw.items():
-            if SCons.Util.is_List(val):
+            if is_List(val):
                 val = _delete_duplicates(val, delete_existing)
             if key not in self._dict or self._dict[key] in ('', None):
                 self._dict[key] = val
-            elif SCons.Util.is_Dict(self._dict[key]) and \
-                 SCons.Util.is_Dict(val):
+            elif is_Dict(self._dict[key]) and \
+                 is_Dict(val):
                 self._dict[key].update(val)
-            elif SCons.Util.is_List(val):
+            elif is_List(val):
                 dk = self._dict[key]
                 if key == 'CPPDEFINES':
                     tmp = []
                     for i in val:
-                        if SCons.Util.is_List(i):
+                        if is_List(i):
                             if len(i) >= 2:
                                 tmp.append((i[0], i[1]))
                             else:
                                 tmp.append((i[0],))
-                        elif SCons.Util.is_Tuple(i):
+                        elif is_Tuple(i):
                             tmp.append(i)
                         else:
                             tmp.append((i,))
                     val = tmp
                     # Construct a list of (key, value) tuples.
-                    if SCons.Util.is_Dict(dk):
+                    if is_Dict(dk):
                         tmp = []
                         for (k, v) in dk.items():
                             if v is not None:
@@ -1306,23 +1322,23 @@ class Base(SubstitutionEnvironment):
                             else:
                                 tmp.append((k,))
                         dk = tmp
-                    elif SCons.Util.is_String(dk):
+                    elif is_String(dk):
                         dk = [(dk,)]
                     else:
                         tmp = []
                         for i in dk:
-                            if SCons.Util.is_List(i):
+                            if is_List(i):
                                 if len(i) >= 2:
                                     tmp.append((i[0], i[1]))
                                 else:
                                     tmp.append((i[0],))
-                            elif SCons.Util.is_Tuple(i):
+                            elif is_Tuple(i):
                                 tmp.append(i)
                             else:
                                 tmp.append((i,))
                         dk = tmp
                 else:
-                    if not SCons.Util.is_List(dk):
+                    if not is_List(dk):
                         dk = [dk]
                 if delete_existing:
                     dk = [x for x in dk if x not in val]
@@ -1331,22 +1347,22 @@ class Base(SubstitutionEnvironment):
                 self._dict[key] = dk + val
             else:
                 dk = self._dict[key]
-                if SCons.Util.is_List(dk):
+                if is_List(dk):
                     if key == 'CPPDEFINES':
                         tmp = []
                         for i in dk:
-                            if SCons.Util.is_List(i):
+                            if is_List(i):
                                 if len(i) >= 2:
                                     tmp.append((i[0], i[1]))
                                 else:
                                     tmp.append((i[0],))
-                            elif SCons.Util.is_Tuple(i):
+                            elif is_Tuple(i):
                                 tmp.append(i)
                             else:
                                 tmp.append((i,))
                         dk = tmp
                         # Construct a list of (key, value) tuples.
-                        if SCons.Util.is_Dict(val):
+                        if is_Dict(val):
                             tmp = []
                             for (k, v) in val.items():
                                 if v is not None:
@@ -1354,7 +1370,7 @@ class Base(SubstitutionEnvironment):
                                 else:
                                     tmp.append((k,))
                             val = tmp
-                        elif SCons.Util.is_String(val):
+                        elif is_String(val):
                             val = [(val,)]
                         if delete_existing:
                             dk = list(filter(lambda x, val=val: x not in val, dk))
@@ -1373,9 +1389,9 @@ class Base(SubstitutionEnvironment):
                                 self._dict[key] = dk + [val]
                 else:
                     if key == 'CPPDEFINES':
-                        if SCons.Util.is_String(dk):
+                        if is_String(dk):
                             dk = [dk]
-                        elif SCons.Util.is_Dict(dk):
+                        elif is_Dict(dk):
                             tmp = []
                             for (k, v) in dk.items():
                                 if v is not None:
@@ -1383,12 +1399,12 @@ class Base(SubstitutionEnvironment):
                                 else:
                                     tmp.append((k,))
                             dk = tmp
-                        if SCons.Util.is_String(val):
+                        if is_String(val):
                             if val in dk:
                                 val = []
                             else:
                                 val = [val]
-                        elif SCons.Util.is_Dict(val):
+                        elif is_Dict(val):
                             tmp = []
                             for i,j in val.items():
                                 if j is not None:
@@ -1483,7 +1499,7 @@ class Base(SubstitutionEnvironment):
     def Decider(self, function):
         copy_function = self._copy2_from_cache
         if function in ('MD5', 'content'):
-            if not SCons.Util.md5:
+            if not md5:
                 raise UserError("MD5 signatures are not available in this version of Python.")
             function = self._changed_content
         elif function == 'MD5-timestamp':
@@ -1511,7 +1527,7 @@ class Base(SubstitutionEnvironment):
             progs (str or list): one or more command names to check for
 
         """
-        if not SCons.Util.is_List(progs):
+        if not is_List(progs):
             progs = [progs]
         for prog in progs:
             path = self.WhereIs(prog)
@@ -1616,7 +1632,7 @@ class Base(SubstitutionEnvironment):
             def parse_conf(env, cmd, unique=unique):
                 return env.MergeFlags(cmd, unique)
             function = parse_conf
-        if SCons.Util.is_List(command):
+        if is_List(command):
             command = ' '.join(command)
         command = self.subst(command)
         return function(self, self.backtick(command))
@@ -1634,7 +1650,7 @@ class Base(SubstitutionEnvironment):
         filename = self.subst(filename)
         try:
             with open(filename, 'r') as fp:
-                lines = SCons.Util.LogicalLines(fp).readlines()
+                lines = LogicalLines(fp).readlines()
         except IOError:
             if must_exist:
                 raise
@@ -1716,14 +1732,14 @@ class Base(SubstitutionEnvironment):
                 else:
                     # The original looks like a dictionary, so update it
                     # based on what we think the value looks like.
-                    if SCons.Util.is_List(val):
+                    if is_List(val):
                         for v in val:
                             orig[v] = None
                     else:
                         try:
                             update_dict(val)
                         except (AttributeError, TypeError, ValueError):
-                            if SCons.Util.is_Dict(val):
+                            if is_Dict(val):
                                 for k, v in val.items():
                                     orig[k] = v
                             else:
@@ -1746,7 +1762,7 @@ class Base(SubstitutionEnvironment):
         if envname in self._dict and name in self._dict[envname]:
             orig = self._dict[envname][name]
 
-        nv = SCons.Util.PrependPath(orig, newpath, sep, delete_existing,
+        nv = PrependPath(orig, newpath, sep, delete_existing,
                                     canonicalize=self._canonicalize)
 
         if envname not in self._dict:
@@ -1762,16 +1778,16 @@ class Base(SubstitutionEnvironment):
         """
         kw = copy_non_reserved_keywords(kw)
         for key, val in kw.items():
-            if SCons.Util.is_List(val):
+            if is_List(val):
                 val = _delete_duplicates(val, not delete_existing)
             if key not in self._dict or self._dict[key] in ('', None):
                 self._dict[key] = val
-            elif SCons.Util.is_Dict(self._dict[key]) and \
-                 SCons.Util.is_Dict(val):
+            elif is_Dict(self._dict[key]) and \
+                 is_Dict(val):
                 self._dict[key].update(val)
-            elif SCons.Util.is_List(val):
+            elif is_List(val):
                 dk = self._dict[key]
-                if not SCons.Util.is_List(dk):
+                if not is_List(dk):
                     dk = [dk]
                 if delete_existing:
                     dk = [x for x in dk if x not in val]
@@ -1780,7 +1796,7 @@ class Base(SubstitutionEnvironment):
                 self._dict[key] = val + dk
             else:
                 dk = self._dict[key]
-                if SCons.Util.is_List(dk):
+                if is_List(dk):
                     # By elimination, val is not a list.  Since dk is a
                     # list, wrap val in a list first.
                     if delete_existing:
@@ -1845,7 +1861,7 @@ class Base(SubstitutionEnvironment):
         return self.fs.Dir(self.subst(tp)).srcnode().get_abspath()
 
     def Tool(self, tool, toolpath=None, **kw):
-        if SCons.Util.is_String(tool):
+        if is_String(tool):
             tool = self.subst(tool)
             if toolpath is None:
                 toolpath = self.get('toolpath', [])
@@ -1861,17 +1877,17 @@ class Base(SubstitutionEnvironment):
                 path = self['ENV']['PATH']
             except KeyError:
                 pass
-        elif SCons.Util.is_String(path):
+        elif is_String(path):
             path = self.subst(path)
         if pathext is None:
             try:
                 pathext = self['ENV']['PATHEXT']
             except KeyError:
                 pass
-        elif SCons.Util.is_String(pathext):
+        elif is_String(pathext):
             pathext = self.subst(pathext)
-        prog = SCons.Util.CLVar(self.subst(prog)) # support "program --with-args"
-        path = SCons.Util.WhereIs(prog[0], path, pathext, reject)
+        prog = CLVar(self.subst(prog)) # support "program --with-args"
+        path = WhereIs(prog[0], path, pathext, reject)
         if path: return path
         return None
 
@@ -1885,7 +1901,7 @@ class Base(SubstitutionEnvironment):
 
     def Action(self, *args, **kw):
         def subst_string(a, self=self):
-            if SCons.Util.is_String(a):
+            if is_String(a):
                 a = self.subst(a)
             return a
         nargs = list(map(subst_string, args))
@@ -1914,7 +1930,7 @@ class Base(SubstitutionEnvironment):
 
     def Alias(self, target, source=[], action=None, **kw):
         tlist = self.arg2nodes(target, self.ans.Alias)
-        if not SCons.Util.is_List(source):
+        if not is_List(source):
             source = [source]
         source = [_f for _f in source if _f]
 
@@ -2062,7 +2078,7 @@ class Base(SubstitutionEnvironment):
         """
         """
         s = self.subst(name)
-        if SCons.Util.is_Sequence(s):
+        if is_Sequence(s):
             result=[]
             for e in s:
                 result.append(self.fs.Dir(e, *args, **kw))
@@ -2071,7 +2087,7 @@ class Base(SubstitutionEnvironment):
 
     def PyPackageDir(self, modulename):
         s = self.subst(modulename)
-        if SCons.Util.is_Sequence(s):
+        if is_Sequence(s):
             result=[]
             for e in s:
                 result.append(self.fs.PyPackageDir(e))
@@ -2100,7 +2116,7 @@ class Base(SubstitutionEnvironment):
         """
         """
         s = self.subst(name)
-        if SCons.Util.is_Sequence(s):
+        if is_Sequence(s):
             result=[]
             for e in s:
                 result.append(self.fs.Entry(e, *args, **kw))
@@ -2128,7 +2144,7 @@ class Base(SubstitutionEnvironment):
         """
         """
         s = self.subst(name)
-        if SCons.Util.is_Sequence(s):
+        if is_Sequence(s):
             result=[]
             for e in s:
                 result.append(self.fs.File(e, *args, **kw))
@@ -2141,11 +2157,11 @@ class Base(SubstitutionEnvironment):
         return SCons.Node.FS.find_file(file, tuple(nodes))
 
     def Flatten(self, sequence):
-        return SCons.Util.flatten(sequence)
+        return flatten(sequence)
 
     def GetBuildPath(self, files):
         result = list(map(str, self.arg2nodes(files, self.fs.Entry)))
-        if SCons.Util.is_List(files):
+        if is_List(files):
             return result
         else:
             return result[0]
@@ -2209,7 +2225,7 @@ class Base(SubstitutionEnvironment):
     def Scanner(self, *args, **kw):
         nargs = []
         for arg in args:
-            if SCons.Util.is_String(arg):
+            if is_String(arg):
                 arg = self.subst(arg)
             nargs.append(arg)
         nkw = self.subst_kw(kw)
@@ -2257,9 +2273,9 @@ class Base(SubstitutionEnvironment):
 
         In all cases, the function returns a list of Nodes and strings."""
 
-        if SCons.Util.is_List(arg):
+        if is_List(arg):
             return list(map(self.subst, arg))
-        elif SCons.Util.is_String(arg):
+        elif is_String(arg):
             return self.subst(arg).split()
         else:
             return [self.subst(arg)]
@@ -2303,7 +2319,7 @@ class Base(SubstitutionEnvironment):
         """
         from SCons.Tool import install
         if install._UNIQUE_INSTALLED_FILES is None:
-            install._UNIQUE_INSTALLED_FILES = SCons.Util.uniquer_hashables(install._INSTALLED_FILES)
+            install._UNIQUE_INSTALLED_FILES = uniquer_hashables(install._INSTALLED_FILES)
         return install._UNIQUE_INSTALLED_FILES
 
 

--- a/SCons/SConfTests.py
+++ b/SCons/SConfTests.py
@@ -27,7 +27,7 @@ import io
 import os
 import re
 import sys
-from types import *
+from types import ModuleType
 import unittest
 
 import TestCmd

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -29,7 +29,9 @@ import unittest
 
 import SCons.Errors
 
-from SCons.Subst import *
+from SCons.Subst import (Literal, SUBST_CMD, SUBST_RAW, SUBST_SIG, SpecialAttrWrapper, collections,
+                         escape_list, quote_spaces, scons_subst, scons_subst_list, scons_subst_once,
+                         subst_dict)
 
 class DummyNode:
     """Simple node work-alike."""

--- a/SCons/Tool/packaging/__init__.py
+++ b/SCons/Tool/packaging/__init__.py
@@ -35,7 +35,7 @@ import SCons.Environment
 from SCons.Errors import UserError, SConsEnvironmentError
 from SCons.Script import AddOption, GetOption
 from SCons.Util import is_List, make_path_relative
-from SCons.Variables import *
+from SCons.Variables import EnumVariable
 from SCons.Warnings import warn, SConsWarning
 
 

--- a/SCons/Tool/packaging/msi.py
+++ b/SCons/Tool/packaging/msi.py
@@ -32,7 +32,7 @@ import SCons
 from SCons.Action import Action
 from SCons.Builder import Builder
 
-from xml.dom.minidom import *
+from xml.dom.minidom import Document
 from xml.sax.saxutils import escape
 
 from SCons.Tool.packaging import stripinstallbuilder

--- a/test/exitfns.py
+++ b/test/exitfns.py
@@ -34,7 +34,7 @@ if test.coverage_run():
     test.skip_test("This test replaces the exit function which is needed by coverage to write test data; skipping test.")
 
 sconstruct = """
-from SCons.exitfuncs import *
+from SCons.exitfuncs import register
 
 def x1():
     print("running x1")

--- a/test/packaging/msi/explicit-target.py
+++ b/test/packaging/msi/explicit-target.py
@@ -36,7 +36,7 @@ python = TestSCons.python
 test = TestSCons.TestSCons()
 
 try:
-    from xml.dom.minidom import *
+    from xml.dom.minidom import parse
 except ImportError:
     test.skip_test('Canoot import xml.dom.minidom skipping test\n')
 

--- a/test/packaging/msi/file-placement.py
+++ b/test/packaging/msi/file-placement.py
@@ -35,7 +35,7 @@ python = TestSCons.python
 test = TestSCons.TestSCons()
 
 try:
-    from xml.dom.minidom import *
+    from xml.dom.minidom import parse
 except ImportError:
     test.skip_test('Cannot import xml.dom.minidom; skipping test\n')
 

--- a/test/packaging/msi/package.py
+++ b/test/packaging/msi/package.py
@@ -35,7 +35,7 @@ python = TestSCons.python
 test = TestSCons.TestSCons()
 
 try:
-    from xml.dom.minidom import *
+    from xml.dom.minidom import parse
 except ImportError:
     test.skip_test('Canoot import xml.dom.minidom skipping test\n')
 


### PR DESCRIPTION
Usually, it's unit tests that do this, and it's not really crucial to kill those off, but checkers do complain, including sider if you
touch anything in one of those files.

In `SCons/Environment,py`, removed all `SCons.Util` prefixes, than turned the import of Util into a star import, running a tool on that then changes it to import only the used symbols from Util. Since there are lots, that ought to be a small performance win, since it doesn't have to do namespace lookups on `SCons.Util`.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
