### PR TITLE
Do not overwrite LINKFLAGS if user set it

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -52,7 +52,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       didn't really differ.
     - Don't strip spaces in INSTALLSTR by using raw subst (issue 2018)
     - Deprecate Python 3.5 as a supported version.
-    - Do not overwrite user-set LINK and LINKFLAGS in linker tool (issue 2357)
+    - Do not overwrite user-set LINKFLAGS in POSIX linker tool (issue 2357)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -52,6 +52,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       didn't really differ.
     - Don't strip spaces in INSTALLSTR by using raw subst (issue 2018)
     - Deprecate Python 3.5 as a supported version.
+    - Do not overwrite user-set LINK and LINKFLAGS in linker tool (issue 2357)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -869,7 +869,7 @@ sys.exit(0)
 
         # avoid SubstitutionEnvironment for these, has no .Append method,
         # which is needed for unique=False test
-        env = Environment(CCFLAGS=None)
+        env = Environment(CCFLAGS="")
         # merge with existing but empty flag
         env.MergeFlags('-X')
         assert env['CCFLAGS'] == ['-X'], env['CCFLAGS']

--- a/SCons/Tool/link.py
+++ b/SCons/Tool/link.py
@@ -23,7 +23,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Tool-specific initialization for the generic Posix linker.
+Tool-specific initialization for the generic POSIX linker.
 
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()
@@ -48,8 +48,7 @@ def generate(env):
     setup_loadable_module_logic(env)
 
     env['SMARTLINK'] = smart_link
-    if 'LINK' not in env:
-        env['LINK'] = "$SMARTLINK"
+    env['LINK'] = "$SMARTLINK"
     if 'LINKFLAGS' not in env:
         env['LINKFLAGS'] = SCons.Util.CLVar('')
 

--- a/SCons/Tool/link.py
+++ b/SCons/Tool/link.py
@@ -21,7 +21,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
 """
 Tool-specific initialization for the generic Posix linker.
 
@@ -48,8 +48,10 @@ def generate(env):
     setup_loadable_module_logic(env)
 
     env['SMARTLINK'] = smart_link
-    env['LINK'] = "$SMARTLINK"
-    env['LINKFLAGS'] = SCons.Util.CLVar('')
+    if 'LINK' not in env:
+        env['LINK'] = "$SMARTLINK"
+    if 'LINKFLAGS' not in env:
+        env['LINKFLAGS'] = SCons.Util.CLVar('')
 
     # __RPATH is only set to something ($_RPATH typically) on platforms that support it.
     env['LINKCOM'] = '$LINK -o $TARGET $LINKFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS'

--- a/test/Libs/SharedLibrary-update-deps.py
+++ b/test/Libs/SharedLibrary-update-deps.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,16 +22,16 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Test that SharedLibrary() updates when a different lib is linked, even if it has the same md5.
+Test that SharedLibrary() updates when a different lib is linked,
+even if it has the same md5.
 This is https://github.com/SCons/scons/issues/2903
 """
 
 import sys
+import sysconfig
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -50,7 +52,7 @@ test.run(arguments='libname=foo')
 test.must_not_contain_any_line(test.stdout(), ["is up to date"])
 
 # Now try changing the link command line (in an innocuous way); should rebuild.
-if sys.platform == 'win32':
+if sys.platform == 'win32' and not sysconfig.get_platform() in ("mingw",):
     extraflags='shlinkflags=/DEBUG'
 else:
     extraflags='shlinkflags=-g'

--- a/test/Libs/SharedLibrary.py
+++ b/test/Libs/SharedLibrary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import sys
@@ -33,38 +32,36 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 import sys
-env=Environment(WINDOWS_INSERT_DEF=1)
-env2 = Environment(LIBS = [ 'foo1', 'foo2', 'foo3' ],
-                   LIBPATH = [ '.' ])
-env.SharedLibrary(target = 'foo1', source = 'f1.c')
+
+env = Environment(WINDOWS_INSERT_DEF=1)
+env2 = Environment(LIBS=['foo1', 'foo2', 'foo3'], LIBPATH=['.'])
+env.SharedLibrary(target='foo1', source='f1.c')
 if sys.platform == 'win32':
-    env.StaticLibrary(target = 'foo1-static', source = 'f1.c')
+    env.StaticLibrary(target='foo1-static', source='f1.c')
 else:
-    env.StaticLibrary(target = 'foo1', source = 'f1.c')
-SharedLibrary(target = 'foo2',
-              source = Split('f2a.c f2b.c f2c.c'),
-              WINDOWS_INSERT_DEF = 1)
-env.SharedLibrary(target = 'foo3', source = ['f3a.c', 'f3b.c', 'f3c.c'], no_import_lib = 1)
-env2.Program(target = 'prog', source = 'prog.c')
+    env.StaticLibrary(target='foo1', source='f1.c')
+SharedLibrary(target='foo2', source=Split('f2a.c f2b.c f2c.c'), WINDOWS_INSERT_DEF=1)
+env.SharedLibrary(target='foo3', source=['f3a.c', 'f3b.c', 'f3c.c'], no_import_lib=1)
+env2.Program(target='prog', source='prog.c')
 """)
 
 test.write('SConstructFoo', """
-env=Environment()
+env = Environment()
 obj = env.Object('foo', 'foo.c')
-Default(env.SharedLibrary(target = 'foo', source = obj))
+Default(env.SharedLibrary(target='foo', source=obj))
 """)
 
 test.write('SConstructFoo2', """
-env=Environment()
+env = Environment()
 obj = env.SharedObject('bar', 'foo.c')
-Default(env.Library(target = 'foo', source = obj))
+Default(env.Library(target='foo', source=obj))
 """)
 
 test.write('SConstructBaz', """
