### PR TITLE
Update manpage section of Fortran suffixes

### DIFF
--- a/SCons/Tool/f03.xml
+++ b/SCons/Tool/f03.xml
@@ -89,7 +89,7 @@ If not set, then &cv-link-F03COM; or &cv-link-FORTRANCOM;
 <summary>
 <para>
 The list of file extensions for which the F03 dialect will be used. By
-default, this is ['.f03']
+default, this is <literal>['.f03']</literal>
 </para>
 </summary>
 </cvar>
@@ -98,7 +98,7 @@ default, this is ['.f03']
 <summary>
 <para>
 The list of file extensions for which the compilation + preprocessor pass for
-F03 dialect will be used. By default, this is empty
+F03 dialect will be used. By default, this is empty.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/f08.xml
+++ b/SCons/Tool/f08.xml
@@ -89,7 +89,7 @@ If not set, then &cv-link-F08COM; or &cv-link-FORTRANCOM;
 <summary>
 <para>
 The list of file extensions for which the F08 dialect will be used. By
-default, this is ['.f08']
+default, this is <literal>['.f08']</literal>
 </para>
 </summary>
 </cvar>
@@ -98,7 +98,7 @@ default, this is ['.f08']
 <summary>
 <para>
 The list of file extensions for which the compilation + preprocessor pass for
-F08 dialect will be used. By default, this is empty
+F08 dialect will be used. By default, this is empty.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/f77.xml
+++ b/SCons/Tool/f77.xml
@@ -91,7 +91,7 @@ for all Fortran versions.
 <summary>
 <para>
 The list of file extensions for which the F77 dialect will be used. By
-default, this is ['.f77']
+default, this is <literal>['.f77']</literal>
 </para>
 </summary>
 </cvar>
@@ -100,7 +100,7 @@ default, this is ['.f77']
 <summary>
 <para>
 The list of file extensions for which the compilation + preprocessor pass for
-F77 dialect will be used. By default, this is empty
+F77 dialect will be used. By default, this is empty.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/f90.xml
+++ b/SCons/Tool/f90.xml
@@ -89,7 +89,7 @@ If not set, then &cv-link-F90COM; or &cv-link-FORTRANCOM;
 <summary>
 <para>
 The list of file extensions for which the F90 dialect will be used. By
-default, this is ['.f90']
+default, this is <literal>['.f90']</literal>
 </para>
 </summary>
 </cvar>
@@ -98,7 +98,7 @@ default, this is ['.f90']
 <summary>
 <para>
 The list of file extensions for which the compilation + preprocessor pass for
-F90 dialect will be used. By default, this is empty
+F90 dialect will be used. By default, this is empty.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/f95.xml
+++ b/SCons/Tool/f95.xml
@@ -89,7 +89,7 @@ If not set, then &cv-link-F95COM; or &cv-link-FORTRANCOM;
 <summary>
 <para>
 The list of file extensions for which the F95 dialect will be used. By
-default, this is ['.f95']
+default, this is <literal>['.f95']</literal>
 </para>
 </summary>
 </cvar>
@@ -98,7 +98,7 @@ default, this is ['.f95']
 <summary>
 <para>
 The list of file extensions for which the compilation + preprocessor pass for
-F95 dialect will be used. By default, this is empty
+F95 dialect will be used. By default, this is empty.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/fortran.xml
+++ b/SCons/Tool/fortran.xml
@@ -85,7 +85,7 @@ If not set, then &cv-link-FORTRANCOM;
 <summary>
 <para>
 The list of file extensions for which the FORTRAN dialect will be used. By
-default, this is ['.f', '.for', '.ftn']
+default, this is <literal>['.f', '.for', '.ftn']</literal>
 </para>
 </summary>
 </cvar>
@@ -94,7 +94,7 @@ default, this is ['.f', '.for', '.ftn']
 <summary>
 <para>
 The list of file extensions for which the compilation + preprocessor pass for
-FORTRAN dialect will be used. By default, this is ['.fpp', '.FPP']
+FORTRAN dialect will be used. By default, this is <literal>['.fpp', '.FPP']</literal>
 </para>
 </summary>
 </cvar>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -6879,20 +6879,35 @@ suffix as a C source file.</para>
 </refsect2>
 
 <refsect2 id='f_file_suffix'>
-<title>.F file suffix</title>
+<title>Fortran file suffixes</title>
 
-<para>&scons; handles the upper-case
-<filename>.F</filename>
-file suffix differently,
+<para>&scons; handles upper-case
+Fortran file suffixes differently
 depending on the capabilities of
 the underlying system.
 On a case-sensitive system
 such as Linux or UNIX,
 &scons; treats a file with a
 <filename>.F</filename>
-suffix as a Fortran source file
+as a Fortran source file
 that is to be first run through
-the standard C preprocessor.
+the standard C preprocessor, 
+while the lower-case version is not.
+This matches the convention of <command>gfortran</command>,
+which may also be followed by other Fortran compilers.
+This also applies to other naming variants,
+<filename>.FOR</filename>,
+<filename>.FTN</filename>,
+<filename>.F90</filename>,
+<filename>.F95</filename>,
+<filename>.F03</filename> and
+<filename>.F08</filename>;
+files suffixed with
+<filename>.FPP</filename>
+and <filename>.fpp</filename>
+are both run through the preprocessor,
+as indicated by the <literal>pp</literal>
+part of the name.
 On a case-insensitive system
 such as Windows,
 &scons; treats a file with a
@@ -6900,6 +6915,15 @@ such as Windows,
 suffix as a Fortran source file that should
 <emphasis>not</emphasis>
 be run through the C preprocessor.</para>
+<para>
+<emphasis>Run through the C preprocessor</emphasis>
+here means that a different set of &consvars; will
+be applied in constructed commands, for example
+&cv-link-FORTRANPPCOM; and &cv-link-FORTRANPPCOMSTR;
+instead of
+&cv-link-FORTRANCOM; and &cv-link-FORTRANCOMSTR;.
+See the Fortran-related &consvars; for more details.
+</para>
 </refsect2>
 
 <refsect2 id='windows_cygwin_tools_and_cygwin_python_v'>


### PR DESCRIPTION
The section mentioned only the .F suffix, added mention of the other variants and a brief note on what the difference means.
Added some markup in the individual Fortran tools

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
