### PR TITLE
[WIP] Improve callable Environment Variable signature check while expanding to string in Subst() (check order and enforce (minimally) target, source, env, for_signature))

### DIFF
--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -25,7 +25,7 @@
 
 import collections
 import re
-from inspect import signature
+from inspect import getfullargspec
 import SCons.Errors
 
 from SCons.Util import is_String, is_Sequence
@@ -420,7 +420,7 @@ class StringSubber:
             # which does not work the signature module, and the Null class returns an empty
             # string if called on, so we make an exception in this condition for Null class
             if (isinstance(s, SCons.Util.Null) or
-                set(signature(s).parameters.keys()) == set(['target', 'source', 'env', 'for_signature'])):
+                    getfullargspec(s).args[:4] == ['target', 'source', 'env', 'for_signature']):
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
                      env=self.env,

--- a/doc/user/builders-writing.xml
+++ b/doc/user/builders-writing.xml
@@ -654,7 +654,11 @@ def generate_actions(source, target, env, for_signature):
 
     <para>
 
-    The &generator; must return a
+    The required arguments must be listed in the function signature
+    in the correct order to be interpreted as a &generator;. More
+    arguments may be specified, but any extra required arguments must
+    be filled (such as by using a Python &partial; function or a &lambda;)
+    before the &generator; is called. The &generator; must return a
     command string or other action that will be used to
     build the specified target(s) from the specified source(s).
 


### PR DESCRIPTION
The change introduced in 52773da0faddc808056ffec34ed0112e2b42b5f7 to
check builder function signatures without relying on TypeError was both
too specific and not specific enough and can lead to confusing results.

Firstly, the check only verifies that the arguments are present and does
not verify that the arguments are in the correct order. Therefore, it is
still possible for someone to write a builder function with an incorrect
signature, having the arguments in the wrong order, that executes
successfully but has incorrect results.

Secondly, the strictness of the check - allowing *only* those arguments
in the documentation - can lead to a well-intentioned person writing
what they think is a builder function with a few extra arguments
(possibly filled by using `partial`) that then does not execute as a
builder function and has incorrect arguments passed to it.

In both of the above situations, users can become confused as to why
their builder functions are not executing properly, and especially in
the second case they can be led to believe that the functions *should*
execute properly because the documentation does not specify that *only*
the given arguments are allowed. In any case, there is no need to be so
strict - it's possible to determine the user's intent while at the same
time minimizing the likelihood of hard-to-diagnose errors.

This change makes the builder function signature check less strict in
the sense that it allows more than the required arguments, but more
strict because, unlike the previous change, those arguments must be in
the correct order. This will allow users to write partial functions that
fill in any remaining required or defaulted arguments before Subst is
called. An associated documentation change makes explicit what is
required and how to produce it, as well as what happens when the
requirement is not met.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
