### PR TITLE
Updated sconsign/SConsignFile docs and tests

### DIFF
--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -2744,58 +2744,61 @@ SConscript('bar/SConscript')	# will chdir to bar
 </arguments>
 <summary>
 <para>
-Store the &SCons; file signature database in
-the file <parameter>name</parameter>,
-using <parameter>dbm_module</parameter>
-as the file format.
+Specify where to store the &SCons; file signature database,
+and which database format to use.
 This may be useful to specify alternate
 database files and/or file locations for different types of builds.
 </para>
 <para>
-If the optional first argument (or
-<parameter>name</parameter> keyword argument)
-is not an absolute path name,
-the file is placed relative to the directory containing the
+The optional <parameter>name</parameter> argument
+is the base name of the database file(s).
+If not an absolute path name,
+these are placed relative to the directory containing the
 top-level &SConstruct; file.
 The default is
 <filename>.sconsign</filename>.
-The actual file name stored on disk
+The actual database file(s) stored on disk
 may have an appropriate suffix appended
 by the chosen
 <parameter>dbm_module</parameter>
 </para>
 <para>
-The optional second argument (or
-<parameter>dbm_module</parameter>
-keyword argument) can be used to specify
-which Python database module to use
+The optional <parameter>dbm_module</parameter>
+argument specifies which
+Python database module to use
 for reading/writing the file.
-The default is to use a custom
-<filename>SCons.dblite</filename>
+The module must be imported first;
+then the imported module name
+is passed as the argument.
+The default is a custom
+<systemitem>SCons.dblite</systemitem>
 module that uses pickled
 Python data structures,
-and which works on all Python versions.
+which works on all Python versions.
+See documentation of the Python
+<systemitem>dbm</systemitem> module
+for other available types.
 </para>
 <para>
-If called with no arguments, 
-the filename will default to
+If called with no arguments,
+the database will default to
 <filename>.sconsign.dblite</filename>
-in the top directory of the project. 
-This also the default if
+in the top directory of the project,
+which is also the default if
 if &f-SConsignFile; is not called.
 </para>
 <para>
 The setting is global, so the only difference
 between the global function and the environment method form
-is variable expansion. There should only be
-one call to this function/method in a given build setup.
+is variable expansion on <parameter>name</parameter>.
+There should only be one active call to this
+function/method in a given build setup.
 </para>
 <para>
-If 
+If
 <parameter>name</parameter>
 is set to
 <constant>None</constant>,
-then
 &scons;
 will store file signatures
 in a separate
@@ -2805,7 +2808,7 @@ not in a single combined database file.
 This is a backwards-compatibility meaure to support
 what was the default behavior
 prior to &SCons; 0.97 (i.e. before 2008).
-Use of this mode is discouraged and may be 
+Use of this mode is discouraged and may be
 deprecated in a future &SCons; release.
 </para>
 
@@ -2830,6 +2833,10 @@ SConsignFile("/home/me/SCons/signatures")
 # Stores signatures in a separate .sconsign file
 # in each directory.
 SConsignFile(None)
+
+# Stores signatures in a GNU dbm format .sconsign file
+import dbm.gnu
+SConsignFile(dbm_module=dbm.gnu)
 </example_commands>
 </summary>
 </scons_function>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -2740,36 +2740,60 @@ SConscript('bar/SConscript')	# will chdir to bar
 
 <scons_function name="SConsignFile">
 <arguments>
-([file, dbm_module])
+([name, dbm_module])
 </arguments>
 <summary>
 <para>
-This tells
-&scons;
-to store all file signatures
-in the specified database
-<parameter>file</parameter>.
-If the
-<parameter>file</parameter>
-name is omitted,
-<filename>.sconsign</filename>
-is used by default.
-(The actual file name(s) stored on disk
-may have an appropriated suffix appended
-by the
-<parameter>dbm_module</parameter>.)
-If
-<parameter>file</parameter>
-is not an absolute path name,
-the file is placed in the same directory as the top-level
-&SConstruct;
-file.
+Store the &SCons; file signature database in
+the file <parameter>name</parameter>,
+using <parameter>dbm_module</parameter>
+as the file format.
+This may be useful to specify alternate
+database files and/or file locations for different types of builds.
 </para>
-
 <para>
