### PR TITLE
Test tweaks to help testing on mingw-only win32 systems

### DIFF
--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -869,7 +869,7 @@ sys.exit(0)
 
         # avoid SubstitutionEnvironment for these, has no .Append method,
         # which is needed for unique=False test
-        env = Environment(CCFLAGS=None)
+        env = Environment(CCFLAGS="")
         # merge with existing but empty flag
         env.MergeFlags('-X')
         assert env['CCFLAGS'] == ['-X'], env['CCFLAGS']

--- a/SCons/Tool/link.py
+++ b/SCons/Tool/link.py
@@ -21,9 +21,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
 """
-Tool-specific initialization for the generic Posix linker.
+Tool-specific initialization for the generic POSIX linker.
 
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()

--- a/test/Decider/MD5-winonly-fixture/test_parse.y
+++ b/test/Decider/MD5-winonly-fixture/test_parse.y
@@ -1,6 +1,9 @@
 %{
 #include<stdio.h>
 
+int yyerror(char *s);
+int yylex();
+
 int regs[26];
 int base;
 
@@ -25,11 +28,13 @@ digit: DIGIT;
 
 
 %%
+int
 main()
 {
  return(yyparse());
 }
 
+int
 yyerror(s)
 char *s;
 {
@@ -37,6 +42,7 @@ char *s;
   return(0);
 }
 
+int
 yywrap()
 {
   return(1);

--- a/test/LEX/LEXFLAGS.py
+++ b/test/LEX/LEXFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
+import sysconfig
 
 import TestSCons
 
@@ -59,10 +59,12 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment(LEX = r'%(_python_)s mylex.py',
-                  LEXFLAGS = '-x -I${TARGET.dir} -I${SOURCE.dir}',
-                  tools=['default', 'lex'])
-env.CFile(target = 'out/aaa', source = 'in/aaa.l')
+env = Environment(
+    LEX=r'%(_python_)s mylex.py',
+    LEXFLAGS='-x -I${TARGET.dir} -I${SOURCE.dir}',
+    tools=['default', 'lex'],
+)
+env.CFile(target='out/aaa', source='in/aaa.l')
 """ % locals())
 
 test.write(['in', 'aaa.l'], "aaa.l\nLEXFLAGS\nI_ARGS\n")
@@ -70,7 +72,7 @@ test.write(['in', 'aaa.l'], "aaa.l\nLEXFLAGS\nI_ARGS\n")
 test.run('.', stderr = None)
 
 lexflags = ' -x -t'
-if sys.platform == 'win32':
+if sys.platform == 'win32' and not sysconfig.get_platform() in ("mingw",):
     lexflags = ' --nounistd' + lexflags
 # Read in with mode='r' because mylex.py implicitley wrote to stdout
 # with mode='w'.

--- a/test/LEX/live_mingw.py
+++ b/test/LEX/live_mingw.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test LEX and LEXFLAGS and unistd.h with a live lex in mingw environment.
@@ -41,7 +40,7 @@ if sys.platform != 'win32':
     test.skip_test('Not windows environment; skipping test.\n')
 
 if not test.where_is('gcc'):
-        test.skip_test('No mingw or cygwin build environment found; skipping test.\n')
+    test.skip_test('No mingw or cygwin build environment found; skipping test.\n')
 
 lex = test.where_is('lex') or test.where_is('flex')
 
@@ -53,12 +52,14 @@ test.file_fixture('wrapper.py')
 test.write('SConstruct', """
 foo = Environment(tools=['default', 'mingw', 'lex'], LEXUNISTD="")
 lex = foo.Dictionary('LEX')
-bar = Environment(LEX = r'%(_python_)s wrapper.py ' + lex,
-                  LEXFLAGS = '-b',
-                  LEXUNISTD="",
-                  tools=['default', 'mingw', 'lex'])
-foo.Program(target = 'foo', source = 'foo.l')
-bar.Program(target = 'bar', source = 'bar.l')
+bar = Environment(
+    LEX=r'%(_python_)s wrapper.py ' + lex,
+    LEXFLAGS='-b',
+    LEXUNISTD="",
+    tools=['default', 'mingw', 'lex'],
+)
+foo.Program(target='foo', source='foo.l')
+bar.Program(target='bar', source='bar.l')
 """ % locals())
 
 lex = r"""

--- a/test/Libs/SharedLibrary-update-deps.py
+++ b/test/Libs/SharedLibrary-update-deps.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,16 +22,16 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Test that SharedLibrary() updates when a different lib is linked, even if it has the same md5.
+Test that SharedLibrary() updates when a different lib is linked,
+even if it has the same md5.
 This is https://github.com/SCons/scons/issues/2903
 """
 
 import sys
