### PR TITLE
Don't allow duplicate side effects to be added

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,8 +40,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       when running multiple tests with multiple jobs.
     - Fix incorrect cache hits and/or misses when running in interactive mode by having
       SCons.Node.Node.clear() clear out all caching-related state.
-    - Change Environment.SideEffect() to not add duplicate side effects. The list of returned
-      side effects will not include any duplicate side effects.
+    - Change Environment.SideEffect() to not add duplicate side effects. 
+      NOTE: The list of returned side effects will not include any duplicate side effects.
 
   From Jason Kenny
     - Fix python3 crash when Value node get_text_content when child content does not have decode()

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       when running multiple tests with multiple jobs.
     - Fix incorrect cache hits and/or misses when running in interactive mode by having
       SCons.Node.Node.clear() clear out all caching-related state.
+    - Change Environment.SideEffect() to not add duplicate side effects. The list of returned
+      side effects will not include any duplicate side effects.
 
   From Jason Kenny
     - Fix python3 crash when Value node get_text_content when child content does not have decode()

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -39,8 +39,8 @@
 
   CHANGED/ENHANCED EXISTING FUNCTIONALITY
 
-    - List modifications to existing features, where the previous behavior
-      wouldn't actually be considered a bug
+    - Environment.SideEffect() no longer adds duplicate side effects.
+      NOTE: The list of returned side effects will not include any duplicate side effects.
 
   FIXES
 

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2249,6 +2249,7 @@ class Base(SubstitutionEnvironment):
         side_effects = self.arg2nodes(side_effect, self.fs.Entry)
         targets = self.arg2nodes(target, self.fs.Entry)
 
+        added_side_effects = []
         for side_effect in side_effects:
             if side_effect.multiple_side_effect_has_builder():
                 raise UserError("Multiple ways to build the same target were specified for: %s" % str(side_effect))
@@ -2256,8 +2257,10 @@ class Base(SubstitutionEnvironment):
             side_effect.side_effect = 1
             self.Precious(side_effect)
             for target in targets:
-                target.side_effects.append(side_effect)
-        return side_effects
+                if side_effect not in target.side_effects:
+                    target.side_effects.append(side_effect)
+                    added_side_effects.append(side_effect)
+        return added_side_effects
 
     def Split(self, arg):
         """This function converts a string or list into a list of strings

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2256,10 +2256,13 @@ class Base(SubstitutionEnvironment):
             side_effect.add_source(targets)
             side_effect.side_effect = 1
             self.Precious(side_effect)
+            added = False
             for target in targets:
                 if side_effect not in target.side_effects:
                     target.side_effects.append(side_effect)
-                    added_side_effects.append(side_effect)
+                    added = True
+            if added:
+                added_side_effects.append(side_effect)
         return added_side_effects
 
     def Split(self, arg):

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -2920,6 +2920,12 @@ or
 &f-env-Clean;
 function.
 </para>
+
+<para>
+This function returns the list of side effects that were successfully added.
+If the list of side effects contained any side effects that had already been added,
+they are not added and included in the returned list.
+</para>
 </summary>
 </scons_function>
 

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -3326,6 +3326,12 @@ def generate(env):
         assert ggg.side_effects == [s], ggg.side_effects
         assert ccc.side_effects == [s], ccc.side_effects
 
+        # Verify that duplicate side effects are not allowed.
+        before = len(ggg.side_effects)
+        s = env.SideEffect('mymmm.pdb', ggg)
+        assert len(s) == 0, len(s)
+        assert len(ggg.side_effects) == before, len(ggg.side_effects)
+
     def test_Split(self):
         """Test the Split() method"""
         env = self.TestEnvironment(FOO = 'fff', BAR = 'bbb')

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -3301,7 +3301,9 @@ def generate(env):
 
         foo = env.Object('foo.obj', 'foo.cpp')[0]
         bar = env.Object('bar.obj', 'bar.cpp')[0]
-        s = env.SideEffect('mylib.pdb', ['foo.obj', 'bar.obj'])[0]
+        s = env.SideEffect('mylib.pdb', ['foo.obj', 'bar.obj'])
+        assert len(s) == 1, len(s)
+        s = s[0]
         assert s.__class__.__name__ == 'Entry', s.__class__.__name__
         assert s.get_internal_path() == 'mylib.pdb'
         assert s.side_effect
@@ -3310,7 +3312,9 @@ def generate(env):
 
         fff = env.Object('fff.obj', 'fff.cpp')[0]
         bbb = env.Object('bbb.obj', 'bbb.cpp')[0]
-        s = env.SideEffect('my${LIB}.pdb', ['${FOO}.obj', '${BAR}.obj'])[0]
+        s = env.SideEffect('my${LIB}.pdb', ['${FOO}.obj', '${BAR}.obj'])
+        assert len(s) == 1, len(s)
+        s = s[0]
         assert s.__class__.__name__ == 'File', s.__class__.__name__
         assert s.get_internal_path() == 'mylll.pdb'
         assert s.side_effect
@@ -3319,7 +3323,9 @@ def generate(env):
 
         ggg = env.Object('ggg.obj', 'ggg.cpp')[0]
         ccc = env.Object('ccc.obj', 'ccc.cpp')[0]
-        s = env.SideEffect('mymmm.pdb', ['ggg.obj', 'ccc.obj'])[0]
+        s = env.SideEffect('mymmm.pdb', ['ggg.obj', 'ccc.obj'])
+        assert len(s) == 1, len(s)
+        s = s[0]
         assert s.__class__.__name__ == 'Dir', s.__class__.__name__
         assert s.get_internal_path() == 'mymmm.pdb'
         assert s.side_effect


### PR DESCRIPTION
SCons disallows adding duplicate sources, but does not place any limits on adding duplicate side effects. This change adds code to not allow adding duplicate side effects.

I considered mimicking Node.sources_set by adding Node.side_effects_set but it seemed unnecessary and would make it harder for Environment.SideEffect to only return the list of side effects that were actually added.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