-If
-<parameter>file</parameter>
-is
+If the optional first argument (or
+<parameter>name</parameter> keyword argument)
+is not an absolute path name,
+the file is placed relative to the directory containing the
+top-level &SConstruct; file.
+The default is
+<filename>.sconsign</filename>.
+The actual file name stored on disk
+may have an appropriate suffix appended
+by the chosen
+<parameter>dbm_module</parameter>
+</para>
+<para>
+The optional second argument (or
+<parameter>dbm_module</parameter>
+keyword argument) can be used to specify
+which Python database module to use
+for reading/writing the file.
+The default is to use a custom
+<filename>SCons.dblite</filename>
+module that uses pickled
+Python data structures,
+and which works on all Python versions.
+</para>
+<para>
+If called with no arguments, 
+the filename will default to
+<filename>.sconsign.dblite</filename>
+in the top directory of the project. 
+This also the default if
+if &f-SConsignFile; is not called.
+</para>
+<para>
+The setting is global, so the only difference
+between the global function and the environment method form
+is variable expansion. There should only be
+one call to this function/method in a given build setup.
+</para>
+<para>
+If 
+<parameter>name</parameter>
+is set to
 <constant>None</constant>,
 then
 &scons;
@@ -2777,21 +2801,12 @@ will store file signatures
 in a separate
 <filename>.sconsign</filename>
 file in each directory,
-not in one global database file.
-(This was the default behavior
-prior to SCons 0.96.91 and 0.97.)
-</para>
-
-<para>
-The optional
-<parameter>dbm_module</parameter>
-argument can be used to specify
-which Python database module
-The default is to use a custom
-<filename>SCons.dblite</filename>
-module that uses pickled
-Python data structures,
-and which works on all Python versions.
+not in a single combined database file.
+This is a backwards-compatibility meaure to support
+what was the default behavior
+prior to &SCons; 0.97 (i.e. before 2008).
+Use of this mode is discouraged and may be 
+deprecated in a future &SCons; release.
 </para>
 
 <para>
@@ -2800,15 +2815,16 @@ Examples:
 
 <example_commands>
 # Explicitly stores signatures in ".sconsign.dblite"
-# in the top-level SConstruct directory (the
-# default behavior).
+# in the top-level SConstruct directory (the default behavior).
 SConsignFile()
 
 # Stores signatures in the file "etc/scons-signatures"
 # relative to the top-level SConstruct directory.
+# SCons will add a database suffix to this name.
 SConsignFile("etc/scons-signatures")
 
 # Stores signatures in the specified absolute file name.
+# SCons will add a database suffix to this name.
 SConsignFile("/home/me/SCons/signatures")
 
 # Stores signatures in a separate .sconsign file

--- a/SCons/__init__.py
+++ b/SCons/__init__.py
@@ -1,9 +1,9 @@
 __version__="4.0.1.9998"
 __copyright__="Copyright (c) 2001 - 2020 The SCons Foundation"
-__developer__="mats"
-__date__="2020-11-26 16:47:04"
-__buildsys__="boulder"
-__revision__="64a80e530b0caef9763eb67bd770dd9c8925ea18"
-__build__="64a80e530b0caef9763eb67bd770dd9c8925ea18"
+__developer__="bdbaddog"
+__date__="2020-10-09 19:00:35"
+__buildsys__="ProDog2020"
+__revision__="93525bed88d19a00f5de400086c0046011d3b833"
+__build__="93525bed88d19a00f5de400086c0046011d3b833"
 # make sure compatibility is always in place
 import SCons.compat # noqa

--- a/SCons/__init__.py
+++ b/SCons/__init__.py
@@ -1,9 +1,9 @@
 __version__="4.0.1.9998"
 __copyright__="Copyright (c) 2001 - 2020 The SCons Foundation"
-__developer__="bdbaddog"
-__date__="2020-10-09 19:00:35"
-__buildsys__="ProDog2020"
-__revision__="93525bed88d19a00f5de400086c0046011d3b833"
-__build__="93525bed88d19a00f5de400086c0046011d3b833"
+__developer__="mats"
+__date__="2020-11-26 16:47:04"
+__buildsys__="boulder"
+__revision__="64a80e530b0caef9763eb67bd770dd9c8925ea18"
+__build__="64a80e530b0caef9763eb67bd770dd9c8925ea18"
 # make sure compatibility is always in place
 import SCons.compat # noqa

