### PR TITLE
[WIP] Bugfix/managan/latex scanner

### DIFF
--- a/SCons/Tool/tex.py
+++ b/SCons/Tool/tex.py
@@ -559,9 +559,9 @@ def is_LaTeX(flist,env,abspath):
             if srcNode is not None:
                 file_test = is_LaTeX(fileList, env, abspath)
 
-            # return on first file that finds latex is needed.
-            if file_test:
-                return file_test
+                # return on first file that finds latex is needed.
+                if file_test:
+                    return file_test
 
         if Verbose:
             print(" done scanning ",str(f))

--- a/test/TEX/missingInput.py
+++ b/test/TEX/missingInput.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+r"""
+Test creation of a LaTeX document that uses \input{filename}.
+Check that SCons does not throw an exception when the 
+file is not found.
+
+
+Test courtesy Rob Managan.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+latex = test.where_is('latex')
+if not latex:
+    test.skip_test("Could not find 'latex'; skipping test.\n")
+
+test.write(['SConstruct'], """\
+import os
+
+env = Environment(tools = ['pdflatex', 'pdftex'])
+
+test = env.PDF(source='test.tex')
+""")
+
+test.write(['test.tex'],
+r"""
+\input{preamble.tex}
+
+\begin{document}
+\title{The uncountability of SCons features}
+\author{Adam Ehlers Nyholm Thomsen}
+\maketitle
+
+\end{document}
+""")
+
+# will write status messages to stderr (grrr...), so ignore it.
+test.run(arguments = '.', stderr=None)
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
This pull request aims to fix a case where the LatexScanner fails. 

The example test is when the source includes `\input{filename}` and the file filename is not present.  This file does not show up in `--tree=all` output and then we get an error from `pdflatex` when it can not find the file.

The scanner needs to be updated to report the file is in the source tree even when it is not present.

The source change avoids an exception being thrown when the builder tries to determine if the deck is a tex file or a latex file.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
