### PR TITLE
Fix 3955 extra shlib output due to _LIBDIRFLAGS content

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix versioned shared library naming for MacOS platform. (Previously was libxyz.dylib.1.2.3,
       has been fixed to libxyz.1.2.3.dylib. Additionally the sonamed symlink had the same issue,
       that is now resolved as well)
+    - Fix #3955 - _LIBDIRFLAGS leaving $( and $) in *COMSTR output.  Added affect_signature flag to
+      _concat function.  If set to False, it will prepend and append $( and $). That way the various
+      Environment variables can use that rather than "$( _concat(...) $)".
 
   From David H:
     - Fix Issue #3906 - `IMPLICIT_COMMAND_DEPENDENCIES` was not properly disabled when

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -14,6 +14,9 @@ NEW FUNCTIONALITY
       Fixes #396
     - Added --experimental flag, to enable various experimental features/tools.  You can specify
       'all', 'none', or any combination of available experimental features.
+    - Added affect_signature flag to  _concat function.  If set to False, it will prepend and append $( and $).
+      That way the various Environment variables can use that rather than "$( _concat(...) $)".
+
 
 DEPRECATED FUNCTIONALITY
 ------------------------

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -94,13 +94,13 @@ def DefaultEnvironment(*args, **kw):
 def StaticObjectEmitter(target, source, env):
     for tgt in target:
         tgt.attributes.shared = None
-    return (target, source)
+    return target, source
 
 
 def SharedObjectEmitter(target, source, env):
     for tgt in target:
         tgt.attributes.shared = 1
-    return (target, source)
+    return target, source
 
 
 def SharedFlagChecker(source, target, env):
@@ -291,7 +291,7 @@ def delete_func(dest, must_exist=0):
             continue
         # os.path.isdir returns True when entry is a link to a dir
         if os.path.isdir(entry) and not os.path.islink(entry):
-            shutil.rmtree(entry, 1)
+            shutil.rmtree(entry, True)
             continue
         os.unlink(entry)
 
@@ -312,7 +312,7 @@ def mkdir_func(dest):
 
 
 Mkdir = ActionFactory(mkdir_func,
-                      lambda dir: 'Mkdir(%s)' % get_paths_str(dir))
+                      lambda _dir: 'Mkdir(%s)' % get_paths_str(_dir))
 
 
 def move_func(dest, src):
