### PR TITLE
Sync SetOption

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -93,6 +93,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       of warnings in some tools which instantiated the class but did nothing
       with them, need to instead call SCons.Warnings.warn with the warn class.
     - Drop overridden changed_since_last_build method in Value class.
+    - Resync the SetOption implementation and the manpage, making sure new
+      options are available and adding a notes column for misc information.
+      SetOption equivalents to --hash-chunksize, --implicit-deps-unchanged
+      and --implicit-deps-changed are enabled.
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -787,9 +787,9 @@ The settable variables with their associated command-line options are:
 <!-- This list comes directly from SConsValues.settable. Keep in sync. -->
 
 <informaltable rowsep="1" colsep="1" frame="topbot">
-<tgroup cols="2">
+<tgroup cols="3">
 <thead>
-<row><entry>Variable</entry><entry>Command-line options</entry></row>
+<row><entry>Variable</entry><entry>Command-line options</entry><entry>Notes</entry></row>
 </thead>
 <tbody>
 <row><entry>
@@ -797,18 +797,18 @@ The settable variables with their associated command-line options are:
 </entry><entry>
 <option>-c</option>, <option>--clean</option>, <option>--remove</option>
 </entry></row>
+
 <row><entry>
 <varname>diskcheck</varname>
 </entry><entry>
 <option>--diskcheck</option>
 </entry></row>
 
-    <row><entry>
+<row><entry>
 <varname>duplicate</varname>
 </entry><entry>
 <option>--duplicate</option>
 </entry></row>
-
 
     <row>
         <entry>
@@ -817,30 +817,74 @@ The settable variables with their associated command-line options are:
         <entry>
             <option>--experimental</option>
         </entry>
+        <entry>
+            <emphasis>since 4.2</emphasis>
+        </entry>
     </row>
 
+<row><entry>
+<varname>hash_chunksize</varname>
+</entry><entry>
+<option>--hash-chunksize</option>
+</entry><entry>
+<emphasis>since 4.2</emphasis>
+</entry></row>
+
+<row><entry>
+<varname>hash_format</varname>
+</entry><entry>
+<option>--hash-format</option>
+</entry><entry>
+<emphasis>since 4.2</emphasis>
+</entry></row>
 
 <row><entry>
 <varname>help</varname>
 </entry><entry>
 <option>-h</option>, <option>--help</option>
 </entry></row>
+
 <row><entry>
 <varname>implicit_cache</varname>
 </entry><entry>
 <option>--implicit-cache</option>
+</entry><entry>
+<emphasis> since 4.2</emphasis>
 </entry></row>
+
 <!--TODO: add implicit-deps-changed, implicit-deps-unchanged ? -->
+<row><entry>
+<varname>implicit_deps_changed</varname>
+</entry><entry>
+<option>--implicit-deps-changed</option>
+</entry><entry>
+Also sets
+<varname>implicit_cache</varname>
+<emphasis>(since 4.2)</emphasis>
+</entry></row>
+
+<row><entry>
+<varname>implicit_deps_unchanged</varname>
+</entry><entry>
+<option>--implicit-deps-unchanged</option>
+</entry><entry>
+Also sets
+<varname>implicit_cache</varname>
+<emphasis>(since 4.2)</emphasis>
+</entry></row>
+
 <row><entry>
 <varname>max_drift</varname>
 </entry><entry>
 <option>--max-drift</option>
 </entry></row>
+
 <row><entry>
 <varname>md5_chunksize</varname>
 </entry><entry>
 <option>--md5-chunksize</option>
 </entry></row>
+
 <row><entry>
 <varname>no_exec</varname>
 </entry><entry>
@@ -848,35 +892,41 @@ The settable variables with their associated command-line options are:
 <option>--just-print</option>, <option>--dry-run</option>,
 <option>--recon</option>
 </entry></row>
+
 <row><entry>
 <varname>no_progress</varname>
 </entry><entry>
 <option>-Q</option>
 </entry></row>
+
 <row><entry>
 <varname>num_jobs</varname>
 </entry><entry>
 <option>-j</option>, <option>--jobs</option>
 </entry></row>
+
 <row><entry>
 <varname>random</varname>
 </entry><entry>
 <option>--random</option>
 </entry></row>
