### PR TITLE
Adjust CompilationDatase documentation

### DIFF
--- a/SCons/Tool/compilation_db.xml
+++ b/SCons/Tool/compilation_db.xml
@@ -31,12 +31,12 @@ See its __doc__ string for a discussion of the format.
         </summary>
         <sets>
             <item>COMPILATIONDB_COMSTR</item>
-<!--            
+<!--
             <item>__COMPILATIONDB_UACTION</item>
             <item>__COMPILATIONDB_UOUTPUT</item>
             <item>__COMPILATIONDB_USOURCE</item>
             <item>__COMPILATIONDB_ENV</item>
--->            
+-->
             <item>COMPILATIONDB_USE_ABSPATH</item>
             <item>COMPILATIONDB_PATH_FILTER</item>
         </sets>
@@ -45,30 +45,55 @@ See its __doc__ string for a discussion of the format.
     <builder name="CompilationDatabase">
         <summary>
             <para>
-                The &b-CompilationDatabase; builder writes a JSON formatted compilation
-                    database according to the
-                <ulink url="https://clang.llvm.org/docs/JSONCompilationDatabase.html">LLVM specification
-                </ulink> which is consumed by a number of clang tools, editors, and other tools.
+                &b-CompilationDatabase; is a special builder which
+                adds a target to create a JSON formatted
+                compilation database compatible with
+                <systemitem>clang</systemitem> tooling
+                (see the
+                <ulink url="https://clang.llvm.org/docs/JSONCompilationDatabase.html">LLVM specification</ulink>).
+                This database is suitable for consumption by various
+                tools and editors who can use it to obtain build and
+                dependency information which otherwise would be
+                internal to &SCons;.
+                The builder does not require any source files to be specified,
+                rather it arranges to emit information about all
+                of the C, C++ and assembler source/output pairs
+                identified in the build that are not excluded by the
+                optional filter &cv-link-COMPILATIONDB_PATH_FILTER;.
+                The target is subject to the usual &SCons; target
+                selection rules.
             </para>
             <para>
-                If you don't specify any files, the builder will default to <filename>compile_commands.json</filename>.
+                If called with no arguments,
+                the builder will default to a target name of
+                <filename>compile_commands.json</filename>.
             </para>
             <para>
-                If you specify a single file as below
-                <programlisting language="python">
-env.CompilationDatabase('my_output.json')
-                </programlisting>
-                SCons will automatically use that as the target file.
-                If you specify more than one source, the source list will be ignored.
+                If called with a single positional argument,
+                &scons; will "deduce" the target name from that source
+                argument, giving it the same name, and then
+                ignore the source.
+                This is the usual way to call the builder if a
+                non-default target name is wanted.
             </para>
             <para>
-                You should not specify source files. The &b-CompilationDatabase; builder instruments SCons to collect them from all
-                the C, C++, assembly source/output pairs.
+                If called with either the <parameter>target=</parameter>
+                or <parameter>source=</parameter> keyword arguments,
+                the value of the argument is taken as the target name.
+                If called with both, the <parameter>target=</parameter>
+                value is used and <parameter>source=</parameter> is ignored.
+                If called with multiple sources,
+                the source list will be ignored,
+                since there is no way to deduce what the intent was;
+                in this case the default target name will be used.
             </para>
-            <para>
-                NOTE: You must load the &t-compilation_db; tool prior to specifying any part of your build or some source/output
-                files will not show up in your output file.
-            </para>
+            <note>
+              <para>
+                You must load the &t-compilation_db; tool prior to specifying
+                any part of your build or some source/output
+                files will not show up in the compilation database.
+              </para>
+            </note>
             <para>
                 <emphasis>Available since &scons; 4.0.</emphasis>
             </para>
@@ -78,7 +103,8 @@ env.CompilationDatabase('my_output.json')
     <cvar name="COMPILATIONDB_COMSTR">
         <summary>
             <para>
-                The string displayed when CompilationDatabase builder's action is run.
+                The string displayed when the &b-CompilationDatabase;
+                builder's action is run.
             </para>
         </summary>
     </cvar>