@@ -347,10 +347,10 @@ Touch = ActionFactory(touch_func,
 
 # Internal utility functions
 
-
+# pylint: disable-msg=too-many-arguments
 def _concat(prefix, items_iter, suffix, env, f=lambda x: x, target=None, source=None, affect_signature=True):
     """
-    Creates a new list from 'iter' by first interpolating each element
+    Creates a new list from 'items_iter' by first interpolating each element
     in the list using the 'env' dictionary and then calling f on the
     list, and finally calling _concat_ixes to concatenate 'prefix' and
     'suffix' onto each element of the list.
@@ -373,11 +373,12 @@ def _concat(prefix, items_iter, suffix, env, f=lambda x: x, target=None, source=
         value += ["$)"]
 
     return value
+# pylint: enable-msg=too-many-arguments
 
 
-def _concat_ixes(prefix, iter, suffix, env):
+def _concat_ixes(prefix, items_iter, suffix, env):
     """
-    Creates a new list from 'iter' by concatenating the 'prefix' and
+    Creates a new list from 'items_iter' by concatenating the 'prefix' and
     'suffix' arguments onto each element of the list.  A trailing space
     on 'prefix' or leading space on 'suffix' will cause them to be put
     into separate list elements rather than being concatenated.
@@ -389,7 +390,7 @@ def _concat_ixes(prefix, iter, suffix, env):
     prefix = str(env.subst(prefix, SCons.Subst.SUBST_RAW))
     suffix = str(env.subst(suffix, SCons.Subst.SUBST_RAW))
 
-    for x in SCons.Util.flatten(iter):
+    for x in SCons.Util.flatten(items_iter):
         if isinstance(x, SCons.Node.FS.File):
             result.append(x)
             continue

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -42,9 +42,9 @@ import SCons.Builder
 import SCons.CacheDir
 import SCons.Environment
 import SCons.PathList
+import SCons.Scanner.Dir
 import SCons.Subst
 import SCons.Tool
-import SCons.Scanner.Dir
 
 # A placeholder for a default Environment (for fetching source files
 # from source code management systems and the like).  This must be

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -361,13 +361,13 @@ def _concat(prefix, items_iter, suffix, env, f=lambda x: x, target=None, source=
 
     l = f(SCons.PathList.PathList(items_iter).subst_path(env, target, source))
     if l is not None:
-        iter = l
+        items_iter = l
 
     if not affect_signature:
         value = ['$(']
     else:
         value = []
-    value += _concat_ixes(prefix, iter, suffix, env)
+    value += _concat_ixes(prefix, items_iter, suffix, env)
 
     if not affect_signature:
         value += ["$)"]

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -25,19 +25,23 @@ See its __doc__ string for a discussion of the format.
 
 <cvar name ="_concat">
 <summary>
-<para>
-A function used to produce variables like &cv-link-_CPPINCFLAGS;. It takes
-four or five
-arguments: a prefix to concatenate onto each element, a list of
-elements, a suffix to concatenate onto each element, an environment
-for variable interpolation, an optional function that will be
-called to transform the list before concatenation, affect_signature which will wrap non-empty returned value with
-    $( and $) to indicate the contents should not affect the signature of the generated command line.
-</para>
+    <para>
+        A function used to produce variables like &cv-link-_CPPINCFLAGS;. It takes
+        four mandatory arguments, and up to 4 additional optional arguments:
+        1) a prefix to concatenate onto each element,
+        2) a list of elements,
+        3) a suffix to concatenate onto each element,
+        4) an environment for variable interpolation,
+        5) an optional function that will be called to transform the list before concatenation,
+        6) an optionally specified target (Can use TARGET),
+        7) an optionally specified source (Can use SOURCE),
+        8) optional affect_signature flag which will wrap non-empty returned value with $( and $) to indicate the contents
+        should not affect the signature of the generated command line.
+    </para>
 
-<example_commands>
-env['_CPPINCFLAGS'] = '${_concat(INCPREFIX, CPPPATH, INCSUFFIX, __env__, RDirs, affect_signature=False)}',
-</example_commands>
+    <example_commands>
+        env['_CPPINCFLAGS'] = '${_concat(INCPREFIX, CPPPATH, INCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
+    </example_commands>
 </summary>
 </cvar>
 

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -30,12 +30,13 @@ A function used to produce variables like &cv-link-_CPPINCFLAGS;. It takes
 four or five
 arguments: a prefix to concatenate onto each element, a list of
 elements, a suffix to concatenate onto each element, an environment
-for variable interpolation, and an optional function that will be
-called to transform the list before concatenation.
+for variable interpolation, an optional function that will be
+called to transform the list before concatenation, affect_signature which will wrap non-empty returned value with
+    $( and $) to indicate the contents should not affect the signature of the generated command line.
 </para>
 
 <example_commands>
-env['_CPPINCFLAGS'] = '$( ${_concat(INCPREFIX, CPPPATH, INCSUFFIX, __env__, RDirs)} $)',
+env['_CPPINCFLAGS'] = '${_concat(INCPREFIX, CPPPATH, INCSUFFIX, __env__, RDirs, affect_signature=False)}',
 </example_commands>
 </summary>
 </cvar>

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -35,7 +35,7 @@ See its __doc__ string for a discussion of the format.
         5) an optional function that will be called to transform the list before concatenation,
         6) an optionally specified target (Can use TARGET),
         7) an optionally specified source (Can use SOURCE),
