### PR TITLE
allow coverage to fail in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
   allow_failures:
     - python: pypy3
     - python: 3.10-dev
+    - name: coverage
 
   include:
     - &test_job


### PR DESCRIPTION
It appears travis coverage (which runs slower in general) causes some race condition or timing issue in the test/Parallel/failed-build.py test, so the coverage job often fails.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
