### PR TITLE
Allow Zip tool to override timestamp on included files.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -43,6 +43,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Change Environment.SideEffect() to not add duplicate side effects. 
       NOTE: The list of returned side effect Nodes will not include any duplicate side effect Nodes.
 
+  From David H:
+    - Add ZIP_OVERRIDE_TIMESTAMP env option to Zip builder which allows for overriding of the file
+      modification times in the archive.
+    - Fix Zip builder not rebuilding when ZIPROOT env option was changed.
+
   From Jason Kenny
     - Fix python3 crash when Value node get_text_content when child content does not have decode()
       NOTE: If you depend on Value node's get_text_content returning concatenated contents of it's

--- a/SCons/Tool/zip.xml
+++ b/SCons/Tool/zip.xml
@@ -164,4 +164,20 @@ containing a file with the name
 </para>
 </summary>
 </cvar>
+
+<cvar name="ZIP_OVERRIDE_TIMESTAMP">
+<summary>
+<para>
+An optional timestamp which overrides the last modification time of
+the file when stored inside the Zip archive. This is a tuple of six values:
+
+Year (>= 1980)
+Month (one-based)
+Day of month (one-based)
+Hours (zero-based)
+Minutes (zero-based)
+Seconds (zero-based)
+</para>
+</summary>
+</cvar>
 </sconsdoc>

--- a/test/ZIP/ZIP.py
+++ b/test/ZIP/ZIP.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import stat
@@ -32,30 +31,6 @@ import TestSCons
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
-
-try:
-    import zipfile
-except ImportError:
-    x = "Python version has no 'ziplib' module; skipping tests.\n"
-    test.skip_test(x)
-
-def zipfile_contains(zipfilename, names):
-    """Returns True if zipfilename contains all the names, False otherwise."""
-    zf=zipfile.ZipFile(zipfilename, 'r')
-    if type(names)==type(''):
-        names=[names]
-    for name in names:
-        try:
-            info=zf.getinfo(name)
-        except KeyError as e:     # name not found
-            zf.close()
-            return False
-    return True
-
-def zipfile_files(fname):
-    """Returns all the filenames in zip file fname."""
-    zf = zipfile.ZipFile(fname, 'r')
-    return [x.filename for x in zf.infolist()]
 
 test.subdir('sub1')
 
@@ -78,12 +53,12 @@ test.write(['sub1', 'file6'], "sub1/file6\n")
 test.run(arguments = 'aaa.zip', stderr = None)
 
 test.must_exist('aaa.zip')
-test.fail_test(not zipfile_contains('aaa.zip', ['file1', 'file2', 'file3']))
+test.fail_test(not test.zipfile_contains('aaa.zip', ['file1', 'file2', 'file3']))
 
 test.run(arguments = 'bbb.zip', stderr = None)
 
 test.must_exist('bbb.zip')
-test.fail_test(not zipfile_contains('bbb.zip', ['sub1/file5', 'sub1/file6', 'file4']))
+test.fail_test(not test.zipfile_contains('bbb.zip', ['sub1/file5', 'sub1/file6', 'file4']))
 
 ######
 
@@ -136,11 +111,11 @@ test.run(arguments = '.', stderr = None)
 test.must_not_exist(test.workpath('f3.zip'))
 test.must_exist(test.workpath('f3.xyzzy'))
 
-test.fail_test(zipfile_files("f1.zip") != ['file10', 'file11', 'file12'])
+test.fail_test(test.zipfile_files("f1.zip") != ['file10', 'file11', 'file12'])
 
-test.fail_test(zipfile_files("f2.zip") != ['file13', 'file14', 'file15'])
+test.fail_test(test.zipfile_files("f2.zip") != ['file13', 'file14', 'file15'])
 
-test.fail_test(zipfile_files("f3.xyzzy") != ['file16', 'file17', 'file18'])
+test.fail_test(test.zipfile_files("f3.xyzzy") != ['file16', 'file17', 'file18'])
 
 f4_size = os.stat('f4.zip')[stat.ST_SIZE]
 f4stored_size = os.stat('f4stored.zip')[stat.ST_SIZE]

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -12,9 +12,28 @@ from those classes, as well as any overridden or additional methods or
 attributes defined in this subclass.
 """
 
-# __COPYRIGHT__
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import os
 import re
@@ -22,6 +41,7 @@ import shutil
 import sys
 import time
 import subprocess
+import zipfile
 from collections import namedtuple
 
 from TestCommon import *
@@ -1603,6 +1623,16 @@ else:
             return False
         else:
             return True
+
+    def zipfile_contains(self, zipfilename, names):
+        """Returns True if zipfilename contains all the names, False otherwise."""
+        with zipfile.ZipFile(zipfilename, 'r') as zf:
+            return all(elem in zf.namelist() for elem in names)
+
+    def zipfile_files(self, fname):
+        """Returns all the filenames in zip file fname."""
+        with zipfile.ZipFile(fname, 'r') as zf:
+            return zf.namelist()
 
 
 class Stat:


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation

Adds ZIP_OVERRIDE_TIMESTAMP to the Zip builder.  Fixes #3843.