### PR TITLE
Add timing of sconsign write if --debug

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Initial support in tests for Python 3.10 - expected bytecode and
       one changed expected exception message. Change some more regexes
       to be specified as rawstrings in response to DeprecationWarnings.
+    - Add timing information for sconsign database dump when --debug=time
+      is selected. Also switch to generally using time.perf_counter,
+      which is the Python recommended way for timing short durations.
 
 
 RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -122,9 +122,9 @@ from SCons.Util import is_String, is_List
 class _null:
     pass
 
-print_actions = 1
-execute_actions = 1
-print_actions_presub = 0
+print_actions = True
+execute_actions = True
+print_actions_presub = False
 
 # Use pickle protocol 1 when pickling functions for signature
 # otherwise python3 and python2 will yield different pickles

--- a/SCons/Debug.py
+++ b/SCons/Debug.py
@@ -193,7 +193,7 @@ if sys.platform == 'win32':
 else:
     TraceDefault = '/dev/tty'
 TimeStampDefault = False
-StartTime = time.time()
+StartTime = time.perf_counter()
 PreviousTime = StartTime
 
 def Trace(msg, tracefile=None, mode='w', tstamp=False):
@@ -238,7 +238,7 @@ def Trace(msg, tracefile=None, mode='w', tstamp=False):
             # Assume we were passed an open file pointer.
             fp = tracefile
     if tstamp:
-        now = time.time()
+        now = time.perf_counter()
         fp.write('%8.4f %8.4f:  ' % (now - StartTime, now - PreviousTime))
         PreviousTime = now
     fp.write(msg)

--- a/SCons/SConsign.py
+++ b/SCons/SConsign.py
@@ -103,7 +103,7 @@ def write():
     global sig_files
 
     if print_time():
-        time1 = time.perf_counter()
+        start_time = time.perf_counter()
 
     for sig_file in sig_files:
         sig_file.write(sync=0)
@@ -122,8 +122,8 @@ def write():
             closemethod()
 
     if print_time():
-        time2 = time.perf_counter()
-        print('Total SConsign sync time: %f seconds' % (time2 - time1))
+        elapsed = time.perf_counter() - start_time
+        print('Total SConsign sync time: %f seconds' % elapsed)
 
 
 class SConsignEntry:

--- a/SCons/SConsign.py
+++ b/SCons/SConsign.py
@@ -27,11 +27,12 @@ import SCons.compat
 
 import os
 import pickle
+import time
 
 import SCons.dblite
 import SCons.Warnings
-
 from SCons.compat import PICKLE_PROTOCOL
+from SCons.Util import print_time
 
 
 def corrupt_dblite_warning(filename):
@@ -100,6 +101,10 @@ normcase = os.path.normcase
 
 def write():
     global sig_files
+
+    if print_time():
+        time1 = time.perf_counter()
+
     for sig_file in sig_files:
         sig_file.write(sync=0)
     for db in DB_sync_list:
@@ -115,6 +120,10 @@ def write():
             pass # Not all dbm modules have close() methods.
         else:
             closemethod()
+
+    if print_time():
+        time2 = time.perf_counter()
+        print('Total SConsign sync time: %f seconds' % (time2 - time1))
 
 
 class SConsignEntry:

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -68,11 +68,11 @@ import SCons.Script.Interactive
 # Global variables
 first_command_start = None
 last_command_end = None
-print_objects = 0
-print_memoizer = 0
-print_stacktrace = 0
-print_time = 0
-print_action_timestamps = 0
+print_objects = False
+print_memoizer = False
+print_stacktrace = False
+print_time = False
+print_action_timestamps = False
 sconscript_time = 0
 cumulative_command_time = 0
 exit_status = 0   # final exit status, assume success by default
@@ -195,11 +195,20 @@ class BuildTask(SCons.Taskmaster.OutOfDateTask):
             global last_command_end
             finish_time = time.time()
             last_command_end = finish_time
