### PR TITLE
Drop the local CLVar class from EnvironmentTests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -45,6 +45,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Remove long-deprecated construction variables PDFCOM, WIN32_INSERT_DEF,
       WIN32DEFPREFIX, WIN32DEFSUFFIX, WIN32EXPPREFIX, WIN32EXPSUFFIX.
       All have been replaced by other names since at least 1.0.
+    - Remove local copy of CLVar in EnvironmentTests unittest file -
+      should be testing against the production version, and they
+      didn't really differ.
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -32,6 +32,7 @@ from collections import UserDict as UD, UserList as UL
 
 import TestCmd
 
+import SCons.Warnings
 from SCons.Environment import (
     Environment,
     NoSubstitutionProxy,
@@ -39,7 +40,7 @@ from SCons.Environment import (
     SubstitutionEnvironment,
     is_valid_construction_var,
 )
-import SCons.Warnings
+from SCons.Util import CLVar
 
 
 def diff_env(env1, env2):
@@ -130,17 +131,6 @@ class Scanner:
     def __str__(self):
         return self.name
 
-
-
-class CLVar(UL):
-    def __init__(self, seq):
-        if isinstance(seq, str):
-            seq = seq.split()
-        UL.__init__(self, seq)
-    def __add__(self, other):
-        return UL.__add__(self, CLVar(other))
-    def __radd__(self, other):
-        return UL.__radd__(self, CLVar(other))
 
 class DummyNode:
     def __init__(self, name):


### PR DESCRIPTION
The one from Util is almost the same, and the tests should be stressing the "real" one anyway.

No doc impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
