### PR TITLE
Adding-emitter example for User Guide

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Initial support in tests for Python 3.10 - expected bytecode and
       one changed expected exception message. Change some more regexes
       to be specified as rawstrings in response to DeprecationWarnings.
+    - Add an example of adding an emitter to User Guide (concept
+      from Jeremy Elson)
 
 
 RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -546,10 +546,10 @@ Example:
 </para>
 
 <example_commands>
-print 'before:',env['ENV']['INCLUDE']
+print('before:', env['ENV']['INCLUDE'])
 include_path = '/foo/bar:/foo'
 env.AppendENVPath('INCLUDE', include_path)
-print 'after:',env['ENV']['INCLUDE']
+print('after:', env['ENV']['INCLUDE'])
 
 yields:
 before: /foo:/biz
@@ -2501,10 +2501,10 @@ Example:
 </para>
 
 <example_commands>
-print 'before:',env['ENV']['INCLUDE']
+print('before:', env['ENV']['INCLUDE'])
 include_path = '/foo/bar:/foo'
 env.PrependENVPath('INCLUDE', include_path)
-print 'after:',env['ENV']['INCLUDE']
+print('after:', env['ENV']['INCLUDE'])
 </example_commands>
 
 <para>

--- a/SCons/__init__.py
+++ b/SCons/__init__.py
@@ -1,9 +1,9 @@
-__version__="4.1.0.post1"
+__version__="4.1.1a"
 __copyright__="Copyright (c) 2001 - 2021 The SCons Foundation"
 __developer__="bdbaddog"
-__date__="2021-01-20 04:32:28"
+__date__="2021-02-26 22:38:25"
 __buildsys__="ProDog2020"
-__revision__="dc58c175da659d6c0bb3e049ba56fb42e77546cd"
-__build__="dc58c175da659d6c0bb3e049ba56fb42e77546cd"
+__revision__="3fa309f8fc5472fa067d7c04481fd0a5d3e86352"
+__build__="3fa309f8fc5472fa067d7c04481fd0a5d3e86352"
 # make sure compatibility is always in place
 import SCons.compat # noqa

--- a/doc/generated/examples/builders_adding_emitter_1.xml
+++ b/doc/generated/examples/builders_adding_emitter_1.xml
@@ -1,0 +1,13 @@
+<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q --tree=prune</userinput>
+cc -o hello.o -c hello.c
+cc -o hello -Wl,-Map=hello.map,--cref hello.o
++-.
+  +-SConstruct
+  +-hello
+  | +-hello.o
+  |   +-hello.c
+  +-hello.c
+  +-hello.map
+  | +-[hello.o]
+  +-[hello.o]
+</screen>

--- a/doc/generated/examples/builderswriting_ex2_1.xml
+++ b/doc/generated/examples/builderswriting_ex2_1.xml
@@ -1,5 +1,5 @@
 <screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
 AttributeError: 'SConsEnvironment' object has no attribute 'Program':
-  File "/home/my/project/SConstruct", line 4:
+  File "/home/my/project/SConstruct", line 7:
     env.Program('hello.c')
 </screen>

--- a/doc/generated/examples/caching_ex-random_1.xml
+++ b/doc/generated/examples/caching_ex-random_1.xml
@@ -1,8 +1,8 @@
 <screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
-cc -o f3.o -c f3.c
-cc -o f1.o -c f1.c
-cc -o f2.o -c f2.c
-cc -o f5.o -c f5.c
 cc -o f4.o -c f4.c
+cc -o f5.o -c f5.c
+cc -o f3.o -c f3.c
+cc -o f2.o -c f2.c
+cc -o f1.o -c f1.c
 cc -o prog f1.o f2.o f3.o f4.o f5.o
 </screen>

--- a/doc/generated/examples/sourcecode_bitkeeper_1.xml
+++ b/doc/generated/examples/sourcecode_bitkeeper_1.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
-AttributeError: 'SConsEnvironment' object has no attribute 'BitKeeper':
-  File "/home/my/project/SConstruct", line 2:
-    env.SourceCode('.', env.BitKeeper())
-</screen>

--- a/doc/generated/examples/sourcecode_cvs_1.xml
+++ b/doc/generated/examples/sourcecode_cvs_1.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
-AttributeError: 'SConsEnvironment' object has no attribute 'CVS':
-  File "/home/my/project/SConstruct", line 2:
-    env.SourceCode('.', env.CVS('/usr/local/CVS'))
-</screen>

--- a/doc/generated/examples/sourcecode_rcs_1.xml
+++ b/doc/generated/examples/sourcecode_rcs_1.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
-AttributeError: 'SConsEnvironment' object has no attribute 'RCS':
-  File "/home/my/project/SConstruct", line 2:
-    env.SourceCode('.', env.RCS())
-</screen>

--- a/doc/generated/examples/sourcecode_sccs_1.xml
+++ b/doc/generated/examples/sourcecode_sccs_1.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
-AttributeError: 'SConsEnvironment' object has no attribute 'SCCS':
-  File "/home/my/project/SConstruct", line 2:
-    env.SourceCode('.', env.SCCS())
-</screen>

