### PR TITLE
Move wix tool into windows tool section

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -79,6 +79,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       runtest test for fallback from qmtest, not needed; added new tests.
     - Eliminate tex tool usage of "for foo in range(len(iterable))"
     - Restore internal Trace function to functional state.
+    - Move wix tool into windows-specific section.
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -694,7 +694,7 @@ def tool_list(platform, env):
         assemblers = ['masm', 'nasm', 'gas', '386asm']
         fortran_compilers = ['gfortran', 'g77', 'ifl', 'cvf', 'f95', 'f90', 'fortran']
         ars = ['mslib', 'ar', 'tlib']
-        other_plat_tools = ['msvs', 'midl']
+        other_plat_tools = ['msvs', 'midl', 'wix']
     elif str(platform) == 'os2':
         "prefer IBM tools on OS/2"
         linkers = ['ilink', 'gnulink', ]  # 'mslink']
@@ -794,7 +794,6 @@ def tool_list(platform, env):
         # TODO: merge 'install' into 'filesystem' and
         # make 'filesystem' the default
         'filesystem',
-        'wix',  # 'midl', 'msvs',
         # Parser generators
         'lex', 'yacc',
         # Foreign function interface


### PR DESCRIPTION
The wix tool has a slightly expensive `exists` function, so its placement in the tool list as generic means non-Windows platforms also pay this cost. Moved to the win32 section in `other_plat_tools` as it's only available on Windows platforms.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
