### PR TITLE
Fix a lingering typo in msvc debug output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -87,6 +87,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Pick a better "Topic" Trove classifier for SCons: SW Dev / Build Tools
     - Use os.replace instead of os.rename in dblite so don't need to
       special-case Windows here. dblite is the default storage engine for the SConsign file(s).
+    - Fix cut-n-paste error in msvc debug printout.
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -203,7 +203,7 @@ def get_host_target(env):
 
     # Retain user requested TARGET_ARCH
     req_target_platform = env.get('TARGET_ARCH')
-    debug("HOST_ARCH:" + str(req_target_platform))
+    debug("TARGET_ARCH:" + str(req_target_platform))
     if req_target_platform:
         # If user requested a specific platform then only try that one.
         target_platform = req_target_platform
@@ -220,9 +220,12 @@ def get_host_target(env):
         target = _ARCH_TO_CANONICAL[target_platform.lower()]
     except KeyError:
         all_archs = str(list(_ARCH_TO_CANONICAL.keys()))
-        raise MSVCUnsupportedTargetArch("Unrecognized target architecture %s\n\tValid architectures: %s" % (target_platform, all_archs))
+        raise MSVCUnsupportedTargetArch(
+            "Unrecognized target architecture %s\n\tValid architectures: %s"
+            % (target_platform, all_archs)
+        )
 
-    return (host, target,req_target_platform)
+    return (host, target, req_target_platform)
 
 # If you update this, update SupportedVSList in Tool/MSCommon/vs.py, and the
 # MSVC_VERSION documentation in Tool/msvc.xml.


### PR DESCRIPTION
Printed HOST when it meant TARGET - this is for debug only.  No functional impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