--- a/doc/generated/examples/troubleshoot_explain1_3.xml
+++ b/doc/generated/examples/troubleshoot_explain1_3.xml
@@ -2,5 +2,5 @@
 cp file.in file.oout
 
 scons: warning: Cannot find target file.out after building
-File "/Users/bdbaddog/devel/scons/git/as_scons/scripts/scons.py", line 96, in &lt;module&gt;
+File "/Users/bdbaddog/devel/scons/git/scons-bugfixes-3/scripts/scons.py", line 96, in &lt;module&gt;
 </screen>

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -481,10 +481,10 @@ Example:
 </para>
 
 <example_commands>
-print 'before:',env['ENV']['INCLUDE']
+print('before:', env['ENV']['INCLUDE'])
 include_path = '/foo/bar:/foo'
 env.AppendENVPath('INCLUDE', include_path)
-print 'after:',env['ENV']['INCLUDE']
+print('after:', env['ENV']['INCLUDE'])
 
 yields:
 before: /foo:/biz
@@ -2973,10 +2973,10 @@ Example:
 </para>
 
 <example_commands>
-print 'before:',env['ENV']['INCLUDE']
+print('before:', env['ENV']['INCLUDE'])
 include_path = '/foo/bar:/foo'
 env.PrependENVPath('INCLUDE', include_path)
-print 'after:',env['ENV']['INCLUDE']
+print('after:', env['ENV']['INCLUDE'])
 </example_commands>
 
 <para>

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -1615,7 +1615,7 @@ Note that, by default,
 &scons;
 does
 <emphasis>not</emphasis>
-propagate the environment in force when you
+propagate the environment in effect when you
 execute
 &scons;
 to the commands used to build target files.

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1522,7 +1522,7 @@ any out-of-date target files, but do not execute the commands.</para>
   <term><option>--no-site-dir</option></term>
   <listitem>
 <para>Prevents the automatic addition of the standard
-<emphasis>site_scons</emphasis>
+<filename>site_scons</filename>
 dirs to
 <varname>sys.path</varname>.
 Also prevents loading the
@@ -1656,7 +1656,7 @@ Also suppresses SCons status messages.</para>
   <listitem>
 <para>Uses the named <replaceable>dir</replaceable> as the site directory
 rather than the default
-<emphasis>site_scons</emphasis>
+<filename>site_scons</filename>
 directories.  This directory will be prepended to
 <varname>sys.path</varname>,
 the module
@@ -1666,7 +1666,7 @@ will be loaded if it exists, and
 will be added to the default toolpath.</para>
 
 <para>The default set of
-<emphasis>site_scons</emphasis>
+<filename>site_scons</filename>
 directories used when
 <option>--site-dir</option>
 is not specified depends on the system platform, as follows.

--- a/doc/user/builders-writing.xml
+++ b/doc/user/builders-writing.xml
@@ -45,78 +45,6 @@
 
 -->
 
-<!--
-
-=head2 Adding new methods
-
-For slightly more demanding changes, you may wish to add new methods to the
-C<cons> package. Here's an example of a very simple extension,
-C<InstallScript>, which installs a tcl script in a requested location, but
-edits the script first to reflect a platform-dependent path that needs to be
-installed in the script:
-
-  # cons::InstallScript - Create a platform dependent version of a shell
-  # script by replacing string ``#!your-path-here'' with platform specific
-  # path $BIN_DIR.
-
-  sub cons::InstallScript {
-	my ($env, $dst, $src) = @_;
-	Command $env $dst, $src, qq(
-		sed s+your-path-here+$BIN_DIR+ %< > %>
-		chmod oug+x %>
-	);
-  }
-
-Notice that this method is defined directly in the C<cons> package (by
-prefixing the name with C<cons::>). A change made in this manner will be
-globally visible to all environments, and could be called as in the
-following example:
-
-  InstallScript $env "$BIN/foo", "foo.tcl";
-
-For a small improvement in generality, the C<BINDIR> variable could be
-passed in as an argument or taken from the construction environment-,-as
-C<%BINDIR>.
-
-
-=head2 Overriding methods
-
-Instead of adding the method to the C<cons> name space, you could define a
-new package which inherits existing methods from the C<cons> package and
-overrides or adds others. This can be done using Perl's inheritance
-mechanisms.
-
-The following example defines a new package C<cons::switch> which
-overrides the standard C<Library> method. The overridden method builds
-linked library modules, rather than library archives. A new
-constructor is provided. Environments created with this constructor
-will have the new library method; others won't.
-
-  package cons::switch;
-  BEGIN {@ISA = 'cons'}
-
-  sub new {
-	shift;
-	bless new cons(@_);
-  }
-
-  sub Library {
-	my($env) = shift;
-	my($lib) = shift;
-	my(@objs) = Objects $env @_;
-	Command $env $lib, @objs, q(
-		%LD -r %LDFLAGS %< -o %>
-	);
-  }
-
-This functionality could be invoked as in the following example:
-
-  $env = new cons::switch(@overrides);
-  ...
-  Library $env 'lib.o', 'foo.c', 'bar.c';
-
--->
-
   <para>
 
   Although &SCons; provides many useful methods
@@ -188,9 +116,8 @@ bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
     <scons_example name="builderswriting_ex1">
        <file name="SConstruct">
 bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
