### PR TITLE
Initial support in tests for Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
   # allow coverage to fail, so we can still do testing for all platforms
   allow_failures:
     - python: pypy3
+    - python: 3.10-dev
 
   include:
     - &test_job
@@ -49,18 +50,24 @@ jobs:
 
     - <<: *test_job
       python: 3.6
+      dist: xenial
 
-    - <<: *test_job
-      python: 3.7
-      dist: xenial  # required for Python >= 3.7
+    # to keep number of runs down, skip this since tested in 'coverage'
+    #- <<: *test_job
+    #  python: 3.7
+    #  dist: xenial  # required for Python >= 3.7
 
     - <<: *test_job
       python: 3.8
-      dist: bionic  # required for Python >= 3.8
+      dist: bionic
 
     - <<: *test_job
       python: 3.9
-      dist: focal  # required for Python >= 3.8
+      dist: focal
+
+    - <<: *test_job
+      python: 3.10-dev
+      dist: focal
 
     - &coverage_jobs
       dist: bionic

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,9 +8,6 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-  From John Doe:
-    - Whatever John Doe did.
-
   From Mats Wichmann:
     - Initial support in tests for Python 3.10 - expected bytecode and
       one changed expected exception message. Change some more regexes

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,9 +8,13 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
+  From John Doe:
+    - Whatever John Doe did.
 
-        - Whatever John Doe did.
+  From Mats Wichmann:
+    - Initial support in tests for Python 3.10 - expected bytecode and
+      one changed expected exception message. Change some more regexes
+      to be specified as rawstrings in response to DeprecationWarnings.
 
 
 RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -145,7 +145,7 @@ def rfile(n):
 def default_exitstatfunc(s):
     return s
 
-strip_quotes = re.compile('^[\'"](.*)[\'"]$')
+strip_quotes = re.compile(r'^[\'"](.*)[\'"]$')
 
 
 def _callable_contents(obj):

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1516,6 +1516,7 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         meth_matches = [
@@ -1695,6 +1696,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
 
         }
 
@@ -1704,6 +1706,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 7): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 10): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         def factory(act, **kw):
@@ -1949,6 +1952,7 @@ class LazyActionTestCase(unittest.TestCase):
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
+            (3, 10): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
         }
 
         meth_matches = [
@@ -2008,6 +2012,7 @@ class ActionCallerTestCase(unittest.TestCase):
             (3, 7): b'd\x00S\x00',
             (3, 8): b'd\x00S\x00',
             (3, 9): b'd\x00S\x00',
+            (3, 10): b'd\x00S\x00',
 
         }
 
@@ -2209,6 +2214,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 7): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
             (3, 8): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
             (3, 9): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
+            (3, 10): bytearray(b'3, 3, 0, 0,(N.),(),(|\x00S\x00),(),()'),
         }
 
         c = SCons.Action._function_contents(func1)
@@ -2236,6 +2242,8 @@ class ObjectContentsTestCase(unittest.TestCase):
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
             (3, 9): bytearray(
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
+            (3, 10): bytearray(
+                b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"),
         }
 
         assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(
@@ -2254,6 +2262,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 7): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
             (3, 8): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
             (3, 9): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
+            (3, 10): bytearray(b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'),
         }
 
         assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(expected[

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -590,7 +590,9 @@ class scons_subst_TestCase(SubstTestCase):
         except SCons.Errors.UserError as e:
             expect = [
                 # Python 3.5 (and 3.x?)
-                "TypeError `func() missing 2 required positional arguments: 'b' and 'c'' trying to evaluate `${func(1)}'"
+                "TypeError `func() missing 2 required positional arguments: 'b' and 'c'' trying to evaluate `${func(1)}'",
+                # Python 3.10
+                "TypeError `scons_subst_TestCase.test_subst_type_errors.<locals>.func() missing 2 required positional arguments: 'b' and 'c'' trying to evaluate `${func(1)}'",
             ]
             assert str(e) in expect, repr(str(e))
         else:

--- a/SCons/Tool/docbook/__init__.py
+++ b/SCons/Tool/docbook/__init__.py
@@ -62,8 +62,8 @@ except Exception:
 prefer_xsltproc = False
 
 # Regexs for parsing Docbook XML sources of MAN pages
-re_manvolnum = re.compile("<manvolnum>([^<]*)</manvolnum>")
-re_refname = re.compile("<refname>([^<]*)</refname>")
+re_manvolnum = re.compile(r"<manvolnum>([^<]*)</manvolnum>")
+re_refname = re.compile(r"<refname>([^<]*)</refname>")
 
 #
 # Helper functions
@@ -203,8 +203,8 @@ def _detect(env):
 #
 # Scanners
 #
-include_re = re.compile('fileref\\s*=\\s*["|\']([^\\n]*)["|\']')
-sentity_re = re.compile('<!ENTITY\\s+%*\\s*[^\\s]+\\s+SYSTEM\\s+["|\']([^\\n]*)["|\']>')
+include_re = re.compile(r'fileref\\s*=\\s*["|\']([^\\n]*)["|\']')
+sentity_re = re.compile(r'<!ENTITY\\s+%*\\s*[^\\s]+\\s+SYSTEM\\s+["|\']([^\\n]*)["|\']>')
 
 def __xml_scan(node, env, path, arg):
     """ Simple XML file scanner, detecting local images and XIncludes as implicit dependencies. """

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -111,7 +111,7 @@ class Variables:
         return [o.key for o in self.options]
 
     def Add(self, key, help="", default=None, validator=None, converter=None, **kw):
-        """Add an option.
+        r"""Add an option.
 
         Args:
           key: the name of the variable, or a list or tuple of arguments

--- a/test/Interactive/configure.py
+++ b/test/Interactive/configure.py
@@ -53,9 +53,9 @@ import re
 
 # The order of this list is related to the order of the counts below
 expected_patterns = [
-    re.compile("^scons>>> .*foo\.cpp.*$"),
-    re.compile("^scons>>> scons: `foo.obj' is up to date\.$"),
-    re.compile("^scons>>>\s*$"),
+    re.compile(r"^scons>>> .*foo\.cpp.*$"),
+    re.compile(r"^scons>>> scons: `foo.obj' is up to date\.$"),
+    re.compile(r"^scons>>>\s*$"),
 ]
 
 # The order of this list is related to the order of the regular expressions above


### PR DESCRIPTION
Expected bytecode and one changed expected exception message.

Change some more regexes to be specified as rawstrings in response to `DeprecationWarnings`.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
