### PR TITLE
Tweak builder-methods manpage section

### DIFF
--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -72,14 +72,13 @@ file.
 <cvar name="_CPPDEFFLAGS">
 <summary>
 <para>
-An automatically-generated construction variable
+An automatically-generated &consvar;
 containing the C preprocessor command-line options
 to define values.
 The value of &cv-_CPPDEFFLAGS; is created
 by respectively prepending and appending
-&cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
-to the beginning and end
-of each definition in &cv-CPPDEFINES;.
+&cv-link-CPPDEFPREFIX; and &cv-link-CPPDEFSUFFIX;
+to each definition in &cv-link-CPPDEFINES;.
 </para>
 </summary>
 </cvar>
@@ -90,7 +89,7 @@ of each definition in &cv-CPPDEFINES;.
 A platform independent specification of C preprocessor definitions.
 The definitions will be added to command lines
 through the automatically-generated
-&cv-_CPPDEFFLAGS; construction variable (see above),
+&cv-link-_CPPDEFFLAGS; &consvar; (see above),
 which is constructed according to
 the type of value of &cv-CPPDEFINES;:
 </para>
@@ -98,10 +97,9 @@ the type of value of &cv-CPPDEFINES;:
 <para>
 If &cv-CPPDEFINES; is a string,
 the values of the
-&cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
-construction variables
-will be respectively prepended and appended to the beginning and end
-of each definition in &cv-CPPDEFINES;.
+&cv-link-CPPDEFPREFIX; and &cv-link-CPPDEFSUFFIX; &consvars;
+will be respectively prepended and appended to 
+each definition in &cv-CPPDEFINES;.
 </para>
 
 <example_commands>
@@ -113,10 +111,9 @@ env = Environment(CPPDEFINES='xyz')
 <para>
 If &cv-CPPDEFINES; is a list,
 the values of the
-&cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
-construction variables
-will be respectively prepended and appended to the beginning and end
-of each element in the list.
+&cv-link-CPPDEFPREFIX; and &cv-link-CPPDEFSUFFIX; &consvars;
+will be respectively prepended and appended to 
+each element in the list.
 If any element is a list or tuple,
 then the first item is the name being
 defined and the second item is its value:
@@ -131,10 +128,9 @@ env = Environment(CPPDEFINES=[('B', 2), 'A'])
 <para>
 If &cv-CPPDEFINES; is a dictionary,
 the values of the
-&cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX;
-construction variables
-will be respectively prepended and appended to the beginning and end
-of each item from the dictionary.
+&cv-link-CPPDEFPREFIX; and &cv-link-CPPDEFSUFFIX; &consvars;
+will be respectively prepended and appended to
+each item from the dictionary.
 The key of each dictionary item
 is a name being defined
 to the dictionary item's corresponding value;
@@ -161,9 +157,9 @@ env = Environment(CPPDEFINES={'B':2, 'A':None})
 <para>
 The prefix used to specify preprocessor definitions
 on the C compiler command line.
-This will be prepended to the beginning of each definition
-in the &cv-CPPDEFINES; construction variable
-when the &cv-_CPPDEFFLAGS; variable is automatically generated.
+This will be prepended to each definition
+in the &cv-link-CPPDEFINES; &consvar;
+when the &cv-link-_CPPDEFFLAGS; variable is automatically generated.
 </para>
 </summary>
 </cvar>
@@ -173,9 +169,9 @@ when the &cv-_CPPDEFFLAGS; variable is automatically generated.
 <para>
 The suffix used to specify preprocessor definitions
 on the C compiler command line.
-This will be appended to the end of each definition
-in the &cv-CPPDEFINES; construction variable
-when the &cv-_CPPDEFFLAGS; variable is automatically generated.
+This will be appended to each definition
+in the &cv-link-CPPDEFINES; &consvar;
+when the &cv-link-_CPPDEFFLAGS; variable is automatically generated.
 </para>
 </summary>
 </cvar>
@@ -183,13 +179,13 @@ when the &cv-_CPPDEFFLAGS; variable is automatically generated.
 <cvar name="_CPPINCFLAGS">
 <summary>
 <para>
-An automatically-generated construction variable
+An automatically-generated &consvar;
 containing the C preprocessor command-line options
 for specifying directories to be searched for include files.
 The value of &cv-_CPPINCFLAGS; is created
