### PR TITLE
UGuide: fix two erroneous uses of Append

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -3560,7 +3560,7 @@ if not conf.CheckCHeader("math.h"):
     Exit(1)
 if conf.CheckLibWithHeader("qt", "qapp.h", "c++", "QApplication qapp(0,0);"):
     # do stuff for qt - usage, e.g.
-    conf.env.Append(CPPFLAGS="-DWITH_QT")
+    conf.env.Append(CPPDEFINES="WITH_QT")
 env = conf.Finish()
 </programlisting>
 

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -1420,8 +1420,8 @@ env.SetDefault(SPECIAL_FLAG='-extra-option')
 
       <scons_example name="environments_ex8">
         <file name="SConstruct" printme="1">
-env = Environment(CCFLAGS = ['-DMY_VALUE'])
-env.Append(CCFLAGS = ['-DLAST'])
+env = Environment(CPPDEFINES=['MY_VALUE'])
+env.Append(CPPDEFINES=['LAST'])
 env.Program('foo.c')
         </file>
         <file name="foo.c">
@@ -1431,7 +1431,9 @@ int main() { }
 
       <para>
 
-      &SCons; then supplies both the <literal>-DMY_VALUE</literal> and
+      &SCons; then adjusts both the &CPPDEFINES; values with the correct
+      prefix/suffix, so that on Linux or POSIX, it will emit the
+      <literal>-DMY_VALUE</literal> and
       <literal>-DLAST</literal> flags when compiling the object file:
 
       </para>
@@ -1520,8 +1522,8 @@ env.AppendUnique(CCFLAGS=['-g'])
 
       <scons_example name="environments_ex9">
         <file name="SConstruct" printme="1">
-env = Environment(CCFLAGS=['-DMY_VALUE'])
-env.Prepend(CCFLAGS=['-DFIRST'])
+env = Environment(CPPDEFINES=['MY_VALUE'])
+env.Prepend(CPPDEFINES=['FIRST'])
 env.Program('foo.c')
         </file>
         <file name="foo.c">
@@ -1531,7 +1533,9 @@ int main() { }
 
       <para>
 
-      &SCons; then supplies both the <literal>-DFIRST</literal> and
+      &SCons; then adjusts both the &CPPDEFINES; values with the correct
+      prefix/suffix, so that on Linux or POSIX, it will emit the
+      <literal>-DFIRST</literal> and
       <literal>-DMY_VALUE</literal> flags when compiling the object file:
 
       </para>

--- a/doc/user/sconf.xml
+++ b/doc/user/sconf.xml
@@ -166,7 +166,7 @@ if not conf.CheckCHeader('math.h'):
     print('Math.h must be installed!')
     Exit(1)
 if conf.CheckCHeader('foo.h'):
-    conf.env.Append('-DHAS_FOO_H')
+    conf.env.Append(CCFLAGS='-DHAS_FOO_H')
 env = conf.Finish()
     </sconstruct>
 
@@ -221,7 +221,7 @@ env = Environment()
 conf = Configure(env)
 if not conf.CheckFunc('strcpy'):
     print('Did not find strcpy(), using local version')
-    conf.env.Append(CPPDEFINES='-Dstrcpy=my_local_strcpy')
+    conf.env.Append(CCFLAGS='-Dstrcpy=my_local_strcpy')
 env = conf.Finish()
     </sconstruct>
 

--- a/doc/user/sconf.xml
+++ b/doc/user/sconf.xml
@@ -166,7 +166,7 @@ if not conf.CheckCHeader('math.h'):
     print('Math.h must be installed!')
     Exit(1)
 if conf.CheckCHeader('foo.h'):
-    conf.env.Append(CCFLAGS='-DHAS_FOO_H')
+    conf.env.Append(CPPDEFINES='HAS_FOO_H')
 env = conf.Finish()
     </sconstruct>
 
@@ -221,7 +221,7 @@ env = Environment()
 conf = Configure(env)
 if not conf.CheckFunc('strcpy'):
     print('Did not find strcpy(), using local version')
-    conf.env.Append(CCFLAGS='-Dstrcpy=my_local_strcpy')
+    conf.env.Append(CPPDEFINES='strcpy=my_local_strcpy')
 env = conf.Finish()
     </sconstruct>
 
@@ -295,7 +295,7 @@ env = Environment()
 conf = Configure(env)
 if not conf.CheckType('off_t'):
     print('Did not find off_t typedef, assuming int')
-    conf.env.Append(CCFLAGS='-Doff_t=int')
+    conf.env.Append(CPPDEFINES='off_t=int')
 env = conf.Finish()
     </sconstruct>
 
@@ -314,7 +314,7 @@ env = Environment()
 conf = Configure(env)
 if not conf.CheckType('off_t', '#include &lt;sys/types.h&gt;\n'):
     print('Did not find off_t typedef, assuming int')
-    conf.env.Append(CCFLAGS='-Doff_t=int')
+    conf.env.Append(CPPDEFINES='off_t=int')
 env = conf.Finish()
     </sconstruct>
 


### PR DESCRIPTION
In the SConf chapter, one use was not as a keyword argument, while the other set a `-DVAR=value` form to append to `CPPDEFINES`, which aren't supposed to be given the prefix - that's the whole reason for `CPPDEFINES`.  Both changed to `CCFLAGS`, to match other usage in the chapter.

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
