### PR TITLE
Restore setting of write bits on Install'd files

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -74,6 +74,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Don't strip spaces in INSTALLSTR by using raw subst (issue 2018)
     - Deprecate Python 3.5 as a supported version.
     - CPPDEFINES now expands construction variable references (issue 2363)
+    - Restore behavior that Install()'d files are writable (issue 3927)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -59,6 +59,9 @@ FIXES
     - DocbookXslt tool: The XSLT stylesheet file is now initialized to an env.File() Node, 
       such that dependencies work correctly in hierarchical builds (eg when using 
       DocbookXslt in SConscript('subdir/SConscript') context.
+    - The Install builder will now set the writable mode on the file(s) it
+      copies. This restores the (previously undocumented) SCons behavior
+      that regressed as of 4.0.0.
 
 
 IMPROVEMENTS

--- a/SCons/Tool/install.py
+++ b/SCons/Tool/install.py
@@ -31,6 +31,7 @@ selection method.
 #
 
 import os
+import stat
 from shutil import copy2, copymode, copystat
 
 import SCons.Action
@@ -152,11 +153,14 @@ def scons_copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
 #
 # Functions doing the actual work of the Install Builder.
 #
-def copyFunc(dest, source, env):
-    """Install a source file or directory into a destination by copying,
+def copyFunc(dest, source, env) -> int:
+    """Install a source file or directory into a destination by copying.
 
-    Mode/permissions bits will be copied as well.
+    Mode/permissions bits will be copied as well, except that the target
+    will be made writable.
 
+    Returns:
+        POSIX-style error code - 0 for success, non-zero for fail
     """
     if os.path.isdir(source):
         if os.path.exists(dest):
@@ -169,19 +173,24 @@ def copyFunc(dest, source, env):
         scons_copytree(source, dest, dirs_exist_ok=True)
     else:
         copy2(source, dest)
-        copymode(source, dest)
+        st = os.stat(source)
+        os.chmod(dest, stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
 
     return 0
 
 #
 # Functions doing the actual work of the InstallVersionedLib Builder.
 #
-def copyFuncVersionedLib(dest, source, env):
-    """Install a versioned library into a destination by copying,
+def copyFuncVersionedLib(dest, source, env) -> int:
+    """Install a versioned library into a destination by copying.
 
-    Mode/permissions bits will be copied as well.
     Any required symbolic links for other library names are created.
 
+    Mode/permissions bits will be copied as well, except that the target
+    will be made writable.
+
+    Returns:
+        POSIX-style error code - 0 for success, non-zero for fail
     """
     if os.path.isdir(source):
         raise SCons.Errors.UserError("cannot install directory `%s' as a version library" % str(source) )
@@ -192,7 +201,8 @@ def copyFuncVersionedLib(dest, source, env):
         except:
             pass
         copy2(source, dest)
-        copymode(source, dest)
+        st = os.stat(source)
+        os.chmod(dest, stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
         installShlibLinks(dest, source, env)
 
     return 0
@@ -223,38 +233,58 @@ def installShlibLinks(dest, source, env):
         CreateLibSymlinks(env, symlinks)
     return
 
-def installFunc(target, source, env):
-    """Install a source file into a target using the function specified
-    as the INSTALL construction variable."""
+def installFunc(target, source, env) -> int:
+    """Install a source file into a target.
+
+    Uses the function specified in the INSTALL construction variable.
+
+    Returns:
+        POSIX-style error code - 0 for success, non-zero for fail
+    """
+
     try:
         install = env['INSTALL']
     except KeyError:
         raise SCons.Errors.UserError('Missing INSTALL construction variable.')
 
-    assert len(target)==len(source), \
-           "Installing source %s into target %s: target and source lists must have same length."%(list(map(str, source)), list(map(str, target)))
-    for t,s in zip(target,source):
-        if install(t.get_path(),s.get_path(),env):
+    assert len(target) == len(source), (
+        "Installing source %s into target %s: "
+        "target and source lists must have same length."
+        % (list(map(str, source)), list(map(str, target)))
+    )
+    for t, s in zip(target, source):
+        if install(t.get_path(), s.get_path(), env):
             return 1
 
     return 0
 
-def installFuncVersionedLib(target, source, env):
-    """Install a versioned library into a target using the function specified
-    as the INSTALLVERSIONEDLIB construction variable."""
+def installFuncVersionedLib(target, source, env) -> int:
+    """Install a versioned library into a target.
+
+    Uses the function specified in the INSTALL construction variable.
+
+    Returns:
+        POSIX-style error code - 0 for success, non-zero for fail
+    """
+
     try:
         install = env['INSTALLVERSIONEDLIB']
     except KeyError:
-        raise SCons.Errors.UserError('Missing INSTALLVERSIONEDLIB construction variable.')
+        raise SCons.Errors.UserError(
+            'Missing INSTALLVERSIONEDLIB construction variable.'
+        )
 
-    assert len(target)==len(source), \
-           "Installing source %s into target %s: target and source lists must have same length."%(list(map(str, source)), list(map(str, target)))
-    for t,s in zip(target,source):
+    assert len(target) == len(source), (
+        "Installing source %s into target %s: "
+        "target and source lists must have same length."
+        % (list(map(str, source)), list(map(str, target)))
+    )
+    for t, s in zip(target, source):
         if hasattr(t.attributes, 'shlibname'):
             tpath = os.path.join(t.get_dir(), t.attributes.shlibname)
         else:
             tpath = t.get_path()
-        if install(tpath,s.get_path(),env):
+        if install(tpath, s.get_path(), env):
             return 1
 
     return 0
@@ -461,12 +491,12 @@ def generate(env):
     try:
         env['INSTALL']
     except KeyError:
-        env['INSTALL']    = copyFunc
+        env['INSTALL'] = copyFunc
 
     try:
         env['INSTALLVERSIONEDLIB']
     except KeyError:
-        env['INSTALLVERSIONEDLIB']    = copyFuncVersionedLib
+        env['INSTALLVERSIONEDLIB'] = copyFuncVersionedLib
 
 def exists(env):
     return 1

--- a/SCons/Tool/install.xml
+++ b/SCons/Tool/install.xml
@@ -46,9 +46,7 @@ which must be a directory.
 The names of the specified source files or directories
 remain the same within the destination directory. The
 sources may be given as a string or as a node returned by
-a builder. Basic metadata from the source files is
-preserved, except that the target files will be marked
-as writable.
+a builder.
 </para>
 
 <example_commands>
@@ -120,8 +118,6 @@ See the note under &Install;.
 <para>
 Installs a versioned shared library. The symlinks appropriate to the
 architecture will be generated based on symlinks of the source library.
-Basic metadata from the source library is preserved,
-except that the target file will be marked as writable.
 </para>
 
 <example_commands>

--- a/SCons/Tool/install.xml
+++ b/SCons/Tool/install.xml
@@ -46,7 +46,9 @@ which must be a directory.
 The names of the specified source files or directories
 remain the same within the destination directory. The
 sources may be given as a string or as a node returned by
-a builder.
+a builder. Basic metadata from the source files is
+preserved, except that the target files will be marked
+as writable.
 </para>
 
 <example_commands>
@@ -118,6 +120,8 @@ See the note under &Install;.
 <para>
 Installs a versioned shared library. The symlinks appropriate to the
 architecture will be generated based on symlinks of the source library.
+Basic metadata from the source library is preserved,
+except that the target file will be marked as writable.
 </para>
 
 <example_commands>

--- a/test/Install/Clone.py
+++ b/test/Install/Clone.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can Install() and InstallAs() from a construction

--- a/test/Install/INSTALLSTR.py
+++ b/test/Install/INSTALLSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $INSTALLSTR variable is displayed when we install a file.

--- a/test/Install/Install-ro.py
+++ b/test/Install/Install-ro.py
@@ -27,9 +27,6 @@
 Test that SCons allows Install on top of an existing read-only file.
 """
 
-import sys
-import os
-import os.path
 import TestSCons
 
 test = TestSCons.TestSCons()

--- a/test/Install/Install-ro.py
+++ b/test/Install/Install-ro.py
@@ -24,29 +24,19 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Verify that we can still call Install() and InstallAs() even when
-no Tool modules have been loaded.
+Test that SCons allows Install on top of an existing read-only file.
 """
 
+import sys
+import os
+import os.path
 import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('iii')
-
-test.write('SConstruct', """
-DefaultEnvironment(tools=[])
-env = Environment(tools=[])
-env.Install('iii', 'foo.in')
-env.InstallAs('foo.out', 'foo.in')
-""")
-
-test.write('foo.in', "foo.in\n")
-
-test.run(arguments='.')
-
-test.must_match(['iii', 'foo.in'], "foo.in\n")
-test.must_match('foo.out', "foo.in\n")
+test.file_fixture('fixture/SConstruct-multi', 'SConstruct')
+test.run(arguments=["-Q"])
+test.run(arguments=["-Q"])
 
 test.pass_test()
 
@@ -54,4 +44,3 @@ test.pass_test()
 # tab-width:4
 # indent-tabs-mode:nil
 # End:
-# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Install/Install.py
+++ b/test/Install/Install.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the Install() Builder works

--- a/test/Install/InstallAs.py
+++ b/test/Install/InstallAs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the InstallAs() Environment method.
@@ -83,7 +82,6 @@ test.must_match(install_file1a_out, "file1.in\n", mode='r')
 
 test.up_to_date(arguments = '.')
 
-#
 test.pass_test()
 
 # Local Variables:

--- a/test/Install/dir-exists.py
+++ b/test/Install/dir-exists.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test using Install() on directories that exist.
@@ -49,7 +48,7 @@ Mkdir("b")
 echo hi > a%sf
 Install directory: "a" as "b%sa"
 """%(os.sep, os.sep)
-test.run(arguments = ["-Q"], stdout = expect)
+test.run(arguments=["-Q"], stdout=expect)
 
 test.must_exist(test.workpath('a', 'f'))
 test.must_exist(test.workpath('b', 'a', 'f'))

--- a/test/Install/directories.py
+++ b/test/Install/directories.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test using Install() on directories.
@@ -33,16 +32,18 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('outside',
-            'work',
-            ['work', 'dir1'],
-            ['work', 'dir1', 'sub'],
-            ['work', 'dir2'],
-            ['work', 'dir2', 'sub'],
-            ['work', 'dir3'],
-            ['work', 'dir3', 'sub'],
-            ['work', 'dir4'],
-            ['work', 'dir4', 'sub'])
+test.subdir(
+    'outside',
+    'work',
+    ['work', 'dir1'],
+    ['work', 'dir1', 'sub'],
+    ['work', 'dir2'],
+    ['work', 'dir2', 'sub'],
+    ['work', 'dir3'],
+    ['work', 'dir3', 'sub'],
+    ['work', 'dir4'],
+    ['work', 'dir4', 'sub'],
+)
 
 test.write(['work', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
@@ -80,7 +81,7 @@ Install directory: "dir3" as "%s"
 Install directory: "dir4" as "%s"
 """ % tuple(arguments))
 
-test.run(chdir = 'work', arguments = arguments, stdout = expect)
+test.run(chdir='work', arguments=arguments, stdout=expect)
 
 test.must_match(test.workpath('outside', 'dir1', 'f2'),         "work/dir1/f2\n")
 test.must_match(test.workpath('outside', 'dir1', 'sub', 'f3'),  "work/dir1/sub/f3\n")

--- a/test/Install/fixture/SConstruct-multi
+++ b/test/Install/fixture/SConstruct-multi
@@ -1,0 +1,24 @@
+# first run creates a src file, makes it read-only, and installs.
+# second run updates src, Install should successfully replace
+# the previous install (read-only attr on Windows might fail it)
+
+import os
+import pathlib
+import stat
+
+destdir = pathlib.Path("bin")
+destdir.mkdir(exist_ok=True)
+
+srcfile = pathlib.Path("hello")
+try:
+    srcfile.chmod(stat.S_IREAD | stat.S_IWRITE)
+except OSError:
+    pass
+
+with srcfile.open(mode="w") as f:
+    print("Hello from ", os.getpid(), file=f)
+srcfile.chmod(stat.S_IREAD)
+
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
+env.Install('bin', 'hello')

--- a/test/Install/multi-dir.py
+++ b/test/Install/multi-dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that using Install to create multiple dir hierarchies outside

--- a/test/Install/multi-dir/src/SConstruct
+++ b/test/Install/multi-dir/src/SConstruct
@@ -1,7 +1,8 @@
 # This tests for a bug where installing a sequence dirs and subdirs
 # outside the source tree can cause SCons to fail to create the dest
 # dir.
-import os, os.path, shutil
+import os
+
 DefaultEnvironment(tools=[])
 env=Environment(tools=[])
 dst='../build'

--- a/test/Install/multi.py
+++ b/test/Install/multi.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that multiple calls to test.Install() with the same file
@@ -42,8 +41,7 @@ env.Install('install', 'file1')
 
 test.write('file1', "file1\n")
 
-test.run(arguments = '.')
-
+test.run(arguments='.')
 test.must_match(['install', 'file1'], "file1\n")
 
 test.pass_test()

--- a/test/Install/no-top-relative.py
+++ b/test/Install/no-top-relative.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can install a file if its file name portion begins

--- a/test/Install/non-ascii-name.py
+++ b/test/Install/non-ascii-name.py
@@ -1,7 +1,8 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the Install() Builder works

--- a/test/Install/option--install-sandbox.py
+++ b/test/Install/option--install-sandbox.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the --install-sandbox commandline option for Install() and InstallAs().
@@ -43,11 +42,8 @@ _SUBDIR_file3_in = os.path.join('$SUBDIR', 'file3.in')
 target_file2_out = os.path.join(target, 'file2.out')
 subdir_file3_in = os.path.join('subdir', 'file3.in')
 target_subdir_file3_out = os.path.join(target, 'subdir', 'file3.out')
-file1_out       = target+os.path.join( target,
-                                       os.path.splitdrive(destdir)[1],
-                                       'file1.out' )
+file1_out = target + os.path.join(target, os.path.splitdrive(destdir)[1], 'file1.out')
 
-#
 test.write('SConstruct', r"""
 DefaultEnvironment(tools=[])
 env = Environment(tools=[], SUBDIR='subdir')

--- a/test/Install/wrap-by-attribute.py
+++ b/test/Install/wrap-by-attribute.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 
@@ -45,6 +44,7 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 import os.path
 
+
 def cat(env, source, target):
     target = str(target[0])
     with open(target, 'wb') as ofp:
@@ -52,18 +52,23 @@ def cat(env, source, target):
             with open(str(src), 'rb') as ifp:
                 ofp.write(ifp.read())
 
+
 env = Environment(tools=[], DESTDIR='dest')
-env.Append(BUILDERS={'Cat':Builder(action=cat)})
+env.Append(BUILDERS={'Cat': Builder(action=cat)})
 
 env.SconsInternalInstallFunc = env.Install
 env.SconsInternalInstallAsFunc = env.InstallAs
 
+
 def InstallWithDestDir(dir, source):
     abspath = os.path.splitdrive(env.Dir(dir).get_abspath())[1]
-    return env.SconsInternalInstallFunc('$DESTDIR'+abspath, source)
+    return env.SconsInternalInstallFunc('$DESTDIR' + abspath, source)
+
+
 def InstallAsWithDestDir(target, source):
     abspath = os.path.splitdrive(env.File(target).get_abspath())[1]
-    return env.SconsInternalInstallAsFunc('$DESTDIR'+abspath, source)
+    return env.SconsInternalInstallAsFunc('$DESTDIR' + abspath, source)
+
 
 # Add the wrappers directly as attributes.
 env.Install = InstallWithDestDir
@@ -82,7 +87,6 @@ t = e2.Cat(target='f3.out', source='f3.in')
 e2.Install('export', source=t)
 t = e2.Cat(target='f4.out', source='f4.in')
 e2.InstallAs('export/f4-new.out', source=t)
-
 """)
 
 test.write('f1.in', "f1.in\n")
@@ -90,7 +94,7 @@ test.write('f2.in', "f2.in\n")
 test.write('f3.in', "f3.in\n")
 test.write('f4.in', "f4.in\n")
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
 export = os.path.splitdrive(test.workpath('export'))[1]
 
@@ -104,7 +108,7 @@ test.must_match(f2_new_out,     "f2.in\n")
 test.must_match(f3_out,         "f3.in\n")
 test.must_match(f4_new_out,     "f4.in\n")
 
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
 test.pass_test()
 


### PR DESCRIPTION
SCons had undocumented behavior that `Install` and `InstallVersionedLib` unconditionally changed the files they copied to writable - `shutil.copy2()`, the underlying function used for copying, preserves mode bits. Restore this behavior so `Install` won't fail in a project where it had previously run, if any of the sources were read-only. (`InstallVersionedLib` much less likely to hit this issue, as usually what's being installed has just been built, and thus will likely already be writable).

Fixes #3927

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
