### PR TITLE
Avoid exception if tool set to empty

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -75,6 +75,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Deprecate Python 3.5 as a supported version.
     - CPPDEFINES now expands construction variable references (issue 2363)
     - Restore behavior that Install()'d files are writable (issue 3927)
+    - Avoid WhereIs exception if user set a tool name to empty (from issue 1742)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1877,9 +1877,10 @@ class Base(SubstitutionEnvironment):
             tool = SCons.Tool.Tool(tool, toolpath, **kw)
         tool(self)
 
-    def WhereIs(self, prog, path=None, pathext=None, reject=[]):
-        """Find prog in the path.
-        """
+    def WhereIs(self, prog, path=None, pathext=None, reject=None):
+        """Find prog in the path. """
+        if not prog:  # nothing to search for, just give up
+            return None
         if path is None:
             try:
                 path = self['ENV']['PATH']
@@ -1894,9 +1895,10 @@ class Base(SubstitutionEnvironment):
                 pass
         elif is_String(pathext):
             pathext = self.subst(pathext)
-        prog = CLVar(self.subst(prog)) # support "program --with-args"
+        prog = CLVar(self.subst(prog))  # support "program --with-args"
         path = WhereIs(prog[0], path, pathext, reject)
-        if path: return path
+        if path:
+            return path
         return None
 
     #######################################################################

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -2583,6 +2583,8 @@ def generate(env):
 
         path = os.pathsep.join(pathdirs_1234)
         env = self.TestEnvironment(ENV = {'PATH' : path})
+        wi = env.WhereIs('')
+        assert wi is None
         wi = env.WhereIs('xxx.exe')
         assert wi == test.workpath(sub3_xxx_exe), wi
         wi = env.WhereIs('xxx.exe', pathdirs_1243)

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -745,7 +745,7 @@ else:
 
 if sys.platform == 'win32':
 
-    def WhereIs(file, path=None, pathext=None, reject=[]):
+    def WhereIs(file, path=None, pathext=None, reject=None):
         if path is None:
             try:
                 path = os.environ['PATH']
@@ -764,6 +764,8 @@ if sys.platform == 'win32':
             if ext.lower() == file[-len(ext):].lower():
                 pathext = ['']
                 break
+        if reject is None:
+            reject = []
         if not is_List(reject) and not is_Tuple(reject):
             reject = [reject]
         for dir in path:
@@ -780,7 +782,7 @@ if sys.platform == 'win32':
 
 elif os.name == 'os2':
 
-    def WhereIs(file, path=None, pathext=None, reject=[]):
+    def WhereIs(file, path=None, pathext=None, reject=None):
         if path is None:
             try:
                 path = os.environ['PATH']
@@ -794,6 +796,8 @@ elif os.name == 'os2':
             if ext.lower() == file[-len(ext):].lower():
                 pathext = ['']
                 break
+        if reject is None:
+            reject = []
         if not is_List(reject) and not is_Tuple(reject):
             reject = [reject]
         for dir in path:
@@ -810,7 +814,7 @@ elif os.name == 'os2':
 
 else:
 
-    def WhereIs(file, path=None, pathext=None, reject=[]):
+    def WhereIs(file, path=None, pathext=None, reject=None):
         import stat
         if path is None:
             try:
@@ -819,6 +823,8 @@ else:
                 return None
         if is_String(path):
             path = path.split(os.pathsep)
+        if reject is None:
+            reject = []
         if not is_List(reject) and not is_Tuple(reject):
             reject = [reject]
         for d in path:


### PR DESCRIPTION
When the reproducer in issue #1742 was run on git head, it failed in a different way than in the issue: an exception "list index out of range", caused by the test setting `CC=""` in the `Environment()` call.  While this is a rather unuseful thing to do in general, the resulting call to `env.WhereIs` should not throw an exception because the general `WhereIs` function ends up indexing into something that can't be indexed. Avoid this by returning `None` immediately if the list of names to look for is empty.  Note this does _not_ fix 1742, it just avoids the new problem it was failing on.

The other changes are to clean up instances in both `env.Whereis` and `Util/Whereis` of should not use mutable as a default parameter. Should not matter since this parameter is never modified, but why not quiet the checkers?

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
