### PR TITLE
WIP: fiddle Parallel fail test

### DIFF
--- a/test/Parallel/failed-build.py
+++ b/test/Parallel/failed-build.py
@@ -106,6 +106,8 @@ env.Fail(target='f3', source='f3.in')
 env.MyCopy(target='f4', source='f4.in')
 env.MyCopy(target='f5', source='f5.in')
 env.MyCopy(target='f6', source='f6.in')
+env.Depends('f5', 'f3')
+env.Depends('f6', 'f4')
 """ % locals())
 
 test.write('f3.in', "f3.in\n")


### PR DESCRIPTION
The test wants to make sure other tests don't run once the contrived failure in one of the two threads is triggered.
Add Depends() to set up dependency so taskmaster doesn't schedule one of the two "later" jobs earlier.

This is kind of a shot in the dark: since the test doesn't fail consistently, failure to trigger doesn't *prove* anything.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