-by respectively prepending and appending &cv-INCPREFIX; and &cv-INCSUFFIX;
-to the beginning and end
-of each directory in &cv-CPPPATH;.
+by respectively prepending and appending
+&cv-link-INCPREFIX; and &cv-link-INCSUFFIX;
+to each directory in &cv-link-CPPPATH;.
 </para>
 </summary>
 </cvar>
@@ -199,13 +195,24 @@ of each directory in &cv-CPPPATH;.
 <para>
 The list of directories that the C preprocessor will search for include
 directories. The C/C++ implicit dependency scanner will search these
-directories for include files. Don't explicitly put include directory
-arguments in CCFLAGS or CXXFLAGS because the result will be non-portable
-and the directories will not be searched by the dependency scanner. Note:
-directory names in CPPPATH will be looked-up relative to the SConscript
-directory when they are used in a command. To force
-&scons;
-to look-up a directory relative to the root of the source tree use #:
+directories for include files. 
+Do not put include directory directives
+directly into &cv-link-CCFLAGS; or &cv-link-CXXFLAGS;
+as the result will be non-portable
+and the directories will not be searched by the dependency scanner.
+&cv-CPPPATH; should be a list of path strings,
+or a single string, not a pathname list joined by
+Python's <systemitem>os.sep</systemitem>.
+</para>
+
+<para>
+Note:
+directory names in &cv-link-CPPPATH;
+will be looked-up relative to the directory of the SConscript file
+when they are used in a command. 
+To force &scons;
+to look-up a directory relative to the root of the source tree use 
+the <literal>#</literal> prefix:
 </para>
 
 <example_commands>
@@ -214,7 +221,7 @@ env = Environment(CPPPATH='#/include')
 
 <para>
 The directory look-up can also be forced using the
-&Dir;()
+&f-link-Dir;
 function:
 </para>
 
@@ -226,17 +233,14 @@ env = Environment(CPPPATH=include)
 <para>
 The directory list will be added to command lines
 through the automatically-generated
-&cv-_CPPINCFLAGS;
-construction variable,
+&cv-link-_CPPINCFLAGS; &consvar;,
 which is constructed by
-respectively prepending and appending the value of the
-&cv-INCPREFIX; and &cv-INCSUFFIX;
-construction variables
-to the beginning and end
-of each directory in &cv-CPPPATH;.
+respectively prepending and appending the values of the
+&cv-link-INCPREFIX; and &cv-link-INCSUFFIX; &consvars;
+to each directory in &cv-link-CPPPATH;.
 Any command lines you define that need
-the CPPPATH directory list should
-include &cv-_CPPINCFLAGS;:
+the &cv-CPPPATH; directory list should
+include &cv-link-_CPPINCFLAGS;:
 </para>
 
 <example_commands>
@@ -302,9 +306,9 @@ The default list is:
 <para>
 The prefix used to specify an include directory on the C compiler command
 line.
-This will be prepended to the beginning of each directory
-in the &cv-CPPPATH; and &cv-FORTRANPATH; construction variables
-when the &cv-_CPPINCFLAGS; and &cv-_FORTRANINCFLAGS;
+This will be prepended to each directory
+in the &cv-link-CPPPATH; and &cv-link-FORTRANPATH; &consvars;
+when the &cv-link-_CPPINCFLAGS; and &cv-link-_FORTRANINCFLAGS;
 variables are automatically generated.
 </para>
 </summary>
@@ -315,9 +319,9 @@ variables are automatically generated.
 <para>
 The suffix used to specify an include directory on the C compiler command
 line.
-This will be appended to the end of each directory
-in the &cv-CPPPATH; and &cv-FORTRANPATH; construction variables
-when the &cv-_CPPINCFLAGS; and &cv-_FORTRANINCFLAGS;
+This will be appended to each directory
+in the &cv-link-CPPPATH; and &cv-link-FORTRANPATH; &consvars;
+when the &cv-link-_CPPINCFLAGS; and &cv-link-_FORTRANINCFLAGS;
 variables are automatically generated.
 </para>
 </summary>
@@ -386,9 +390,9 @@ An automatically-generated construction variable
 containing the linker command-line options
 for specifying directories to be searched for library.
 The value of &cv-_LIBDIRFLAGS; is created
