### PR TITLE
Expansion of CPPDEFINES now substs consvars

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       didn't really differ.
     - Don't strip spaces in INSTALLSTR by using raw subst (issue 2018)
     - Deprecate Python 3.5 as a supported version.
+    - CPPDEFINES now expands construction variable references (issue 2363)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -358,26 +358,26 @@ Touch = ActionFactory(touch_func,
 # Internal utility functions
 
 
-def _concat(prefix, list, suffix, env, f=lambda x: x, target=None, source=None):
+def _concat(prefix, iter, suffix, env, f=lambda x: x, target=None, source=None):
     """
-    Creates a new list from 'list' by first interpolating each element
+    Creates a new list from 'iter' by first interpolating each element
     in the list using the 'env' dictionary and then calling f on the
     list, and finally calling _concat_ixes to concatenate 'prefix' and
     'suffix' onto each element of the list.
     """
-    if not list:
-        return list
+    if not iter:
+        return iter
 
-    l = f(SCons.PathList.PathList(list).subst_path(env, target, source))
+    l = f(SCons.PathList.PathList(iter).subst_path(env, target, source))
     if l is not None:
-        list = l
+        iter = l
 
-    return _concat_ixes(prefix, list, suffix, env)
+    return _concat_ixes(prefix, iter, suffix, env)
 
 
-def _concat_ixes(prefix, list, suffix, env):
+def _concat_ixes(prefix, iter, suffix, env):
     """
-    Creates a new list from 'list' by concatenating the 'prefix' and
+    Creates a new list from 'iter' by concatenating the 'prefix' and
     'suffix' arguments onto each element of the list.  A trailing space
     on 'prefix' or leading space on 'suffix' will cause them to be put
     into separate list elements rather than being concatenated.
@@ -389,7 +389,7 @@ def _concat_ixes(prefix, list, suffix, env):
     prefix = str(env.subst(prefix, SCons.Subst.SUBST_RAW))
     suffix = str(env.subst(suffix, SCons.Subst.SUBST_RAW))
 
-    for x in list:
+    for x in SCons.Util.flatten(iter):
         if isinstance(x, SCons.Node.FS.File):
             result.append(x)
             continue
@@ -513,7 +513,7 @@ def _defines(prefix, defs, suffix, env, c=_concat_ixes):
     into a list of C preprocessor command-line definitions.
     """
 
-    return c(prefix, env.subst_path(processDefines(defs)), suffix, env)
+    return c(prefix, env.subst_list(processDefines(defs)), suffix, env)
 
 
 class NullCmdGenerator:

--- a/test/CPPDEFINES/basic.py
+++ b/test/CPPDEFINES/basic.py
@@ -38,12 +38,13 @@ test_list = [
     ['x', 'y', 'z'],
     ['x', ['y', 123], 'z', ('int', '$INTEGER')],
     { 'c' : 3, 'b': None, 'a' : 1 },
+    "${TESTDEFS}",
 ]
 for i in test_list:
-    env = Environment(CPPDEFPREFIX='-D', CPPDEFSUFFIX='', INTEGER=0)
+    env = Environment(CPPDEFPREFIX='-D', CPPDEFSUFFIX='', INTEGER=0, TESTDEFS=["FOO", "BAR=1"])
     print(env.Clone(CPPDEFINES=i).subst('$_CPPDEFFLAGS'))
 for i in test_list:
-    env = Environment(CPPDEFPREFIX='|', CPPDEFSUFFIX='|', INTEGER=1)
+    env = Environment(CPPDEFPREFIX='|', CPPDEFSUFFIX='|', INTEGER=1, TESTDEFS=["FOO", "BAR=1"])
     print(env.Clone(CPPDEFINES=i).subst('$_CPPDEFFLAGS'))
 """)
 
@@ -53,10 +54,12 @@ expect = test.wrap_stdout(build_str="scons: `.' is up to date.\n",
 -Dx -Dy -Dz
 -Dx -Dy=123 -Dz -Dint=0
 -Da=1 -Db -Dc=3
+-DFOO -DBAR=1
 |xyz|
 |x| |y| |z|
 |x| |y=123| |z| |int=1|
 |a=1| |b| |c=3|
+|FOO| |BAR=1|
 """)
 
 test.run(arguments = '.', stdout=expect)


### PR DESCRIPTION
By calling `env.subst_list` instead of `env.subst_path`, and then flattening the result, the processed defines can have construction vars interpolated.

Note issue of SOURCE and TARGET not being expanded, as they're special and are not passed to the relevant function (as in issue #3477), is not fixed by this change.

Fixes #2363

No doc impact.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
