### PR TITLE
Stop stripping INSTALLSTR

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -45,6 +45,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Remove long-deprecated construction variables PDFCOM, WIN32_INSERT_DEF,
       WIN32DEFPREFIX, WIN32DEFSUFFIX, WIN32EXPPREFIX, WIN32EXPSUFFIX.
       All have been replaced by other names since at least 1.0.
+    - Don't strip spaces in INSTALLSTR by using raw subst (issue 2018)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/Tool/install.py
+++ b/SCons/Tool/install.py
@@ -35,8 +35,13 @@ from shutil import copy2, copymode, copystat
 
 import SCons.Action
 import SCons.Tool
-from SCons.Tool.linkCommon import StringizeLibSymlinks, CreateLibSymlinks, EmitLibSymlinks
 import SCons.Util
+from SCons.Subst import SUBST_RAW
+from SCons.Tool.linkCommon import (
+    StringizeLibSymlinks,
+    CreateLibSymlinks,
+    EmitLibSymlinks,
+)
 
 #
 # We keep track of *all* installed files.
@@ -257,7 +262,7 @@ def installFuncVersionedLib(target, source, env):
 def stringFunc(target, source, env):
     installstr = env.get('INSTALLSTR')
     if installstr:
-        return env.subst_target_source(installstr, 0, target, source)
+        return env.subst_target_source(installstr, SUBST_RAW, target, source)
     target = str(target[0])
     source = str(source[0])
     if os.path.isdir(source):

--- a/test/Install/INSTALLSTR.py
+++ b/test/Install/INSTALLSTR.py
@@ -36,16 +36,18 @@ test = TestSCons.TestSCons()
 
 test.subdir('install')
 
+# Check that spaces aren't stripped in INSTALLSTR  by using
+# extra whitespace in the string (issue 2018)
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=[], INSTALLSTR = 'INSTALL $SOURCE => $TARGET!')
+env = Environment(tools=[], INSTALLSTR='INSTALL  $SOURCE => $TARGET!')
 env.Install('install', 'file')
 """)
 
 test.write('file', "file\n")
 
 test.run(stdout=test.wrap_stdout("""\
-INSTALL file => %s!
+INSTALL  file => %s!
 """) % os.path.join('install', 'file'))
 
 test.must_match(['install', 'file'], "file\n")


### PR DESCRIPTION
The install module now calls the substitution routine with a raw argument.

Fixes issue #2018

No doc impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
