### PR TITLE
Fix (and simplify) starting tests in debugger

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -199,11 +199,8 @@ if args.short_progress:
     suppress_output = catch_output = True
 
 if args.debug:
-    for d in sys.path:
-        pdb = os.path.join(d, 'pdb.py')
-        if os.path.exists(pdb):
-            debug = pdb
-        break
+    # TODO: add a way to pass a specific debugger
+    debug = "pdb"
 
 if args.exec:
     scons = args.exec
@@ -710,7 +707,7 @@ def run_test(t, io_lock=None, run_async=True):
     t.headline = ""
     command_args = []
     if debug:
-        command_args.append(debug)
+        command_args.extend(['-m', debug])
     if args.devmode and sys.version_info >= (3, 7, 0):
         command_args.append('-X dev')
     command_args.append(t.path)


### PR DESCRIPTION
A mis-indented break statement caused the "-d" option to runtest.py to start a test in the debugger to be inoperative.  It's not necessary to search for the path to the debugger module, so this can be simplified to just supply `"-m pdb"`.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