+import sysconfig
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -50,7 +52,7 @@ test.run(arguments='libname=foo')
 test.must_not_contain_any_line(test.stdout(), ["is up to date"])
 
 # Now try changing the link command line (in an innocuous way); should rebuild.
-if sys.platform == 'win32':
+if sys.platform == 'win32' and not sysconfig.get_platform() in ("mingw",):
     extraflags='shlinkflags=/DEBUG'
 else:
     extraflags='shlinkflags=-g'

--- a/test/Libs/SharedLibrary.py
+++ b/test/Libs/SharedLibrary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import sys
@@ -33,38 +32,36 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 import sys
-env=Environment(WINDOWS_INSERT_DEF=1)
-env2 = Environment(LIBS = [ 'foo1', 'foo2', 'foo3' ],
-                   LIBPATH = [ '.' ])
-env.SharedLibrary(target = 'foo1', source = 'f1.c')
+
+env = Environment(WINDOWS_INSERT_DEF=1)
+env2 = Environment(LIBS=['foo1', 'foo2', 'foo3'], LIBPATH=['.'])
+env.SharedLibrary(target='foo1', source='f1.c')
 if sys.platform == 'win32':
-    env.StaticLibrary(target = 'foo1-static', source = 'f1.c')
+    env.StaticLibrary(target='foo1-static', source='f1.c')
 else:
-    env.StaticLibrary(target = 'foo1', source = 'f1.c')
-SharedLibrary(target = 'foo2',
-              source = Split('f2a.c f2b.c f2c.c'),
-              WINDOWS_INSERT_DEF = 1)
-env.SharedLibrary(target = 'foo3', source = ['f3a.c', 'f3b.c', 'f3c.c'], no_import_lib = 1)
-env2.Program(target = 'prog', source = 'prog.c')
+    env.StaticLibrary(target='foo1', source='f1.c')
+SharedLibrary(target='foo2', source=Split('f2a.c f2b.c f2c.c'), WINDOWS_INSERT_DEF=1)
+env.SharedLibrary(target='foo3', source=['f3a.c', 'f3b.c', 'f3c.c'], no_import_lib=1)
+env2.Program(target='prog', source='prog.c')
 """)
 
 test.write('SConstructFoo', """
-env=Environment()
+env = Environment()
 obj = env.Object('foo', 'foo.c')
-Default(env.SharedLibrary(target = 'foo', source = obj))
+Default(env.SharedLibrary(target='foo', source=obj))
 """)
 
 test.write('SConstructFoo2', """
-env=Environment()
+env = Environment()
 obj = env.SharedObject('bar', 'foo.c')
-Default(env.Library(target = 'foo', source = obj))
+Default(env.Library(target='foo', source=obj))
 """)
 
 test.write('SConstructBaz', """
-env=Environment()
+env = Environment()
 env['SHLIBVERSION'] = '1.0.0'
 obj = env.SharedObject('baz', 'foo.c')
-Default(env.SharedLibrary(target = 'baz', source = obj))
+Default(env.SharedLibrary(target='baz', source=obj))
 """)
 
 test.write('foo.c', r"""
@@ -252,7 +249,7 @@ env2.Program(target = 'progbar', source = 'progbar.c')
     test.write('f4.c', r"""
 #include <stdio.h>
 
-f4(void)
+void f4(void)
 {
         printf("f4.c\n");
         fflush(stdout);

--- a/test/MinGW/MinGWSharedLibrary.py
+++ b/test/MinGW/MinGWSharedLibrary.py
@@ -41,30 +41,28 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-if sys.platform not in ('cygwin','win32',):
-    test.skip_test("Skipping mingw test on non-Windows %s platform."%sys.platform)
+if sys.platform not in ('cygwin', 'win32',):
+    test.skip_test("Skipping mingw test on non-Windows platform %s." % sys.platform)
 
-gcc = SCons.Tool.find_program_path(test.Environment(), 'gcc', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
+dp = MINGW_DEFAULT_PATHS
+gcc = SCons.Tool.find_program_path(test.Environment(), 'gcc', default_paths=dp)
 if not gcc:
     test.skip_test("Skipping mingw test, no MinGW found.\n")
 
 test.write('foobar.cc', """
 int abc(int a) {
   return (a+1);
-  }
-  """)
+}
+""")
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
-env = Environment(tools=['mingw','link','g++'])
-#env.Tool('mingw')
+env = Environment(tools=['mingw', 'link', 'g++'])
 foobar_obj = env.SharedObject('foobar.cc')
 env.SharedLibrary('foobar', foobar_obj)
 
 # Now verify versioned shared library doesn't fail
 env.SharedLibrary('foobar_ver', foobar_obj, SHLIBVERSION='2.4')