-by respectively prepending and appending &cv-LIBDIRPREFIX; and &cv-LIBDIRSUFFIX;
-to the beginning and end
-of each directory in &cv-LIBPATH;.
+by respectively prepending and appending &cv-link-LIBDIRPREFIX;
+and &cv-link-LIBDIRSUFFIX;
+to each directory in &cv-link-LIBPATH;.
 </para>
 </summary>
 </cvar>
@@ -397,9 +401,9 @@ of each directory in &cv-LIBPATH;.
 <summary>
 <para>
 The prefix used to specify a library directory on the linker command line.
-This will be prepended to the beginning of each directory
-in the &cv-LIBPATH; construction variable
-when the &cv-_LIBDIRFLAGS; variable is automatically generated.
+This will be prepended to each directory
+in the &cv-link-LIBPATH; construction variable
+when the &cv-link-_LIBDIRFLAGS; variable is automatically generated.
 </para>
 </summary>
 </cvar>
@@ -408,9 +412,9 @@ when the &cv-_LIBDIRFLAGS; variable is automatically generated.
 <summary>
 <para>
 The suffix used to specify a library directory on the linker command line.
-This will be appended to the end of each directory
-in the &cv-LIBPATH; construction variable
-when the &cv-_LIBDIRFLAGS; variable is automatically generated.
+This will be appended to each directory
+in the &cv-link-LIBPATH; construction variable
+when the &cv-link-_LIBDIRFLAGS; variable is automatically generated.
 </para>
 </summary>
 </cvar>
@@ -421,10 +425,10 @@ when the &cv-_LIBDIRFLAGS; variable is automatically generated.
 An automatically-generated construction variable
 containing the linker command-line options
 for specifying libraries to be linked with the resulting target.
-The value of &cv-_LIBFLAGS; is created
-by respectively prepending and appending &cv-LIBLINKPREFIX; and &cv-LIBLINKSUFFIX;
-to the beginning and end
-of each filename in &cv-LIBS;.
+The value of &cv-link-_LIBFLAGS; is created
+by respectively prepending and appending &cv-link-LIBLINKPREFIX;
+and &cv-link-LIBLINKSUFFIX;
+to each filename in &cv-link-LIBS;.
 </para>
 </summary>
 </cvar>
@@ -433,9 +437,9 @@ of each filename in &cv-LIBS;.
 <summary>
 <para>
 The prefix used to specify a library to link on the linker command line.
-This will be prepended to the beginning of each library
-in the &cv-LIBS; construction variable
-when the &cv-_LIBFLAGS; variable is automatically generated.
+This will be prepended to each library
+in the &cv-link-LIBS; construction variable
+when the &cv-link-_LIBFLAGS; variable is automatically generated.
 </para>
 </summary>
 </cvar>
@@ -444,9 +448,9 @@ when the &cv-_LIBFLAGS; variable is automatically generated.
 <summary>
 <para>
 The suffix used to specify a library to link on the linker command line.
-This will be appended to the end of each library
-in the &cv-LIBS; construction variable
-when the &cv-_LIBFLAGS; variable is automatically generated.
+This will be appended to each library
+in the &cv-link-LIBS; construction variable
+when the &cv-link-_LIBFLAGS; variable is automatically generated.
 </para>
 </summary>
 </cvar>
@@ -454,16 +458,33 @@ when the &cv-_LIBFLAGS; variable is automatically generated.
 <cvar name="LIBPATH">
 <summary>
 <para>
-The list of directories that will be searched for libraries.
+The list of directories that will be searched for libraries
+specified by the &cv-link-LIBS; &consvar;.
+&cv-LIBPATH; should be a list of path strings,
+or a single string, not a pathname list joined by
+Python's <systemitem>os.sep</systemitem>.
+<!-- XXX OLD
 The implicit dependency scanner will search these
 directories for include files. Don't explicitly put include directory
-arguments in &cv-LINKFLAGS; or &cv-SHLINKFLAGS;
+arguments into &cv-LINKFLAGS; or &cv-SHLINKFLAGS;
 because the result will be non-portable