-env=Environment()
+env = Environment()
 env['SHLIBVERSION'] = '1.0.0'
 obj = env.SharedObject('baz', 'foo.c')
-Default(env.SharedLibrary(target = 'baz', source = obj))
+Default(env.SharedLibrary(target='baz', source=obj))
 """)
 
 test.write('foo.c', r"""
@@ -252,7 +249,7 @@ env2.Program(target = 'progbar', source = 'progbar.c')
     test.write('f4.c', r"""
 #include <stdio.h>
 
-f4(void)
+void f4(void)
 {
         printf("f4.c\n");
         fflush(stdout);

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the sconsign script works with files generated when
@@ -99,13 +98,15 @@ sub2_inc2_h     = 'sub2/inc2.h'
 
 test.write(['SConstruct'], """\
 SConsignFile()
-env1 = Environment(PROGSUFFIX = '.exe',
-                   OBJSUFFIX = '.obj',
-                   CCCOM = [[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-                   LINKCOM = [[r'%(fake_link_py)s', '$TARGET', '$SOURCE']])
+env1 = Environment(
+    PROGSUFFIX='.exe',
+    OBJSUFFIX='.obj',
+    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+)
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
-env2 = env1.Clone(CPPPATH = ['sub2'])
+env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
 """ % locals())
 

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the sconsign script works when using a .sconsign file in
@@ -108,16 +107,18 @@ test.chmod(fake_link_py, 0o755)
 test.write('SConstruct', """
 SConsignFile(None)
 Decider('timestamp-newer')
-env1 = Environment(PROGSUFFIX = '.exe',
-                   OBJSUFFIX = '.obj',
-                   # Specify the command lines with lists-of-lists so
-                   # finding the implicit dependencies works even with
-                   # spaces in the fake_*_py path names.
-                   CCCOM = [[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-                   LINKCOM = [[r'%(fake_link_py)s', '$TARGET', '$SOURCE']])
+env1 = Environment(
+    PROGSUFFIX='.exe',
+    OBJSUFFIX='.obj',
+    # Specify the command lines with lists-of-lists so
+    # finding the implicit dependencies works even with
+    # spaces in the fake_*_py path names.
+    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+)
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
-env2 = env1.Clone(CPPPATH = ['sub2'])
+env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
 """ % locals())
 

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -110,16 +112,18 @@ sub2_inc2_h     = 'sub2/inc2.h'
 
 test.write(['SConstruct'], """
 SConsignFile(None)
-env1 = Environment(PROGSUFFIX = '.exe',
-                   OBJSUFFIX = '.obj',
-                   # Specify the command lines with lists-of-lists so
-                   # finding the implicit dependencies works even with
-                   # spaces in the fake_*_py path names.
-                   CCCOM = [[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-                   LINKCOM = [[r'%(fake_link_py)s', '$TARGET', '$SOURCE']])
+env1 = Environment(
+    PROGSUFFIX='.exe',
+    OBJSUFFIX='.obj',
+    # Specify the command lines with lists-of-lists so
+    # finding the implicit dependencies works even with
+    # spaces in the fake_*_py path names.
+    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+)
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
-env2 = env1.Clone(CPPPATH = ['sub2'])
+env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
 """ % locals())
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -415,7 +415,7 @@ def fail_test(self=None, condition=True, function=None, skip=0, message=None):
     sys.exit(1)
 
 
-def no_result(self=None, condition=True, function=None, skip=0):
+def no_result(self=None, condition=True, function=None, skip=False):
     """Causes a test to exit with no valid result.
 
     By default, the no_result() method reports NO RESULT for the test
@@ -1226,7 +1226,7 @@ class TestCmd:
 
     match_re_dotall = staticmethod(match_re_dotall)
 
-    def no_result(self, condition=True, function=None, skip=0):
+    def no_result(self, condition=True, function=None, skip=False):
         """Report that the test could not be run."""
         if not condition:
             return

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -103,6 +103,7 @@ import glob
 import os
 import stat
 import sys
+import sysconfig
 
 from collections import UserList
 
@@ -122,9 +123,13 @@ __all__.extend([ 'TestCommon',
 
 # Variables that describe the prefixes and suffixes on this system.
 if sys.platform == 'win32':
+    if sysconfig.get_platform() == "mingw":
+        obj_suffix   = '.o'
+        shobj_suffix = '.o'
+    else:
+        obj_suffix   = '.obj'
+        shobj_suffix = '.obj'
     exe_suffix   = '.exe'
-    obj_suffix   = '.obj'
-    shobj_suffix = '.obj'
     shobj_prefix = ''
     lib_prefix   = ''
     lib_suffix   = '.lib'
@@ -744,11 +749,11 @@ class TestCommon(TestCmd):
             sys.stdout.flush()
         pass_skips = os.environ.get('TESTCOMMON_PASS_SKIPS')
         if pass_skips in [None, 0, '0']:
-            # skip=1 means skip this function when showing where this
+            # skip=True means skip this function when showing where this
             # result came from.  They only care about the line where the
             # script called test.skip_test(), not the line number where
             # we call test.no_result().
-            self.no_result(skip=1)
+            self.no_result(skip=True)
         else:
             # We're under the development directory for this change,
             # so this is an Aegis invocation; pass the test (exit 0).


### PR DESCRIPTION
The `link.py` tool unconditionally set `LINKFLAGS` (and `LINK`), keep existing values if user tried to set them.

Fixes issue #2357

No attempt to fix this generally - there are lots of tools which set something without checking, and the referenced issue has some discussion of making a special type that does a bit better. Leave that topic for another time.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