-            cumulative_command_time = cumulative_command_time+finish_time-start_time
+            cumulative_command_time += finish_time - start_time
             if print_action_timestamps:
-                sys.stdout.write("Command execution start timestamp: %s: %f\n"%(str(self.node), start_time))
-                sys.stdout.write("Command execution end timestamp: %s: %f\n"%(str(self.node), finish_time))
-            sys.stdout.write("Command execution time: %s: %f seconds\n"%(str(self.node), finish_time-start_time))
+                sys.stdout.write(
+                    "Command execution start timestamp: %s: %f\n"
+                    % (str(self.node), start_time)
+                )
+                sys.stdout.write(
+                    "Command execution end timestamp: %s: %f\n"
+                    % (str(self.node), finish_time)
+                )
+            sys.stdout.write(
+                "Command execution time: %s: %f seconds\n"
+                % (str(self.node), (finish_time - start_time))
+            )
 
     def do_failed(self, status=2):
         _BuildFailures.append(self.exception[1])
@@ -658,22 +667,22 @@ def _set_debug_values(options):
     if print_objects:
         SCons.Debug.track_instances = True
     if "presub" in debug_values:
-        SCons.Action.print_actions_presub = 1
+        SCons.Action.print_actions_presub = True
     if "stacktrace" in debug_values:
-        print_stacktrace = 1
+        print_stacktrace = True
     if "stree" in debug_values:
         options.tree_printers.append(TreePrinter(status=True))
     if "time" in debug_values:
-        print_time = 1
+        print_time = True
     if "action-timestamps" in debug_values:
-        print_time = 1
-        print_action_timestamps = 1
+        print_time = True
+        print_action_timestamps = True
     if "tree" in debug_values:
         options.tree_printers.append(TreePrinter())
     if "prepare" in debug_values:
-        SCons.Taskmaster.print_prepare = 1
+        SCons.Taskmaster.print_prepare = True
     if "duplicate" in debug_values:
-        SCons.Node.print_duplicate = 1
+        SCons.Node.print_duplicate = True
 
 def _create_path(plist):
     path = '.'
@@ -1010,7 +1019,8 @@ def _main(parser):
 
     progress_display("scons: Reading SConscript files ...")
 
-    start_time = time.perf_counter()
+    if print_time:
+        start_time = time.time()
     try:
         for script in scripts:
             SCons.Script._SConscript._SConscript(fs, script)
@@ -1023,8 +1033,9 @@ def _main(parser):
         revert_io()
         sys.stderr.write("scons: *** %s  Stop.\n" % e)
         sys.exit(2)
-    global sconscript_time
-    sconscript_time = time.perf_counter() - start_time
+    if print_time:
+        global sconscript_time
+        sconscript_time = time.time() - start_time
 
     progress_display("scons: done reading SConscript files.")
 

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -185,7 +185,7 @@ class BuildTask(SCons.Taskmaster.OutOfDateTask):
 
     def execute(self):
         if print_time:
-            start_time = time.time()
+            start_time = time.perf_counter()
             global first_command_start
             if first_command_start is None:
                 first_command_start = start_time
@@ -193,7 +193,7 @@ class BuildTask(SCons.Taskmaster.OutOfDateTask):
         if print_time:
             global cumulative_command_time
             global last_command_end
-            finish_time = time.time()
+            finish_time = time.perf_counter()
             last_command_end = finish_time
             cumulative_command_time = cumulative_command_time+finish_time-start_time
             if print_action_timestamps:
@@ -1010,7 +1010,7 @@ def _main(parser):
 
     progress_display("scons: Reading SConscript files ...")
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     try:
         for script in scripts:
             SCons.Script._SConscript._SConscript(fs, script)
@@ -1024,7 +1024,7 @@ def _main(parser):
         sys.stderr.write("scons: *** %s  Stop.\n" % e)
         sys.exit(2)
     global sconscript_time
-    sconscript_time = time.time() - start_time
+    sconscript_time = time.perf_counter() - start_time
 
     progress_display("scons: done reading SConscript files.")
 
