### PR TITLE
 The XSLT stylesheet file is now initialized to an env.File() Node, such that dependencies work correctly in hierarchical builds.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,11 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Henrik Maier:
+   - DocbookXslt tool: The XSLT stylesheet file is now initialized to an env.File() Node, 
+     such that dependencies work correctly in hierarchical builds (eg when using 
+     DocbookXslt in SConscript('subdir/SConscript') context.
+
   From William Deegan:
     - Improve Subst()'s logic to check for proper callable function or class's argument list.
       It will now allow callables with expected args, and any extra args as long as they

--- a/SCons/Tool/docbook/__init__.py
+++ b/SCons/Tool/docbook/__init__.py
@@ -761,7 +761,7 @@ def DocbookXslt(env, target, source=None, *args, **kw):
     target, source = __extend_targets_sources(target, source)
 
     # Init XSL stylesheet
-    kw['DOCBOOK_XSL'] = kw.get('xsl', 'transform.xsl')
+    kw['DOCBOOK_XSL'] = env.File(kw.get('xsl', 'transform.xsl'))
 
     # Setup builder
     __builder = __select_builder(__lxml_builder, __xsltproc_builder)

--- a/test/Docbook/basic/xsltsubdir/image/SConstruct
+++ b/test/Docbook/basic/xsltsubdir/image/SConstruct
@@ -1,0 +1,3 @@
+env = Environment()
+
+SConscript('subdir/SConscript', 'env')

--- a/test/Docbook/basic/xsltsubdir/image/subdir/SConscript
+++ b/test/Docbook/basic/xsltsubdir/image/subdir/SConscript
@@ -1,0 +1,8 @@
+Import('env')
+env = env.Clone(tools=['docbook'])
+
+#
+# Create document
+#
+env.DocbookXslt('out.xml', 'in.xml', 
+                xsl='to_docbook.xslt')

--- a/test/Docbook/basic/xsltsubdir/image/subdir/in.xml
+++ b/test/Docbook/basic/xsltsubdir/image/subdir/in.xml
@@ -1,0 +1,77 @@
+<book xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+  <bookinfo>
+    <title>SCons 2.3.5</title>
+    <subtitle>User Guide</subtitle>
+
+    <author>
+      <firstname>Steven</firstname>
+      <surname>Knight</surname>
+    </author>
+
+    <corpauthor>Steven Knight and the SCons Development Team</corpauthor>
+
+    <pubdate>2004 - 2020</pubdate>
+
+    <copyright>
+      <year>2004 - 2020</year>
+      <holder>The SCons Foundation</holder>
+    </copyright>
+
+    <legalnotice xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
+    <blockquote>
+        <para>
+            SCons User's Guide Copyright (c) 2004-2019 Steven Knight
+        </para>
+    </blockquote>
+
+
+</legalnotice>
+
+    <releaseinfo>version 2.3.5</releaseinfo>
+
+  </bookinfo>
+
+
+<chapter xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+<title>Builders</title>
+
+<para>...</para>
+
+<section>
+<title>Test</title>
+
+<para>...</para>
+</section>
+
+</chapter>
+
+<appendix xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+<title>Construction Variables</title>
+
+<para>
+In this appendix...
+</para>
+
+<variablelist xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+  <varlistentry id="cv-ASCOMSTR">
+    <term>
+      <envar>ASCOMSTR</envar>
+    </term>
+    <listitem><para>
+The string displayed when an object file
+is generated from an assembly-language source file.
+If this is not set, then $ASCOM (the command line) is displayed.
+</para>
+
+<example_commands>
+env = Environment(ASCOMSTR = "Assembling $TARGET")
+</example_commands>
+</listitem>
+  </varlistentry>
+</variablelist>
+
+</appendix>
+
+</book>
+

--- a/test/Docbook/basic/xsltsubdir/image/subdir/to_docbook.xslt
+++ b/test/Docbook/basic/xsltsubdir/image/subdir/to_docbook.xslt
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Changing element names from SCons XSD to real Docbook.
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+                              xmlns:fo="http://www.w3.org/1999/XSL/Format" 
+                              xmlns:scons="http://www.scons.org/dbxsd/v1.0">
+  <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+ 
+  <!-- Copy everything unmatched -->
+  <xsl:template match="*">
+    <xsl:element name="{local-name()}">
+      <xsl:copy-of select="@*"/>      
+      <xsl:apply-templates select="node()"/>
+    </xsl:element>
+  </xsl:template>
+ 
+  <xsl:template match="text() | comment() | processing-instruction()">
+    <xsl:copy/>
+  </xsl:template>
+
+  <!-- Helper function for replacing strings in strings -->
+  <xsl:template name="string-replace-all">
+    <xsl:param name="text" />
+    <xsl:param name="replace" />
+    <xsl:param name="by" />
+    <xsl:choose>
+      <xsl:when test="contains($text, $replace)">
+        <xsl:value-of select="substring-before($text,$replace)" />
+        <xsl:value-of select="$by" />
+        <xsl:call-template name="string-replace-all">
+          <xsl:with-param name="text"
+          select="substring-after($text,$replace)" />
+          <xsl:with-param name="replace" select="$replace" />
+          <xsl:with-param name="by" select="$by" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$text" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- Leaving scons_example empty -->
+  <xsl:template match="scons:scons_example">
+    <xsl:apply-templates select="node()"/>
+  </xsl:template>
+ 
+  <!-- Changing example_commands to screen -->
+  <xsl:template match="scons:example_commands">
+    <xsl:element name="screen">
+      <xsl:apply-templates select="node()"/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- Leaving scons_output empty, should already
+       have been handled by xinclude_examples.xslt -->
+  <xsl:template match="scons:scons_output">
+    <xsl:apply-templates select="node()"/>
+  </xsl:template>
+
+  <!-- Leaving scons_output_command empty, should already
+       have been handled by xinclude_examples.xslt.
+    -->
+  <xsl:template match="scons:scons_output_command">
+  </xsl:template>
+
+  <!-- Leaving scons_example_file empty, should already
+       have been handled by xinclude_examples.xslt.
+    -->
+  <xsl:template match="scons:scons_example_file">
+  </xsl:template>
+
+  <!-- Changing file to programlisting if printme == '1' -->
+  <xsl:template match="scons:file">
+    <xsl:if test="@printme='1'">
+      <xsl:element name="programlisting">
+       <xsl:call-template name="string-replace-all">
+        <xsl:with-param name="text" select="node()" />
+        <xsl:with-param name="replace" select="'__ROOT__'" />
+        <xsl:with-param name="by" select="''" />
+       </xsl:call-template>
+      </xsl:element>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Changing sconstruct to programlisting -->
+  <xsl:template match="scons:sconstruct">
+    <xsl:element name="programlisting">
+      <xsl:call-template name="string-replace-all">
+       <xsl:with-param name="text" select="node()" />
+       <xsl:with-param name="replace" select="'__ROOT__'" />
+       <xsl:with-param name="by" select="''" />
+      </xsl:call-template>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- Leave directory empty -->
+  <xsl:template match="scons:directory">
+  </xsl:template>
+ 
+</xsl:stylesheet>

--- a/test/Docbook/basic/xsltsubdir/xsltsubdir.py
+++ b/test/Docbook/basic/xsltsubdir/xsltsubdir.py
@@ -31,7 +31,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 try:
-    import lxml
+    import lxml # noqa: F401
 except Exception:
     test.skip_test('Cannot find installed Python binding for lxml, skipping test.\n')
 

--- a/test/Docbook/basic/xsltsubdir/xsltsubdir.py
+++ b/test/Docbook/basic/xsltsubdir/xsltsubdir.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2001-2010 The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Test the Xslt builder in a hierarchical build scenario
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+try:
+    import lxml
+except Exception:
+    test.skip_test('Cannot find installed Python binding for lxml, skipping test.\n')
+
+test.dir_fixture('image')
+
+# Normal invocation
+test.run()
+test.must_not_be_empty(test.workpath('subdir/out.xml'))
+test.must_contain(test.workpath('subdir/out.xml'),'<screen>', mode='r')
+test.must_not_contain(test.workpath('subdir/out.xml'),'<example_commands>', mode='r')
+
+
+# Cleanup
+test.run(arguments='-c')
+test.must_not_exist(test.workpath('subdir/out.xml'))
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Re-applying a patch I submitted already in 2013 and was accepted back then. Refer to commit e63d742d2026 in the old Mercurial https://bitbucket.org/dirkbaechle/scons_docbook repo.

Somehow during upgrade and integration of the docbook this must have got lost.

I only stumbled across this because I finally upgraded from Scons 3 to 4 after all those years.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
