### PR TITLE
Fix checker-spotted issues in Environment apply_tools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -98,6 +98,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       SetOption equivalents to --hash-chunksize, --implicit-deps-unchanged
       and --implicit-deps-changed are enabled.
     - Add tests for SetOption failing on disallowed options and value types.
+   - Maintenance: fix checker-spotted issues in Environment (apply_tools)
+      and EnvironmentTests (asserts comparing with self)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -98,8 +98,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       SetOption equivalents to --hash-chunksize, --implicit-deps-unchanged
       and --implicit-deps-changed are enabled.
     - Add tests for SetOption failing on disallowed options and value types.
-   - Maintenance: fix checker-spotted issues in Environment (apply_tools)
-      and EnvironmentTests (asserts comparing with self)
+    - Maintenance: fix checker-spotted issues in Environment (apply_tools)
+      and EnvironmentTests (asserts comparing with self).
+      For consistency, env.Tool() now returns a tool object the same way
+      Tool() has done.
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1869,13 +1869,13 @@ class Base(SubstitutionEnvironment):
     def _find_toolpath_dir(self, tp):
         return self.fs.Dir(self.subst(tp)).srcnode().get_abspath()
 
-    def Tool(self, tool, toolpath=None, **kw) -> SCons.Tool.Tool:
+    def Tool(self, tool, toolpath=None, **kwargs) -> SCons.Tool.Tool:
         if is_String(tool):
             tool = self.subst(tool)
             if toolpath is None:
                 toolpath = self.get('toolpath', [])
             toolpath = list(map(self._find_toolpath_dir, toolpath))
