### PR TITLE
Update CacheDir to use uuid for CacheDir tmpfile unique name generation.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,11 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Daniel Moody:
+    - Update CacheDir to use uuid for tmpfile uniqueness instead of pid.
+      This fixes cases for shared cache where two systems write to the same
+      cache tmpfile at the same time because the happened to get the same pid.
+
   From Mats Wichmann:
     - Initial support in tests for Python 3.10 - expected bytecode and
       one changed expected exception message. Change some more regexes
@@ -55,7 +60,7 @@ RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700
       when running multiple tests with multiple jobs.
     - Fix incorrect cache hits and/or misses when running in interactive mode by having
       SCons.Node.Node.clear() clear out all caching-related state.
-    - Change Environment.SideEffect() to not add duplicate side effects. 
+    - Change Environment.SideEffect() to not add duplicate side effects.
       NOTE: The list of returned side effect Nodes will not include any duplicate side effect Nodes.
 
   From David H:
@@ -94,10 +99,10 @@ RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700
       looks like an abbreviation of one one added by AddOption. (#3653)
     - Tool module not found will now raise a UserError to more clearly indicate this is
       probably an SConscript problem, and to make the traceback more relevant.
-    - Fix three issues with MergeFlags: 
-      - Signature/return did not match documentation or existing usage - the implementation 
+    - Fix three issues with MergeFlags:
+      - Signature/return did not match documentation or existing usage - the implementation
         now no longer returns the passed env
-      - merging --param arguments did not work (issue #3107); 
+      - merging --param arguments did not work (issue #3107);
       - passing a dict to merge where the values are strings failed (issue #2961).
     - Include previously-excluded SideEffect section in User Guide.
     - Clean up unneeded imports (autoflake tool).

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -102,7 +102,7 @@ def CachePushFunc(target, source, env):
 
     cd.CacheDebug('CachePush(%s):  pushing to %s\n', t, cachefile)
 
-    tempfile = f"{cachefile}.tmp{cache_tmp_uuid}"
+    tempfile = "%s.tmp%s"%(cachefile,cache_tmp_uuid)
     errfmt = "Unable to copy %s to cache. Cache file is %s"
 
     if not fs.isdir(cachedir):

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -29,6 +29,7 @@ import json
 import os
 import stat
 import sys
+import uuid
 
 import SCons.Action
 import SCons.Errors
@@ -39,6 +40,7 @@ cache_debug = False
 cache_force = False
 cache_show = False
 cache_readonly = False
+cache_tmp_uuid = uuid.uuid4().hex
 
 def CacheRetrieveFunc(target, source, env):
     t = target[0]
@@ -100,7 +102,7 @@ def CachePushFunc(target, source, env):
 
     cd.CacheDebug('CachePush(%s):  pushing to %s\n', t, cachefile)
 
-    tempfile = cachefile+'.tmp'+str(os.getpid())
+    tempfile = f"{cachefile}.tmp{cache_tmp_uuid}"
     errfmt = "Unable to copy %s to cache. Cache file is %s"
 
     if not fs.isdir(cachedir):


### PR DESCRIPTION
MongoDB ran into this while using shared cache across multiple systems building the same files. 

Correlating commit: https://github.com/mongodb/mongo/commit/42d2e4a817581ae34931bad2f5354dcd46f05dc5

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
