### PR TITLE
Don't chop some shlib names in _get_shlib_stem and adjustixes

### DIFF
--- a/SCons/Tool/linkCommon/SharedLibrary.py
+++ b/SCons/Tool/linkCommon/SharedLibrary.py
@@ -114,14 +114,17 @@ def _soname(target, source, env, for_signature):
         return "$SHLIBPREFIX$_get_shlib_stem${SHLIBSUFFIX}$_SHLIBSOVERSION"
 
 
-def _get_shlib_stem(target, source, env, for_signature):
-    """
-    Get the basename for a library (so for libxyz.so, return xyz)
-    :param target:
-    :param source:
-    :param env:
-    :param for_signature:
-    :return:
+def _get_shlib_stem(target, source, env, for_signature: bool) -> str:
+    """Get the base name of a shared library.
+
+    Args:
+        target: target node containing the lib name
+        source: source node, not used
+        env: environment context for running subst
+        for_signature: whether this is being done for signature generation
+
+    Returns:
+        the library name without prefix/suffix
     """
     verbose = False
 
@@ -135,10 +138,12 @@ def _get_shlib_stem(target, source, env, for_signature):
             % (target_name, shlibprefix, shlibsuffix)
         )
 
-    if target_name.startswith(shlibprefix):
-        target_name = target_name[len(shlibprefix) :]
+    if shlibprefix and target_name.startswith(shlibprefix):
+        # skip pathlogical case were target _is_ the prefix
+        if target_name != shlibprefix:
+            target_name = target_name[len(shlibprefix) :]
 
-    if target_name.endswith(shlibsuffix):
+    if shlibsuffix and target_name.endswith(shlibsuffix):
         target_name = target_name[: -len(shlibsuffix)]
 
     if verbose and not for_signature:
@@ -147,9 +152,17 @@ def _get_shlib_stem(target, source, env, for_signature):
     return target_name
 
 
-def _get_shlib_dir(target, source, env, for_signature):
-    """
-    Get the directory the shlib is in.
+def _get_shlib_dir(target, source, env, for_signature: bool) -> str:
+    """Get the directory the shared library is in.
+
+    Args:
+        target: target node
+        source: source node, not used
+        env: environment context, not used
+        for_signature: whether this is being done for signature generation
+
+    Returns:
+        the directory the library will be in (empty string if '.')
     """
     if target.dir and str(target.dir) != ".":
         print("target.dir:%s" % target.dir)
@@ -159,10 +172,10 @@ def _get_shlib_dir(target, source, env, for_signature):
 
 
 def setup_shared_lib_logic(env):