-            tool = SCons.Tool.Tool(tool, toolpath, **kw)
+            tool = SCons.Tool.Tool(tool, toolpath, **kwargs)
         tool(self)
         return tool
 

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -100,22 +100,23 @@ AliasBuilder = SCons.Builder.Builder(
 
 def apply_tools(env, tools, toolpath):
     # Store the toolpath in the Environment.
+    # This is expected to work even if no tools are given, so do this first.
     if toolpath is not None:
         env['toolpath'] = toolpath
-
     if not tools:
         return
+
     # Filter out null tools from the list.
     for tool in [_f for _f in tools if _f]:
-        if is_List(tool) or isinstance(tool, tuple):
+        if is_List(tool) or is_Tuple(tool):
             toolname = tool[0]
-            toolargs = tool[1] # should be a dict of kw args
-            tool = env.Tool(toolname, **toolargs)
+            toolargs = tool[1]  # should be a dict of kw args
+            env.Tool(toolname, **toolargs)
         else:
             env.Tool(tool)
 
 # These names are (or will be) controlled by SCons; users should never
-# set or override them.  This warning can optionally be turned off,
+# set or override them.  The warning can optionally be turned off,
 # but scons will still ignore the illegal variable names even if it's off.
 reserved_construction_var_names = [
     'CHANGED_SOURCES',
@@ -132,7 +133,7 @@ future_reserved_construction_var_names = [
     #'HOST_OS',
     #'HOST_ARCH',
     #'HOST_CPU',
-    ]
+]
 
 def copy_non_reserved_keywords(dict):
     result = semi_deepcopy(dict)

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -109,11 +109,11 @@ def apply_tools(env, tools, toolpath):
     # Filter out null tools from the list.
     for tool in [_f for _f in tools if _f]:
         if is_List(tool) or is_Tuple(tool):
-            toolname = tool[0]
-            toolargs = tool[1]  # should be a dict of kw args
-            env.Tool(toolname, **toolargs)
+            # toolargs should be a dict of kw args
+            toolname, toolargs, *rest = tool
+            _ = env.Tool(toolname, **toolargs)
         else:
-            env.Tool(tool)
+            _ = env.Tool(tool)
 
 # These names are (or will be) controlled by SCons; users should never
 # set or override them.  The warning can optionally be turned off,
@@ -1869,7 +1869,7 @@ class Base(SubstitutionEnvironment):
     def _find_toolpath_dir(self, tp):
         return self.fs.Dir(self.subst(tp)).srcnode().get_abspath()
 
-    def Tool(self, tool, toolpath=None, **kw):
+    def Tool(self, tool, toolpath=None, **kw) -> SCons.Tool.Tool:
         if is_String(tool):
             tool = self.subst(tool)
             if toolpath is None:
@@ -1877,6 +1877,7 @@ class Base(SubstitutionEnvironment):
             toolpath = list(map(self._find_toolpath_dir, toolpath))
             tool = SCons.Tool.Tool(tool, toolpath, **kw)
         tool(self)
+        return tool
 
     def WhereIs(self, prog, path=None, pathext=None, reject=None):
         """Find prog in the path. """

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -3222,31 +3222,34 @@ source_nodes = env.subst('$EXPAND_TO_NODELIST', conv=lambda x: x)
 <summary>
 
 <para>
-Locates and possibly runs the tool identified by
-<parameter>name</parameter>, which is
-searched for in standard locations and any
-paths specified by the optional
-<parameter>toolpath</parameter>.
-When run, the tool
-updates a &consenv; with &consvars; and arranges
-any other initialization
-needed to use the mechanisms that tool describes.
+Locates the tool specification module <parameter>name</parameter>
+and returns a callable tool object for that tool.
+The tool module is searched for in standard locations
+and in any paths specified by the optional
+<parameter>toolpath</parameter> parameter.
+The standard locations are &SCons;' own internal
+path for tools plus the toolpath, if any (see the
+<emphasis role="bold">Tools</emphasis> section in the manual page
+for more details).
 Any additional keyword arguments
 <parameter>kwargs</parameter> are passed
-on to the tool module's <function>generate</function> function.
-Returns a callable tool object.
+to the tool module's <function>generate</function> function
+during tool object construction.
 </para>
 
 <para>
-When called as &f-env-Tool;,
-the tool module is called to update <varname>env</varname>
+When called, the tool object
+updates a &consenv; with &consvars; and arranges
+any other initialization
+needed to use the mechanisms that tool describes.
+</para>
+
+<para>
+When the &f-env-Tool; form is used,
+the tool object is automatically called to update <varname>env</varname>
 and the value of <parameter>tool</parameter> is
 appended to the &cv-link-TOOLS;
 &consvar; in that environment.
-In this form, there is usually no need to save
-the returned tool object, since it is of no further use.
-<emphasis>Prior to &SCons; 4.2, &f-env-Tool; returned
-<constant>None</constant></emphasis>
 </para>
 
 <para>
@@ -3259,14 +3262,16 @@ env.Tool('opengl', toolpath=['build/tools'])
 </example_commands>
 
 <para>
-When called as a global function &f-Tool;,
+When the global function &f-Tool; form is used,
 the tool object is constructed but not called,
 as it lacks the context of an environment to update.
 The tool object can be passed to an
 &f-link-Environment; or &f-link-Clone; call
 as part of the <parameter>tools</parameter> keyword argument,
+in which case the tool is applied to the environment being constructed,
 or it can be called directly,
-passing a &consenv; to update as the argument.
+in which case a &consenv; to update must be
+passed as the argument.
 Either approach will also update the
 &cv-TOOLS; &consvar;.
 </para>
@@ -3284,6 +3289,12 @@ msvctool(env)  # adds 'msvc' to the TOOLS variable
 gltool = Tool('opengl', toolpath = ['tools'])
 gltool(env)  # adds 'opengl' to the TOOLS variable
 </example_commands>
+
+<para>
+<emphasis>Changed in &SCons; 4.2: &f-env-Tool; now returns
+the tool object, previously it did not return
+(i.e. returned <constant>None</constant>).</emphasis>
+</para>
 </summary>
 </scons_function>
 

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -3222,24 +3222,31 @@ source_nodes = env.subst('$EXPAND_TO_NODELIST', conv=lambda x: x)
 <summary>
 
 <para>
-Runs the tool identified by
+Locates and possibly runs the tool identified by
 <parameter>name</parameter>, which is
 searched for in standard locations and any
 paths specified by the optional
-<parameter>toolpath</parameter>,
-to update a &consenv; with &consvars;
+<parameter>toolpath</parameter>.
+When run, the tool
+updates a &consenv; with &consvars; and arranges
+any other initialization
 needed to use the mechanisms that tool describes.
 Any additional keyword arguments
 <parameter>kwargs</parameter> are passed
 on to the tool module's <function>generate</function> function.
+Returns a callable tool object.
 </para>
 
 <para>
-When called as a &consenv; method,
-the tool module is called to update the
-&consenv; and the name of the tool is
+When called as &f-env-Tool;,
+the tool module is called to update <varname>env</varname>
+and the value of <parameter>tool</parameter> is
 appended to the &cv-link-TOOLS;
 &consvar; in that environment.
+In this form, there is usually no need to save
+the returned tool object, since it is of no further use.
+<emphasis>Prior to &SCons; 4.2, &f-env-Tool; returned
+<constant>None</constant></emphasis>
 </para>
 
 <para>
@@ -3252,11 +3259,10 @@ env.Tool('opengl', toolpath=['build/tools'])
 </example_commands>
 
 <para>
-When called as a global function,
-returns a callable tool object;
-the tool is not called at this time,
+When called as a global function &f-Tool;,
+the tool object is constructed but not called,
 as it lacks the context of an environment to update.
-This tool object can be passed to an
+The tool object can be passed to an
 &f-link-Environment; or &f-link-Clone; call
 as part of the <parameter>tools</parameter> keyword argument,
 or it can be called directly,
@@ -3273,10 +3279,10 @@ Examples:
 env = Environment(tools=[Tool('msvc')])
 
 env = Environment()
-t = Tool('msvc')
-t(env)  # adds 'msvc' to the TOOLS variable
-u = Tool('opengl', toolpath = ['tools'])
-u(env)  # adds 'opengl' to the TOOLS variable
+msvctool = Tool('msvc')
+msvctool(env)  # adds 'msvc' to the TOOLS variable
+gltool = Tool('opengl', toolpath = ['tools'])
+gltool(env)  # adds 'opengl' to the TOOLS variable
 </example_commands>
 </summary>
 </scons_function>

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -2500,9 +2500,11 @@ f5: \
 
         exc_caught = None
         try:
-            env.Tool('does_not_exist')
+            tool = env.Tool('does_not_exist')
         except SCons.Errors.UserError:
             exc_caught = 1
+        else:
+            assert isinstance(tool, SCons.Tool.Tool)
         assert exc_caught, "did not catch expected UserError"
 
         exc_caught = None

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -994,19 +994,18 @@ class BaseTestCase(unittest.TestCase,TestEnvironmentFixture):
         assert called_it['source'] is None, called_it
 
     def test_BuilderWrapper_attributes(self):
-        """Test getting and setting of BuilderWrapper attributes
-        """
+        """Test getting and setting of BuilderWrapper attributes."""
         b1 = Builder()
         b2 = Builder()
         e1 = Environment()
         e2 = Environment()
 
-        e1.Replace(BUILDERS = {'b' : b1})
+        e1.Replace(BUILDERS={'b': b1})
         bw = e1.b
 
-        assert bw.env == e1
+        assert bw.env is e1
         bw.env = e2
-        assert bw.env == e2
+        assert bw.env is e2
 
         assert bw.builder is b1
         bw.builder = b2
@@ -1800,7 +1799,7 @@ def exists(env):
         updates and check that the original remains intact
         and the copy has the updated values.
         """
-        env1 = self.TestEnvironment(XXX = 'x', YYY = 'y')
+        env1 = self.TestEnvironment(XXX='x', YYY='y')
         env2 = env1.Clone()
         env1copy = env1.Clone()
         assert env1copy == env1
@@ -1809,7 +1808,7 @@ def exists(env):
         assert env1 != env2
         assert env1 == env1copy
 
-        env3 = env1.Clone(XXX = 'x3', ZZZ = 'z3')
+        env3 = env1.Clone(XXX='x3', ZZZ='z3')
         assert env3 != env1
         assert env3.Dictionary('XXX') == 'x3'
         assert env1.Dictionary('XXX') == 'x'
@@ -1832,7 +1831,7 @@ def exists(env):
         assert 5 not in env1.Dictionary('ZZZ')
 
         #
-        env1 = self.TestEnvironment(BUILDERS = {'b1' : Builder()})
+        env1 = self.TestEnvironment(BUILDERS={'b1': Builder()})
         assert hasattr(env1, 'b1'), "env1.b1 was not set"
         assert env1.b1.object == env1, "b1.object doesn't point to env1"
         env2 = env1.Clone(BUILDERS = {'b2' : Builder()})

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -107,7 +107,7 @@ TOOL_ALIASES = {
 
 
 class Tool:
-    def __init__(self, name, toolpath=None, **kw):
+    def __init__(self, name, toolpath=None, **kwargs):
         if toolpath is None:
             toolpath = []
 
@@ -115,7 +115,7 @@ class Tool:
         self.name = TOOL_ALIASES.get(name, name)
         self.toolpath = toolpath + DefaultToolpath
         # remember these so we can merge them into the call
-        self.init_kw = kw
+        self.init_kw = kwargs
 
         module = self._tool_module()
         self.generate = module.generate

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -13,8 +13,8 @@
 
 <variablelist xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
   <varlistentry id="f-Action">
-    <term><function>Action</function>(<parameter>action, [cmd/str/fun, [var, ...]] [option=value, ...]</parameter>)</term>
-    <term><replaceable>env</replaceable>.<methodname>Action</methodname>(<parameter>action, [cmd/str/fun, [var, ...]] [option=value, ...]</parameter>)</term>
+    <term><function>Action</function>(<parameter>action, [output, [var, ...]] [key=value, ...]</parameter>)</term>
+    <term><replaceable>env</replaceable>.<methodname>Action</methodname>(<parameter>action, [output, [var, ...]] [key=value, ...]</parameter>)</term>
     <listitem><para>
 A factory function to create an Action object for
 the specified
@@ -4248,24 +4248,31 @@ Tag('file2.txt', DOC)
     <term><function>Tool</function>(<parameter>name, [toolpath, **kwargs]</parameter>)</term>
     <term><replaceable>env</replaceable>.<methodname>Tool</methodname>(<parameter>name, [toolpath, **kwargs]</parameter>)</term>
     <listitem><para>
-Runs the tool identified by
+Locates and possibly runs the tool identified by
 <parameter>name</parameter>, which is
 searched for in standard locations and any
 paths specified by the optional
-<parameter>toolpath</parameter>,
-to update a &consenv; with &consvars;
+<parameter>toolpath</parameter>.
+When run, the tool
+updates a &consenv; with &consvars; and arranges
+any other initialization
 needed to use the mechanisms that tool describes.
 Any additional keyword arguments
 <parameter>kwargs</parameter> are passed
 on to the tool module's <function>generate</function> function.
+Returns a callable tool object.
 </para>
 
 <para>
-When called as a &consenv; method,
-the tool module is called to update the
-&consenv; and the name of the tool is
+When called as &f-env-Tool;,
+the tool module is called to update <varname>env</varname>
+and the <parameter>tool</parameter> is
 appended to the &cv-link-TOOLS;
 &consvar; in that environment.
+In this form, there is usually no need to save
+the returned tool object, since it is of no further use.
+<emphasis>Prior to &SCons; 4.2, &f-env-Tool; returned
+<constant>None</constant></emphasis>
 </para>
 
 <para>
@@ -4278,11 +4285,10 @@ env.Tool('opengl', toolpath=['build/tools'])
 </example_commands>
 
 <para>
-When called as a global function,
-returns a callable tool object;
-the tool is not called at this time,
+When called as a global function &f-Tool;,
+the tool object is constructed but not called,
 as it lacks the context of an environment to update.
-This tool object can be passed to an
+The tool object can be passed to an
 &f-link-Environment; or &f-link-Clone; call
 as part of the <parameter>tools</parameter> keyword argument,
 or it can be called directly,
@@ -4299,10 +4305,10 @@ Examples:
 env = Environment(tools=[Tool('msvc')])
 
 env = Environment()
-t = Tool('msvc')
-t(env)  # adds 'msvc' to the TOOLS variable
-u = Tool('opengl', toolpath = ['tools'])
-u(env)  # adds 'opengl' to the TOOLS variable
+msvctool = Tool('msvc')
+msvctool(env)  # adds 'msvc' to the TOOLS variable
+gltool = Tool('opengl', toolpath = ['tools'])
+gltool(env)  # adds 'opengl' to the TOOLS variable
 </example_commands>
 </listitem>
   </varlistentry>


### PR DESCRIPTION
If tools is a list, it is looped over, calling Tool on each; that call overwrote the loop variable - since Tool() doesn't return any value anyway just eliminate the assignment.

EnvironmentTests had some asserts comparing with self, which is pointless.  Tried to determine what this should be to be meaningful.

Also quieted one test which got a default action string, unit tests normally just print a row of dots and here it was putting out text which interrupted the flow of dots.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
