### PR TITLE
Change warnings behavior of missing SConscript

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -103,6 +103,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       and EnvironmentTests (asserts comparing with self).
       For consistency, env.Tool() now returns a tool object the same way
       Tool() has done.
+    - Change SConscript() missing SConscript behavior - if must_exist=False,
+      the warning is suppressed.
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -46,6 +46,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
     - Update BuildTask to pass all targets to the progress object fixing an issue
       where multi-target build nodes only got the first target passed to the progress
       object.
+    - Change SConscript() missing SConscript behavior - if must_exist=False,
+      the warning is suppressed.
 
 
 FIXES

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -148,31 +148,37 @@ stack_bottom = '% Stack boTTom %' # hard to define a variable w/this name :)
 def handle_missing_SConscript(f, must_exist=None):
     """Take appropriate action on missing file in SConscript() call.
 
-    Print a warning or raise an exception on missing file.
+    Print a warning or raise an exception on missing file, unless
+    missing is explicitly allowed by the *must_exist* value.
     On first warning, print a deprecation message.
 
     Args:
         f (str): path of missing configuration file
-        must_exist (bool): raise exception if file does not exist
+        must_exist (bool): if true, fail.  If false, but not ``None``,
+          allow the file to be missing.  The default is ``None``,
+          which means issue the warning.  The default is deprecated.
 
     Raises:
-        UserError if 'must_exist' is True or if global
-          SCons.Script._no_missing_sconscript is True.
+        UserError: if *must_exist* is true or if global
+          :data:`SCons.Script._no_missing_sconscript` is true.
     """
 
     if must_exist or (SCons.Script._no_missing_sconscript and must_exist is not False):
         msg = "Fatal: missing SConscript '%s'" % f.get_internal_path()
         raise SCons.Errors.UserError(msg)
 
-    if SCons.Script._warn_missing_sconscript_deprecated and must_exist is None:
-        msg = "Calling missing SConscript without error is deprecated.\n" + \
-              "Transition by adding must_exist=0 to SConscript calls.\n" + \
-              "Missing SConscript '%s'" % f.get_internal_path()
-        SCons.Warnings.warn(SCons.Warnings.MissingSConscriptWarning, msg)
-        SCons.Script._warn_missing_sconscript_deprecated = False
-    else:
-        msg = "Ignoring missing SConscript '%s'" % f.get_internal_path()
-        SCons.Warnings.warn(SCons.Warnings.MissingSConscriptWarning, msg)
+    if must_exist is None:
+        if SCons.Script._warn_missing_sconscript_deprecated:
+            msg = (
+                "Calling missing SConscript without error is deprecated.\n"
+                "Transition by adding must_exist=False to SConscript calls.\n"
+                "Missing SConscript '%s'" % f.get_internal_path()
+            )
+            SCons.Warnings.warn(SCons.Warnings.MissingSConscriptWarning, msg)
+            SCons.Script._warn_missing_sconscript_deprecated = False
+        else:
+            msg = "Ignoring missing SConscript '%s'" % f.get_internal_path()
+            SCons.Warnings.warn(SCons.Warnings.MissingSConscriptWarning, msg)
 
 def _SConscript(fs, *files, **kw):
     top = fs.Top

--- a/test/SConscript/must_exist.py
+++ b/test/SConscript/must_exist.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,14 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-'''
+"""
 Test handling of must_exist flag and global setting requiring the
 file to exist in an SConscript call
-'''
+"""
 
 import os
 import TestSCons
@@ -43,32 +42,32 @@ from SCons.Warnings import _warningOut
 import sys
 
 DefaultEnvironment(tools=[])
-# 1. call should succeed with deprecation warning
+# 1. 1st default call should succeed with deprecation warning
 try:
     SConscript('missing/SConscript')
 except SCons.Errors.UserError as e:
     if _warningOut:
         _warningOut(e)
-# 2. call should succeed with warning
+# 2. 2nd default call should succeed with warning (no depr)
 try:
     SConscript('missing/SConscript')
 except SCons.Errors.UserError as e:
     if _warningOut:
         _warningOut(e)
-# 3. call should raise exception
+# 3. must_exist True call should raise exception
 try:
     SConscript('missing/SConscript', must_exist=True)
 except SCons.Errors.UserError as e:
     if _warningOut:
         _warningOut(e)
-# 4. call should succeed with warning
+# 4. must_exist False call should succeed silently
 try:
     SConscript('missing/SConscript', must_exist=False)
 except SCons.Errors.UserError as e:
     if _warningOut:
         _warningOut(e)
-SCons.Script.set_missing_sconscript_error()
 # 5. with system setting changed, should raise exception
+SCons.Script.set_missing_sconscript_error()
 try:
     SConscript('missing/SConscript')
 except SCons.Errors.UserError as e:
@@ -88,7 +87,7 @@ except SCons.Errors.UserError as e:
 missing = os.path.normpath('missing/SConscript')
 warn1 = """
 scons: warning: Calling missing SConscript without error is deprecated.