-    """
-    Just the logic for shared libraries
-    :param env:
-    :return:
+    """Initialize an environment for shared library building.
+
+    Args:
+        env: environment to set up
     """
     createSharedLibBuilder(env)
 

--- a/SCons/Tool/linkCommon/SharedLibrary.py
+++ b/SCons/Tool/linkCommon/SharedLibrary.py
@@ -28,7 +28,7 @@ from . import lib_emitter, EmitLibSymlinks, StringizeLibSymlinks
 
 
 def shlib_symlink_emitter(target, source, env, **kw):
-    verbose = True
+    verbose = False
 
     if "variable_prefix" in kw:
         var_prefix = kw["variable_prefix"]
@@ -138,13 +138,15 @@ def _get_shlib_stem(target, source, env, for_signature: bool) -> str:
             % (target_name, shlibprefix, shlibsuffix)
         )
 
-    if shlibprefix and target_name.startswith(shlibprefix):
-        # skip pathlogical case were target _is_ the prefix
-        if target_name != shlibprefix:
-            target_name = target_name[len(shlibprefix) :]
 
     if shlibsuffix and target_name.endswith(shlibsuffix):
         target_name = target_name[: -len(shlibsuffix)]
+
+    if shlibprefix and target_name.startswith(shlibprefix):
+        # skip pathological case were target _is_ the prefix
+        if target_name != shlibprefix:
+            target_name = target_name[len(shlibprefix) :]
+
 
     if verbose and not for_signature:
         print("_get_shlib_stem: target_name:%s AFTER" % (target_name,))

--- a/SCons/Tool/linkCommon/linkCommmonTests.py
+++ b/SCons/Tool/linkCommon/linkCommmonTests.py
@@ -38,7 +38,7 @@ class SharedLibraryTestCase(unittest.TestCase):
         """Test shlib_symlink_emitter() """
         env = Environment(tools=['gnulink'])
 
-        target = env.SharedLibrary('lib', 'lib.c', SHLIBSUFFIX=".so")
+        target = env.SharedLibrary('lib', 'lib.c', SHLIBPREFIX='lib', SHLIBSUFFIX=".so")
 
         target_name = str(target[0])
         self.assertEqual(str(target_name), 'liblib.so', "Expected target 'liblib.so' != '%s'" % target_name)

--- a/SCons/Tool/linkCommon/linkCommmonTests.py
+++ b/SCons/Tool/linkCommon/linkCommmonTests.py
@@ -1,0 +1,75 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Unit tests for linkCommon package
+"""
+
+import unittest
+
+from SCons.Environment import Environment
+
+
+class SharedLibraryTestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_shlib_symlink_emitter(self):
+        """Test shlib_symlink_emitter() """
+        env = Environment(tools=['gnulink'])
+
+        target = env.SharedLibrary('lib', 'lib.c', SHLIBSUFFIX=".so")
+
+        target_name = str(target[0])
+        self.assertEqual(str(target_name), 'liblib.so', "Expected target 'liblib.so' != '%s'" % target_name)
+
+        target = env.SharedLibrary('xyz', 'lib.c', SHLIBPREFIX='xyz', SHLIBSUFFIX=".so", SHLIBVERSION='1.2.3')
+
+        t0 = target[0]
+        target_name = str(t0)
+
+        assert target_name == 'xyzxyz.so.1.2.3', "Expected target 'xyzxyz.so.1.2.3' != '%s'" % target_name
+
+        if hasattr(t0.attributes, 'shliblinks'):
+            (soname_symlink, t0_1) = t0.attributes.shliblinks[0]
+            (shlib_noversion_symlink, t0_2) = t0.attributes.shliblinks[1]
+
+            self.assertEqual(t0_1, t0, "soname_symlink target is not target[0]")
+            self.assertEqual(t0_2, t0, "shlib_noversion_symlink target is not target[0]")
+            self.assertEqual(str(soname_symlink), 'xyzxyz.so.1',
+                             "soname symlink is not 'xyzxyz.so.1': '%s'" % str(soname_symlink))
+            self.assertEqual(str(shlib_noversion_symlink), 'xyzxyz.so',
+                             "shlib_noversion_symlink is not 'xyzxyz.so': '%s'" % str(shlib_noversion_symlink))
+
+        else:
+            self.fail('Target xyzxyz.so.1.2.3 has no .attributes.shliblinks')
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1114,10 +1114,14 @@ else:
 
 
 def adjustixes(fname, pre, suf, ensure_suffix=False):
-    if pre or suf:
+    """
+    Add prefix to file if specified.
+    Add suffix to file if specified and if ensure_suffix = True
+
+    """
+    if pre:
         path, fn = os.path.split(os.path.normpath(fname))
 
-    if pre:
         # Handle the odd case where the filename = the prefix.
         # In that case, we still want to add the prefix to the file
         if fn[:len(pre)] != pre or fn == pre:
@@ -1127,7 +1131,7 @@ def adjustixes(fname, pre, suf, ensure_suffix=False):
     # is present or there's no suffix on it at all.
     # Also handle the odd case where the filename = the suffix.
     # in that case we still want to append the suffix
-    if suf and (fname[-len(suf):] != suf or fn == suf) and \
+    if suf and fname[-len(suf):] != suf and \
             (ensure_suffix or not splitext(fname)[1]):
         fname = fname + suf
     return fname

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1112,15 +1112,20 @@ else:
     def case_sensitive_suffixes(s1, s2):
         return (os.path.normcase(s1) != os.path.normcase(s2))
 
+
 def adjustixes(fname, pre, suf, ensure_suffix=False):
     if pre:
         path, fn = os.path.split(os.path.normpath(fname))
+        # Handle the odd case where the filename = the prefix.
+        # In that case, we still want to add the prefix to the file
         if fn[:len(pre)] != pre or fn == pre:
             fname = os.path.join(path, pre + fn)
     # Only append a suffix if the suffix we're going to add isn't already
     # there, and if either we've been asked to ensure the specific suffix
     # is present or there's no suffix on it at all.
-    if suf and fname[-len(suf):] != suf and \
+    # Also handle the odd case where the filename = the suffix.
+    # in that case we still want to append the suffix
+    if suf and (fname[-len(suf):] != suf or fn == suf) and \
        (ensure_suffix or not splitext(fname)[1]):
             fname = fname + suf
     return fname

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1115,7 +1115,7 @@ else:
 def adjustixes(fname, pre, suf, ensure_suffix=False):
     if pre:
         path, fn = os.path.split(os.path.normpath(fname))