--- a/doc/man/sconsign.xml
+++ b/doc/man/sconsign.xml
@@ -49,67 +49,58 @@
 
 
 <refsect1 id='description'><title>DESCRIPTION</title>
-<para>The
-<command>sconsign</command>
-command
-displays the contents of one or more signature database
-(<firstterm>sconsign</firstterm>)
-files used by the <command>scons</command> build tool.
+<para>
+Displays the contents of one or more
+<firstterm>sconsign files</firstterm>,
+the signature database files
+used by the <application>SCons</application> build tool.
 </para>
 
 <para>By default,
 <command>sconsign</command>
 dumps the entire contents of the
 sconsign file(s).
-Without the verbose option,
-each entry is printed in the following format:</para>
+Without options,
+individual dependency entries are printed in the following format:</para>
 
-<literallayout class="monospaced">
-file: signature timestamp length
-        implicit_dependency_1: signature timestamp length
-        implicit_dependency_2: signature timestamp length
+<screen>
+depfile: signature timestamp length
+        implicit_dependency_1: content_signature timestamp length
+        implicit_dependency_2: content_signature timestamp length
         ...
         action_signature [action string]
-</literallayout>
+</screen>
 
 <para><emphasis role="bold">None</emphasis>
-is printed
-in place of any missing timestamp, <firstterm>build signature</firstterm>
-(<emphasis role="bold">bsig</emphasis>),
-or <firstterm>content signature</firstterm>
+is printed in place of any missing timestamp,
+ <firstterm>content signature</firstterm>
 (<emphasis role="bold">csig</emphasis>)
-values for
-any entry
+or
+<firstterm>build action signature</firstterm>
+values for any entry
 or any of its dependencies.
 If the entry has no implicit dependencies,
 or no build action,
-the lines are simply omitted.</para>
-
-<para>
-The verbose option expands the display into a more human
-readable format.
-</para>
+those lines are omitted.</para>
 
 <para>By default,
 <command>sconsign</command>
 assumes that any
 <replaceable>file</replaceable>
 arguments that end with a
-<filename>.dbm</filename>
+<filename>.dblite</filename>
 suffix contains
 signature entries for
 more than one directory
 (that is,
 was specified by the
-<emphasis role="bold">SConsignFile</emphasis>
+<function>SConsignFile</function>
 function).
 Any
 <replaceable>file</replaceable>
-argument that ends in
-<filename>.dblite</filename>
-is assumed to be a traditional
-sconsign
-file containing the signature entries
+argument that has no suffix
+is assumed to be an old-style
+sconsign file containing the signature entries
 for a single directory.
 If neither of those is true,
 <command>sconsign</command>
@@ -127,7 +118,7 @@ If there are no
 <replaceable>file</replaceable>
 arguments, the name
 <filename>.sconsign.dblite</filename>
-is assumed.
+is assumed by default.
 </para>
 
 </refsect1>
@@ -145,7 +136,7 @@ and the format:</para>
     <option>--action</option>
   </term>
   <listitem>
-<para>Prints the build action information
+<para>Prints only the build action information
 for all entries or the specified entries.</para>
 
   </listitem>
@@ -156,7 +147,7 @@ for all entries or the specified entries.</para>
     <option>--csig</option>
   </term>
   <listitem>
-<para>Prints the content signature (csig) information
+<para>Prints only the content signature (csig) information
 for all entries or the specified entries.</para>
 
   </listitem>
@@ -169,11 +160,11 @@ for all entries or the specified entries.</para>
   <listitem>
 <para>When the signatures are being
 read from a
-<filename>.dbm</filename>
+<filename>.dblite</filename>
 file, or the
-<option>-f dbm</option>
+<option>-f dblite</option>
 or
-<option>--format=dbm</option>
+<option>--format=dblite</option>
 options are used,
 prints information about
 only the signatures
@@ -208,15 +199,15 @@ options are specified on the command line.</para>
 are in the specified
 <replaceable>FORMAT</replaceable>.
 Legal values are