+
 <row><entry>
 <varname>silent</varname>
 </entry><entry>
-<option>--silent</option>.
+<option>--silent</option>
 </entry></row>
+
 <row><entry>
 <varname>stack_size</varname>
 </entry><entry>
 <option>--stack-size</option>
 </entry></row>
+
 <row><entry>
 <varname>warn</varname>
 </entry><entry>
-<option>--warn</option>.
+<option>--warn</option>
 </entry></row>
 </tbody>
 </tgroup>

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -768,15 +768,21 @@ Multiple targets can be passed in to a single call to
 Sets &scons; option variable <parameter>name</parameter>
 to <parameter>value</parameter>.
 These options are all also settable via
-&scons; command-line options but the variable name
-may differ from the command-line option name (see table).
+command-line options but the variable name
+may differ from the command-line option name - 
+see the table for correspondences.
 A value set via command-line option will take
 precedence over one set with &f-SetOption;, which
 allows setting a project default in the scripts and
 temporarily overriding it via command line.
+Project-wide
+&f-SetOption; calls can also be placed in the
+<filename>site_init.py</filename> file.
+</para>
+<para>
 Options which affect the reading and processing of SConscript files
-are not settable this way, since those files must
-be read in order to find the &f-SetOption; call.
+are not settable using &f-SetOption; since those files must
+be read in order to find the &f-SetOption; call in the first place.
 </para>
 
 <para>
@@ -789,145 +795,127 @@ The settable variables with their associated command-line options are:
 <informaltable rowsep="1" colsep="1" frame="topbot">
 <tgroup cols="3">
 <thead>
-<row><entry>Variable</entry><entry>Command-line options</entry><entry>Notes</entry></row>
+<row>
+  <entry>Variable</entry>
+  <entry>Command-line options</entry>
+  <entry>Notes</entry>
+</row>
 </thead>
+
 <tbody>
-<row><entry>
-<varname>clean</varname>
-</entry><entry>
-<option>-c</option>, <option>--clean</option>, <option>--remove</option>
-</entry></row>
+<row>
+  <entry><varname>clean</varname></entry>
+  <entry>
+    <option>-c</option>,
+    <option>--clean</option>,
+    <option>--remove</option>
+  </entry>
+</row>
 
-<row><entry>
-<varname>diskcheck</varname>
-</entry><entry>
-<option>--diskcheck</option>
-</entry></row>
+<row>
+  <entry><varname>diskcheck</varname></entry>
+  <entry><option>--diskcheck</option></entry>
+</row>
 
-<row><entry>
-<varname>duplicate</varname>
-</entry><entry>
-<option>--duplicate</option>
-</entry></row>
+<row>
+  <entry><varname>duplicate</varname></entry>
+  <entry><option>--duplicate</option></entry>
+</row>
 
-    <row>
-        <entry>
-            <varname>experimental</varname>
-        </entry>
-        <entry>
-            <option>--experimental</option>
-        </entry>
-        <entry>
-            <emphasis>since 4.2</emphasis>
-        </entry>
-    </row>
+<row>
+  <entry><varname>experimental</varname></entry>
+  <entry><option>--experimental</option></entry>
+  <entry><emphasis>since 4.2</emphasis></entry>
+</row>
 
-<row><entry>
-<varname>hash_chunksize</varname>
-</entry><entry>
-<option>--hash-chunksize</option>
-</entry><entry>
-<emphasis>since 4.2</emphasis>
-</entry></row>
+<row>
+  <entry><varname>hash_chunksize</varname></entry>
+  <entry><option>--hash-chunksize</option></entry>
+  <entry><emphasis>since 4.2</emphasis></entry>
+</row>
 
-<row><entry>
-<varname>hash_format</varname>
-</entry><entry>
-<option>--hash-format</option>
-</entry><entry>
-<emphasis>since 4.2</emphasis>
-</entry></row>
+<row>
+  <entry><varname>hash_format</varname></entry>
+  <entry><option>--hash-format</option></entry>
+  <entry><emphasis>since 4.2</emphasis></entry>
+</row>
 
