### PR TITLE
remove unnecessary python check in swig test

### DIFF
--- a/test/SWIG/recursive-includes-cpp.py
+++ b/test/SWIG/recursive-includes-cpp.py
@@ -40,9 +40,8 @@ DefaultEnvironment( tools = [ 'swig' ] )
 test = TestSCons.TestSCons()
 
 # Check for prerequisites of this test.
-for pre_req in ['swig', 'python']:
-    if not test.where_is(pre_req):
-        test.skip_test('Can not find installed "' + pre_req + '", skipping test.%s' % os.linesep)
+if not test.where_is('swig'):
+    test.skip_test('Can not find installed "swig", skipping test.%s' % os.linesep)
 
 python, python_include, python_libpath, python_lib = \
              test.get_platform_python_info(python_h_required=True)


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation

The test is running in python and the test gets the current python environment just after checking for swig, so no reason to check for a bin specifically named 'python', i.e this test skips if you only have python3.8 installed