### PR TITLE
Drop overridden `changed_since_last_build` method in Value class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -89,6 +89,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Maintenance: remove obsolete __getslice__ definitions (Py3 never calls);
       add Node.fs.scandir to call new (Py3.5) os.scandir; Node.fs.makedirs
       now passes the exist_ok flag; Cachedir creation now uses this flag.
+    - Drop overridden changed_since_last_build method in Value class.
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/Node/Python.py
+++ b/SCons/Node/Python.py
@@ -146,13 +146,6 @@ class Value(SCons.Node.Node):
         """Get contents for signature calculations."""
         return self.get_text_contents().encode()
 
-    def changed_since_last_build(self, target, prev_ni):
-        cur_csig = self.get_csig()
-        try:
-            return cur_csig != prev_ni.csig
-        except AttributeError:
-            return True
-
     def get_csig(self, calc=None):
         """Because we're a Python value node and don't have a real
         timestamp, we get to ignore the calculator and just use the


### PR DESCRIPTION
Value defined this method, but the `__init__` method also does `self.changed_since_last_build = 6` to set an index into the decider map, meaning no instance of Value will ever see that function.  The map index will cause picking the "real" function,
`changed_since_last_build_python()`, which has identical impl to the now emoved method.

No doc or test impacts, this is just cleanout of unused code.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