@@ -1423,7 +1423,7 @@ def main():
     SCons.Taskmaster.dump_stats()
 
     if print_time:
-        total_time = time.time() - SCons.Script.start_time
+        total_time = time.perf_counter() - SCons.Script.start_time
         if num_jobs == 1:
             ct = cumulative_command_time
         else:

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -185,7 +185,7 @@ class BuildTask(SCons.Taskmaster.OutOfDateTask):
 
     def execute(self):
         if print_time:
-            start_time = time.perf_counter()
+            start_time = time.time()
             global first_command_start
             if first_command_start is None:
                 first_command_start = start_time
@@ -193,7 +193,7 @@ class BuildTask(SCons.Taskmaster.OutOfDateTask):
         if print_time:
             global cumulative_command_time
             global last_command_end
-            finish_time = time.perf_counter()
+            finish_time = time.time()
             last_command_end = finish_time
             cumulative_command_time = cumulative_command_time+finish_time-start_time
             if print_action_timestamps:
@@ -1423,7 +1423,7 @@ def main():
     SCons.Taskmaster.dump_stats()
 
     if print_time:
-        total_time = time.perf_counter() - SCons.Script.start_time
+        total_time = time.time() - SCons.Script.start_time
         if num_jobs == 1:
             ct = cumulative_command_time
         else:

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -34,6 +34,7 @@ _ = gettext.gettext
 import SCons.Node.FS
 import SCons.Platform.virtualenv
 import SCons.Warnings
+from . import Main
 
 OptionValueError        = optparse.OptionValueError
 SUPPRESS_HELP           = optparse.SUPPRESS_HELP
@@ -837,7 +838,6 @@ def Parser(version):
     tree_options = ["all", "derived", "prune", "status", "linedraw"]
 
     def opt_tree(option, opt, value, parser, tree_options=tree_options):
-        from . import Main
         tp = Main.TreePrinter()
         for o in value.split(','):
             if o == 'all':

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -34,7 +34,6 @@ import SCons.Node.Alias
 import SCons.Node.FS
 import SCons.Platform
 import SCons.SConf
-import SCons.Script.Main
 import SCons.Tool
 from SCons.Util import is_List, is_String, is_Dict, flatten
 from SCons.Node import SConscriptNodes
@@ -273,7 +272,7 @@ def _SConscript(fs, *files, **kw):
                     try:
                         try:
                             if Main.print_time:
-                                time1 = time.time()
+                                time1 = time.perf_counter()
                             scriptdata = _file_.read()
                             scriptname = _file_.name
                             _file_.close()
@@ -282,7 +281,7 @@ def _SConscript(fs, *files, **kw):
                             pass
                     finally:
                         if Main.print_time:
-                            time2 = time.time()
+                            time2 = time.perf_counter()
                             print('SConscript:%s  took %0.3f ms' % (f.get_abspath(), (time2 - time1) * 1000.0))
 
                         if old_file is not None:

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -272,7 +272,7 @@ def _SConscript(fs, *files, **kw):
                     try:
                         try:
                             if Main.print_time:
-                                time1 = time.perf_counter()
+                                start_time = time.perf_counter()
                             scriptdata = _file_.read()
                             scriptname = _file_.name
                             _file_.close()
@@ -281,8 +281,8 @@ def _SConscript(fs, *files, **kw):
                             pass
                     finally:
                         if Main.print_time:
-                            time2 = time.perf_counter()
-                            print('SConscript:%s  took %0.3f ms' % (f.get_abspath(), (time2 - time1) * 1000.0))
+                            elapsed = time.perf_counter() - start_time
+                            print('SConscript:%s  took %0.3f ms' % (f.get_abspath(), elapsed * 1000.0))
 
                         if old_file is not None:
                             call_stack[-1].globals.update({__file__:old_file})