-<emphasis role="bold">dbm</emphasis>
-(the DBM format used
-when the
-<emphasis role="bold">SConsignFile</emphasis>
-function is used)
-or
-<command>sconsign</command>
-(the default format
-used for an individual
+<emphasis role="bold">dblite</emphasis>
+(the SCons.dblite format used by default,
+as well as when the
+<function>SConsignFile</function>
+function is called, except when a filename argument
+of <constant>None</constant> is given)
+and
+<emphasis role="bold">sconsign</emphasis>
+(the format used for an individual
 <filename>.sconsign</filename>
 file in each directory).</para>
 

--- a/test/SConsignFile/default.py
+++ b/test/SConsignFile/default.py
@@ -23,9 +23,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""
-Verify the behavior of SConsignFile() called with a subst-able path.
-"""
+"""Verify the default behavior of SConsignFile() called with no arguments."""
 
 import TestSCons
 

--- a/test/SConsignFile/default.py
+++ b/test/SConsignFile/default.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,12 +22,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Verify the default behavior of SConsignFile(), called with no arguments.
+Verify the behavior of SConsignFile() called with a subst-able path.
 """
 
 import TestSCons
@@ -46,12 +45,13 @@ sys.exit(0)
 #
 test.write('SConstruct', """
 SConsignFile()
-B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
-env.B(target = 'f1.out', source = 'f1.in')
-env.B(target = 'f2.out', source = 'f2.in')
-env.B(target = 'subdir/f3.out', source = 'subdir/f3.in')
-env.B(target = 'subdir/f4.out', source = 'subdir/f4.in')
+DefaultEnvironment(tools=[])
+B = Builder(action=r'%(_python_)s build.py $TARGETS $SOURCES')
+env = Environment(BUILDERS={'B': B}, tools=[])
+env.B(target='f1.out', source='f1.in')
+env.B(target='f2.out', source='f2.in')
+env.B(target='subdir/f3.out', source='subdir/f3.in')
+env.B(target='subdir/f4.out', source='subdir/f4.in')
 """ % locals())
 
 test.write('f1.in', "f1.in\n")
@@ -70,7 +70,7 @@ test.must_match('f2.out', "f2.in\n")
 test.must_match(['subdir', 'f3.out'], "subdir/f3.in\n")
 test.must_match(['subdir', 'f4.out'], "subdir/f4.in\n")
 
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
 test.must_exist(test.workpath('.sconsign.dblite'))
 test.must_not_exist(test.workpath('.sconsign'))

--- a/test/SConsignFile/explicit-dbm-module.py
+++ b/test/SConsignFile/explicit-dbm-module.py
@@ -3,6 +3,7 @@
 # MIT License
 #
 # Copyright The SCons Foundation
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -47,8 +48,8 @@ sys.exit(0)
 test.write('SConstruct', """
 import %(use_db)s
 SConsignFile(dbm_module=%(use_db)s)
-B = Builder(action=r'%(_python_)s build.py $TARGETS $SOURCES')
 DefaultEnvironment(tools=[])
+B = Builder(action=r'%(_python_)s build.py $TARGETS $SOURCES')
 env = Environment(BUILDERS={'B': B}, tools=[])
 env.B(target='f1.out', source='f1.in')
 env.B(target='f2.out', source='f2.in')

--- a/test/SConsignFile/explicit-dbm-module.py
+++ b/test/SConsignFile/explicit-dbm-module.py
@@ -25,15 +25,12 @@
 
 """Verify SConsignFile() when used with explicit SCons.dblite."""
 
-import os.path
-
 import TestSCons
 
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-import SCons.dblite
 use_db = 'SCons.dblite'
 
 test.subdir('subdir')

--- a/test/SConsignFile/explicit-dbm-module.py
+++ b/test/SConsignFile/explicit-dbm-module.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Verify SConsignFile() when used with explicit SCons.dblite."""
+
+import os.path
+
+import TestSCons
+
+_python_ = TestSCons._python_
+
+test = TestSCons.TestSCons()
+
+import SCons.dblite
+use_db = 'SCons.dblite'
+
+test.subdir('subdir')
+
+test.write('build.py', r"""
+import sys
+with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
+    ofp.write(ifp.read())
+sys.exit(0)
+""")
+
+test.write('SConstruct', """
+import %(use_db)s
+SConsignFile(dbm_module=%(use_db)s)
+B = Builder(action=r'%(_python_)s build.py $TARGETS $SOURCES')
+DefaultEnvironment(tools=[])
+env = Environment(BUILDERS={'B': B}, tools=[])
+env.B(target='f1.out', source='f1.in')
+env.B(target='f2.out', source='f2.in')
+env.B(target='subdir/f3.out', source='subdir/f3.in')
+env.B(target='subdir/f4.out', source='subdir/f4.in')
+""" % locals())
+
+test.write('f1.in', "f1.in\n")
+test.write('f2.in', "f2.in\n")
+test.write(['subdir', 'f3.in'], "subdir/f3.in\n")
+test.write(['subdir', 'f4.in'], "subdir/f4.in\n")
+
+test.run()
+
+test.must_exist(test.workpath('.sconsign.dblite'))
+test.must_not_exist(test.workpath('.sconsign'))
+test.must_not_exist(test.workpath('subdir', '.sconsign'))
+
+test.must_match('f1.out', "f1.in\n")
+test.must_match('f2.out', "f2.in\n")
+test.must_match(['subdir', 'f3.out'], "subdir/f3.in\n")
+test.must_match(['subdir', 'f4.out'], "subdir/f4.in\n")
+
+test.up_to_date(arguments='.')
+
+test.must_exist(test.workpath('.sconsign.dblite'))
+test.must_not_exist(test.workpath('.sconsign'))
+test.must_not_exist(test.workpath('subdir', '.sconsign'))
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/SConsignFile/explicit-file.py
+++ b/test/SConsignFile/explicit-file.py
@@ -23,9 +23,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""
-Verify the default behavior of env.SConsignFile(), called with no arguments.
-"""
+"""Verify the behavior of env.SConsignFile() called with a subst-able path."""
 
 import TestSCons
 

--- a/test/SConsignFile/explicit-file.py
+++ b/test/SConsignFile/explicit-file.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,12 +22,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Verify the default behavior of SConsignFile(), called with no arguments.
+Verify the default behavior of env.SConsignFile(), called with no arguments.
 """
 
 import TestSCons
@@ -44,14 +43,15 @@ with open(sys.argv[1], 'wb') as ofp, open(sys.argv[2], 'rb') as ifp:
 
 #
 test.write('SConstruct', """
-e = Environment(XXX = 'scons')
+DefaultEnvironment(tools=[])
+e = Environment(XXX='scons', tools=[])
 e.SConsignFile('my_${XXX}ign')
-B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
-env.B(target = 'f5.out', source = 'f5.in')
-env.B(target = 'f6.out', source = 'f6.in')
-env.B(target = 'subdir/f7.out', source = 'subdir/f7.in')
-env.B(target = 'subdir/f8.out', source = 'subdir/f8.in')
+B = Builder(action=r'%(_python_)s build.py $TARGETS $SOURCES')
+env = Environment(BUILDERS={'B': B}, tools=[])
+env.B(target='f5.out', source='f5.in')
+env.B(target='f6.out', source='f6.in')
+env.B(target='subdir/f7.out', source='subdir/f7.in')
+env.B(target='subdir/f8.out', source='subdir/f8.in')
 """ % locals())
 
 test.write('f5.in', "f5.in\n")
@@ -70,7 +70,7 @@ test.must_match('f6.out', "f6.in\n")
 test.must_match(['subdir', 'f7.out'], "subdir/f7.in\n")
 test.must_match(['subdir', 'f8.out'], "subdir/f8.in\n")
 
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
 test.must_exist(test.workpath('my_sconsign.dblite'))
 test.must_not_exist(test.workpath('.sconsign'))

--- a/test/SConsignFile/make-directory.py
+++ b/test/SConsignFile/make-directory.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the ability to make a SConsignFile() in a non-existent
@@ -40,15 +39,17 @@ bar_foo_txt = os.path.join('bar', 'foo.txt')
 
 test.write('SConstruct', """
 import SCons.dblite
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env.SConsignFile("sub/dir/sconsign", SCons.dblite)
 env.Install('bar', 'foo.txt')
 """)
 
 test.write('foo.txt', "Foo\n")
-
-expect = test.wrap_stdout(read_str = 'Mkdir("%s")\n' % sub_dir,
-              build_str = 'Install file: "foo.txt" as "%s"\n' % bar_foo_txt)
+expect = test.wrap_stdout(
+    read_str='Mkdir("%s")\n' % sub_dir,
+    build_str='Install file: "foo.txt" as "%s"\n' % bar_foo_txt,
+)
 
 test.run(options='-n', stdout=expect)
 

--- a/test/SConsignFile/use-dbhash.py
+++ b/test/SConsignFile/use-dbhash.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify SConsignFile() when used with dbhash.
@@ -36,8 +35,9 @@ test = TestSCons.TestSCons()
 
 try:
     import dbm.bsd
+    use_dbm = 'dbm.bsd'
 except ImportError:
-    test.skip_test('No dbhash in this version of Python; skipping test.\n')
+    test.skip_test('No dbm.bsd in this version of Python; skipping test.\n')
 
 test.subdir('subdir')
 
@@ -50,11 +50,11 @@ sys.exit(0)
 
 #
 test.write('SConstruct', """
-import sys
-import dbhash
-SConsignFile('.sconsign', dbhash)
+import %(use_dbm
+SConsignFile('.sconsign', %(use_dbm)s)
+DefaultEnvironment(tools=[])
 B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
+env = Environment(BUILDERS={'B': B}, tools=[])
 env.B(target = 'f1.out', source = 'f1.in')
 env.B(target = 'f2.out', source = 'f2.in')
 env.B(target = 'subdir/f3.out', source = 'subdir/f3.in')

--- a/test/SConsignFile/use-dbhash.py
+++ b/test/SConsignFile/use-dbhash.py
@@ -50,7 +50,7 @@ sys.exit(0)
 
 #
 test.write('SConstruct', """
-import %(use_dbm
+import %(use_dbm)s
 SConsignFile('.sconsign', %(use_dbm)s)
 DefaultEnvironment(tools=[])
 B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')

--- a/test/SConsignFile/use-dbm.py
+++ b/test/SConsignFile/use-dbm.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify SConsignFile() when used with dbm.
@@ -37,15 +36,9 @@ test = TestSCons.TestSCons()
 
 try:
     import dbm.ndbm
-
-    use_db = 'dbm.ndbm'
+    use_dbm = 'dbm.ndbm'
 except ImportError:
-    try:
-        import dbm
-
-        use_db = 'dbm'
-    except ImportError:
-        test.skip_test('No dbm.ndbm in this version of Python; skipping test.\n')
+    test.skip_test('No dbm.ndbm in this version of Python; skipping test.\n')
 
 test.subdir('subdir')
 
@@ -58,16 +51,15 @@ sys.exit(0)
 
 #
 test.write('SConstruct', """
-import sys
-import %(use_db)s
-SConsignFile('.sconsign', %(use_db)s)
-B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
+import %(use_dbm)s
+SConsignFile('.sconsign', %(use_dbm)s)
 DefaultEnvironment(tools=[])
-env = Environment(BUILDERS = { 'B' : B }, tools=[])
-env.B(target = 'f1.out', source = 'f1.in')
-env.B(target = 'f2.out', source = 'f2.in')
-env.B(target = 'subdir/f3.out', source = 'subdir/f3.in')
-env.B(target = 'subdir/f4.out', source = 'subdir/f4.in')
+B = Builder(action=r'%(_python_)s build.py $TARGETS $SOURCES')
+env = Environment(BUILDERS={'B': B}, tools=[])
+env.B(target='f1.out', source='f1.in')
+env.B(target='f2.out', source='f2.in')
+env.B(target='subdir/f3.out', source='subdir/f3.in')
+env.B(target='subdir/f4.out', source='subdir/f4.in')
 """ % locals())
 
 test.write('f1.in', "f1.in\n")
@@ -80,8 +72,10 @@ test.run()
 # We don't check for explicit .db or other file, because base "dbm"
 # can use different file extensions on different implementations.
 
-test.fail_test(os.path.exists('.sconsign') and 'dbm' not in dbm.whichdb('.sconsign'),
-               message=".sconsign existed and wasn't any type of dbm file")
+test.fail_test(
+    os.path.exists('.sconsign') and 'dbm' not in dbm.whichdb('.sconsign'),
+    message=".sconsign existed and wasn't any type of dbm file",
+)
 test.must_not_exist(test.workpath('.sconsign.dblite'))
 test.must_not_exist(test.workpath('subdir', '.sconsign'))
 test.must_not_exist(test.workpath('subdir', '.sconsign.dblite'))

--- a/test/SConsignFile/use-dumbdbm.py
+++ b/test/SConsignFile/use-dumbdbm.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify SConsignFile() when used with dumbdbm.
@@ -36,7 +35,7 @@ test = TestSCons.TestSCons()
 
 try:
     import dbm.dumb
-    use_dbm='dbm.dumb'
+    use_dbm = 'dbm.dumb'
 except ImportError:
     test.skip_test('No dbm.dumb in this version of Python; skipping test.\n')
 
@@ -51,15 +50,15 @@ sys.exit(0)
 
 #
 test.write('SConstruct', """
-import sys
 import %(use_dbm)s
 SConsignFile('.sconsign', %(use_dbm)s)
-B = Builder(action = r'%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
-env.B(target = 'f1.out', source = 'f1.in')
-env.B(target = 'f2.out', source = 'f2.in')
-env.B(target = 'subdir/f3.out', source = 'subdir/f3.in')
-env.B(target = 'subdir/f4.out', source = 'subdir/f4.in')
+DefaultEnvironment(tools=[])
+B = Builder(action=r'%(_python_)s build.py $TARGETS $SOURCES')
+env = Environment(BUILDERS={'B': B}, tools=[])
+env.B(target='f1.out', source='f1.in')
+env.B(target='f2.out', source='f2.in')
+env.B(target='subdir/f3.out', source='subdir/f3.in')
+env.B(target='subdir/f4.out', source='subdir/f4.in')
 """ % locals())
 
 test.write('f1.in', "f1.in\n")
@@ -83,7 +82,7 @@ test.must_match('f2.out', "f2.in\n")
 test.must_match(['subdir', 'f3.out'], "subdir/f3.in\n")
 test.must_match(['subdir', 'f4.out'], "subdir/f4.in\n")
 
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
 test.must_exist(test.workpath('.sconsign.dat'))
 test.must_exist(test.workpath('.sconsign.dir'))

--- a/test/SConsignFile/use-gdbm.py
+++ b/test/SConsignFile/use-gdbm.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify SConsignFile() when used with gdbm.
@@ -51,15 +50,15 @@ sys.exit(0)
 
 #
 test.write('SConstruct', """
-import sys
 import %(use_dbm)s
 SConsignFile('.sconsign', %(use_dbm)s)
-B = Builder(action = '%(_python_)s build.py $TARGETS $SOURCES')
-env = Environment(BUILDERS = { 'B' : B })
-env.B(target = 'f1.out', source = 'f1.in')
-env.B(target = 'f2.out', source = 'f2.in')
-env.B(target = 'subdir/f3.out', source = 'subdir/f3.in')
-env.B(target = 'subdir/f4.out', source = 'subdir/f4.in')
+DefaultEnvironment(tools=[])
+B = Builder(action='%(_python_)s build.py $TARGETS $SOURCES')
+env = Environment(BUILDERS={'B': B}, tools=[])
+env.B(target='f1.out', source='f1.in')
+env.B(target='f2.out', source='f2.in')
+env.B(target='subdir/f3.out', source='subdir/f3.in')
+env.B(target='subdir/f4.out', source='subdir/f4.in')
 """ % locals())
 
 test.write('f1.in', "f1.in\n")
@@ -79,7 +78,7 @@ test.must_match('f2.out', "f2.in\n")
 test.must_match(['subdir', 'f3.out'], "subdir/f3.in\n")
 test.must_match(['subdir', 'f4.out'], "subdir/f4.in\n")
 
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
 test.must_exist(test.workpath('.sconsign'))
 test.must_not_exist(test.workpath('.sconsign.dblite'))


### PR DESCRIPTION
The `sconsign` manpage had some considerably out of date claims, updated to current usage and defaults.

The `SConsignFile` manpage/userguide entry was reworded, mainly to clarify that there's one setting (the presence of `env.SConsignFile` *might* suggest there could be per-env settings), but also fiddled the wording a fair bit.  Use the same arg names as the actual function, since those are usable as kwargs (manpage used to use "file", function accepts "name").

Subsequent commit updated the SConsignFile tests and added an additional one, otherwise it's just docs.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
