### PR TITLE
Skip empty cmdline args as targets

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       which is the Python recommended way for timing short durations.
     - Drop remaining definitions of dict-like has_key methods, since
       Python 3 doesn't have a dictionary has_key (maintenance)
+    - Ignore empty cmdline arguments when computing targets (issue 2986)
 
 
 RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -984,13 +984,17 @@ def _main(parser):
     if options.interactive:
         SCons.Node.interactive = True
 
-    # That should cover (most of) the options.  Next, set up the variables
-    # that hold command-line arguments, so the SConscript files that we
-    # read and execute have access to them.
+    # That should cover (most of) the options.
+    # Next, set up the variables that hold command-line arguments,
+    # so the SConscript files that we read and execute have access to them.
+    # TODO: for options defined via AddOption which take space-separated
+    # option-args, the option-args will collect into targets here,
+    # because we don't yet know to do any different.
     targets = []
     xmit_args = []
     for a in parser.largs:
-        if a[:1] == '-':
+        # Skip so-far unrecognized options, and empty string args
+        if a.startswith('-') or a in ('', '""', "''"):
             continue
         if '=' in a:
             xmit_args.append(a)

--- a/test/TARGETS.py
+++ b/test/TARGETS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test use of the COMMAND_LINE_TARGETS and DEFAULT_TARGETS variables.
@@ -134,6 +133,21 @@ scons: Nothing to be done for `command_line_target'.
 scons: Nothing to be done for `sconscript_target'.
 """)
 test.run(arguments = 'command_line_target', stdout = expect)
+
+
+
+# blanks in cmdline should not be treated as targets (issue 2986)
+test.write(
+    file='SConstruct',
+    content="""\
+tgt_foo = Textfile(target="foo", source="foostuff")
+tgt_bar = Textfile(target="bar", source="bartuff")
+Default(tgt_foo)
+""",
+)
+test.run(arguments=["-Q", "-n", "''"], stdout="Creating 'foo.txt'\n")
+test.run(arguments=["-Q", "-n", ""], stdout="Creating 'foo.txt'\n")
+test.run(arguments=["-Q", "-n", '""'], stdout="Creating 'foo.txt'\n")
 
 
 


### PR DESCRIPTION
Previously, quoted empty arguments like `''`, `'""`', `"''"` were added to targets, which had some side effects - a blank would eventually turn into a Node for the top directory (`'.'`), meaning `Default` calls were ignored since a target is specified and
thus the whole tree will be built,

Fixes #2986

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
