### PR TITLE
Fix env = Program usage in docs

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2828,7 +2828,7 @@ broken into individual settings and merged into the appropriate &consvars;.
 </para>
 
 <programlisting language="python">
-env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
+env.Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
 </programlisting>
 
 <para>This example adds 'include' to

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -1702,7 +1702,8 @@ void main() { }
 
       <scons_example name="builders_override_ex2">
         <file name="SConstruct" printme="1">
-env = Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
+env = Environment()
+env.Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
         </file>
         <file name="hello.c">
 #include &lt;stdio.h&gt;


### PR DESCRIPTION
Two dodgy bits of example code were discovered which do `env = Program(....)`, fixed up.

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
