### PR TITLE
Quiet some msvs debug output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -87,7 +87,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Pick a better "Topic" Trove classifier for SCons: SW Dev / Build Tools
     - Use os.replace instead of os.rename in dblite so don't need to
       special-case Windows here. dblite is the default storage engine for the SConsign file(s).
-    - Fix cut-n-paste error in msvc debug printout.
+    - Fix cut-n-paste error in msvc debug printout and make some debug output
+      in msvs and msvsTests.py be off until needed (uncomment to use)
 
   From Simon Tegelid
     - Fix using TEMPFILE in multiple actions in an action list. Previously a builder, or command

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -607,8 +607,8 @@ class _DSPGenerator:
                 config.platform = 'Win32'
 
             self.configs[variant] = config
-            # DEBUG
-            # print("Adding '" + self.name + ' - ' + config.variant + '|' + config.platform + "' to '" + str(dspfile) + "'")
+            # DEBUG: leave enabled, test/MSVS/CPPPATH-dirs.py expects this
+            print("Adding '" + self.name + ' - ' + config.variant + '|' + config.platform + "' to '" + str(dspfile) + "'")
 
         for i in range(len(variants)):
             AddConfig(self, variants[i], buildtarget[i], outdir[i], runfile[i], cmdargs[i], cppdefines[i], cpppaths[i], cppflags[i])

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -607,7 +607,8 @@ class _DSPGenerator:
                 config.platform = 'Win32'
 
             self.configs[variant] = config
-            print("Adding '" + self.name + ' - ' + config.variant + '|' + config.platform + "' to '" + str(dspfile) + "'")
+            # DEBUG
+            # print("Adding '" + self.name + ' - ' + config.variant + '|' + config.platform + "' to '" + str(dspfile) + "'")
 
         for i in range(len(variants)):
             AddConfig(self, variants[i], buildtarget[i], outdir[i], runfile[i], cmdargs[i], cppdefines[i], cpppaths[i], cppflags[i])
@@ -1444,7 +1445,9 @@ class _GenerateV10DSP(_DSPGenerator, _GenerateV10User):
                         '\t</ItemGroup>\n' % str(self.sconscript))
 
     def Parse(self):
-        print("_GenerateV10DSP.Parse()")
+        # DEBUG
+        # print("_GenerateV10DSP.Parse()")
+        pass
 
     def Build(self):
         try:
@@ -1530,7 +1533,8 @@ class _GenerateV7DSW(_DSWGenerator):
                 config.platform = 'Win32'
 
             self.configs[variant] = config
-            print("Adding '" + self.name + ' - ' + config.variant + '|' + config.platform + "' to '" + str(dswfile) + "'")
+            # DEBUG
+            # print("Adding '" + self.name + ' - ' + config.variant + '|' + config.platform + "' to '" + str(dswfile) + "'")
 
         if 'variant' not in env:
             raise SCons.Errors.InternalError("You must specify a 'variant' argument (i.e. 'Debug' or " +\

--- a/SCons/Tool/msvsTests.py
+++ b/SCons/Tool/msvsTests.py
@@ -564,17 +564,20 @@ def DummyEnumKey(key, index):
         rv = key.keyarray[index]
     except IndexError:
         raise SCons.Util.RegError
-#    print "Enum Key",key.name,"[",index,"] =>",rv
+    # DEBUG
+    # print "Enum Key",key.name,"[",index,"] =>",rv
     return rv
 
 def DummyEnumValue(key, index):
     rv = key.valindex(index)
-#    print "Enum Value",key.name,"[",index,"] =>",rv
+    # DEBUG
+    # print "Enum Value",key.name,"[",index,"] =>",rv
     return rv
 
 def DummyQueryValue(key, value):
     rv = key.value(value)
-#    print "Query Value",key.name+"\\"+value,"=>",rv
+    # DEBUG
+    # print "Query Value",key.name+"\\"+value,"=>",rv
     return rv
 
 def DummyExists(path):
@@ -726,8 +729,18 @@ class msvsTestCase(unittest.TestCase):
             for param_cppdefines, expected_cppdefines in tests_cppdefines:
                 for param_cpppaths, expected_cpppaths in tests_cpppaths:
                     for param_cppflags, expected_cppflags in tests_cppflags:
-                        print('Testing %s. with :\n  variant = %s \n  cmdargs = "%s" \n  cppdefines = "%s" \n  cpppaths = "%s" \n  cppflags = "%s"' % \
-                              (str_function_test, list_variant, param_cmdargs, param_cppdefines, param_cpppaths, param_cppflags))
+                        # DEBUG:
+                        # print(
+                        #     'Testing %s. with :\n  variant = %s \n  cmdargs = "%s" \n  cppdefines = "%s" \n  cpppaths = "%s" \n  cppflags = "%s"'
+                        #     % (
+                        #         str_function_test,
+                        #         list_variant,
+                        #         param_cmdargs,
+                        #         param_cppdefines,
+                        #         param_cpppaths,
+                        #         param_cppflags,
+                        #     )
+                        # )
                         param_configs = []
                         expected_configs = {}
                         for platform in ['Win32', 'x64']:
@@ -959,7 +972,8 @@ if __name__ == "__main__":
     ]
 
     for test_class in test_classes:
-        print("TEST: ", test_class.__doc__)
+        # DEBUG
+        # print("TEST: ", test_class.__doc__)
         back_osenv = copy.deepcopy(os.environ)
         try:
             # XXX: overriding the os.environ is bad, but doing it


### PR DESCRIPTION
Unconditional prints in msvs.py and msvsTests.py really are only for debugging, comment out and mark with # DEBUG so they're easy to find and turn on again if needed. Reduces size of test run log on Windows by about 2/3.

No doc impact.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