-env = Environment(BUILDERS = {'Foo' : bld})
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+env = Environment(BUILDERS={'Foo': bld})
+env.AppendENVPath('PATH', os.getcwd())
 env.Foo('file.foo', 'file.input')
        </file>
        <file name="file.input">
@@ -203,7 +130,7 @@ cat
 
     <sconstruct>
 bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
-env = Environment(BUILDERS = {'Foo' : bld})
+env = Environment(BUILDERS={'Foo': bld})
     </sconstruct>
 
     <para>
@@ -261,14 +188,17 @@ env.Foo('file.foo', 'file.input')
    -->
     <scons_example name="builderswriting_ex2">
        <file name="SConstruct">
-import SCons.Defaults; SCons.Defaults.ConstructionEnvironment['TOOLS'] = {}; bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
-env = Environment(BUILDERS = {'Foo' : bld})
+import SCons.Defaults
+
+SCons.Defaults.ConstructionEnvironment['TOOLS'] = {}
+bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
+env = Environment(BUILDERS={'Foo': bld})
 env.Foo('file.foo', 'file.input')
 env.Program('hello.c')
        </file>
        <file name="SConstruct.printme" printme="1">
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
-env = Environment(BUILDERS = {'Foo' : bld})
+bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
+env = Environment(BUILDERS={'Foo': bld})
 env.Foo('file.foo', 'file.input')
 env.Program('hello.c')
        </file>
@@ -296,10 +226,9 @@ hello.c
     <scons_example name="builderswriting_ex3">
        <file name="SConstruct">
 env = Environment()
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
-env.Append(BUILDERS = {'Foo' : bld})
+env.AppendENVPath('PATH', os.getcwd())
+bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
+env.Append(BUILDERS={'Foo': bld})
 env.Foo('file.foo', 'file.input')
 env.Program('hello.c')
        </file>
@@ -316,8 +245,8 @@ cat
 
     <sconstruct>
 env = Environment()
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
-env.Append(BUILDERS = {'Foo' : bld})
+bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
+env.Append(BUILDERS={'Foo': bld})
 env.Foo('file.foo', 'file.input')
 env.Program('hello.c')
     </sconstruct>
@@ -331,7 +260,7 @@ env.Program('hello.c')
 
     <sconstruct>
 env = Environment()
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
+bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
 env['BUILDERS']['Foo'] = bld
 env.Foo('file.foo', 'file.input')
 env.Program('hello.c')
@@ -374,12 +303,13 @@ env.Program('hello.c')
 
     <scons_example name="builderswriting_ex4">
        <file name="SConstruct">
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET',
-              suffix = '.foo',
-              src_suffix = '.input')
-env = Environment(BUILDERS = {'Foo' : bld})
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+bld = Builder(
+    action='foobuild &lt; $SOURCE &gt; $TARGET',
+    suffix='.foo',
+    src_suffix='.input',
+)
+env = Environment(BUILDERS={'Foo': bld})
+env.AppendENVPath('PATH', os.getcwd())
 env.Foo('file1')
 env.Foo('file2')
        </file>
@@ -395,10 +325,12 @@ cat
     </scons_example>
 
     <sconstruct>
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET',
-              suffix = '.foo',
-              src_suffix = '.input')
-env = Environment(BUILDERS = {'Foo' : bld})
+bld = Builder(
+    action='foobuild &lt; $SOURCE &gt; $TARGET',
+    suffix='.foo',
+    src_suffix='.input',
+)
+env = Environment(BUILDERS={'Foo': bld})
 env.Foo('file1')
 env.Foo('file2')
     </sconstruct>
@@ -525,10 +457,13 @@ def build_function(target, source, env):
 def build_function(target, source, env):
     # Code to build "target" from "source"
     return None
-bld = Builder(action = build_function,
-              suffix = '.foo',
-              src_suffix = '.input')
-env = Environment(BUILDERS = {'Foo' : bld})
+
+bld = Builder(
+    action=build_function,
+    suffix='.foo',
+    src_suffix='.input',
+)
+env = Environment(BUILDERS={'Foo': bld})
 env.Foo('file')
        </file>
        <file name="file.input">
@@ -673,12 +608,14 @@ def generate_actions(source, target, env, for_signature):
        <file name="SConstruct">
 def generate_actions(source, target, env, for_signature):
     return 'foobuild &lt; %s &gt; %s' % (source[0], target[0])
-bld = Builder(generator = generate_actions,
-              suffix = '.foo',
-              src_suffix = '.input')
-env = Environment(BUILDERS = {'Foo' : bld})
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+
+bld = Builder(
+    generator=generate_actions,
+    suffix='.foo',
+    src_suffix='.input',
+)
+env = Environment(BUILDERS={'Foo': bld})
+env.AppendENVPath('PATH', os.getcwd())
 env.Foo('file')
        </file>
        <file name="file.input">
@@ -692,10 +629,13 @@ cat
     <sconstruct>
 def generate_actions(source, target, env, for_signature):
     return 'foobuild &lt; %s &gt; %s' % (source[0], target[0])
