### PR TITLE
Fix Isssue #3035 by disabling versioned library symlinks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       It will now allow callables with expected args, and any extra args as long as they
       have default arguments. Additionally functions with no defaults for extra arguments
       as long as they are set using functools.partial to create a new callable which set them.
+    - Fix Issue #3035 - mingw with SHLIBVERSION set fails with either not a dll error or 
+      "Multiple ways to build the same target were specified for:".  Now mingw will disable
+      creating the symlinks (and adding version string to ) dlls.  It sets SHLIBNOVERSIONSYMLINKS,
+      IMPLIBNOVERSIONSYMLINKS and LDMODULENOVERSIONSYMLINKS to True.
 
   From Daniel Moody:
     - Update CacheDir to use uuid for tmpfile uniqueness instead of pid.

--- a/SCons/Tool/linkCommon/SharedLibrary.py
+++ b/SCons/Tool/linkCommon/SharedLibrary.py
@@ -28,7 +28,7 @@ from . import lib_emitter, EmitLibSymlinks, StringizeLibSymlinks
 
 
 def shlib_symlink_emitter(target, source, env, **kw):
-    verbose = False
+    verbose = True
 
     if "variable_prefix" in kw:
         var_prefix = kw["variable_prefix"]

--- a/SCons/Tool/mingw.py
+++ b/SCons/Tool/mingw.py
@@ -198,6 +198,11 @@ def generate(env):
     env['_SHLIBSUFFIX'] = '$SHLIBSUFFIX'
     env["SHLIBPREFIX"] = ""
 
+    # Disable creating symlinks for versioned shared library.
+    env['SHLIBNOVERSIONSYMLINKS'] = True
+    env['LDMODULENOVERSIONSYMLINKS'] = True
+    env['IMPLIBNOVERSIONSYMLINKS'] = True
+
 
 
 def exists(env):

--- a/test/MinGW/MinGWSharedLibrary.py
+++ b/test/MinGW/MinGWSharedLibrary.py
@@ -58,7 +58,13 @@ test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 env = Environment(tools=['mingw','link','g++'])
 #env.Tool('mingw')
-env.SharedLibrary('foobar', 'foobar.cc')
+foobar_obj = env.SharedObject('foobar.cc')
+env.SharedLibrary('foobar', foobar_obj)
+
+# Now verify versioned shared library doesn't fail
+env.SharedLibrary('foobar_ver', foobar_obj, SHLIBVERSION='2.4')
+
+
 """ % locals())
 
 test.run(arguments = ".")


### PR DESCRIPTION
Fixes #3035  - mingw with SHLIBVERSION set fails with either not a dll error or 
      "Multiple ways to build the same target were specified for:".  Now mingw will disable
      creating the symlinks (and adding version string to ) dlls.  It sets SHLIBNOVERSIONSYMLINKS,
      IMPLIBNOVERSIONSYMLINKS and LDMODULENOVERSIONSYMLINKS to True.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
