### PR TITLE
Drop yet more py2 compatibility stuff

### DIFF
--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -2721,7 +2721,7 @@ class File(Base):
             try:
                 return contents.decode('latin-1')
             except UnicodeDecodeError as e:
-                return contents.decode('utf-8', error='backslashreplace')
+                return contents.decode('utf-8', errors='backslashreplace')
 
 
     def get_content_hash(self):

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -42,23 +42,15 @@ be able to depend on any other type of "thing."
 
 import collections
 import copy
-from itertools import chain
-
-try:
-    from itertools import zip_longest
-except ImportError:
-    from itertools import izip_longest as zip_longest
+from itertools import chain, zip_longest
 
 import SCons.Debug
-from SCons.Debug import logInstanceCreation
 import SCons.Executor
 import SCons.Memoize
 import SCons.Util
-from SCons.Util import MD5signature
-
-from SCons.Debug import Trace
-
 from SCons.compat import NoSlotsPyPy
+from SCons.Debug import logInstanceCreation, Trace
+from SCons.Util import MD5signature
 
 print_duplicate = 0
 

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -28,12 +28,8 @@ import textwrap
 
 no_hyphen_re = re.compile(r'(\s+|(?<=[\w!\"\'&.,?])-{2,}(?=\w))')
 
-try:
-    from gettext import gettext
-except ImportError:
-    def gettext(message):
-        return message
-_ = gettext
+import gettext
+_ = gettext.gettext
 
 import SCons.Node.FS
 import SCons.Platform.virtualenv

--- a/SCons/compat/__init__.py
+++ b/SCons/compat/__init__.py
@@ -85,15 +85,6 @@ def rename_module(new, old):
 # Python 3.8 introduced protocol 5 which is mainly an improvement for for out-of-band data buffers
 PICKLE_PROTOCOL = 4
 
-import shutil
-try:
-    shutil.SameFileError
-except AttributeError:
-    class SameFileError(Exception):
-        pass
-
-    shutil.SameFileError = SameFileError
-
 
 class NoSlotsPyPy(type):
     """ Metaclass for PyPy compatitbility.


### PR DESCRIPTION
A checker flagged the `zip_longest`/`izip_longest` workaround, that's no longer needed. Similar for the `shutil.SameFileError` piece, that's standard since 3.4 and doesn't need checking for.

The checker also complained about `return contents.decode('utf-8', error='backslashreplace')` the correct kwarg is `errors`, not `error` - corrected (this was not a Py2 issue)

Existing CHANGES.txt entry for this scons version should already cover these.  No doc impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