-bld = Builder(generator = generate_actions,
-              suffix = '.foo',
-              src_suffix = '.input')
-env = Environment(BUILDERS = {'Foo' : bld})
+
+bld = Builder(
+    generator=generate_actions,
+    suffix='.foo',
+    src_suffix='.input',
+)
+env = Environment(BUILDERS={'Foo': bld})
 env.Foo('file')
     </sconstruct>
 
@@ -736,7 +676,7 @@ env.Foo('file')
     <para>
 
     For example, suppose you want to define a Builder
-    that always calls a <filename>foobuild</filename> program,
+    that always calls a <command>foobuild</command> program,
     and you want to automatically add
     a new target file named
     <filename>new_target</filename>
@@ -753,13 +693,15 @@ def modify_targets(target, source, env):
     target.append('new_target')
     source.append('new_source')
     return target, source
-bld = Builder(action = 'foobuild $TARGETS - $SOURCES',
-              suffix = '.foo',
-              src_suffix = '.input',
-              emitter = modify_targets)
-env = Environment(BUILDERS = {'Foo' : bld})
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+
+bld = Builder(
+    action='foobuild $TARGETS - $SOURCES',
+    suffix='.foo',
+    src_suffix='.input',
+    emitter=modify_targets,
+)
+env = Environment(BUILDERS={'Foo': bld})
+env.AppendENVPath('PATH', os.getcwd())
 env.Foo('file')
        </file>
        <file name="file.input">
@@ -778,11 +720,14 @@ def modify_targets(target, source, env):
     target.append('new_target')
     source.append('new_source')
     return target, source
-bld = Builder(action = 'foobuild $TARGETS - $SOURCES',
-              suffix = '.foo',
-              src_suffix = '.input',
-              emitter = modify_targets)
-env = Environment(BUILDERS = {'Foo' : bld})
+
+bld = Builder(
+    action='foobuild $TARGETS - $SOURCES',
+    suffix='.foo',
+    src_suffix='.input',
+    emitter=modify_targets,
+)
+env = Environment(BUILDERS={'Foo': bld})
 env.Foo('file')
     </sconstruct>
 
@@ -805,7 +750,7 @@ env.Foo('file')
     To do this, specify a string
     containing a construction variable
     expansion as the emitter when you call
-    the &Builder; function,
+    the &f-link-Builder; function,
     and set that construction variable to
     the desired emitter function
     in different construction environments:
@@ -815,18 +760,21 @@ env.Foo('file')
     <scons_example name="builderswriting_MY_EMITTER">
 
       <file name="SConstruct" printme="1">
-bld = Builder(action = './my_command $SOURCES &gt; $TARGET',
-              suffix = '.foo',
-              src_suffix = '.input',
-              emitter = '$MY_EMITTER')
+bld = Builder(
+    action='./my_command $SOURCES &gt; $TARGET',
+    suffix='.foo',
+    src_suffix='.input',
+    emitter='$MY_EMITTER',
+)
+
 def modify1(target, source, env):
     return target, source + ['modify1.in']
+
 def modify2(target, source, env):
     return target, source + ['modify2.in']
-env1 = Environment(BUILDERS = {'Foo' : bld},
-                   MY_EMITTER = modify1)
-env2 = Environment(BUILDERS = {'Foo' : bld},
-                   MY_EMITTER = modify2)
+
+env1 = Environment(BUILDERS={'Foo': bld}, MY_EMITTER=modify1)
+env2 = Environment(BUILDERS={'Foo': bld}, MY_EMITTER=modify2)
 env1.Foo('file1')
 env2.Foo('file2')
         </file>
@@ -863,7 +811,92 @@ cat
 
   </section>
 
-  <!--
+  <section>
+  <title>Modifying a Builder by adding an Emitter</title>
+
+    <para>
+
+    Defining an emitter to work with a custom Builder
+    is a powerful concept, but sometimes all you really want
+    is to be able to use an existing builder but change its
+    concept of what targets are created.
+    In this case, 
+    trying to recreate the logic of an existing Builder to
+    supply a special emitter can be a lot of work. 
+    The typical case for this is when you want to use a compiler flag
+    that causes additional files to be generated.
+    For example the GNU linker accepts an option
+    <option>-Map</option> which outputs a link map
+    to the file specified by the option's argument.
+    If this option is just supplied to the build,
+    &SCons; will not consider the link map file a tracked target,
+    which has various undesirable efffects.
+
+    </para>
+
+    <para>
+
+    To help with this, &SCons; provides &consvars; which correspond
+    to a few standard builders: 
+    &cv-link-PROGEMITTER; for &b-link-Program;; 
+    &cv-link-LIBEMITTER; for &b-link-Library;; 
+    &cv-link-SHLIBEMITTER; for &b-link-SharedLibrary; and 
+    &cv-link-LDMODULEEMITTER; for &b-link-LoadableModule;;.
+    Adding an emitter to one of these will cause it to be 
+    invoked in addition to any existing emitter for the
+    corresponding builder.
+
+    </para>
+
+    <para>
+
+    This example adds map creation as a linker flag,
+    and modifies the standard &b-link-Program;
+    emitter to know that map generation is a side-effect:
+
+    </para>
+
+    <scons_example name="builders_adding_emitter">
+
+      <file name="SConstruct" printme="1">
+def map_emitter(target, source, env):
+    target.append(map_filename)
+    return target, source
+
+env = Environment()
+map_filename = "${TARGET.name}" + ".map"
+env.Append(LINKFLAGS="-Wl,-Map={},--cref".format(map_filename))
+env.Append(PROGEMITTER=map_emitter)
+env.Program('hello.c')
+      </file>
+      <file name="hello.c">
+#include &lt;stdio.h&gt;
+
+int
+main()
+{
+    printf("Hello, world!\n");
+}
+      </file>
+    </scons_example>
+
+    <para>
+
+    If you run this example, adding an option to tell &SCons; to
+    dump some information about the dependencies it knows,
+    it shows the map file option in use, and that &SCons; indeed
+    knows about the map file,
+    it's not just a silent side effect of the compiler:
+
+    </para>
+
+    <scons_output example="builders_adding_emitter" suffix="1">
+      <scons_output_command>scons -Q --tree=prune</scons_output_command>
+    </scons_output>
+
+  </section>
+
+  <!-- Placeholder for describing other keyword args to Builder
 
   <section>
   <title>target_factor=, source_factory=</title>
