### PR TITLE
Fix Trace function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -78,6 +78,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       tests, can quickly try if a change improves all the fails. Dropped
       runtest test for fallback from qmtest, not needed; added new tests.
     - Eliminate tex tool usage of "for foo in range(len(iterable))"
+    - Restore internal Trace function to functional state.
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/SCons/Debug.py
+++ b/SCons/Debug.py
@@ -196,17 +196,17 @@ TimeStampDefault = False
 StartTime = time.time()
 PreviousTime = StartTime
 
-def Trace(msg, filename=None, mode='w', tstamp=False):
+def Trace(msg, tracefile=None, mode='w', tstamp=False):
     """Write a trace message.
 
     Write messages when debugging which do not interfere with stdout.
     Useful in tests, which monitor stdout and would break with
     unexpected output. Trace messages can go to the console (which is
-    opened as a file), or to a disk file; the file argument persists
+    opened as a file), or to a disk file; the tracefile argument persists
     across calls unless overridden.
 
     Args:
-        filename: file to write trace message to. If omitted,
+        tracefile: file to write trace message to. If omitted,
           write to the previous trace file (default: console).
         mode: file open mode (default: 'w')
         tstamp: write relative timestamps with trace. Outputs time since
@@ -220,23 +220,23 @@ def Trace(msg, filename=None, mode='w', tstamp=False):
     def trace_cleanup(traceFP):
         traceFP.close()
 
-    if file is None:
-        file = TraceDefault
+    if tracefile is None:
+        tracefile = TraceDefault
     else:
-        TraceDefault = file
+        TraceDefault = tracefile
     if not tstamp:
         tstamp = TimeStampDefault
     else:
         TimeStampDefault = tstamp
     try:
-        fp = TraceFP[file]
+        fp = TraceFP[tracefile]
     except KeyError:
         try:
-            fp = TraceFP[file] = open(file, mode)
+            fp = TraceFP[tracefile] = open(tracefile, mode)
             atexit.register(trace_cleanup, fp)
         except TypeError:
             # Assume we were passed an open file pointer.
-            fp = file
+            fp = tracefile
     if tstamp:
         now = time.time()
         fp.write('%8.4f %8.4f:  ' % (now - StartTime, now - PreviousTime))


### PR DESCRIPTION
The (internal) Trace function had been left in an inconsistent state by an earlier change, with a variable name mismatch. Fixed.

Apparntly there's no test and no current consumers since the problem could have been easily detected otherwise.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
