### PR TITLE
Change site-dir arg handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       which is the Python recommended way for timing short durations.
     - Drop remaining definitions of dict-like has_key methods, since
       Python 3 doesn't have a dictionary has_key (maintenance)
+    - Do not treat --site-dir=DIR and --no-site-dir as distinct options.
+      Allows a later instance to override an earlier one.
 
 
 RELEASE 4.1.0 - Tues, 19 Jan 2021 15:04:42 -0700

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -775,7 +775,7 @@ def _load_site_scons_dir(topdir, site_dir_name=None):
         raise
 
 
-def _load_all_site_scons_dirs(topdir, verbose=None):
+def _load_all_site_scons_dirs(topdir, verbose=False):
     """Load all of the predefined site_scons dir.
     Order is significant; we load them in order from most generic
     (machine-wide) to most specific (topdir).
@@ -968,10 +968,12 @@ def _main(parser):
     if options.no_progress or options.silent:
         progress_display.set_mode(0)
 
-    if options.site_dir:
-        _load_site_scons_dir(d.get_internal_path(), options.site_dir)
-    elif not options.no_site_dir:
+    # if site_dir unchanged from default None, neither --site-dir
+    # nor --no-site-dir was seen, use SCons default
+    if options.site_dir is None:
         _load_all_site_scons_dirs(d.get_internal_path())
+    elif options.site_dir:  # if a dir was set, use it
+        _load_site_scons_dir(d.get_internal_path(), options.site_dir)
 
     if options.include_dir:
         sys.path = options.include_dir + sys.path

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -801,8 +801,8 @@ def Parser(version):
                   help="Don't build; just print commands.")
 
     op.add_option('--no-site-dir',
-                  dest='no_site_dir', default=False,
-                  action="store_true",
+                  dest='site_dir',
+                  action="store_false",
                   help="Don't search or use the usual site_scons dir.")
 
     op.add_option('--profile',

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -7750,8 +7750,14 @@ release, it may be necessary to specify
   <varlistentry id="v-SCONSFLAGS">
     <term><envar>SCONSFLAGS</envar></term>
     <listitem>
-<para>A string of options that will be used by &scons;
-in addition to those passed on the command line.</para>
+<para>A string containing options that will be used by &scons;
+in addition to those passed on the command line.
+Can be used to reduce frequent retyping of common options.
+The contents of <envar>SCONSFLAGS</envar> are considered
+before any passed command line options,
+so the command line can be used to override
+<envar>SCONSFLAGS</envar> options if necessary.
+</para>
     </listitem>
   </varlistentry>
 
@@ -7760,8 +7766,8 @@ in addition to those passed on the command line.</para>
     <listitem>
 <para>(Windows only). If set, save the shell environment variables
 generated when setting up the Microsoft Visual C++ compiler
-(and/or Build Tools) to a file to give these settings,
-which are expensive to generate, persistence
+(and/or Build Tools) to a cache file, to give these settings,
+which are relatively expensive to generate, persistence
 across &scons; invocations.
 Use of this option is primarily intended to aid performance
 in tightly controlled Continuous Integration setups.</para>

--- a/test/site_scons/basic.py
+++ b/test/site_scons/basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/site_scons/no-site-dir.py
+++ b/test/site_scons/no-site-dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of the --no-site-dir option:

--- a/test/site_scons/nonexistent.py
+++ b/test/site_scons/nonexistent.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that specifying --site-dir= with a nonexistent directory

--- a/test/site_scons/override.py
+++ b/test/site_scons/override.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 
 """

--- a/test/site_scons/site_init.py
+++ b/test/site_scons/site_init.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify various aspects of the handling of site_init.py.
@@ -41,7 +40,7 @@ test.subdir('site_scons')
 
 def _test_metadata():
     """Test site_init's module metadata.
-    
+
     The following special variables should be predefined: __doc__,
     __file__ and __name__. No special variables should be transferred from
     SCons.Script.

--- a/test/site_scons/sys-path.py
+++ b/test/site_scons/sys-path.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the site_scons dir is added to sys.path as an

--- a/test/site_scons/sysdirs.py
+++ b/test/site_scons/sysdirs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the


### PR DESCRIPTION
chat discussion: this should work to not use a site_dir:
```
$ export SCONSFLAGS=--site-dir=foo
$ scons --no-site-dir
```
Commit changes the two options to write to the same variable, so "last one on command line wins" works out. Added a test for
this to `test/site_scons/site-dir.py`.

Manpage updated to clarify the order of considering `SCONSFLAGS`, since order does matter.

Closes #3904

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
