### PR TITLE
Fix Issue #3933 and applelink's versioned shared library file and symlink naming.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       IMPLIBNOVERSIONSYMLINKS and LDMODULENOVERSIONSYMLINKS to True.
     - Added --experimental flag, to enable various experimental features/tools.  You can specify
       'all', 'none', or any combination of available experimental features.
+    - Fix Issue #3933 - Remove unguarded print of debug information in SharedLibrary logic when
+      SHLIBVERSION is specified.
+    - Fix versioned shared library naming for MacOS platform. (Previously was libxyz.dylib.1.2.3,
+      has been fixed to libxyz.1.2.3.dylib. Additionally the sonamed symlink had the same issue,
+      that is now resolved as well)
 
   From David H:
     - Fix Issue #3906 - `IMPLICIT_COMMAND_DEPENDENCIES` was not properly disabled when

--- a/SCons/Tool/linkCommon/SharedLibrary.py
+++ b/SCons/Tool/linkCommon/SharedLibrary.py
@@ -166,8 +166,12 @@ def _get_shlib_dir(target, source, env, for_signature: bool) -> str:
     Returns:
         the directory the library will be in (empty string if '.')
     """
+    verbose = False
+
     if target.dir and str(target.dir) != ".":
-        print("target.dir:%s" % target.dir)
+        if verbose:
+            print("_get_shlib_dir: target.dir:%s" % target.dir)
+
         return "%s/" % str(target.dir)
     else:
         return ""

--- a/test/LINK/SHLIBVERSIONFLAGS.py
+++ b/test/LINK/SHLIBVERSIONFLAGS.py
@@ -47,9 +47,9 @@ elif 'sunlink' in tool_list:
     soname = 'libfoo.so.4'
     sonameVersionFlags = r".+ -h %s( .+)+" % soname
 elif 'applelink' in tool_list:
-    versionflags = r"    'libfoo.1.dylib'->'libfoo.1.2.3.dylib'"
+    versionflags = r".+ -Wl,-current_version,1.2.3( .+)+"
     soname = 'libfoo.4.dylib'
-    sonameVersionFlags = r"    '%s'->'libfoo.1.2.3.dylib'(.+)+" % soname
+    sonameVersionFlags = r".+ -Wl,-compatibility_version,1.2.0(.+)+"
 else:
     test.skip_test('No testable linkers found, skipping the test\n')
 


### PR DESCRIPTION
Fix #3933 debug output removed from SharedLibrary when SHLIBVER…SION is specified. Also fixed shared library file naming, and symlink naming for applelink. Was libxyz.dylib.1.2.3 for example, is now libxyz.1.2.3.dylib

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