--- a/SCons/Taskmaster.py
+++ b/SCons/Taskmaster.py
@@ -63,7 +63,7 @@ NODE_UP_TO_DATE = SCons.Node.up_to_date
 NODE_EXECUTED = SCons.Node.executed
 NODE_FAILED = SCons.Node.failed
 
-print_prepare = 0               # set by option --debug=prepare
+print_prepare = False               # set by option --debug=prepare
 
 # A subsystem for recording stats about how different Nodes are handled by
 # the main Taskmaster loop.  There's no external control here (no need for

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1648,6 +1648,11 @@ def get_os_env_bool(name, default=False):
     """
     return get_env_bool(os.environ, name, default)
 
+def print_time():
+    """Hack to return a value from Main if can't import Main."""
+    from SCons.Script.Main import print_time
+    return print_time
+
 # Local Variables:
 # tab-width:4
 # indent-tabs-mode:nil

--- a/test/MSVC/msvc.py
+++ b/test/MSVC/msvc.py
@@ -170,13 +170,13 @@ test.must_not_exist(test.workpath('test.pdb'))
 test.must_exist(test.workpath('test.obj'))
 
 
-start = time.time()
+start = time.perf_counter()
 test.run(arguments='fast.obj', stderr=None)
-fast = time.time() - start
+fast = time.perf_counter() - start
 
-start = time.time()
+start = time.perf_counter()
 test.run(arguments='slow.obj', stderr=None)
-slow = time.time() - start
+slow = time.perf_counter() - start
 
 
 # TODO: Reevaluate if having this part of the test makes sense any longer

--- a/test/option/debug-time.py
+++ b/test/option/debug-time.py
@@ -95,15 +95,15 @@ def get_command_time(stdout):
 test.write('pass.py', "pass\n")
 test.read(test.program)
 
-start_time = time.time()
+start_time = time.perf_counter()
 test.run(program=TestSCons.python, arguments=test.workpath('pass.py'))
-overhead = time.time() - start_time 
+overhead = time.perf_counter() - start_time
 
 
 
-start_time = time.time()
+start_time = time.perf_counter()
 test.run(arguments = "-j1 --debug=time . SLEEP=0")
-complete_time = time.time() - start_time
+complete_time = time.perf_counter() - start_time
 
 
 
@@ -132,7 +132,7 @@ warnings = []
 
 if  targets != expected_targets:
     failures.append("""\
-Scons reported the targets of timing information as %(targets)s, 
+Scons reported the targets of timing information as %(targets)s,
 but the actual targets should have been %(expected_targets)s.
 """ %locals())
 

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -2169,15 +2169,15 @@ class sleep_TestCase(TestCmdTestCase):
         """Test sleep()"""
         test = TestCmd.TestCmd()
 
-        start = time.time()
+        start = time.perf_counter()
         test.sleep()
-        end = time.time()
+        end = time.perf_counter()
         diff = end - start
         assert diff > 0.9, "only slept %f seconds (start %f, end %f), not default" % (diff, start, end)
 
-        start = time.time()
+        start = time.perf_counter()
         test.sleep(3)
-        end = time.time()
+        end = time.perf_counter()
         diff = end - start
         assert diff > 2.9, "only slept %f seconds (start %f, end %f), not 3" % (diff, start, end)
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1887,11 +1887,11 @@ class TimeSCons(TestSCons):
         --debug=memory and --debug=time options to have SCons report
         its own memory and timing statistics.
         """
-        self.startTime = time.time()
+        self.startTime = time.perf_counter()
         try:
             result = TestSCons.run(self, *args, **kw)
         finally:
-            self.endTime = time.time()
+            self.endTime = time.perf_counter()
         return result
 
     def copy_timing_configuration(self, source_dir, dest_dir):


### PR DESCRIPTION
A line is now emitted showing sconsign sync time if -`-debug=time`

Some calls to `time.time` replaced with `time.perf_counter`, where the objective was to time sections of code (i.e. where there wasn't an actual need to get time-since-epoch) - Python recommends this as getting the best-available timer.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