@@ -916,8 +949,8 @@ cat
     <para>
 
     Each system type (Windows, Mac, Linux, etc.) searches a canonical
-    set of directories for site_scons; see the man page for details.
-    The top-level SConstruct's site_scons dir is always searched last,
+    set of directories for <filename>site_scons</filename>; see the man page for details.
+    The top-level SConstruct's <filename>site_scons</filename> dir is always searched last,
     and its dir is placed first in the tool path so it overrides all
     others.
 
@@ -946,11 +979,12 @@ cat
     <scons_example name="builderswriting_site1">
       <file name="site_scons/site_init.py" printme="1">
 def TOOL_ADD_HEADER(env):
-   """A Tool to add a header from $HEADER to the source file"""
-   add_header = Builder(action=['echo "$HEADER" &gt; $TARGET',
-                                'cat $SOURCE &gt;&gt; $TARGET'])
-   env.Append(BUILDERS = {'AddHeader' : add_header})
-   env['HEADER'] = '' # set default value
+    """A Tool to add a header from $HEADER to the source file"""
+    add_header = Builder(
+        action=['echo "$HEADER" &gt; $TARGET', 'cat $SOURCE &gt;&gt; $TARGET']
+    )
+    env.Append(BUILDERS={'AddHeader': add_header})
+    env['HEADER'] = ''  # set default value
       </file>
       <file name="SConstruct">
 env=Environment(tools=['default', TOOL_ADD_HEADER], HEADER="=====")
@@ -1019,13 +1053,15 @@ env.AddHeader('tgt', 'src')
       
     <scons_example name="builderswriting_site2">
       <file name="site_scons/my_utils.py" printme="1">
-from SCons.Script import *   # for Execute and Mkdir
+from SCons.Script import *  # for Execute and Mkdir
+
 def build_id():
-   """Return a build ID (stub version)"""
-   return "100"
+    """Return a build ID (stub version)"""
+    return "100"
+
 def MakeWorkDir(workdir):
-   """Create the specified dir immediately"""
-   Execute(Mkdir(workdir))
+    """Create the specified dir immediately"""
+    Execute(Mkdir(workdir))
       </file>
       <file name="SConscript">
 import my_utils
@@ -1070,11 +1106,11 @@ from SCons.Script import *
       You can use any of the user- or machine-wide site dirs such as
       <filename>~/.scons/site_scons</filename> instead of
       <filename>./site_scons</filename>, or use the
-      <literal>--site-dir</literal> option to point to your own dir.
+      <option>--site-dir</option> option to point to your own dir.
       <filename>site_init.py</filename> and
       <filename>site_tools</filename> will be located under that dir.
       To avoid using a <filename>site_scons</filename> dir at all,
-      even if it exists, use the <literal>--no-site-dir</literal>
+      even if it exists, use the <option>--no-site-dir</option>
       option.
 
     </para>

--- a/doc/user/builders-writing.xml
+++ b/doc/user/builders-writing.xml
@@ -864,12 +864,13 @@ cat
     <scons_example name="builders_adding_emitter">
 
       <file name="SConstruct" printme="1">
+env = Environment()
+map_filename = "${TARGET.name}.map"
+
 def map_emitter(target, source, env):
     target.append(map_filename)
     return target, source
 
-env = Environment()
-map_filename = "${TARGET.name}" + ".map"
 env.Append(LINKFLAGS="-Wl,-Map={},--cref".format(map_filename))
 env.Append(PROGEMITTER=map_emitter)
 env.Program('hello.c')

--- a/doc/user/builders-writing.xml
+++ b/doc/user/builders-writing.xml
@@ -115,7 +115,8 @@ bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
 
     <scons_example name="builderswriting_ex1">
        <file name="SConstruct">
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
+import os
+bld=Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
 env = Environment(BUILDERS={'Foo': bld})
 env.AppendENVPath('PATH', os.getcwd())
 env.Foo('file.foo', 'file.input')
@@ -129,7 +130,7 @@ cat
     </scons_example>
 
     <sconstruct>
-bld = Builder(action = 'foobuild &lt; $SOURCE &gt; $TARGET')
+bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
 env = Environment(BUILDERS={'Foo': bld})
     </sconstruct>
 