-<row><entry>
-<varname>help</varname>
-</entry><entry>
-<option>-h</option>, <option>--help</option>
-</entry></row>
+<row>
+  <entry><varname>help</varname></entry>
+  <entry><option>-h</option>, <option>--help</option></entry>
+</row>
 
-<row><entry>
-<varname>implicit_cache</varname>
-</entry><entry>
-<option>--implicit-cache</option>
-</entry><entry>
-<emphasis> since 4.2</emphasis>
-</entry></row>
+<row>
+  <entry><varname>implicit_cache</varname></entry>
+  <entry><option>--implicit-cache</option></entry>
+  <entry><emphasis> since 4.2</emphasis></entry>
+</row>
 
-<!--TODO: add implicit-deps-changed, implicit-deps-unchanged ? -->
-<row><entry>
-<varname>implicit_deps_changed</varname>
-</entry><entry>
-<option>--implicit-deps-changed</option>
-</entry><entry>
-Also sets
-<varname>implicit_cache</varname>
-<emphasis>(since 4.2)</emphasis>
-</entry></row>
+<row>
+  <entry><varname>implicit_deps_changed</varname></entry>
+  <entry><option>--implicit-deps-changed</option></entry>
+  <entry>Also sets <varname>implicit_cache</varname>
+  <emphasis>(since 4.2)</emphasis></entry>
+</row>
 
-<row><entry>
-<varname>implicit_deps_unchanged</varname>
-</entry><entry>
-<option>--implicit-deps-unchanged</option>
-</entry><entry>
-Also sets
-<varname>implicit_cache</varname>
-<emphasis>(since 4.2)</emphasis>
-</entry></row>
+<row>
+  <entry><varname>implicit_deps_unchanged</varname></entry>
+  <entry><option>--implicit-deps-unchanged</option></entry>
+  <entry>Also sets <varname>implicit_cache</varname>
+  <emphasis>(since 4.2)</emphasis></entry>
+</row>
 
-<row><entry>
-<varname>max_drift</varname>
-</entry><entry>
-<option>--max-drift</option>
-</entry></row>
+<row>
+  <entry><varname>max_drift</varname></entry>
+  <entry><option>--max-drift</option></entry>
+</row>
 
-<row><entry>
-<varname>md5_chunksize</varname>
-</entry><entry>
-<option>--md5-chunksize</option>
-</entry></row>
+<row>
+  <entry><varname>md5_chunksize</varname></entry>
+  <entry><option>--md5-chunksize</option></entry>
+</row>
 
-<row><entry>
-<varname>no_exec</varname>
-</entry><entry>
-<option>-n</option>, <option>--no-exec</option>,
-<option>--just-print</option>, <option>--dry-run</option>,
-<option>--recon</option>
-</entry></row>
+<row>
+  <entry><varname>no_exec</varname></entry>
+  <entry>
+    <option>-n</option>,
+    <option>--no-exec</option>,
+    <option>--just-print</option>,
+    <option>--dry-run</option>,
+    <option>--recon</option>
+  </entry>
+</row>
 
-<row><entry>
-<varname>no_progress</varname>
-</entry><entry>
-<option>-Q</option>
-</entry></row>
+<row>
+  <entry><varname>no_progress</varname></entry>
+  <entry><option>-Q</option></entry>
+</row>
 
-<row><entry>
-<varname>num_jobs</varname>
-</entry><entry>
-<option>-j</option>, <option>--jobs</option>
-</entry></row>
+<row>
+  <entry><varname>num_jobs</varname></entry>
+  <entry><option>-j</option>, <option>--jobs</option></entry>
+</row>
 
-<row><entry>
-<varname>random</varname>
-</entry><entry>
-<option>--random</option>
-</entry></row>
+<row>
+  <entry><varname>random</varname></entry>
+  <entry><option>--random</option></entry>
+</row>
 
-<row><entry>
-<varname>silent</varname>
-</entry><entry>
-<option>--silent</option>
-</entry></row>
+<row>
+  <entry><varname>silent</varname></entry>
+  <entry><option>--silent</option></entry>
+</row>
 
-<row><entry>
-<varname>stack_size</varname>
-</entry><entry>
-<option>--stack-size</option>
-</entry></row>
+<row>
+  <entry><varname>stack_size</varname></entry>
+  <entry><option>--stack-size</option></entry>
+</row>
 
