### PR TITLE
Work around Py3.10 optimizing out a builder test

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -111,6 +111,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add /snap/bin to env['PATH'] on POSIX, although this is only
       really useful for a subset of POSIX systems that use snaps.
       Was needed for CI builds, which run on Ubuntu LTS images.
+    - Eliminate Py2-ism __nonzero__ (now __bool__). Work around issue #3860
+      where a check for BuilderBase raising exc. on __bool__ was optimized out.
 
 
 RELEASE 4.0.1 - Mon, 16 Jul 2020 16:06:40 -0700

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -430,11 +430,8 @@ class BuilderBase:
             src_builder = [ src_builder ]
         self.src_builder = src_builder
 
-    def __nonzero__(self):
-        raise InternalError("Do not test for the Node.builder attribute directly; use Node.has_builder() instead")
-
     def __bool__(self):
-        return self.__nonzero__()
+        raise InternalError("Do not test for the Node.builder attribute directly; use Node.has_builder() instead")
 
     def get_name(self, env):
         """Attempts to get the name of the Builder.

--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -207,13 +207,14 @@ class BuilderTestCase(unittest.TestCase):
         x = builder.overrides['OVERRIDE']
         assert x == 'x', x
 
-    def test__nonzero__(self):
-        """Test a builder raising an exception when __nonzero__ is called
-        """
+    def test__bool__(self):
+        """Test a builder raising an exception when __bool__ is called. """
+
+        # basic test: explicitly call it
         builder = SCons.Builder.Builder(action="foo")
         exc_caught = None
         try:
-            builder.__nonzero__()
+            builder.__bool__()
         except SCons.Errors.InternalError:
             exc_caught = 1
         assert exc_caught, "did not catch expected InternalError exception"
@@ -221,12 +222,18 @@ class BuilderTestCase(unittest.TestCase):
         class Node:
              pass
 
+        # the interesting test: checking the attribute this way
+        # should call back to Builder.__bool__ - so we can tell
+        # people not to check that way (for performance).
+        # TODO: workaround #3860: with just a "pass" in the check body,
+        # py3.10a optimizes out the whole thing, so add a "real" stmt
         n = Node()
         n.builder = builder
         exc_caught = None
         try:
             if n.builder:
-                pass
+                #pass
+                _ = True
         except SCons.Errors.InternalError:
             exc_caught = 1
         assert exc_caught, "did not catch expected InternalError exception"

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1538,7 +1538,7 @@ class Base(SubstitutionEnvironment):
 
 
     def Dictionary(self, *args):
-        """Return construction variables from an environment.
+        r"""Return construction variables from an environment.
 
         Args:
           \*args (optional): variable names to look up

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -886,7 +886,7 @@ class Node(object, metaclass=NoSlotsPyPy):
         than simply examining the builder attribute directly ("if
         node.builder: ..."). When the builder attribute is examined
         directly, it ends up calling __getattr__ for both the __len__
-        and __nonzero__ attributes on instances of our Builder Proxy
+        and __bool__ attributes on instances of our Builder Proxy
         class(es), generating a bazillion extra calls and slowing
         things down immensely.
         """

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -125,11 +125,8 @@ class NodeList(UserList):
 #                 self.data = [ initlist,]
 
 
-    def __nonzero__(self):
-        return len(self.data) != 0
-
     def __bool__(self):
-        return self.__nonzero__()
+        return len(self.data) != 0
 
     def __str__(self):
         return ' '.join(map(str, self.data))
@@ -1563,8 +1560,6 @@ class Null:
         return self
     def __repr__(self):
         return "Null(0x%08X)" % id(self)
-    def __nonzero__(self):
-        return False
     def __bool__(self):
         return False
     def __getattr__(self, name):


### PR DESCRIPTION
BuilderBase class traps `__bool__` call and raises `InternalError`. On Py 3.10a the unit test for this got optimized out, avoid this.

While we're at it, eliminate remaining references to `__nonzero__`, which was a Py2-ism, replaced by `__bool__`.

Closes #3860

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