-Transition by adding must_exist=0 to SConscript calls.
+Transition by adding must_exist=False to SConscript calls.
 Missing SConscript '{}'
 """.format(missing) + test.python_file_line(SConstruct_path, 8)
 
@@ -100,19 +99,13 @@ err1 = """
 scons: warning: Fatal: missing SConscript '{}'
 """.format(missing) + test.python_file_line(SConstruct_path, 23)
 
-warn3 = """
-scons: warning: Ignoring missing SConscript '{}'
-""".format(missing) + test.python_file_line(SConstruct_path, 26)
-
 err2 = """
 scons: warning: Fatal: missing SConscript '{}'
 """.format(missing) + test.python_file_line(SConstruct_path, 36)
 
-warn4 = """
-scons: warning: Ignoring missing SConscript '{}'
-""".format(missing) + test.python_file_line(SConstruct_path, 39)
+nowarn = ""
 
-expect_stderr = warn1 + warn2 + err1 + warn3 + err2 + warn4
+expect_stderr = warn1 + warn2 + err1 + nowarn + err2 + nowarn
 test.run(arguments = ".", stderr = expect_stderr)
 test.pass_test()
 

--- a/test/SConscript/must_exist_deprecation.py
+++ b/test/SConscript/must_exist_deprecation.py
@@ -40,17 +40,14 @@ test.file_fixture("fixture/SConstruct")
 # we should see two warnings, the second being the deprecation message.
 # need to build the path in the expected msg in an OS-agnostic way
 missing = os.path.normpath('missing/SConscript')
-warn1 = """
-scons: warning: Ignoring missing SConscript '{}'
-""".format(missing) + test.python_file_line(SConstruct_path, 8)
-warn2 = """
+warnmsg = """
 scons: warning: Calling missing SConscript without error is deprecated.
 Transition by adding must_exist=False to SConscript calls.
 Missing SConscript '{}'
 """.format(missing) + test.python_file_line(SConstruct_path, 14)
 
-expect_stderr = warn2
-test.run(arguments = ".", stderr = expect_stderr)
+expect_stderr = warnmsg
+test.run(arguments=".", stderr=expect_stderr)
 test.pass_test()
 
 # Local Variables:

--- a/test/SConscript/must_exist_deprecation.py
+++ b/test/SConscript/must_exist_deprecation.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-'''
-Test deprecation warning if must_exist flag is used in a SConscript call
-'''
+"""
+Test deprecation warning if must_exist flag is used in an SConscript() call
+"""
 
 import os
 import TestSCons
@@ -46,11 +45,11 @@ scons: warning: Ignoring missing SConscript '{}'
 """.format(missing) + test.python_file_line(SConstruct_path, 8)
 warn2 = """
 scons: warning: Calling missing SConscript without error is deprecated.