-and the directories will not be searched by the dependency scanner. Note:
-directory names in LIBPATH will be looked-up relative to the SConscript
-directory when they are used in a command. To force
-&scons;
-to look-up a directory relative to the root of the source tree use #:
+and the directories will not be searched by the dependency scanner.
+-->
+<!-- XXX NEW -->
+Do not put library search directives directly
+into &cv-LINKFLAGS; or &cv-SHLINKFLAGS;
+as the result will be non-portable.
+<!-- end NEW -->
+</para>
+
+<para>
+Note:
+directory names in &cv-LIBPATH; will be looked-up relative to the
+directory of the SConscript file
+when they are used in a command. 
+To force &scons;
+to look-up a directory relative to the root of the source tree use 
+the <literal>#</literal> prefix:
 </para>
 
 <example_commands>
@@ -472,8 +493,7 @@ env = Environment(LIBPATH='#/libs')
 
 <para>
 The directory look-up can also be forced using the
-&Dir;()
-function:
+&f-link-Dir; function:
 </para>
 
 <example_commands>
@@ -484,16 +504,15 @@ env = Environment(LIBPATH=libs)
 <para>
 The directory list will be added to command lines
 through the automatically-generated
-&cv-_LIBDIRFLAGS;
+&cv-link-_LIBDIRFLAGS;
 construction variable,
 which is constructed by
 respectively prepending and appending the values of the
-&cv-LIBDIRPREFIX; and &cv-LIBDIRSUFFIX;
+&cv-link-LIBDIRPREFIX; and &cv-link-LIBDIRSUFFIX;
 construction variables
-to the beginning and end
-of each directory in &cv-LIBPATH;.
+to each directory in &cv-LIBPATH;.
 Any command lines you define that need
-the LIBPATH directory list should
+the &cv-LIBPATH; directory list should
 include &cv-_LIBDIRFLAGS;:
 </para>
 
