### PR TITLE
Fix cachedir race ala pr 3114

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Change SCons's build so the generated `SCons/__init__.py` is no longer removed by `scons -c`
     - Completely rewrote versioned shared libraries logic. Added support for SOVERSION via dmoody's initial PR #3733
     - No longer automatically disable setting SONAME on shared libraries on OpenBSD.
+    - Fix race condition bug when initializing a scons cache directory at the
+      same time from multiple threads or processes. Problem described in PR #3114.
+      This is a simpler fix which should avoid some problems identified with the initial PR.
+      (Credit to Fredrik Medley for reporting the issue, the initial PR, and discussing and testing
+       this solution)
 
   From Michał Górny:
     - Fix dvipdf test failure due to passing incorrect flag to dvipdf.

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -194,7 +194,6 @@ class CacheDir:
                 msg = "Failed to read cache configuration for " + path
                 raise SCons.Errors.SConsEnvironmentError(msg)
 
-
     def CacheDebug(self, fmt, target, cachefile):
         if cache_debug != self.current_cache_debug:
             if cache_debug == '-':

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1995,15 +1995,16 @@ class Base(SubstitutionEnvironment):
         return SCons.Builder.Builder(**nkw)
 
     def CacheDir(self, path):
-        import SCons.CacheDir
         if path is not None:
             path = self.subst(path)
         self._CacheDir_path = path
 
-        # Now initialized the CacheDir and prevent a race condition which can
-        # happen when there's no existing cache dir and you are building with
-        # multiple threads, but initializing it before the task walk starts
-        self.get_CacheDir()
+        if SCons.Action.execute_actions:
+            # Only initialize the CacheDir if  -n/-no_exec was NOT specified.
+            # Now initialized the CacheDir and prevent a race condition which can
+            # happen when there's no existing cache dir and you are building with
+            # multiple threads, but initializing it before the task walk starts
+            self.get_CacheDir()
 
     def Clean(self, targets, files):
         global CleanTargets

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2000,6 +2000,11 @@ class Base(SubstitutionEnvironment):
             path = self.subst(path)
         self._CacheDir_path = path
 
+        # Now initialized the CacheDir and prevent a race condition which can
+        # happen when there's no existing cache dir and you are building with
+        # multiple threads, but initializing it before the task walk starts
+        self.get_CacheDir()
+
     def Clean(self, targets, files):
         global CleanTargets
         tlist = self.arg2nodes(targets, self.fs.Entry)

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -31,7 +31,6 @@ import unittest
 from collections import UserDict as UD, UserList as UL
 
 import TestCmd
-import TestUnit
 
 from SCons.Environment import (
     Environment,
@@ -41,6 +40,7 @@ from SCons.Environment import (
     is_valid_construction_var,
 )
 import SCons.Warnings
+
 
 def diff_env(env1, env2):
     s1 = "env1 = {\n"
@@ -2804,6 +2804,8 @@ def generate(env):
         test_cachedir_config = os.path.join(test_cachedir, 'config')
         test_foo = os.path.join(test.workpath(), 'foo-cachedir')
         test_foo_config = os.path.join(test_foo,'config')
+        test_foo1 = os.path.join(test.workpath(), 'foo1-cachedir')
+        test_foo1_config = os.path.join(test_foo1, 'config')
 
         env = self.TestEnvironment(CD = test_cachedir)
 
@@ -2814,6 +2816,14 @@ def generate(env):
         env.CacheDir('$CD')
         assert env._CacheDir_path == test_cachedir, env._CacheDir_path
         assert os.path.isfile(test_cachedir_config), "No file %s"%test_cachedir_config
+
+        # Now verify that -n/-no_exec wil prevent the CacheDir/config from being created
+        import SCons.Action
+        SCons.Action.execute_actions = False
+        env.CacheDir(test_foo1)
+        assert env._CacheDir_path == test_foo1, env._CacheDir_path
+        assert not os.path.isfile(test_foo1_config), "No file %s"%test_foo1_config
+
 
     def test_Clean(self):
         """Test the Clean() method"""

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -2797,13 +2797,24 @@ def generate(env):
 
     def test_CacheDir(self):
         """Test the CacheDir() method"""
-        env = self.TestEnvironment(CD = 'CacheDir')
 
-        env.CacheDir('foo')
-        assert env._CacheDir_path == 'foo', env._CacheDir_path
+        test = TestCmd.TestCmd(workdir = '')
+        save = os.getcwd()
+
+        test_cachedir = os.path.join(test.workpath(),'CacheDir')
+        test_cachedir_config = os.path.join(test_cachedir, 'config')
+        test_foo = os.path.join(test.workpath(), 'foo-cachedir')
+        test_foo_config = os.path.join(test_foo,'config')
+
+        env = self.TestEnvironment(CD = test_cachedir)
+
+        env.CacheDir(test_foo)
+        assert env._CacheDir_path == test_foo, env._CacheDir_path
+        assert os.path.isfile(test_foo_config), "No file %s"%test_foo_config
 
         env.CacheDir('$CD')
-        assert env._CacheDir_path == 'CacheDir', env._CacheDir_path
+        assert env._CacheDir_path == test_cachedir, env._CacheDir_path
+        assert os.path.isfile(test_cachedir_config), "No file %s"%test_cachedir_config
 
     def test_Clean(self):
         """Test the Clean() method"""

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -2799,7 +2799,6 @@ def generate(env):
         """Test the CacheDir() method"""
 
         test = TestCmd.TestCmd(workdir = '')
-        save = os.getcwd()
 
         test_cachedir = os.path.join(test.workpath(),'CacheDir')
         test_cachedir_config = os.path.join(test_cachedir, 'config')


### PR DESCRIPTION
From #3114 

There is a documented race condition when initializing the cache.
The race condition exists both between processes and threads within one
process, the latter is undocumented but more likely.

This is a (hopefully) full fix for this issue which is implemented by creating the config file in the cachedir when `CacheDir()` is called.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