@@ -225,6 +226,7 @@ hello.c
 
     <scons_example name="builderswriting_ex3">
        <file name="SConstruct">
+import os
 env = Environment()
 env.AppendENVPath('PATH', os.getcwd())
 bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
@@ -303,6 +305,7 @@ env.Program('hello.c')
 
     <scons_example name="builderswriting_ex4">
        <file name="SConstruct">
+import os
 bld = Builder(
     action='foobuild &lt; $SOURCE &gt; $TARGET',
     suffix='.foo',
@@ -606,6 +609,7 @@ def generate_actions(source, target, env, for_signature):
 
     <scons_example name="builderswriting_ex6">
        <file name="SConstruct">
+import os
 def generate_actions(source, target, env, for_signature):
     return 'foobuild &lt; %s &gt; %s' % (source[0], target[0])
 
@@ -689,6 +693,7 @@ env.Foo('file')
 
     <scons_example name="builderswriting_ex7">
        <file name="SConstruct">
+import os
 def modify_targets(target, source, env):
     target.append('new_target')
     source.append('new_source')

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -1010,8 +1010,8 @@ DefaultEnvironment(CC='/usr/local/bin/gcc')
       </para>
 
       <sconstruct>
-denv = DefaultEnvironment()
-denv['CC'] = '/usr/local/bin/gcc'
+def_env = DefaultEnvironment()
+def_env['CC'] = '/usr/local/bin/gcc'
       </sconstruct>
 
       <para>
@@ -1037,7 +1037,7 @@ denv['CC'] = '/usr/local/bin/gcc'
       </para>
 
       <sconstruct>
-denv = DefaultEnvironment(tools=['gcc', 'gnulink'], CC='/usr/local/bin/gcc')
+def_env = DefaultEnvironment(tools=['gcc', 'gnulink'], CC='/usr/local/bin/gcc')
       </sconstruct>
 
       <para>

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -1010,8 +1010,8 @@ DefaultEnvironment(CC='/usr/local/bin/gcc')
       </para>
 
       <sconstruct>
-env = DefaultEnvironment()
-env['CC'] = '/usr/local/bin/gcc'
+denv = DefaultEnvironment()
+denv['CC'] = '/usr/local/bin/gcc'
       </sconstruct>
 
       <para>
@@ -1037,8 +1037,7 @@ env['CC'] = '/usr/local/bin/gcc'
       </para>
 
       <sconstruct>
-env = DefaultEnvironment(tools=['gcc', 'gnulink'],
-                         CC='/usr/local/bin/gcc')
+denv = DefaultEnvironment(tools=['gcc', 'gnulink'], CC='/usr/local/bin/gcc')
       </sconstruct>
 
       <para>

--- a/doc/user/factories.xml
+++ b/doc/user/factories.xml
@@ -150,7 +150,7 @@ Command("file.out", [], Copy("$TARGET", "file.in"))
 Command(
     "file.out",
     "file.in",
-    [
+    action=[
         Copy("tempfile", "$SOURCE"),
         "modify tempfile",
         Copy("$TARGET", "tempfile"),
@@ -159,8 +159,8 @@ Command(
       </file>
       <file name="SConstruct">
 import os
-env = DefaultEnvironment()
-env.AppendENVPath('PATH', os.getcwd())
+denv = DefaultEnvironment()
+denv.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -222,7 +222,7 @@ Command("LinkIn", "FileOrDirectoryOut", Copy("$TARGET", "$SOURCE", False))
 Command(
     "file.out",
     "file.in",
-    [
+    action=[
         Delete("tempfile"),
         Copy("tempfile", "$SOURCE"),
         "modify tempfile",
@@ -232,8 +232,8 @@ Command(
       </file>
       <file name="SConstruct">
 import os
-env = DefaultEnvironment()
-env.AppendENVPath('PATH', os.getcwd())
+denv = DefaultEnvironment()
+denv.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -266,7 +266,7 @@ touch $*
 Command(
     "file.out",
     "file.in",
-    [
+    action=[
         Delete("$TARGET"),
         Copy("$TARGET", "$SOURCE"),
     ],
@@ -323,7 +323,7 @@ Command(
 Command(
     "file.out",
     "file.in",
-    [
+    action=[
         Copy("tempfile", "$SOURCE"),
         "modify tempfile",
         Move("$TARGET", "tempfile"),
@@ -332,8 +332,8 @@ Command(
       </file>
       <file name="SConstruct">
 import os
-env = DefaultEnvironment()
-env.AppendENVPath('PATH', os.getcwd())
+denv = DefaultEnvironment()
+denv.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -370,7 +370,7 @@ touch $*
 Command(
     "file.out",
     "file.in",
-    [
+    action=[
         Copy("$TARGET", "$SOURCE"),
         Touch("$TARGET"),
     ]
@@ -378,8 +378,8 @@ Command(
       </file>
       <file name="SConstruct">
 import os
-env = DefaultEnvironment()
-env.AppendENVPath('PATH', os.getcwd())
+denv = DefaultEnvironment()
+denv.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -417,7 +417,7 @@ SConscript('S')
 Command(
     "file.out",
     "file.in",
-    [
+    action=[
         Delete("tempdir"),
         Mkdir("tempdir"),
         Copy("tempdir/${SOURCE.file}", "$SOURCE"),
@@ -429,8 +429,8 @@ Command(
       </file>
       <file name="SConstruct">
 import os
-env = DefaultEnvironment()
-env.AppendENVPath('PATH', os.getcwd())
+denv = DefaultEnvironment()
+denv.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -470,7 +470,7 @@ touch $*
 Command(
     "file.out",
     "file.in",
-    [
+    action=[
         Copy("$TARGET", "$SOURCE"),
         Chmod("$TARGET", 0o755),
     ]

--- a/doc/user/factories.xml
+++ b/doc/user/factories.xml
@@ -147,17 +147,19 @@ Command("file.out", [], Copy("$TARGET", "file.in"))
 
     <scons_example name="factories_Copy3">
       <file name="S" printme="1">
-Command("file.out", "file.in",
-        [
-          Copy("tempfile", "$SOURCE"),
-          "modify tempfile",
-          Copy("$TARGET", "tempfile"),
-        ])
+Command(
+    "file.out",
+    "file.in",
+    [
+        Copy("tempfile", "$SOURCE"),
+        "modify tempfile",
+        Copy("$TARGET", "tempfile"),
+    ],
+)
       </file>
       <file name="SConstruct">
 env = DefaultEnvironment()
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -216,18 +218,20 @@ Command("LinkIn", "FileOrDirectoryOut", Copy("$TARGET", "$SOURCE", False))
 
     <scons_example name="factories_Delete1">
       <file name="S" printme="1">
-Command("file.out", "file.in",
-        [
-          Delete("tempfile"),
-          Copy("tempfile", "$SOURCE"),
-          "modify tempfile",
-          Copy("$TARGET", "tempfile"),
-        ])
+Command(
+    "file.out",
+    "file.in",
+    [
+        Delete("tempfile"),
+        Copy("tempfile", "$SOURCE"),
+        "modify tempfile",
+        Copy("$TARGET", "tempfile"),
+    ],
+)
       </file>
       <file name="SConstruct">
 env = DefaultEnvironment()
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -257,11 +261,14 @@ touch $*
 
     <scons_example name="factories_Delete2">
       <file name="SConstruct" printme="1">
-Command("file.out", "file.in",
-        [
-          Delete("$TARGET"),
-          Copy("$TARGET", "$SOURCE")
-        ])
+Command(
+    "file.out",
+    "file.in",
+    [
+        Delete("$TARGET"),
+        Copy("$TARGET", "$SOURCE"),
+    ],
+)
       </file>
       <file name="file.in">file.in</file>
     </scons_example>
@@ -311,17 +318,19 @@ Command("file.out", "file.in",
 
     <scons_example name="factories_Move">
       <file name="S" printme="1">
-Command("file.out", "file.in",
-        [
-          Copy("tempfile", "$SOURCE"),
-          "modify tempfile",
-          Move("$TARGET", "tempfile"),
-        ])
+Command(
+    "file.out",
+    "file.in",
+    [
+        Copy("tempfile", "$SOURCE"),
+        "modify tempfile",
+        Move("$TARGET", "tempfile"),
+    ],
+)
       </file>
       <file name="SConstruct">
 env = DefaultEnvironment()
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -355,16 +364,18 @@ touch $*
 
     <scons_example name="factories_Touch">
       <file name="S" printme="1">
-Command("file.out", "file.in",
-        [
-          Copy("$TARGET", "$SOURCE"),
-          Touch("$TARGET"),
-        ])
+Command(
+    "file.out",
+    "file.in",
+    [
+        Copy("$TARGET", "$SOURCE"),
+        Touch("$TARGET"),
+    ]
+)
       </file>
       <file name="SConstruct">
 env = DefaultEnvironment()
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -399,20 +410,22 @@ SConscript('S')
 
     <scons_example name="factories_Mkdir">
       <file name="S" printme="1">
-Command("file.out", "file.in",
-        [
-          Delete("tempdir"),
-          Mkdir("tempdir"),
-          Copy("tempdir/${SOURCE.file}", "$SOURCE"),
-          "process tempdir",
-          Move("$TARGET", "tempdir/output_file"),
-          Delete("tempdir"),
-        ])
+Command(
+    "file.out",
+    "file.in",
+    [
+        Delete("tempdir"),
+        Mkdir("tempdir"),
+        Copy("tempdir/${SOURCE.file}", "$SOURCE"),
+        "process tempdir",
+        Move("$TARGET", "tempdir/output_file"),
+        Delete("tempdir"),
+    ],
+)
       </file>
       <file name="SConstruct">
 env = DefaultEnvironment()
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -449,11 +462,14 @@ touch $*
 
     <scons_example name="factories_Chmod">
       <file name="SConstruct" printme="1">
-Command("file.out", "file.in",
-        [
-          Copy("$TARGET", "$SOURCE"),
-          Chmod("$TARGET", 0o755),
-        ])
+Command(
+    "file.out",
+    "file.in",
+    [
+        Copy("$TARGET", "$SOURCE"),
+        Chmod("$TARGET", 0o755),
+    ]
+)
       </file>
       <file name="file.in">file.in</file>
     </scons_example>

--- a/doc/user/factories.xml
+++ b/doc/user/factories.xml
@@ -157,10 +157,10 @@ Command(
     ],
 )
       </file>
+      <!-- this is a non-displayed script that fiddles PATH to allow dummy "modify" command to work -->
       <file name="SConstruct">
-import os
-denv = DefaultEnvironment()
-denv.AppendENVPath('PATH', os.getcwd())
+def_env = DefaultEnvironment()
+def_env.AppendENVPath('PATH', Dir('.'))
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -230,10 +230,10 @@ Command(
     ],
 )
       </file>
+      <!-- this is a non-displayed script that fiddles PATH to allow dummy "modify" command to work -->
       <file name="SConstruct">
-import os
-denv = DefaultEnvironment()
-denv.AppendENVPath('PATH', os.getcwd())
+def_env = DefaultEnvironment()
+def_env.AppendENVPath('PATH', Dir('.'))
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -330,10 +330,10 @@ Command(
     ],
 )
       </file>
+      <!-- this is a non-displayed script that fiddles PATH to allow dummy "modify" command to work -->
       <file name="SConstruct">
-import os
-denv = DefaultEnvironment()
-denv.AppendENVPath('PATH', os.getcwd())
+def_env = DefaultEnvironment()
+def_env.AppendENVPath('PATH', Dir('.'))
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -377,9 +377,6 @@ Command(
 )
       </file>
       <file name="SConstruct">
-import os
-denv = DefaultEnvironment()
-denv.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>
@@ -427,10 +424,10 @@ Command(
     ],
 )
       </file>
+      <!-- this is a non-displayed script that fiddles PATH to allow dummy "process" command to work -->
       <file name="SConstruct">
-import os
-denv = DefaultEnvironment()
-denv.AppendENVPath('PATH', os.getcwd())
+def_env = DefaultEnvironment()
+def_env.AppendENVPath('PATH', Dir('.'))
 SConscript('S')
       </file>
       <file name="file.in">file.in</file>

--- a/doc/user/factories.xml
+++ b/doc/user/factories.xml
@@ -158,6 +158,7 @@ Command(
 )
       </file>
       <file name="SConstruct">
+import os
 env = DefaultEnvironment()
 env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
@@ -230,6 +231,7 @@ Command(
 )
       </file>
       <file name="SConstruct">
+import os
 env = DefaultEnvironment()
 env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
@@ -329,6 +331,7 @@ Command(
 )
       </file>
       <file name="SConstruct">
+import os
 env = DefaultEnvironment()
 env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
@@ -374,6 +377,7 @@ Command(
 )
       </file>
       <file name="SConstruct">
+import os
 env = DefaultEnvironment()
 env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
@@ -424,6 +428,7 @@ Command(
 )
       </file>
       <file name="SConstruct">
+import os
 env = DefaultEnvironment()
 env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')

--- a/doc/user/file-removal.xml
+++ b/doc/user/file-removal.xml
@@ -204,8 +204,8 @@ Clean(t, 'foo.log')
       </file>
       <file name="SConstruct">
 import os
-env = DefaultEnvironment()
-env.AppendENVPath('PATH', os.getcwd())
+denv = DefaultEnvironment()
+denv.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="foo.in">

--- a/doc/user/file-removal.xml
+++ b/doc/user/file-removal.xml
@@ -204,8 +204,7 @@ Clean(t, 'foo.log')
       </file>
       <file name="SConstruct">
 env = DefaultEnvironment()
-import os
-env['ENV']['PATH'] = env['ENV']['PATH'] + os.pathsep + os.getcwd()
+env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')
       </file>
       <file name="foo.in">

--- a/doc/user/file-removal.xml
+++ b/doc/user/file-removal.xml
@@ -202,10 +202,10 @@ int f3() { }
 t = Command('foo.out', 'foo.in', 'build -o $TARGET $SOURCE')
 Clean(t, 'foo.log')
       </file>
+      <!-- this is a non-displayed script that fiddles PATH to allow dummy "build" command to work -->
       <file name="SConstruct">
-import os
-denv = DefaultEnvironment()
-denv.AppendENVPath('PATH', os.getcwd())
+def_env = DefaultEnvironment()
+def_env.AppendENVPath('PATH', Dir('.'))
 SConscript('S')
       </file>
       <file name="foo.in">

--- a/doc/user/file-removal.xml
+++ b/doc/user/file-removal.xml
@@ -203,6 +203,7 @@ t = Command('foo.out', 'foo.in', 'build -o $TARGET $SOURCE')
 Clean(t, 'foo.log')
       </file>
       <file name="SConstruct">
+import os
 env = DefaultEnvironment()
 env.AppendENVPath('PATH', os.getcwd())
 SConscript('S')


### PR DESCRIPTION
Add an example on adding an emitter to an existing builder, based on a mailing-list discussion with Jeremy Elson.

Also:

* Try to model "best practice" by changing instances of hand-modifying `env['ENV']['PATH']` in examples to using `AppendENVPath` function.
* Fixed a couple of Py2-style print statements.
* Tweaked markup on a couple of instances of site_scons.
* Black-formatted examples in the two userguide sections that were otherwise modified.
* Dropped old cons doc content which was included as a big   comment at the fromt of builders-writing.xml.

No scons code changes in this PR.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