@@ -86,9 +112,10 @@ env.CompilationDatabase('my_output.json')
     <cvar name="COMPILATIONDB_USE_ABSPATH">
         <summary>
             <para>
-                This is a boolean flag to instruct &b-link-CompilationDatabase; to
-                write the <literal>file</literal> and <literal>output</literal> members
-                in the compilation database with absolute or relative paths.
+                A boolean flag to instruct &b-link-CompilationDatabase;
+                whether to write the <literal>file</literal> and
+                <literal>output</literal> members
+                in the compilation database using absolute or relative paths.
             </para>
             <para>
                 The default value is False (use relative paths)
@@ -99,7 +126,7 @@ env.CompilationDatabase('my_output.json')
     <cvar name="COMPILATIONDB_PATH_FILTER">
         <summary>
             <para>
-                This is a string which instructs &b-link-CompilationDatabase; to
+                A string which instructs &b-link-CompilationDatabase; to
                 only include entries where the <literal>output</literal> member
                 matches the pattern in the filter string using fnmatch, which
                 uses glob style wildcards.

--- a/doc/generated/examples/external_cdb_ex1_1.xml
+++ b/doc/generated/examples/external_cdb_ex1_1.xml
@@ -1,0 +1,5 @@
+<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
+Building compilation database compile_commands.json
+cc -o hello.o -c hello.c
+cc -o hello hello.o
+</screen>

--- a/doc/generated/examples/external_cdb_ex2_1.xml
+++ b/doc/generated/examples/external_cdb_ex2_1.xml
@@ -1,0 +1,3 @@
+<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q cdb</userinput>
+Building compilation database compile_database.json
+</screen>

--- a/doc/user/external.xml
+++ b/doc/user/external.xml
@@ -70,7 +70,7 @@
 
     <para>
 
-    Tooling which wants to perform analysis and modification 
+    Tooling to perform analysis and modification
     of source code often needs to know not only the source code
     itself, but also how it will be compiled, as the compilation line
     affects the behavior of macros, includes, etc. &SCons; has a
@@ -93,7 +93,7 @@
     compilation database in this format
     by enabling the &t-link-compilation_db; tool
     and calling the &b-link-CompilationDatabase; builder
-    (available since 4.0).
+    (<emphasis>available since &scons; 4.0</emphasis>).
 
     </para>
 
@@ -107,12 +107,12 @@
     which defaults to <constant>False</constant>.
     The entries in this file can be filtered by using
 
-    <envar>COMPILATIONDB_PATH_FILTER='fnmatch pattern'</envar>
-    where the filter string is a
+    <envar>COMPILATIONDB_PATH_FILTER='pattern'</envar>
+    where the filter pattern is a string following the Python
     <ulink url="https://docs.python.org/3/library/fnmatch.html">
-      <citetitle>fnmatch</citetitle>
+      <systemitem>fnmatch</systemitem>
     </ulink>
-    based pattern which is a typical file glob syntax.
+    syntax.
     This filtering can be used for outputting different
     build variants to different compilation database files.
 
@@ -120,38 +120,104 @@
 
     <para>
 
-    Example of absolute paths for output and source:
+    The following example illustrates generating a compilation
+    database containing absolute paths:
 
     </para>
 
-    <sconstruct>
+    <scons_example name="external_cdb_ex1">
+      <file name="SConstruct" printme="1">
 env = Environment(COMPILATIONDB_USE_ABSPATH=True)
 env.Tool('compilation_db')
-env.CompilationDatabase('compile_commands.json')
-    </sconstruct>
+env.CompilationDatabase()
+env.Program('hello.c')
+      </file>
+      <file name="hello.c">
+int main( int argc, char* argv[] )
+{
+  return 0;
+}
+      </file>
+    </scons_example>
+
+    <scons_output example="external_cdb_ex1" suffix="1">
+      <scons_output_command>scons -Q</scons_output_command>
+    </scons_output>
+
+    <para><filename>compile_commands.json</filename> contains:</para>
 
     <programlisting language="json">
 [
     {
-        "command": "gcc -o test_main.o -c test_main.c",
+        "command": "gcc -o hello.o -c hello.c",
         "directory": "/home/user/sandbox",
-        "file": "/home/user/sandbox/test_main.c",
-        "output": "/home/user/sandbox/test_main.o"
+        "file": "/home/user/sandbox/hello.c",
+        "output": "/home/user/sandbox/hello.o"
     }
 ]
     </programlisting>
 
     <para>
 