-Transition by adding must_exist=0 to SConscript calls.
+Transition by adding must_exist=False to SConscript calls.
 Missing SConscript '{}'
 """.format(missing) + test.python_file_line(SConstruct_path, 14)
 
-expect_stderr = warn1 + warn2
+expect_stderr = warn2
 test.run(arguments = ".", stderr = expect_stderr)
 test.pass_test()
 

--- a/test/option/option-f.py
+++ b/test/option/option-f.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -54,56 +53,93 @@ print("Build2 "+ os.getcwd())
 
 wpath = test.workpath()
 
-test.run(arguments = '-f SConscript .',
-         stdout = test.wrap_stdout(read_str = 'SConscript %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='-f SConscript .',
+    stdout=test.wrap_stdout(
+        read_str='SConscript %s\n' % wpath, build_str="scons: `.' is up to date.\n"
+    ),
+)
 
-test.run(arguments = '-f %s .' % subdir_BuildThis,
-         stdout = test.wrap_stdout(read_str = 'subdir/BuildThis %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='-f %s .' % subdir_BuildThis,
+    stdout=test.wrap_stdout(
+        read_str='subdir/BuildThis %s\n' % wpath,
+        build_str="scons: `.' is up to date.\n",
+    ),
+)
 
-test.run(arguments = '--file=SConscript .',
-         stdout = test.wrap_stdout(read_str = 'SConscript %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='--file=SConscript .',
+    stdout=test.wrap_stdout(
+        read_str='SConscript %s\n' % wpath, build_str="scons: `.' is up to date.\n"
+    ),
+)
 
-test.run(arguments = '--file=%s .' % subdir_BuildThis,
-         stdout = test.wrap_stdout(read_str = 'subdir/BuildThis %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='--file=%s .' % subdir_BuildThis,
+    stdout=test.wrap_stdout(
+        read_str='subdir/BuildThis %s\n' % wpath,
+        build_str="scons: `.' is up to date.\n",
+    ),
+)
 
-test.run(arguments = '--makefile=SConscript .',
-         stdout = test.wrap_stdout(read_str = 'SConscript %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='--makefile=SConscript .',
+    stdout=test.wrap_stdout(
+        read_str='SConscript %s\n' % wpath, build_str="scons: `.' is up to date.\n"
+    ),
+)
 
-test.run(arguments = '--makefile=%s .' % subdir_BuildThis,
-         stdout = test.wrap_stdout(read_str = 'subdir/BuildThis %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='--makefile=%s .' % subdir_BuildThis,
+    stdout=test.wrap_stdout(
+        read_str='subdir/BuildThis %s\n' % wpath,
+        build_str="scons: `.' is up to date.\n",
+    ),
+)
 
-test.run(arguments = '--sconstruct=SConscript .',
-         stdout = test.wrap_stdout(read_str = 'SConscript %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='--sconstruct=SConscript .',
+    stdout=test.wrap_stdout(
+        read_str='SConscript %s\n' % wpath, build_str="scons: `.' is up to date.\n"
+    ),
+)
 
-test.run(arguments = '--sconstruct=%s .' % subdir_BuildThis,
-         stdout = test.wrap_stdout(read_str = 'subdir/BuildThis %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+test.run(
+    arguments='--sconstruct=%s .' % subdir_BuildThis,
+    stdout=test.wrap_stdout(
+        read_str='subdir/BuildThis %s\n' % wpath,
+        build_str="scons: `.' is up to date.\n",
+    ),
+)
 
-test.run(arguments = '-f - .', stdin = """
+test.run(
+    arguments='-f - .',
+    stdin="""
 DefaultEnvironment(tools=[])
 import os
 print("STDIN " + os.getcwd())
 """,
-         stdout = test.wrap_stdout(read_str = 'STDIN %s\n' % wpath,
-                                   build_str = "scons: `.' is up to date.\n"))
+    stdout=test.wrap_stdout(
+        read_str='STDIN %s\n' % wpath, build_str="scons: `.' is up to date.\n"
+    ),
+)
 
-expect = test.wrap_stdout(read_str = 'Build2 %s\nSConscript %s\n' % (wpath, wpath),
-                          build_str = "scons: `.' is up to date.\n")
-test.run(arguments = '-f Build2 -f SConscript .', stdout=expect)
+expect = test.wrap_stdout(
+    read_str='Build2 %s\nSConscript %s\n' % (wpath, wpath),
+    build_str="scons: `.' is up to date.\n",
+)
+test.run(arguments='-f Build2 -f SConscript .', stdout=expect)
 
-test.run(arguments = '-f no_such_file .',
-         stdout = test.wrap_stdout("scons: `.' is up to date.\n"),
-         stderr = None)
+test.run(
+    arguments='-f no_such_file .',
+    stdout=test.wrap_stdout("scons: `.' is up to date.\n"),
+    stderr=None,
+)
+
 expect = """
 scons: warning: Calling missing SConscript without error is deprecated.
-Transition by adding must_exist=0 to SConscript calls.
+Transition by adding must_exist=False to SConscript calls.
 Missing SConscript 'no_such_file'"""
 stderr = test.stderr()
 test.must_contain_all(test.stderr(), expect)

--- a/test/option/warn-missing-sconscript.py
+++ b/test/option/warn-missing-sconscript.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of the --warn=missing-sconscript option.
@@ -53,7 +52,7 @@ test.write("foo.c","""
 
 expect = r"""
 scons: warning: Calling missing SConscript without error is deprecated.
-Transition by adding must_exist=0 to SConscript calls.
+Transition by adding must_exist=False to SConscript calls.
 Missing SConscript 'no_such_file'
 """ + TestSCons.file_expr
 


### PR DESCRIPTION
If `SConscript()` is called with `must_exist=False`, accept the user's will without issuing a warning about the file being missing.

There is no functional change, only the one combination now does not issue a warning where it used to.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
