### PR TITLE
Drop dictionary has_key references: Py2-ism.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,6 +32,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add timing information for sconsign database dump when --debug=time
       is selected. Also switch to generally using time.perf_counter,
       which is the Python recommended way for timing short durations.
+    - Drop remaining definitions of dict-like has_key methods, since
+      Python 3 doesn't have a dictionary has_key (maintenance)
 
 
 RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,8 +29,9 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
       It will now allow callables with expected args, and any extra args as long as they
       have default arguments. Additionally functions with no defaults for extra arguments
       as long as they are set using functools.partial to create a new callable which set them.
-    - Internal has_key methods removed from SCons' dictionary-like objects,
-      to match Python 3 which no longer has dict.has_key.
+    - Internal has_key methods removed from SCons' dictionary-like objects
+      SubstitutionEnvironment and OverrideEnvironment - in other words,
+      an env - to match Python 3 which no longer has dict.has_key.
 
 FIXES
 -----

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
       It will now allow callables with expected args, and any extra args as long as they
       have default arguments. Additionally functions with no defaults for extra arguments
       as long as they are set using functools.partial to create a new callable which set them.
+    - Internal has_key methods removed from SCons' dictionary-like objects,
+      to match Python 3 which no longer has dict.has_key.
 
 FIXES
 -----

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -157,8 +157,8 @@ class Environment:
     def __setitem__(self, item, value):
         self.d[item] = value
 
-    def has_key(self, item):
-        return item in self.d
+    def __contains__(self, key):
+        return key in self.d
 
     def get(self, key, value=None):
         return self.d.get(key, value)

--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -118,10 +118,8 @@ class Environment:
         self.d[item] = var
     def __getitem__(self, item):
         return self.d[item]
-    def __contains__(self, item):
-        return self.d.__contains__(item)
-    def has_key(self, item):
-        return item in self.d
+    def __contains__(self, key):
+        return key in self.d
     def keys(self):
         return list(self.d.keys())
     def get(self, key, value=None):

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2411,7 +2411,7 @@ class OverrideEnvironment(Base):
             return self.__dict__['__subject'].get(key, default)
 
     def __contains__(self, key):
-        if key in self.__dict__['overrides']
+        if key in self.__dict__['overrides']:
             return True
         return key in self.__dict__['__subject']
 

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -413,7 +413,7 @@ class SubstitutionEnvironment:
         return self._dict.get(key, default)
 
     def __contains__(self, key):
-        return self._dict.__contains__(key)
+        return key in self._dict
 
     def keys(self):
         """Emulates the keys() method of dictionaries."""
@@ -2411,9 +2411,9 @@ class OverrideEnvironment(Base):
             return self.__dict__['__subject'].get(key, default)
 
     def __contains__(self, key):
-        if self.__dict__['overrides'].__contains__(key):
+        if key in self.__dict__['overrides']
             return True
-        return self.__dict__['__subject'].__contains__(key)
+        return key in self.__dict__['__subject']
 
     def Dictionary(self, *args):
         d = self.__dict__['__subject'].Dictionary().copy()

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -369,8 +369,7 @@ class SubstitutionEnvironment:
         self._special_set['SCANNERS'] = _set_SCANNERS
 
         # Freeze the keys of self._special_set in a list for use by
-        # methods that need to check.  (Empirically, list scanning has
-        # gotten better than dict.has_key() in Python 2.5.)
+        # methods that need to check.
         self._special_set_keys = list(self._special_set.keys())
 
     def __eq__(self, other):
@@ -392,10 +391,9 @@ class SubstitutionEnvironment:
         #
         # The "key in self._special_set_keys" test here seems to perform
         # pretty well for the number of keys we have.  A hard-coded
-        # list works a little better in Python 2.5, but that has the
+        # list worked a little better in Python 2.5, but that has the
         # disadvantage of maybe getting out of sync if we ever add more
-        # variable names.  Using self._special_set.has_key() works a
-        # little better in Python 2.4, but is worse than this test.
+        # variable names.
         # So right now it seems like a good trade-off, but feel free to
         # revisit this with bench/env.__setitem__.py as needed (and
         # as newer versions of Python come out).
@@ -413,10 +411,6 @@ class SubstitutionEnvironment:
     def get(self, key, default=None):
         """Emulates the get() method of dictionaries."""
         return self._dict.get(key, default)
-
-    def has_key(self, key):
-        """Emulates the has_key() method of dictionaries."""
-        return key in self._dict
 
     def __contains__(self, key):
         return self._dict.__contains__(key)
@@ -2416,17 +2410,9 @@ class OverrideEnvironment(Base):
         except KeyError:
             return self.__dict__['__subject'].get(key, default)
 