-    Example of relative paths for output and source:
+    Notice that the generated database contains only an entry for
+    the <filename>hello.c/hello.o</filename> pairing,
+    and nothing for the generation of the final executable
+    <filename>hello</filename> - the transformation of
+    <filename>hello.o</filename> to <filename>hello</filename>
+    does not have any information that affects interpretation
+    of the source code,
+    so it is not interesting to the compilation database.
 
     </para>
 
-    <sconstruct>
+    <para>
+
+    Although it can be a little surprising at first glance,
+    a compilation database target is, like any other target,
+    subject to &scons; target selection rules.
+    This means if you set a default target (that does not
+    include the compilation database), or use command-line
+    targets, it might not be selected for building.
+    This can actually be an advantage, since you don't
+    necessarily want to regenerate the compilation database
+    every build.
+    The following example
+    shows selecting relative paths (the default)
+    for output and source,
+    and also giving a non-default name to the database.
+    In order to be able to generate the database separately from building,
+    an alias is set referring to the database,
+    which can then be used as a target - here we are only
+    building the compilation database target, not the code.
+
+    </para>
+
+    <scons_example name="external_cdb_ex2">
+      <file name="SConstruct" printme="1">
 env = Environment()
 env.Tool('compilation_db')
-env.CompilationDatabase('compile_commands.json')
-    </sconstruct>
+cdb = env.CompilationDatabase('compile_database.json')
+Alias('cdb', cdb)
+env.Program('test_main.c')
+      </file>
+      <file name="test_main.c">
+#include "test_main.h"
+int main( int argc, char* argv[] )
+{
+  return 0;
+}
+      </file>
+      <file name="test_main.h">
+/* dummy include file */
+      </file>
+    </scons_example>
+
+    <scons_output example="external_cdb_ex2" suffix="1">
+      <scons_output_command>scons -Q cdb</scons_output_command>
+    </scons_output>
+
+    <para><filename>compile_database.json</filename> contains:</para>
+
     <programlisting language="json">
 [
     {
@@ -165,7 +231,15 @@ env.CompilationDatabase('compile_commands.json')
 
     <para>
 
-    Example of using filtering for build variants:
+    The following (incomplete) example shows using filtering
+    to separate build variants.
+    In the case of using variants,
+    you want different compilation databases for each,
+    since the build parameters differ, so the code analysis
+    needs to see the correct build lines for the 32-bit build
+    and 64-bit build hinted at here.
+    For simplicity of presentation,
+    the example omits the setup details of the variant directories:
 
     </para>
 
@@ -181,6 +255,9 @@ env2 = env.Clone()
 env2['COMPILATIONDB_PATH_FILTER'] = 'build/linux64/*'
 env2.CompilationDatabase('compile_commands-linux64.json')
     </sconstruct>
+
+    <para><filename>compile_commands-linux32.json</filename> contains:</para>
+
     <programlisting language="json">
 [
     {
@@ -191,6 +268,9 @@ env2.CompilationDatabase('compile_commands-linux64.json')
     }
 ]
     </programlisting>
+
+    <para><filename>compile_commands-linux64.json</filename> contains:</para>
+
     <programlisting language="json">
 [
     {
@@ -203,5 +283,4 @@ env2.CompilationDatabase('compile_commands-linux64.json')
     </programlisting>
 
   </section>
-
 </chapter>


### PR DESCRIPTION
Try to be a bit more descriptive about compilation databases.

Two of the User Guide examples now use the scons_examples style to show a little more what happens, and have a little more explanation. Changed wording on how target name is generated, and note target selection. 

Fixes #3845.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