-<row><entry>
-<varname>warn</varname>
-</entry><entry>
-<option>--warn</option>
-</entry></row>
+<row>
+  <entry><varname>warn</varname></entry>
+  <entry><option>--warn</option></entry>
+</row>
+
 </tbody>
 </tgroup>
 </informaltable>
@@ -935,15 +923,19 @@ Also sets
 <para>
 See the documentation in the manpage for the
 corresponding command line option for information about each specific option.
-Option values which are boolean in nature (that is, they are
-either on or off) should be set to a true value (<constant>True</constant>,
-<constant>1</constant>) or a false value (<constant>False</constant>,
+The <parameter>value</parameter> parameter is mandatory,
+for option values which are boolean in nature
+(that is, the command line option does not take an argument)
+use a <parameter>value</parameter>
+which evaluates to true (e.g. <constant>True</constant>,
+<constant>1</constant>) or false (e.g. <constant>False</constant>,
 <constant>0</constant>).
 </para>
 
 <note>
 <para>
 If <varname>no_progress</varname> is set via &f-SetOption;
+in an SConscript file,
 there will still be initial progress output as &SCons; has
 to start reading SConscript files before it can see the
 &f-SetOption; in an SConscript file:
@@ -956,7 +948,7 @@ Example:
 </para>
 
 <example_commands>
-SetOption('max_drift', True)
+SetOption('max_drift', 0)
 </example_commands>
 </summary>
 </scons_function>

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -129,28 +129,31 @@ class SConsValues(optparse.Values):
         'clean',
         'diskcheck',
         'duplicate',
+        'experimental',
+        'hash_chunksize',
         'hash_format',
         'help',
         'implicit_cache',
         'max_drift',
         'md5_chunksize',
         'no_exec',
+        'no_progress',
         'num_jobs',
         'random',
+        'silent',
         'stack_size',
         'warn',
-        'silent',
-        'no_progress',
-        'experimental',
     ]
 
     def set_option(self, name, value):
-        """
-        Sets an option from an SConscript file.
-        """
-        if name not in self.settable:
-            raise SCons.Errors.UserError("This option is not settable from a SConscript file: %s"%name)
+        """Sets an option from an SConscript file."""
 
+        if name not in self.settable:
+            raise SCons.Errors.UserError(
+                "This option is not settable from a SConscript file: %s" % name
+            )
+
+        # the following are for options that need some extra processing
         if name == 'num_jobs':
             try:
                 value = int(value)
@@ -188,7 +191,7 @@ class SConsValues(optparse.Values):
                 value = int(value)
             except ValueError:
                 raise SCons.Errors.UserError("An integer is required: %s"%repr(value))
-        elif name == 'md5_chunksize':
+        elif name in ('md5_chunksize', 'hash_chunksize'):
             try:
                 value = int(value)
             except ValueError:
@@ -204,8 +207,6 @@ class SConsValues(optparse.Values):
             if SCons.Util.is_String(value):
                 value = [value]
             value = self.__SConscript_settings__.get(name, []) + value
-
-
 
         self.__SConscript_settings__[name] = value
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1124,7 +1124,7 @@ the mechanisms in the specified order.</para>
   </listitem>
   </varlistentry>
 
-  <varlistentry id="opt--experimental">
+  <varlistentry id="opt-experimental">
     <term>
       <option>--experimental=<replaceable>all</replaceable></option>,
       <option>--experimental=<replaceable>none</replaceable></option>
@@ -1132,6 +1132,7 @@ the mechanisms in the specified order.</para>
     <listitem>
       <para>Enable experimental features and/or tools. <emphasis role="strong">No Support offered for any features or tools enabled by this flag</emphasis></para>
       <para>The default setting is none.</para>
+      <para><emphasis>Available since &scons; 4.2.</emphasis></para>
     </listitem>
   </varlistentry>
 


### PR DESCRIPTION
Resync the `SetOption` implementation and the manpage, making sure new  options are available and adding a notes column for misc information.

SetOption equivalents to `--hash-chunksize` (new to 4.2, but a synonym for `md5_chunksize`), `--implicit-deps-unchanged`  and `--implicit-deps-changed` are enabled.

Addresses part of #3780 but does not close it.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