-
-
 """ % locals())
 
 test.run(arguments = ".")

--- a/test/MinGW/RCCOM.py
+++ b/test/MinGW/RCCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $RCCOM construction variable
-when using MinGW.
+when using MinGW. This test does not use a compiler.
 """
 
 import sys
@@ -37,14 +36,17 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 
 if sys.platform in ('irix6',):
-    test.skip_test("Skipping mingw test on non-Windows %s platform."%sys.platform)
+    test.skip_test("Skipping mingw test on non-Windows platform %s." % sys.platform)
 
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'mingw'],
-                  RCCOM = r'%(_python_)s mycompile.py rc $TARGET $SOURCES')
-env.RES(target = 'aaa', source = 'aaa.rc')
+DefaultEnvironment(tools=[])
+env = Environment(
+    tools=['default', 'mingw'],
+    RCCOM=r'%(_python_)s mycompile.py rc $TARGET $SOURCES',
+)
+env.RES(target='aaa', source='aaa.rc')
 """ % locals())
 
 test.write('aaa.rc', "aaa.rc\n/*rc*/\n")

--- a/test/MinGW/RCCOMSTR.py
+++ b/test/MinGW/RCCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $RCCOMSTR construction variable allows you to customize
-the displayed string when rc is called.
+the displayed string when rc is called when using MinGW.
+This test does not use a compiler.
 """
 
 import sys
@@ -42,10 +42,13 @@ if sys.platform in ('irix6',):
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'mingw'],
-                  RCCOM = r'%(_python_)s mycompile.py rc $TARGET $SOURCES',
-                  RCCOMSTR = 'RCing $TARGET from $SOURCE')
-env.RES(target = 'aaa', source = 'aaa.rc')
+DefaultEnvironment(tools=[])
+env = Environment(
+    tools=['default', 'mingw'],
+    RCCOM=r'%(_python_)s mycompile.py rc $TARGET $SOURCES',
+    RCCOMSTR='RCing $TARGET from $SOURCE',
+)
+env.RES(target='aaa', source='aaa.rc')
 """ % locals())
 
 test.write('aaa.rc', "aaa.rc\n/*rc*/\n")

--- a/test/MinGW/WINDOWS_INSERT_DEF.py
+++ b/test/MinGW/WINDOWS_INSERT_DEF.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Make sure that WINDOWS_INSERT_DEF isn't ignored when using MinGW.
@@ -39,11 +38,11 @@ from SCons.Platform.cygwin import CYGWIN_DEFAULT_PATHS
 
 test = TestSCons.TestSCons()
 
-if sys.platform not in ('cygwin', 'win32'):
-    test.skip_test(
-        "Skipping mingw test on non-Windows platform: %s" % sys.platform)
+if sys.platform not in ('cygwin', 'win32',):
+    test.skip_test("Skipping mingw test on non-Windows platform %s\n" % sys.platform)
 
-gcc = SCons.Tool.find_program_path(test.Environment(), 'gcc', default_paths=MINGW_DEFAULT_PATHS + CYGWIN_DEFAULT_PATHS )
+dp = MINGW_DEFAULT_PATHS
+gcc = SCons.Tool.find_program_path(test.Environment(), 'gcc', default_paths=dp)
 if not gcc:
     test.skip_test("Skipping mingw test, no MinGW found.\n")
 
@@ -53,9 +52,9 @@ int hello_world(void) { return printf("Orbis, te saluto!\n"); }
 """)
 
 test.write('SConstruct', """
-env = Environment(TOOLS = ['mingw'])
-hello_dll = env.SharedLibrary(WINDOWS_INSERT_DEF = 0,
-    target = 'hello', source = 'hello.c')
+DefaultEnvironment(tools=[])
+env = Environment(TOOLS=['mingw'])
+hello_dll = env.SharedLibrary(WINDOWS_INSERT_DEF=0, target='hello', source='hello.c')
 """ % locals())
 
 test.run(arguments = ".")