-    def has_key(self, key):
-        """Emulates the has_key() method of dictionaries."""
-        try:
-            self.__dict__['overrides'][key]
-            return 1
-        except KeyError:
-            return key in self.__dict__['__subject']
-
     def __contains__(self, key):
         if self.__dict__['overrides'].__contains__(key):
-            return 1
+            return True
         return self.__dict__['__subject'].__contains__(key)
 
     def Dictionary(self, *args):

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -219,12 +219,6 @@ class SubstitutionTestCase(unittest.TestCase):
         assert env.get('XXX') == 'x', env.get('XXX')
         assert env.get('YYY') is None, env.get('YYY')
 
-    def test_has_key(self):
-        """Test the SubstitutionEnvironment has_key() method."""
-        env = SubstitutionEnvironment(XXX = 'x')
-        assert 'XXX' in env
-        assert 'YYY' not in env
-
     def test_contains(self):
         """Test the SubstitutionEnvironment __contains__() method."""
         env = SubstitutionEnvironment(XXX = 'x')
@@ -3632,8 +3626,8 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
         assert env2.get('ZZZ') is None, env2.get('ZZZ')
         assert env3.get('ZZZ') == 'z3', env3.get('ZZZ')
 
-    def test_has_key(self):
-        """Test the OverrideEnvironment has_key() method"""
+    def test_contains(self):
+        """Test the OverrideEnvironment __contains__() method"""
         env, env2, env3 = self.envs
         assert 'XXX' in env, 'XXX' in env
         assert 'XXX' in env2, 'XXX' in env2
@@ -3644,19 +3638,6 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
         assert 'ZZZ' not in env, 'ZZZ' in env
         assert 'ZZZ' not in env2, 'ZZZ' in env2
         assert 'ZZZ' in env3, 'ZZZ' in env3
-
-    def test_contains(self):
-        """Test the OverrideEnvironment __contains__() method"""
-        env, env2, env3 = self.envs
-        assert 'XXX' in env
-        assert 'XXX' in env2
-        assert 'XXX' in env3
-        assert 'YYY' in env
-        assert 'YYY' in env2
-        assert 'YYY' in env3
-        assert 'ZZZ' not in env
-        assert 'ZZZ' not in env2
-        assert 'ZZZ' in env3
 
     def test_Dictionary(self):
         """Test the OverrideEnvironment Dictionary() method"""

--- a/SCons/Scanner/FortranTests.py
+++ b/SCons/Scanner/FortranTests.py
@@ -214,7 +214,7 @@ class DummyEnvironment:
         else:
             raise KeyError("Dummy environment only has FORTRANPATH attribute.")
 
-    def has_key(self, key):
+    def __contains__(self, key):
         return key in self.Dictionary()
 
     def __getitem__(self, key):

--- a/SCons/Scanner/IDLTests.py
+++ b/SCons/Scanner/IDLTests.py
@@ -207,7 +207,7 @@ class DummyEnvironment:
             path = [path]
         return list(map(self.subst, path))
 
-    def has_key(self, key):
+    def __contains__(self, key):
         return key in self.Dictionary()
 
     def __getitem__(self,key):

--- a/SCons/Scanner/ProgTests.py
+++ b/SCons/Scanner/ProgTests.py
@@ -57,7 +57,7 @@ class DummyEnvironment:
         else:
             return [self._dict[x] for x in args]
 
-    def has_key(self, key):
+    def __contains__(self, key):
         return key in self.Dictionary()
 
     def __getitem__(self,key):

--- a/SCons/Scanner/RCTests.py
+++ b/SCons/Scanner/RCTests.py
@@ -89,8 +89,8 @@ class DummyEnvironment(collections.UserDict):
             path = [path]
         return list(map(self.subst, path))
 
-    def has_key(self, key):
-        return key in self.Dictionary()
+    def __contains__(self, key):
+        return key in self.data
 
     def get_calculator(self):
         return None

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -227,7 +227,10 @@ class SConsOption(optparse.Option):
             fmt = "option %s: nargs='?' is incompatible with short options"
             raise SCons.Errors.UserError(fmt % self._short_opts[0])
 
-    CHECK_METHODS = optparse.Option.CHECK_METHODS + [_check_nargs_optional]
+    CHECK_METHODS = optparse.Option.CHECK_METHODS
+    if CHECK_METHODS is None:
+        CHECK_METHODS = []
+    CHECK_METHODS += [_check_nargs_optional]
     CONST_ACTIONS = optparse.Option.CONST_ACTIONS + optparse.Option.TYPED_ACTIONS
 
 class SConsOptionGroup(optparse.OptionGroup):

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -230,7 +230,7 @@ class SConsOption(optparse.Option):
     CHECK_METHODS = optparse.Option.CHECK_METHODS
     if CHECK_METHODS is None:
         CHECK_METHODS = []