@@ -509,22 +528,33 @@ env = Environment(LINKCOM="my_linker $_LIBDIRFLAGS $_LIBFLAGS -o $TARGET $SOURCE
 A list of one or more libraries
 that will be linked with
 any executable programs
-created by this environment.
+created by this environment,
+or if used in an override,
+executable programs created by the Builder for which
+the override is in effect.
 </para>
 
 <para>
+String-valued library names should include
+only the library base names
+(without prefixes such as <filename>lib</filename>
+or suffixes such as <filename>.so</filename> or <filename>.dll</filename>).
 The library list will be added to command lines
 through the automatically-generated
-&cv-_LIBFLAGS;
-construction variable,
+&cv-_LIBFLAGS; &consvar;
 which is constructed by
 respectively prepending and appending the values of the
-&cv-LIBLINKPREFIX; and &cv-LIBLINKSUFFIX;
-construction variables
-to the beginning and end
-of each filename in &cv-LIBS;.
+&cv-LIBLINKPREFIX; and &cv-LIBLINKSUFFIX; &consvars;
+to each library name in &cv-LIBS;.
+Library name strings should not include a
+path component, instead the compiler will be
+directed to look for libraries in the paths
+specified by &cv-link-LIBPATH;.
+</para>
+
+<para>
 Any command lines you define that need
-the LIBS library list should
+the &cv-LIBS; library list should
 include &cv-_LIBFLAGS;:
 </para>
 
@@ -534,12 +564,12 @@ env = Environment(LINKCOM="my_linker $_LIBDIRFLAGS $_LIBFLAGS -o $TARGET $SOURCE
 
 <para>
 If you add a
-File
+<classname>File</classname>
 object to the
 &cv-LIBS;
 list, the name of that file will be added to
 &cv-_LIBFLAGS;,
-and thus the link line, as is, without
+and thus to the link line, as-is, without
 &cv-LIBLINKPREFIX;
 or
 &cv-LIBLINKSUFFIX;.

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -526,19 +526,16 @@ env = Environment(LINKCOM="my_linker $_LIBDIRFLAGS $_LIBFLAGS -o $TARGET $SOURCE
 <summary>
 <para>
 A list of one or more libraries
-that will be linked with
-any executable programs
-created by this environment,
-or if used in an override,
-executable programs created by the Builder for which
-the override is in effect.
+that will be added to the link line
+for linking with any executable program
+created by the &consenv; or override.
 </para>
 
 <para>
 String-valued library names should include
-only the library base names
-(without prefixes such as <filename>lib</filename>
-or suffixes such as <filename>.so</filename> or <filename>.dll</filename>).
+only the library base names,
+without prefixes such as <filename>lib</filename>
+or suffixes such as <filename>.so</filename> or <filename>.dll</filename>.
 The library list will be added to command lines
 through the automatically-generated
 &cv-_LIBFLAGS; &consvar;

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -196,7 +196,7 @@ to each directory in &cv-link-CPPPATH;.
 The list of directories that the C preprocessor will search for include
 directories. The C/C++ implicit dependency scanner will search these
 directories for include files. 
-Do not put include directory directives
+In general it's not advised to put include directory directives
 directly into &cv-link-CCFLAGS; or &cv-link-CXXFLAGS;
 as the result will be non-portable
 and the directories will not be searched by the dependency scanner.
@@ -527,7 +527,7 @@ env = Environment(LINKCOM="my_linker $_LIBDIRFLAGS $_LIBFLAGS -o $TARGET $SOURCE
 <para>
 A list of one or more libraries
 that will be added to the link line
-for linking with any executable program
+for linking with any executable program, shared library, or loadable module 
 created by the &consenv; or override.
 </para>
 

--- a/SCons/Platform/Platform.xml
+++ b/SCons/Platform/Platform.xml
@@ -53,7 +53,7 @@ A list of all legal prefixes for library file names.
 When searching for library dependencies,
 SCons will look for files with these prefixes,
 the base library name,
-and suffixes in the &cv-LIBSUFFIXES; list.
+and suffixes from the &cv-link-LIBSUFFIXES; list.
 </para>
 </summary>
 </cvar>
@@ -76,7 +76,7 @@ to reflect the names of the libraries they create.
 <para>
 A list of all legal suffixes for library file names.
 When searching for library dependencies,
-SCons will look for files with prefixes, in the &cv-LIBPREFIXES; list,
+SCons will look for files with prefixes from the &cv-link-LIBPREFIXES; list,
 the base library name,
 and these suffixes.
 </para>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2612,9 +2612,20 @@ env.SomeTool(targets, sources)
 <title>Builder Methods</title>
 
 <para>You tell &scons; what to build
-by calling <firstterm>Builders</firstterm>, functions which know to take a
-particular action to produce a particular result type
-when given source files of a particular type. &scons;
+by calling <firstterm>Builders</firstterm>,
+functions which take
+particular actions to produce a particular result type
+(conventionally described by the builder name)
+when given source files of a particular type. 
+Calling a builder defines one or more targets to the build system;
+whether the targets are actually built on a given
+invocation is determined by command-line options,
+target selection rules, and whether &SCons;
+determines the target(s) are out of date.
+</para>
+
+<para>
+&SCons;
 defines a number of builders, and you can also write your own.
 Builders are attached to a &consenv; as methods,
 and the available builder methods are listed as
@@ -2625,11 +2636,12 @@ for debugging purposes:
 </para>
 
 <programlisting language="python">
+env = Environment()
 print("Builders:", list(env['BUILDERS']))
 </programlisting>
 
 <para>
-Builder methods always take two arguments:
+Builder methods take two required arguments:
 <replaceable>target</replaceable>
 (a target or a list of targets to be built)
 and
@@ -2637,9 +2649,13 @@ and
 (a source or list of sources to be used as input
 when building),
 although in some circumstances,
-the target argument can actually be omitted (see below).
+the target argument can be omitted (see below).
 Builder methods also take a variety of
 keyword arguments, described below.
+The builder <emphasis>may</emphasis> add other targets
+beyond those requested if indicated by an <firstterm>Emitter</firstterm>
+(see <xref linkend="builder_objects"/> and, for example,
+&cv-link-PROGEMITTER; for more information).
 </para>
 
 <para>Because long lists of file names
@@ -2856,7 +2872,7 @@ has determined are appropriate for the local system.</para>
 
 <para>Builder methods that can be called without an explicit
 environment (indicated in the listing of builders without
-a leading <literal><replaceable>env</replaceable>.</literal>)
+a leading <varname>env.</varname>)
 may be called from custom Python modules that you
 import into an SConscript file by adding the following
 to the Python module:</para>
@@ -2865,32 +2881,38 @@ to the Python module:</para>
 from SCons.Script import *
 </programlisting>
 
-<para>All builder methods return a list-like object
-containing Nodes that will be built.
-A <firstterm>Node</firstterm>
-is an internal SCons object
-which represents
-build targets or sources.
-See <xref linkend="node_objects"/> for more information.</para>
+<para>Builder methods return a <firstterm>Node-list</firstterm>,
+a list-like object whose elements are Nodes,
+&SCons;' internal representation of build targets or sources.
+See <xref linkend="node_objects"/> for more information.
+</para>
 
 <para>The returned Node-list object
 can be passed to other builder methods as source(s)
 or passed to any &SCons; function or method
 where a filename would normally be accepted.
-For example, if it were necessary
+Node-lists should not be used to set &consvars;
+such as &cv-link-LIBS; that expect to do transformation
+on strings - for that case,
+use the base name of the library as a string.
+</para>
+
+<para> For example, 
 to add a specific preprocessor define
-when compiling one specific object file:</para>
+when compiling one specific object file
+but not the others:</para>
 
 <programlisting language="python">
 bar_obj_list = env.StaticObject('bar.c', CPPDEFINES='-DBAR')
 env.Program(source=['foo.c', bar_obj_list, 'main.c'])
 </programlisting>
 
-<para>Using a Node in this way
+<para>Using a Node as in this example
 makes for a more portable build
 by avoiding having to specify
 a platform-specific object suffix
-when calling the &Program; builder method.</para>
+when calling the &Program; builder method.
+</para>
 
 <para>Builder calls will automatically "flatten"
 lists passed as source and target, so they are free to

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2614,9 +2614,9 @@ env.SomeTool(targets, sources)
 <para>You tell &scons; what to build
 by calling <firstterm>Builders</firstterm>,
 functions which take
-particular actions to produce a particular result type
-(conventionally described by the builder name)
-when given source files of a particular type. 
+particular action(s) to produce a particular result type
+(conventionally described by the builder name such as &b-Program;)
+when given source files of a particular type.
 Calling a builder defines one or more targets to the build system;
 whether the targets are actually built on a given
 invocation is determined by command-line options,
@@ -2630,7 +2630,7 @@ defines a number of builders, and you can also write your own.
 Builders are attached to a &consenv; as methods,
 and the available builder methods are listed as
 key-value pairs in the
-<envar>BUILDERS</envar> attribute of the &consenv;.
+<varname>BUILDERS</varname> attribute of the &consenv;.
 The available builders can be displayed like this
 for debugging purposes:
 </para>
@@ -2642,16 +2642,23 @@ print("Builders:", list(env['BUILDERS']))
 
 <para>
 Builder methods take two required arguments:
-<replaceable>target</replaceable>
-(a target or a list of targets to be built)
+<parameter>target</parameter>
 and
-<replaceable>source</replaceable>
-(a source or list of sources to be used as input
-when building),
-although in some circumstances,
-the target argument can be omitted (see below).
+<parameter>source</parameter>.
+Either can be passed as a scalar or as a list.
+The target and source arguments
+can be specified either as positional arguments,
+in which case <parameter>target</parameter> comes first, or as
+keyword arguments, using <parameter>target=</parameter>
+and <parameter>source=</parameter>.
+Although both arguments are required,
+in one particular case the target argument can actually be omitted
+because it can be inferred and &SCons; supplies it (see below).
 Builder methods also take a variety of
 keyword arguments, described below.
+</para>
+
+<para>
 The builder <emphasis>may</emphasis> add other targets
 beyond those requested if indicated by an <firstterm>Emitter</firstterm>
 (see <xref linkend="builder_objects"/> and, for example,
@@ -2671,11 +2678,6 @@ strings of white-space characters as the delimiter.
 method, but succeeds even if the input isn't a string.)</para>
 
 <para>
-The target and source arguments to a builder method
-can be specified either as positional arguments,
-in which case the target comes first, or as
-keyword arguments, using <parameter>target=</parameter>
-and <parameter>source=</parameter>.
 The following are equivalent examples of calling the
 &Program; builder method:
 </para>
@@ -2703,6 +2705,7 @@ contains separator characters, the search follows down
 from the starting point, which is the top of the directory tree for
 an absolute path and the current directory for a relative path.
 </para>
+
 <para>
 &scons; recognizes a third way to specify
 path strings: if the string begins with
@@ -2881,26 +2884,24 @@ to the Python module:</para>
 from SCons.Script import *
 </programlisting>
 
-<para>Builder methods return a <classname>NodeList</classname>
+<para>Builder methods return a <classname>NodeList</classname>,
 a list-like object whose elements are Nodes,
 &SCons;' internal representation of build targets or sources.
 See <xref linkend="node_objects"/> for more information.
-</para>
-
-<para>The returned i<classname>NodeList</classname> object
+The returned <classname>NodeList</classname> object
 can be passed to other builder methods as source(s)
 or passed to any &SCons; function or method
 where a filename would normally be accepted.
 </para>
 
-<para> For example, 
+<para> For example,
 to add a specific preprocessor define
 when compiling one specific object file
 but not the others:</para>
 
 <programlisting language="python">
 bar_obj_list = env.StaticObject('bar.c', CPPDEFINES='-DBAR')
-env.Program(source=['foo.c', bar_obj_list, 'main.c'])
+env.Program("prog", ['foo.c', bar_obj_list, 'main.c'])
 </programlisting>
 
 <para>Using a Node as in this example
@@ -2909,6 +2910,16 @@ by avoiding having to specify
 a platform-specific object suffix
 when calling the &Program; builder method.
 </para>
+
+<para>The <classname>NodeList</classname> object
+is also convenient to pass to the &f-link-Default; function,
+for the same reason of avoiding a platform-specific name:
+</para>
+
+<programlisting language="python">
+tgt = env.Program("prog", ["foo.c", "bar.c", "main.c"])
+Default(tgt)
+</programlisting>
 
 <para>Builder calls will automatically "flatten"
 lists passed as source and target, so they are free to
@@ -3476,14 +3487,34 @@ env = Environment(CC="cc")
 env2 = env.Clone(CC="cl.exe")
 </programlisting>
 
+<para>
+&Consvars; can also be supplied as keyword
+arguments to a builder, in which case those settings
+affect only the work done by that builder call,
+and not the &consenv; as a whole.
+This concept is called an <firstterm>override</firstterm>:
+</para>
+
+<programlisting language="python">
+env.Program('hello', 'hello.c', LIBS=['gl', 'glut'])
+</programlisting>
+
 <para>A number of useful &consvars; are automatically defined by
 scons for each supported platform, and additional &consvars;
 can be defined by the user. The following is a list of the possible
-automatically defined &consvars;.  The actual list available
+automatically defined &consvars;.
+</para>
+
+<para>Note the actual list available
 at execution time will not include all of these, as the ones
 detected as not being useful (wrong platform, necessary
 external command or files not installed, etc.) will not be set up.
-:</para>
+Correct build setups should be resilient to the possible
+absence of certain &consvars; before using them,
+for example by using a &Python; dictionary
+<function>get</function> method to retrieve the value and
+taking alternative action if the return indicates the variable is unset.
+</para>
 
 <!-- '\""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""" -->
 <!-- '\" BEGIN GENERATED CONSTRUCTION VARIABLE DESCRIPTIONS -->

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2881,20 +2881,16 @@ to the Python module:</para>
 from SCons.Script import *
 </programlisting>
 
-<para>Builder methods return a <firstterm>Node-list</firstterm>,
+<para>Builder methods return a <classname>NodeList</classname>
 a list-like object whose elements are Nodes,
 &SCons;' internal representation of build targets or sources.
 See <xref linkend="node_objects"/> for more information.
 </para>
 
-<para>The returned Node-list object
+<para>The returned i<classname>NodeList</classname> object
 can be passed to other builder methods as source(s)
 or passed to any &SCons; function or method
 where a filename would normally be accepted.
-Node-lists should not be used to set &consvars;
-such as &cv-link-LIBS; that expect to do transformation
-on strings - for that case,
-use the base name of the library as a string.
 </para>
 
 <para> For example, 
@@ -2951,7 +2947,7 @@ operator (<literal>+</literal> or <literal>+=</literal>)
 to append builder results to a Python list.
 Because the list and the object are different types,
 Python will not update the original list in place,
-but will instead create a new Node-list object
+but will instead create a new <classname>NodeList</classname> object
 containing the concatenation of the list
 elements and the builder results.
 This will cause problems for any other Python variables


### PR DESCRIPTION
A little more clarification, warning not to use returned node-list in certain places.

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