--- a/test/MinGW/bug_2799/SConstruct
+++ b/test/MinGW/bug_2799/SConstruct
@@ -1,12 +1,12 @@
 env = Environment(
-        tools = ['mingw'],
-        SHCCCOMSTR = 'SHCC $TARGET',
-        SHLINKCOMSTR = 'SHLINK $TARGET',
-        LDMODULECOMSTR = 'LDMODULE $TARGET',
-        SHOBSUFFIX='.o',
-        SHLIBSUFFIX='.so',
-        SHLIBPREFIX='lib',
-        LDMODULESUFFIX='.so',
+    tools=['mingw'],
+    SHCCCOMSTR='SHCC $TARGET',
+    SHLINKCOMSTR='SHLINK $TARGET',
+    LDMODULECOMSTR='LDMODULE $TARGET',
+    SHOBSUFFIX='.o',
+    SHLIBSUFFIX='.so',
+    SHLIBPREFIX='lib',
+    LDMODULESUFFIX='.so',
 )
 
 env.SharedLibrary('testlib', 'shlib.c')

--- a/test/MinGW/mingw_uses_comstr_issue_2799.py
+++ b/test/MinGW/mingw_uses_comstr_issue_2799.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -37,13 +39,16 @@ test = TestSCons.TestSCons()
 test.dir_fixture('bug_2799')
 
 test.run('-n -Q')
-test.must_contain_all_lines(test.stdout(),
-              [
-                  'SHCC shlib.o',
-                  'SHLINK libtestlib.so',
-                  'SHCC module.o',
-                  'LDMODULE libtestmodule.so',''],
-              )
+test.must_contain_all_lines(
+    test.stdout(),
+    [
+        'SHCC shlib.o',
+        'SHLINK libtestlib.so',
+        'SHCC module.o',
+        'LDMODULE libtestmodule.so',
+        '',
+    ],
+)
 
 test.pass_test()
 

--- a/test/Win32/mingw.py
+++ b/test/Win32/mingw.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -21,10 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 """
 This tests the MinGW C/C++ compiler support.
+This test requires MinGW to be installed.
 """
-
 
 import os
 import sys
@@ -39,13 +41,11 @@ if sys.platform != 'win32':
     msg = "Skipping mingw test on non-Windows platform '%s'\n" % sys.platform
     test.skip_test(msg)
 
