### PR TITLE
Tweak intro section of manpage

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -105,6 +105,7 @@ component pieces must be built or rebuilt and invoking the necessary
 commands to build them.
 &SCons; offers many features to improve developer productivity
 such as parallel builds, caching of build artifacts,
+automatic dependency scanning,
 and a database of information about previous builds so
 details do not have to be recalculated each run.
 </para>
@@ -123,7 +124,7 @@ build system by writing a script
 that describes things to build (<firstterm>targets</firstterm>), and,
 if necessary, the rules to build those files (<firstterm>actions</firstterm>).
 &SCons; comes with a collection of <firstterm>Builder</firstterm> methods
-which apply premade rules for building many common software components
+which apply premade actions for building many common software components
 such as executable programs, object files and libraries,
 so that for many software projects,
 only the targets and input files (<firstterm>sources</firstterm>)
@@ -131,7 +132,7 @@ need be specified in a call to a builder.
 &scons; thus can operate at a level of abstraction above that of pure files.
 For example if you specify a library target named "foo",
 &scons; keeps track of the actual operating system dependent filename
-(for example <filename>libfoo.so</filename> on a GNU/Linux system),
+(such as <filename>libfoo.so</filename> on a GNU/Linux system),
 and how to refer to that library in later construction steps
 that want to use it, so you don't have to specify that precise
 information yourself.
@@ -146,7 +147,7 @@ looks for a file named
 &SConstruct;
 in the current directory and reads the
 build configuration from that file
-(other names are possible,
+(other names are allowed,
 see <xref linkend="sconscript_files"/> for more information).
 The &SConstruct;
 file may specify subsidiary
@@ -158,7 +159,7 @@ these subsidiary files are named
 although any name may be used.
 As a result of this naming convention,
 the term <firstterm>SConscript files</firstterm>
-is often used to refer
+is used to refer
 generically to the complete set of
 configuration files for a project
 (including the &SConstruct; file),
@@ -292,14 +293,14 @@ integration setups.
 </para>
 
 <para>&scons;
-can scan known input files automatically for dependency
+can scan known input file types automatically for dependency
 information (for example, <literal>#include</literal>
 preprocessor directives in C or C++ files)
 and will rebuild dependent files appropriately
 whenever any "included" input file changes.
 &scons;
 supports the
-ability to define new scanners for unknown input file types.</para>
+ability to define new scanners to support additional input file types.</para>
 
 <para>&scons;
 is normally executed in a top-level directory containing an
@@ -309,9 +310,7 @@ the command line (including the contents of the
 <link linkend="v-SCONSFLAGS">&SCONSFLAGS;</link>
 environment variable, if set) is processed.
 Command-line options (see <xref linkend="options"/>) are consumed.
-Any variable argument assignments
-(see <xref linkend="commandline_construction_variables"/>)
-are collected, and
+Any variable argument assignments are collected, and
 remaining arguments are taken as targets to build.</para>
 
 <para>Values of variables to be passed to the SConscript files
@@ -339,6 +338,11 @@ indexed by their order on the command line.
 This allows you to process them in order rather than by name,
 if necessary. Each &ARGLIST; entry is a tuple containing
 (<replaceable>argname</replaceable>, <replaceable>argvalue</replaceable>).
+</para>
+
+<para>
+See <xref linkend="commandline_construction_variables"/>
+for more information.
 </para>
 
 <para>&scons;
@@ -429,7 +433,7 @@ and are made available in the
 </listitem>
 <listitem>
 <para>
-If there are no targets from the previous steps,
+If no targets are selected by the previous steps,
 &scons; selects the current directory for scanning,
 unless command-line options which affect the target
 scan are detected


### PR DESCRIPTION
Doc-only change - some minor fiddling to the **Description** section of the manpage.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