-        8) optional affect_signature flag which will wrap non-empty returned value with $( and $) to indicate the contents
+        8) optional <parameter>affect_signature</parameter> flag which will wrap non-empty returned value with $( and $) to indicate the contents
         should not affect the signature of the generated command line.
     </para>
 

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -143,7 +143,7 @@ class DummyNode:
         return self
 
 def test_tool( env ):
-    env['_F77INCFLAGS'] = '$( ${_concat(INCPREFIX, F77PATH, INCSUFFIX, __env__, RDirs, TARGET, SOURCE)} $)'
+    env['_F77INCFLAGS'] = '${_concat(INCPREFIX, F77PATH, INCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
 
 class TestEnvironmentFixture:
     def TestEnvironment(self, *args, **kw):
@@ -1488,6 +1488,9 @@ def exists(env):
         assert x == 'prea bsuf', x
         x = s("${_concat(PRE, LIST, SUF, __env__)}")
         assert x == 'preasuf prebsuf', x
+        x = s("${_concat(PRE, LIST, SUF, __env__,affect_signature=False)}", raw=True)
+        assert x == '$( preasuf prebsuf $)', x
+
 
     def test_concat_nested(self):
         """Test _concat() on a nested substitution strings."""

--- a/SCons/Tool/FortranCommon.py
+++ b/SCons/Tool/FortranCommon.py
@@ -1,9 +1,3 @@
-"""SCons.Tool.FortranCommon
-
-Stuff for processing Fortran, common to all fortran dialects.
-
-"""
-
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -25,7 +19,12 @@ Stuff for processing Fortran, common to all fortran dialects.
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""SCons.Tool.FortranCommon
+
+Stuff for processing Fortran, common to all fortran dialects.
+
+"""
 
 import re
 import os.path
@@ -34,6 +33,7 @@ import SCons.Action
 import SCons.Scanner.Fortran
 import SCons.Tool
 import SCons.Util
+
 
 def isfortran(env, source):
     """Return 1 if any of code in source has fortran files in it, 0
@@ -147,7 +147,7 @@ def DialectAddToEnv(env, dialect, suffixes, ppsuffixes, support_module = 0):
     if 'INC%sSUFFIX' % dialect not in env:
         env['INC%sSUFFIX' % dialect] = '$INCSUFFIX'
 
-    env['_%sINCFLAGS' % dialect] = '$( ${_concat(INC%sPREFIX, %sPATH, INC%sSUFFIX, __env__, RDirs, TARGET, SOURCE)} $)' % (dialect, dialect, dialect)
+    env['_%sINCFLAGS' % dialect] = '${_concat(INC%sPREFIX, %sPATH, INC%sSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}' % (dialect, dialect, dialect)
 
     if support_module == 1:
         env['%sCOM' % dialect]     = '$%s -o $TARGET -c $%sFLAGS $_%sINCFLAGS $_FORTRANMODFLAG $SOURCES' % (dialect, dialect, dialect)

--- a/SCons/Tool/linkCommon/SharedLibrary.py
+++ b/SCons/Tool/linkCommon/SharedLibrary.py
@@ -208,11 +208,11 @@ def setup_shared_lib_logic(env):
     env["SHLIBEMITTER"] = [lib_emitter, shlib_symlink_emitter]
 
     # If it's already set, then don't overwrite.
-    env["SHLIBPREFIX"] = env.get('SHLIBPREFIX',"lib")
+    env["SHLIBPREFIX"] = env.get('SHLIBPREFIX', "lib")
     env["_SHLIBSUFFIX"] = "${SHLIBSUFFIX}${_SHLIBVERSION}"
 
     env["SHLINKFLAGS"] = CLVar("$LINKFLAGS -shared")
 
     env["SHLINKCOM"] = "$SHLINK -o $TARGET $SHLINKFLAGS $__SHLIBVERSIONFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS"
-    env["SHLINKCOMSTR"] = "$SHLINKCOM"
+
     env["SHLINK"] = "$LINK"

--- a/SCons/Tool/mingw.py
+++ b/SCons/Tool/mingw.py
@@ -180,7 +180,7 @@ def generate(env):
     env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 1
     env['RC'] = 'windres'
     env['RCFLAGS'] = SCons.Util.CLVar('')
