### PR TITLE
Some code modernization: fs layer methods and others

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Simplified Mkdir(), the internal mkdir_func no longer needs to handle
       existing directories, it can now pass exist_ok=True to os.makedirs().
     - Avoid WhereIs exception if user set a tool name to empty (from issue 1742)
+    - Maintenance: remove obsolete __getslice__ definitions (Py3 never calls);
+      add Node.fs.scandir to call new (Py3.5) os.scandir; Node.fs.makedirs
+      now passes the exist_ok flag; Cachedir creation now uses this flag.
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -106,16 +106,11 @@ def CachePushFunc(target, source, env):
     tempfile = "%s.tmp%s"%(cachefile,cache_tmp_uuid)
     errfmt = "Unable to copy %s to cache. Cache file is %s"
 
-    if not fs.isdir(cachedir):
-        try:
-            fs.makedirs(cachedir)
-        except EnvironmentError:
-            # We may have received an exception because another process
-            # has beaten us creating the directory.
-            if not fs.isdir(cachedir):
-                msg = errfmt % (str(target), cachefile)
-                raise SCons.Errors.SConsEnvironmentError(msg)
-
+    try:
+        fs.makedirs(cachedir, exist_ok=True)
+    except OSError:
+        msg = errfmt % (str(target), cachefile)
+        raise SCons.Errors.SConsEnvironmentError(msg)
     try:
         if fs.islink(t.get_internal_path()):
             fs.symlink(fs.readlink(t.get_internal_path()), tempfile)

--- a/SCons/Executor.py
+++ b/SCons/Executor.py
@@ -63,10 +63,6 @@ class TSList(collections.UserList):
     def __getitem__(self, i):
         nl = self.func()
         return nl[i]
-    def __getslice__(self, i, j):
-        nl = self.func()
-        i, j = max(i, 0), max(j, 0)
-        return nl[i:j]
     def __str__(self):
         nl = self.func()
         return str(nl)

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -1140,10 +1140,12 @@ class LocalFS:
         return os.lstat(path)
     def listdir(self, path):
         return os.listdir(path)
-    def makedirs(self, path):
-        return os.makedirs(path)
-    def mkdir(self, path):
-        return os.mkdir(path)
+    def scandir(self, path):
+        return os.scandir(path)
+    def makedirs(self, path, mode=0o777, exist_ok=False):
+        return os.makedirs(path, mode=mode, exist_ok=exist_ok)
+    def mkdir(self, path, mode=0o777):
+        return os.mkdir(path, mode=mode)
     def rename(self, old, new):
         return os.rename(old, new)
     def stat(self, path):

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -1116,58 +1116,81 @@ class LocalFS:
     needs to use os.chdir() directly to avoid recursion.  Will we
     really need this one?
     """
-    #def chdir(self, path):
-    #    return os.chdir(path)
+
     def chmod(self, path, mode):
         return os.chmod(path, mode)
+
     def copy(self, src, dst):
         return shutil.copy(src, dst)
+
     def copy2(self, src, dst):
         return shutil.copy2(src, dst)
+
     def exists(self, path):
         return os.path.exists(path)
+
     def getmtime(self, path):
         return os.path.getmtime(path)
+
     def getsize(self, path):
         return os.path.getsize(path)
+
     def isdir(self, path):
         return os.path.isdir(path)
+
     def isfile(self, path):
         return os.path.isfile(path)
+
     def link(self, src, dst):
         return os.link(src, dst)
+
     def lstat(self, path):
         return os.lstat(path)
+
     def listdir(self, path):
         return os.listdir(path)
+
     def scandir(self, path):
         return os.scandir(path)
+
     def makedirs(self, path, mode=0o777, exist_ok=False):
         return os.makedirs(path, mode=mode, exist_ok=exist_ok)
+
     def mkdir(self, path, mode=0o777):
         return os.mkdir(path, mode=mode)
+
     def rename(self, old, new):
         return os.rename(old, new)
+
     def stat(self, path):
         return os.stat(path)
+
     def symlink(self, src, dst):
         return os.symlink(src, dst)
+
     def open(self, path):
         return open(path)
+
     def unlink(self, path):
         return os.unlink(path)
 
     if hasattr(os, 'symlink'):
+
         def islink(self, path):
             return os.path.islink(path)
+
     else:
+
         def islink(self, path):
-            return 0                    # no symlinks
+            return False  # no symlinks
 
     if hasattr(os, 'readlink'):
+
         def readlink(self, file):
             return os.readlink(file)
+
     else:
+
         def readlink(self, file):
             return ''
 

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -217,10 +217,6 @@ class Targets_or_Sources(collections.UserList):
     def __getitem__(self, i):
         nl = self.nl._create_nodelist()
         return nl[i]
-    def __getslice__(self, i, j):
-        nl = self.nl._create_nodelist()
-        i = max(i, 0); j = max(j, 0)
-        return nl[i:j]
     def __str__(self):
         nl = self.nl._create_nodelist()
         return str(nl)

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1345,12 +1345,6 @@ class UniqueList(UserList):
     def __setitem__(self, i, item):
         UserList.__setitem__(self, i, item)
         self.unique = False
-    def __getslice__(self, i, j):
-        self.__make_unique()
-        return UserList.__getslice__(self, i, j)
-    def __setslice__(self, i, j, other):
-        UserList.__setslice__(self, i, j, other)
-        self.unique = False
     def __add__(self, other):
         result = UserList.__add__(self, other)
         result.unique = False


### PR DESCRIPTION
* Remove obsolete `__getslice__` and `__setslice__` definitions
* add `Node.fs.scandir` to call new (Py3.5) `os.scandir`
* `Node.fs.makedirs` now passes the `exist_ok` flag
* Cachedir creation now uses this `fs.makedirs` with `exist_ok=True`

No test changes: tests still pass, no visible behavior change. No doc impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