-# This test requires MinGW to be installed:
 test.write('SConstruct',"""
-from SCons.Tool.mingw import exists
 import sys
+from SCons.Tool.mingw import exists
 
 DefaultEnvironment(tools=[])
-
 env = Environment()
 if exists(env):
     print('mingw exists')
@@ -61,12 +61,17 @@ test.subdir('header')
 # Do the actual testing:
 test.write('SConstruct',"""
 DefaultEnvironment(tools=[])
-env=Environment(tools=['mingw'])
+env = Environment(tools=['mingw'])
 assert env['CC'] == 'gcc'
 env.StaticLibrary('static', 'static.cpp')
 env.SharedLibrary('shared', 'shared.cpp')
 env.SharedLibrary('cshared', ['cshared.c', 'cshared.def'], WINDOWS_INSERT_DEF=1)
-env.Program('test', ['test.cpp', env.RES('resource.rc', CPPPATH=['header'])], LIBS=['static', 'shared', 'cshared'], LIBPATH=['.'])
+env.Program(
+    'test',
+    ['test.cpp', env.RES('resource.rc', CPPPATH=['header'])],
+    LIBS=['static', 'shared', 'cshared'],
+    LIBPATH=['.'],
+)
 """)
 
 test.write('test.cpp', '''

--- a/test/Win32/msvc_mingw_env.py
+++ b/test/Win32/msvc_mingw_env.py
@@ -1,10 +1,8 @@
-"""
-This tests the MinGW  with MSVC tool.
-"""
-
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -24,9 +22,10 @@ This tests the MinGW  with MSVC tool.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""
+This tests the MinGW  with MSVC tool.
+"""
 
 import sys
 
@@ -43,21 +42,22 @@ test.skip_if_not_msvc()
 
 # control test: check for nologo and cl in env
 test.write('SConstruct',"""
-env=Environment(tools=['default'])
+DefaultEnvironment(tools=[])
+env = Environment(tools=['default'])
 print('CCFLAGS=' + str(env['CCFLAGS']).strip())
 print('CC=' + str(env['CC']).strip())
 """)
 test.run(arguments='-Q -s')
-if('CCFLAGS=/nologo' not in test.stdout()
-    or 'CC=cl' not in test.stdout()):
+if 'CCFLAGS=/nologo' not in test.stdout() or 'CC=cl' not in test.stdout():
     test.fail_test()
 
 # make sure windows msvc doesnt add bad mingw flags 
 # and that gcc is selected
 test.write('SConstruct',"""
-env=Environment(tools=['default', 'mingw'])
-print('CCFLAGS="' +  str(env['CCFLAGS']).strip() + '"')
-print('CC=' +  str(env['CC']).strip())
+DefaultEnvironment(tools=[])
+env = Environment(tools=['default', 'mingw'])
+print('CCFLAGS="' + str(env['CCFLAGS']).strip() + '"')
+print('CC=' + str(env['CC']).strip())
 """)
 test.run(arguments='-Q -s')
 if('CCFLAGS=""' not in test.stdout()
@@ -66,18 +66,19 @@ if('CCFLAGS=""' not in test.stdout()
 
 # msvc should overwrite the flags and use cl
 test.write('SConstruct',"""
-env=Environment(tools=['mingw', 'default'])
+DefaultEnvironment(tools=[])
+env = Environment(tools=['mingw', 'default'])
 print('CCFLAGS=' + str(env['CCFLAGS']).strip())
 print('CC=' + str(env['CC']).strip())
 """)
 test.run(arguments='-Q -s')
-if('CCFLAGS=/nologo' not in test.stdout()
-    or 'CC=cl' not in test.stdout()):
+if 'CCFLAGS=/nologo' not in test.stdout() or 'CC=cl' not in test.stdout():
     test.fail_test()
 
 # test that CCFLAGS are preserved
 test.write('SConstruct',"""
-env=Environment(tools=['mingw'], CCFLAGS='-myflag')
+DefaultEnvironment(tools=[])
+env = Environment(tools=['mingw'], CCFLAGS='-myflag')
 print(env['CCFLAGS'])
 """)
 test.run(arguments='-Q -s')
@@ -86,7 +87,8 @@ if '-myflag' not in test.stdout():
 
 # test that it handles a list
 test.write('SConstruct',"""
-env=Environment(tools=['mingw'], CCFLAGS=['-myflag', '-myflag2'])
+DefaultEnvironment(tools=[])
+env = Environment(tools=['mingw'], CCFLAGS=['-myflag', '-myflag2'])
 print(str(env['CCFLAGS']))
 """)
 test.run(arguments='-Q -s')

--- a/test/long-lines/signature.py
+++ b/test/long-lines/signature.py
@@ -67,7 +67,7 @@ while len(extra_arguments) <= MAXLINE:
 env = Environment(
     tools=[],
     FILECOM=[
-        '%(build_py)s',
+        r'%(build_py)s',
         '$TARGET',
         '$SOURCE',
         '$FILEFLAG',

--- a/test/long-lines/signature.py
+++ b/test/long-lines/signature.py
@@ -83,7 +83,7 @@ env = Environment(
     TEMPFILEPREFIX='@',
 )
 env.PrependENVPath('PATHEXT', '.PY')
-env.Command('file.out', 'file.in', '%(_python_)s ${TEMPFILE(FILECOM)}')
+env.Command('file.out', 'file.in', r'%(_python_)s ${TEMPFILE(FILECOM)}')
 """ % locals())
 
 test.write('file.in', "file.in\n", mode='w')

--- a/test/scons-time/func/chdir.py
+++ b/test/scons-time/func/chdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the func -C and --chdir options change directory before
@@ -52,7 +51,7 @@ for i in range(9):
     i = str(i)
     test.subdir(i)
     test.profile_data('profs/foo-%s.prof' % i, '%s/prof.py' % i, '_main', input)
-    s = r'\d.\d\d\d %s/prof\.py:1\(_main\)' % re.escape(test.workpath(i))
+    s = r'\d.\d\d\d %s.prof\.py:1\(_main\)' % re.escape(test.workpath(i))
     expect.append(s + '\n')
 
 expect = ''.join(expect)

--- a/test/scons-time/func/funcglob.py
+++ b/test/scons-time/func/funcglob.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the func subcommands globs for files.
@@ -46,7 +45,7 @@ expect = []
 for i in range(9):
     test.subdir(str(i))
     test.profile_data('foo-%s.prof' % i, '%s/prof.py' % i, '_main', input)
-    expect.append((r'\d.\d\d\d %s/prof\.py:1\(_main\)' + '\n') % i)
+    expect.append((r'\d.\d\d\d %s.prof\.py:1\(_main\)' + '\n') % i)
 
 expect = ''.join(expect)
 

--- a/test/scons-time/func/tail.py
+++ b/test/scons-time/func/tail.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the func subcommand only prints results for the last number
@@ -47,7 +46,7 @@ expect = []
 for i in range(9):
     test.subdir(str(i))
     test.profile_data('foo-%s.prof' % i, '%s/prof.py' % i, '_main', input)
-    expect.append((r'\d.\d\d\d %s/prof\.py:1\(_main\)' + '\n') % i)
+    expect.append((r'\d.\d\d\d %s.prof\.py:1\(_main\)' + '\n') % i)
 
 test.run(arguments = 'func -t 3 foo-*.prof', stdout = ''.join(expect[-3:]))
 

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -111,8 +111,8 @@ env2.Program('sub2/hello.c')
 """ % locals())
 # TODO in the above, we would normally want to run a python program
 # using "our python" as in:
-#    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-#    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+#    CCCOM=[[r'%(_python_)s', r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+#    LINKCOM=[[r'%(_python_)s', r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
 # however we're looking at dependencies with sconsign, so that breaks things
 
 test.write(['sub1', 'hello.c'], r"""

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the sconsign script works with files generated when
@@ -99,15 +98,22 @@ sub2_inc2_h     = 'sub2/inc2.h'
 
 test.write(['SConstruct'], """\
 SConsignFile()
-env1 = Environment(PROGSUFFIX = '.exe',
-                   OBJSUFFIX = '.obj',
-                   CCCOM = [[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-                   LINKCOM = [[r'%(fake_link_py)s', '$TARGET', '$SOURCE']])
+env1 = Environment(
+    PROGSUFFIX='.exe',
+    OBJSUFFIX='.obj',
+    CCCOM=[['%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[['%(fake_link_py)s', '$TARGET', '$SOURCE']],
+)
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
-env2 = env1.Clone(CPPPATH = ['sub2'])
+env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
 """ % locals())
+# TODO in the above, we would normally want to run a python program
+# using "our python" as in:
+#    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+#    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+# however we're looking at dependencies with sconsign, so that breaks things
 
 test.write(['sub1', 'hello.c'], r"""
 sub1/hello.c

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -101,8 +101,8 @@ SConsignFile()
 env1 = Environment(
     PROGSUFFIX='.exe',
     OBJSUFFIX='.obj',
-    CCCOM=[['%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-    LINKCOM=[['%(fake_link_py)s', '$TARGET', '$SOURCE']],
+    CCCOM=[[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[[r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
 )
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -123,8 +123,8 @@ env2.Program('sub2/hello.c')
 """ % locals())
 # TODO in the above, we would normally want to run a python program
 # using "our python" as in:
-#    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-#    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+#    CCCOM=[[r'%(_python_)s', r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+#    LINKCOM=[[r'%(_python_)s', r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
 # however we're looking at dependencies with sconsign, so that breaks things
 
 test.write(['sub1', 'hello.c'], r"""\

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -113,8 +113,8 @@ env1 = Environment(
     # Specify the command lines with lists-of-lists so
     # finding the implicit dependencies works even with
     # spaces in the fake_*_py path names.
-    CCCOM=[['%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-    LINKCOM=[['%(fake_link_py)s', '$TARGET', '$SOURCE']],
+    CCCOM=[[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[[r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
 )
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the sconsign script works when using a .sconsign file in
@@ -108,18 +107,25 @@ test.chmod(fake_link_py, 0o755)
 test.write('SConstruct', """
 SConsignFile(None)
 Decider('timestamp-newer')
-env1 = Environment(PROGSUFFIX = '.exe',
-                   OBJSUFFIX = '.obj',
-                   # Specify the command lines with lists-of-lists so
-                   # finding the implicit dependencies works even with
-                   # spaces in the fake_*_py path names.
-                   CCCOM = [[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-                   LINKCOM = [[r'%(fake_link_py)s', '$TARGET', '$SOURCE']])
+env1 = Environment(
+    PROGSUFFIX='.exe',
+    OBJSUFFIX='.obj',
+    # Specify the command lines with lists-of-lists so
+    # finding the implicit dependencies works even with
+    # spaces in the fake_*_py path names.
+    CCCOM=[['%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[['%(fake_link_py)s', '$TARGET', '$SOURCE']],
+)
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
-env2 = env1.Clone(CPPPATH = ['sub2'])
+env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
 """ % locals())
+# TODO in the above, we would normally want to run a python program
+# using "our python" as in:
+#    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+#    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+# however we're looking at dependencies with sconsign, so that breaks things
 
 test.write(['sub1', 'hello.c'], r"""\
 sub1/hello.c

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -118,8 +118,8 @@ env1 = Environment(
     # Specify the command lines with lists-of-lists so
     # finding the implicit dependencies works even with
     # spaces in the fake_*_py path names.
-    CCCOM=[['%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-    LINKCOM=[['%(fake_link_py)s', '$TARGET', '$SOURCE']],
+    CCCOM=[[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[[r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
 )
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -110,18 +112,25 @@ sub2_inc2_h     = 'sub2/inc2.h'
 
 test.write(['SConstruct'], """
 SConsignFile(None)
-env1 = Environment(PROGSUFFIX = '.exe',
-                   OBJSUFFIX = '.obj',
-                   # Specify the command lines with lists-of-lists so
-                   # finding the implicit dependencies works even with
-                   # spaces in the fake_*_py path names.
-                   CCCOM = [[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-                   LINKCOM = [[r'%(fake_link_py)s', '$TARGET', '$SOURCE']])
+env1 = Environment(
+    PROGSUFFIX='.exe',
+    OBJSUFFIX='.obj',
+    # Specify the command lines with lists-of-lists so
+    # finding the implicit dependencies works even with
+    # spaces in the fake_*_py path names.
+    CCCOM=[['%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[['%(fake_link_py)s', '$TARGET', '$SOURCE']],
+)
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
-env2 = env1.Clone(CPPPATH = ['sub2'])
+env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
 """ % locals())
+# TODO in the above, we would normally want to run a python program
+# using "our python" as in:
+#    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+#    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+# however we're looking at dependencies with sconsign, so that breaks things
 
 test.write(['sub1', 'hello.c'], r"""\
 sub1/hello.c

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -128,8 +128,8 @@ env2.Program('sub2/hello.c')
 """ % locals())
 # TODO in the above, we would normally want to run a python program
 # using "our python" as in:
-#    CCCOM=[['%(_python_)s', '%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-#    LINKCOM=[['%(_python_)s', '%(fake_link_py)s', '$TARGET', '$SOURCE']],
+#    CCCOM=[[r'%(_python_)s', r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
+#    LINKCOM=[[r'%(_python_)s', r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
 # however we're looking at dependencies with sconsign, so that breaks things
 
 test.write(['sub1', 'hello.c'], r"""\

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -785,10 +785,6 @@ class TestCommon(TestCmd):
             sys.stdout.flush()
         pass_skips = os.environ.get('TESTCOMMON_PASS_SKIPS')
         if pass_skips in [None, 0, '0']:
-            # skip=1 means skip this function when showing where this
-            # result came from.  They only care about the line where the
-            # script called test.skip_test(), not the line number where
-            # we call test.no_result().
             if from_fw:
                 self.no_result(skip=2)
             else:


### PR DESCRIPTION
On a system where SCons is started from the mingw bash shell, and mingw Python is the interpreter, the secondary self-identification differs. Use that in a few tests which otherwise make the wrong decision.

EnvironmentTests used an invalid value for `CCFLAGS`, an empty string is a better choice.

Change a couple of cases where Python code was run directly so it's prefixed by the-Python-in-use, which fails if there is not
a Windows-registered program for .py files - we didn't really want to use the Windows-native Python anyway.

Test-only change, no docs or SCons engine code.

Signed-off-by: Mats Wichmann <mats@linux.com>


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