-    env['RCINCFLAGS'] = '$( ${_concat(RCINCPREFIX, CPPPATH, RCINCSUFFIX, __env__, RDirs, TARGET, SOURCE)} $)'
+    env['RCINCFLAGS'] = '${_concat(RCINCPREFIX, CPPPATH, RCINCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
     env['RCINCPREFIX'] = '--include-dir '
     env['RCINCSUFFIX'] = ''
     env['RCCOM'] = '$RC $_CPPDEFFLAGS $RCINCFLAGS ${RCINCPREFIX} ${SOURCE.dir} $RCFLAGS -i $SOURCE -o $TARGET'

--- a/SCons/Tool/swig.py
+++ b/SCons/Tool/swig.py
@@ -204,8 +204,8 @@ def generate(env):
     env['SWIGPATH'] = []
     env['SWIGINCPREFIX'] = '-I'
     env['SWIGINCSUFFIX'] = ''
-    env[
-        '_SWIGINCFLAGS'] = '${_concat(SWIGINCPREFIX, SWIGPATH, SWIGINCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
+    env['_SWIGINCFLAGS'] = '${_concat(SWIGINCPREFIX, SWIGPATH, SWIGINCSUFFIX,' \
+                            '__env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
     env['SWIGCOM'] = '$SWIG -o $TARGET ${_SWIGOUTDIR} ${_SWIGINCFLAGS} $SWIGFLAGS $SOURCES'
 
 def exists(env):