-        if fn[:len(pre)] != pre:
+        if fn[:len(pre)] != pre or fn == pre:
             fname = os.path.join(path, pre + fn)
     # Only append a suffix if the suffix we're going to add isn't already
     # there, and if either we've been asked to ensure the specific suffix

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -23,12 +23,12 @@
 
 """Various SCons utility functions."""
 
-import os
-import sys
 import copy
-import re
-import pprint
 import hashlib
+import os
+import pprint
+import re
+import sys
 from collections import UserDict, UserList, UserString, OrderedDict
 from collections.abc import MappingView
 from types import MethodType, FunctionType
@@ -1114,8 +1114,10 @@ else:
 
 
 def adjustixes(fname, pre, suf, ensure_suffix=False):
-    if pre:
+    if pre or suf:
         path, fn = os.path.split(os.path.normpath(fname))
+
+    if pre:
         # Handle the odd case where the filename = the prefix.
         # In that case, we still want to add the prefix to the file
         if fn[:len(pre)] != pre or fn == pre:
@@ -1126,8 +1128,8 @@ def adjustixes(fname, pre, suf, ensure_suffix=False):
     # Also handle the odd case where the filename = the suffix.
     # in that case we still want to append the suffix
     if suf and (fname[-len(suf):] != suf or fn == suf) and \
-       (ensure_suffix or not splitext(fname)[1]):
-            fname = fname + suf
+            (ensure_suffix or not splitext(fname)[1]):
+        fname = fname + suf
     return fname
 
 

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -714,6 +714,10 @@ class UtilTestCase(unittest.TestCase):
         assert r == 'pre-file.xxx', r
         r = adjustixes('dir/file', 'pre-', '-suf')
         assert r == os.path.join('dir', 'pre-file-suf'), r
+        r = adjustixes('PREFIX', 'PREFIX', 'SUFFIX')
+        assert r == 'PREFIXPREFIXSUFFIX', "Failed handling when filename = PREFIX [r='%s']"%r
+        r = adjustixes('SUFFIX', 'PREFIX', 'SUFFIX')
+        assert r == 'PREFIXSUFFIXSUFFIX', "Failed handling when filename = SUFFIX [r='%s']"%r
 
     def test_containsAny(self):
         """Test the containsAny() function"""

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -714,10 +714,11 @@ class UtilTestCase(unittest.TestCase):
         assert r == 'pre-file.xxx', r
         r = adjustixes('dir/file', 'pre-', '-suf')
         assert r == os.path.join('dir', 'pre-file-suf'), r
+
+        # Verify that the odd case when library name is specified as 'lib'
+        # doesn't yield lib.so, but yields the expected liblib.so
         r = adjustixes('PREFIX', 'PREFIX', 'SUFFIX')
         assert r == 'PREFIXPREFIXSUFFIX', "Failed handling when filename = PREFIX [r='%s']"%r
-        r = adjustixes('SUFFIX', 'PREFIX', 'SUFFIX')
-        assert r == 'PREFIXSUFFIXSUFFIX', "Failed handling when filename = SUFFIX [r='%s']"%r
 
     def test_containsAny(self):
         """Test the containsAny() function"""

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -21,12 +21,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from collections import UserDict, UserList, UserString
 import functools
 import io
 import os
 import sys
 import unittest
+from collections import UserDict, UserList, UserString
 
 import TestCmd
 
@@ -718,7 +718,7 @@ class UtilTestCase(unittest.TestCase):
         # Verify that the odd case when library name is specified as 'lib'
         # doesn't yield lib.so, but yields the expected liblib.so
         r = adjustixes('PREFIX', 'PREFIX', 'SUFFIX')
-        assert r == 'PREFIXPREFIXSUFFIX', "Failed handling when filename = PREFIX [r='%s']"%r
+        assert r == 'PREFIXPREFIXSUFFIX', "Failed handling when filename = PREFIX [r='%s']" % r
 
     def test_containsAny(self):
         """Test the containsAny() function"""


### PR DESCRIPTION
Avoid a couple of pathological cases: if `SHLIBPREFIX` or `SHLIBSUFFIX` is empty, there's nothing to chop anyway , so just skip (the latter case had the chance of returning an empty string).  If the libname is exactly `SHLIBPREFIX`, leave it alone, else we'd return an empty string.

Fiddle some docstrings.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
