### PR TITLE
Allow subst callables to handle default value args and functions constructed using functools.partial to set extraneous args

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,12 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From William Deegan:
+    - Improve Subst()'s logic to check for proper callable function or class's argument list.
+      It will now allow callables with expected args, and any extra args as long as they
+      have default arguments. Additionally functions with no defaults for extra arguments
+      as long as they are set using functools.partial to create a new callable which set them.
+
   From Daniel Moody:
     - Update CacheDir to use uuid for tmpfile uniqueness instead of pid.
       This fixes cases for shared cache where two systems write to the same

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -19,8 +19,10 @@ DEPRECATED FUNCTIONALITY
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 
-- List modifications to existing features, where the previous behavior
-  wouldn't actually be considered a bug
+    - Improve Subst()'s logic to check for proper callable function or class's argument list.
+      It will now allow callables with expected args, and any extra args as long as they
+      have default arguments. Additionally functions with no defaults for extra arguments
+      as long as they are set using functools.partial to create a new callable which set them.
 
 FIXES
 -----

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -425,8 +425,8 @@ class StringSubber:
             # string if called on, so we make an exception in this condition for Null class
             # Also allow callables where the only non default valued args match the expected defaults
             # this should also allow functools.partial's to work.
-            if isinstance(s, SCons.Util.Null) or set([k for k, v in signature(s).parameters.items() if k in _callable_args_set or
-                                                      v.default == Parameter.empty]) == _callable_args_set:
+            if isinstance(s, SCons.Util.Null) or {k for k, v in signature(s).parameters.items() if
+                                                  k in _callable_args_set or v.default == Parameter.empty} == _callable_args_set:
 
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
@@ -602,9 +602,8 @@ class ListSubber(collections.UserList):
             # string if called on, so we make an exception in this condition for Null class
             # Also allow callables where the only non default valued args match the expected defaults
             # this should also allow functools.partial's to work.
-            if isinstance(s, SCons.Util.Null) or set(
-                    [k for k, v in signature(s).parameters.items() if k in _callable_args_set or
-                                                                      v.default == Parameter.empty]) == _callable_args_set:
+            if isinstance(s, SCons.Util.Null) or {k for k, v in signature(s).parameters.items() if
+                                                  k in _callable_args_set or v.default == Parameter.empty} == _callable_args_set:
 
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -25,9 +25,9 @@
 
 import collections
 import re
-from inspect import signature
-import SCons.Errors
+from inspect import signature, Parameter
 
+import SCons.Errors
 from SCons.Util import is_String, is_Sequence
 
 # Indexed by the SUBST_* constants below.
@@ -328,6 +328,8 @@ def subst_dict(target, source):
     return dict
 
 
+_callable_args_set = {'target', 'source', 'env', 'for_signature'}
+
 class StringSubber:
     """A class to construct the results of a scons_subst() call.
 
@@ -335,6 +337,8 @@ class StringSubber:
     source with two methods (substitute() and expand()) that handle
     the expansion.
     """
+
+
     def __init__(self, env, mode, conv, gvars):
         self.env = env
         self.mode = mode
@@ -419,8 +423,11 @@ class StringSubber:
             # SCons has the unusual Null class where any __getattr__ call returns it's self, 
             # which does not work the signature module, and the Null class returns an empty
             # string if called on, so we make an exception in this condition for Null class
-            if (isinstance(s, SCons.Util.Null) or
-                set(signature(s).parameters.keys()) == set(['target', 'source', 'env', 'for_signature'])):
+            # Also allow callables where the only non default valued args match the expected defaults
+            # this should also allow functools.partial's to work.
+            if isinstance(s, SCons.Util.Null) or set([k for k, v in signature(s).parameters.items() if k in _callable_args_set or
+                                                      v.default == Parameter.empty]) == _callable_args_set:
+
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
                      env=self.env,
@@ -593,8 +600,12 @@ class ListSubber(collections.UserList):
             # SCons has the unusual Null class where any __getattr__ call returns it's self, 
             # which does not work the signature module, and the Null class returns an empty
             # string if called on, so we make an exception in this condition for Null class
-            if (isinstance(s, SCons.Util.Null) or
-                set(signature(s).parameters.keys()) == set(['target', 'source', 'env', 'for_signature'])):
+            # Also allow callables where the only non default valued args match the expected defaults
+            # this should also allow functools.partial's to work.
+            if isinstance(s, SCons.Util.Null) or set(
+                    [k for k, v in signature(s).parameters.items() if k in _callable_args_set or
+                                                                      v.default == Parameter.empty]) == _callable_args_set:
+
                 s = s(target=lvars['TARGETS'],
                      source=lvars['SOURCES'],
                      env=self.env,


### PR DESCRIPTION
Allow subst callables to handle default value args and functions constructed using functools.partial to set extraneous args

This is an improved implementation of the logic in PR #3889 

These cases should now be handled
(You can find this sample SConstruct [here](https://github.com/bdbaddog/scons-bugswork/blob/main/subst_callable_class/SConstruct) )

```
import functools


class foo:
    def __init__(self, arg):
        self.arg = arg

    def __call__(self, target, source, env, for_signature):
        return self.arg + " bar"


# Will expand $BAR to "my argument bar baz"
env = Environment(FOO=foo, BAR="${FOO('my argument')} baz")

other_foo = foo(' Bananas')
env['BANANAS'] = other_foo

print("$BAR    ->%s" % env.subst("$BAR"))
print("$BANANAS->%s" % env.subst("$BANANAS"))


def afunc(target, source, env, for_signature, other_flag='one'):
    return "Fun %s" % other_flag


env['AFUNC'] = afunc
print("afunc   ->%s" % env.subst("$AFUNC"))

bfunc = functools.partial(afunc, other_flag='two')
env['BFUNC'] = bfunc
print("bfunc   ->%s" % env.subst("$BFUNC"))

def cs(target=None, source=None, env=None, for_signature=None):
    return 'cs'

env['CS'] = cs

print("CS     ->%s"%env.subst("$CS"))
```

Output:
```
scons: Reading SConscript files ...
$BAR    ->my argument bar baz
$BANANAS->Bananas bar
afunc   ->Fun one
bfunc   ->Fun two
CS     ->cs
scons: done reading SConscript files.
scons: Building targets ...
scons: `.' is up to date.
scons: done building targets.
```

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