-    CHECK_METHODS += [_check_nargs_optional]
+    CHECK_METHODS = CHECK_METHODS + [_check_nargs_optional]
     CONST_ACTIONS = optparse.Option.CONST_ACTIONS + optparse.Option.TYPED_ACTIONS
 
 class SConsOptionGroup(optparse.OptionGroup):

--- a/SCons/Tool/FortranCommonTests.py
+++ b/SCons/Tool/FortranCommonTests.py
@@ -49,7 +49,7 @@ class DummyEnvironment:
         self.fs = SCons.Node.FS.FS(test.workpath(''))
         self.dictionary = {}
 
-    def has_key(self, key):
+    def __contains__(self, key):
         return key in self.dictionary
 
     def __getitem__(self, key):

--- a/SCons/Tool/ToolTests.py
+++ b/SCons/Tool/ToolTests.py
@@ -47,8 +47,6 @@ class DummyEnvironment:
         self.dict[key] = val
     def __contains__(self, key):
         return key in self.dict
-    def __contains__(self, key):
-        return key in self.dict
     def subst(self, string, *args, **kwargs):
         return string
 

--- a/SCons/Tool/ToolTests.py
+++ b/SCons/Tool/ToolTests.py
@@ -46,8 +46,8 @@ class DummyEnvironment:
     def __setitem__(self, key, val):
         self.dict[key] = val
     def __contains__(self, key):
-        return self.dict.__contains__(key)
-    def has_key(self, key):
+        return key in self.dict
+    def __contains__(self, key):
         return key in self.dict
     def subst(self, string, *args, **kwargs):
         return string

--- a/SCons/Tool/msvsTests.py
+++ b/SCons/Tool/msvsTests.py
@@ -412,9 +412,6 @@ class DummyEnv:
     def __contains__(self, key):
         return key in self.dict
 
-    def has_key(self, name):
-        return name in self.dict
-
     def get(self, name, value=None):
         if name in self.dict:
             return self.dict[name]

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1216,14 +1216,13 @@ def uniquer(seq, idfun=None):
         idfun = default_idfun
     seen = {}
     result = []
+    result_append = result.append
     for item in seq:
         marker = idfun(item)
-        # in old Python versions:
-        # if seen.has_key(marker)
-        # but in new ones:
-        if marker in seen: continue
+        if marker in seen:
+            continue
         seen[marker] = 1
-        result.append(item)
+        result_append(item)
     return result
 
 # A more efficient implementation of Alex's uniquer(), this avoids the
@@ -1233,11 +1232,11 @@ def uniquer(seq, idfun=None):
 def uniquer_hashables(seq):
     seen = {}
     result = []
+    result_append = result.append
     for item in seq:
-        #if not item in seen:
         if item not in seen:
             seen[item] = 1
-            result.append(item)
+            result_append(item)
     return result
 
 

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1216,7 +1216,7 @@ def uniquer(seq, idfun=None):
         idfun = default_idfun
     seen = {}
     result = []
-    result_append = result.append
+    result_append = result.append  # perf: avoid repeated method lookups
     for item in seq:
         marker = idfun(item)
         if marker in seen:
@@ -1232,7 +1232,7 @@ def uniquer(seq, idfun=None):
 def uniquer_hashables(seq):
     seen = {}
     result = []
-    result_append = result.append
+    result_append = result.append  # perf: avoid repeated method lookups
     for item in seq:
         if item not in seen:
             seen[item] = 1

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -41,11 +41,7 @@ class Environment:
     def __getitem__(self, key):
         return self.dict[key]
     def __contains__(self, key):
-        return self.dict.__contains__(key)
-    def has_key(self, key):
         return key in self.dict
-
-
 
 
 def check(key, value, env):

--- a/SCons/dblite.py
+++ b/SCons/dblite.py
@@ -197,9 +197,6 @@ class dblite:
     def keys(self):
         return list(self._dict.keys())
 
-    def has_key(self, key):
-        return key in self._dict
-
     def __contains__(self, key):
         return key in self._dict
 


### PR DESCRIPTION
In some cases, added a `__contains__` method instead, not because it necessarily was needed, but for completeness.

No doc impacts: `has_key` already no longer appeared in either user guide or manpage.

Also one completely unrelated change because it happened to be sitting modified in the tree when I committed modified files: be a little more cautious about building `CHECK_METHODS` in our subclassing of the optparse `Option` class... current cpython starts it at `None`, then fills it in, so it *shouldn't* be `None` when we subclass, but this was a checker complaint.


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