--- a/SCons/Tool/swig.py
+++ b/SCons/Tool/swig.py
@@ -29,15 +29,15 @@ selection method.
 """
 
 import os.path
-import sys
 import re
 import subprocess
+import sys
 
 import SCons.Action
 import SCons.Defaults
+import SCons.Node
 import SCons.Tool
 import SCons.Util
-import SCons.Node
 import SCons.Warnings
 
 verbose = False
@@ -194,17 +194,19 @@ def generate(env):
 
     if 'SWIG' not in env:
         env['SWIG'] = env.Detect(swigs) or swigs[0]
-    env['SWIGVERSION']       = _get_swig_version(env, env['SWIG'])
-    env['SWIGFLAGS']         = SCons.Util.CLVar('')
+
+    env['SWIGVERSION'] = _get_swig_version(env, env['SWIG'])
+    env['SWIGFLAGS'] = SCons.Util.CLVar('')
     env['SWIGDIRECTORSUFFIX'] = '_wrap.h'
-    env['SWIGCFILESUFFIX']   = '_wrap$CFILESUFFIX'
+    env['SWIGCFILESUFFIX'] = '_wrap$CFILESUFFIX'
     env['SWIGCXXFILESUFFIX'] = '_wrap$CXXFILESUFFIX'
-    env['_SWIGOUTDIR']       = r'${"-outdir \"%s\"" % SWIGOUTDIR}'
-    env['SWIGPATH']          = []
-    env['SWIGINCPREFIX']     = '-I'
-    env['SWIGINCSUFFIX']     = ''
-    env['_SWIGINCFLAGS']     = '${_concat(SWIGINCPREFIX, SWIGPATH, SWIGINCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
-    env['SWIGCOM']           = '$SWIG -o $TARGET ${_SWIGOUTDIR} ${_SWIGINCFLAGS} $SWIGFLAGS $SOURCES'
+    env['_SWIGOUTDIR'] = r'${"-outdir \"%s\"" % SWIGOUTDIR}'
+    env['SWIGPATH'] = []
+    env['SWIGINCPREFIX'] = '-I'
+    env['SWIGINCSUFFIX'] = ''
+    env[
+        '_SWIGINCFLAGS'] = '${_concat(SWIGINCPREFIX, SWIGPATH, SWIGINCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
+    env['SWIGCOM'] = '$SWIG -o $TARGET ${_SWIGOUTDIR} ${_SWIGINCFLAGS} $SWIGFLAGS $SOURCES'
 
 def exists(env):
     swig = env.get('SWIG') or env.Detect(['swig'])

--- a/SCons/Tool/swig.py
+++ b/SCons/Tool/swig.py
@@ -203,7 +203,7 @@ def generate(env):
     env['SWIGPATH']          = []
     env['SWIGINCPREFIX']     = '-I'
     env['SWIGINCSUFFIX']     = ''
-    env['_SWIGINCFLAGS']     = '$( ${_concat(SWIGINCPREFIX, SWIGPATH, SWIGINCSUFFIX, __env__, RDirs, TARGET, SOURCE)} $)'
+    env['_SWIGINCFLAGS']     = '${_concat(SWIGINCPREFIX, SWIGPATH, SWIGINCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}'
     env['SWIGCOM']           = '$SWIG -o $TARGET ${_SWIGOUTDIR} ${_SWIGINCFLAGS} $SWIGFLAGS $SOURCES'
 
 def exists(env):

--- a/test/SWIG/SWIGOUTDIR.py
+++ b/test/SWIG/SWIGOUTDIR.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +21,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that use of the $SWIGOUTDIR variable causes SCons to recognize

--- a/test/SWIG/generated_swigfile.py
+++ b/test/SWIG/generated_swigfile.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +21,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that SCons realizes the -noproxy option means no .py file will
@@ -38,14 +36,8 @@ import TestSCons
 if sys.platform == 'win32':
     _dll = '.dll'
 else:
-    _dll   = '.so'
+    _dll = '.so'
 
-# swig-python expects specific filenames.
-# the platform specific suffix won't necessarily work.
-if sys.platform == 'win32':
-    _dll = '.dll'
-else:
-    _dll   = '.so'
 
 test = TestSCons.TestSCons()
 
@@ -54,11 +46,10 @@ if not swig:
     test.skip_test('Can not find installed "swig", skipping test.\n')
 
 python, python_include, python_libpath, python_lib = \
-             test.get_platform_python_info(python_h_required=True)
+    test.get_platform_python_info(python_h_required=True)
 
 # handle testing on other platforms:
 ldmodule_prefix = '_'
-
 
 test.write('SConstruct', """
 foo = Environment(CPPPATH=[r'%(python_include)s'],
@@ -69,7 +60,6 @@ python_interface = foo.Command( 'test_py_swig.i', Value(1), 'echo %%module test_
 python_c_file    = foo.CFile( target='python_swig_test',source=python_interface, SWIGFLAGS = '-python -c++' )
 java_interface  = foo.Command( 'test_java_swig.i', Value(1),'echo %%module test_java_swig > test_java_swig.i' )
 java_c_file     = foo.CFile( target='java_swig_test'  ,source=java_interface, SWIGFLAGS = '-java -c++' )
-
 """ % locals())
 
 expected_stdout = """\
@@ -78,12 +68,11 @@ echo %%module test_java_swig > test_java_swig.i
 echo %%module test_py_swig > test_py_swig.i
 %(swig)s -o python_swig_test_wrap.cc -python -c++ test_py_swig.i
 """ % locals()
-test.run(arguments = '.',stdout=test.wrap_stdout(expected_stdout))
-
+test.run(arguments='.', stdout=test.wrap_stdout(expected_stdout))
 
 # If we mistakenly depend on the .py file that SWIG didn't create
 # (suppressed by the -noproxy option) then the build won't be up-to-date.
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
 test.pass_test()
 

--- a/test/_CPPINCFLAGS.py
+++ b/test/_CPPINCFLAGS.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +21,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that we can expand $_CPPINCFLAGS correctly regardless of whether


### PR DESCRIPTION
Fixes #3955 

The issue was the string was

`$( ${_concat(...)} $)`  

Which would yield $( $) if content returned nothing.

The solution was to add affect_signature flag to _concat and remove the other escaping

`${_concat(...,affect_signature=False)}` 

Which will only add `$(` and `$)` if the results of `_concat` is not an empty string.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
