### PR TITLE
Addopt tests

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -157,6 +157,7 @@ if args.testlistfile:
     # args.testlistfile changes from a string to a pathlib Path object
     try:
         p = Path(args.testlistfile)
+        # TODO simplify when Py3.5 dropped
         if sys.version_info.major == 3 and sys.version_info.minor < 6:
             args.testlistfile = p.resolve()
         else:
@@ -172,6 +173,7 @@ if args.excludelistfile:
     # args.excludelistfile changes from a string to a pathlib Path object
     try:
         p = Path(args.excludelistfile)
+        # TODO simplify when Py3.5 dropped
         if sys.version_info.major == 3 and sys.version_info.minor < 6:
             args.excludelistfile = p.resolve()
         else:
@@ -564,21 +566,22 @@ def find_e2e_tests(directory):
         if 'sconstest.skip' in filenames:
             continue
 
-        p = Path(dirpath).joinpath(".exclude_tests")
-        try:
+        # Slurp in any tests in exclude lists
+        excludes = []
+        if ".exclude_tests" in filenames:
+            p = Path(dirpath).joinpath(".exclude_tests")
+            # TODO simplify when Py3.5 dropped
             if sys.version_info.major == 3 and sys.version_info.minor < 6:
                 excludefile = p.resolve()
             else:
                 excludefile = p.resolve(strict=True)
-        except FileNotFoundError:
-            excludes = []
-        else:
             with excludefile.open() as f:
                 excludes = scanlist(f)
 
         for fname in filenames:
             if fname.endswith(".py") and fname not in excludes:
                 result.append(os.path.join(dirpath, fname))
+
     return sorted(result)
 
 

--- a/runtest.py
+++ b/runtest.py
@@ -563,11 +563,19 @@ def find_e2e_tests(directory):
         # Skip folders containing a sconstest.skip file
         if 'sconstest.skip' in filenames:
             continue
+
+        p = Path(dirpath).joinpath( ".exclude_tests")
         try:
-            with open(os.path.join(dirpath, ".exclude_tests")) as f:
-                excludes = scanlist(f)
-        except EnvironmentError:
+            if sys.version_info.major == 3 and sys.version_info.minor < 6:
+                excludefile = p.resolve()
+            else:
+                excludefile = p.resolve(strict=True)
+        except FileNotFoundError:
             excludes = []
+        else:
+            with excludefile.open() as f:
+                excludes = scanlist(f)
+
         for fname in filenames:
             if fname.endswith(".py") and fname not in excludes:
                 result.append(os.path.join(dirpath, fname))

--- a/runtest.py
+++ b/runtest.py
@@ -564,7 +564,7 @@ def find_e2e_tests(directory):
         if 'sconstest.skip' in filenames:
             continue
 
-        p = Path(dirpath).joinpath( ".exclude_tests")
+        p = Path(dirpath).joinpath(".exclude_tests")
         try:
             if sys.version_info.major == 3 and sys.version_info.minor < 6:
                 excludefile = p.resolve()

--- a/test/AddOption/.exclude_tests
+++ b/test/AddOption/.exclude_tests
@@ -1,0 +1,4 @@
+# for now, thee tests showing problems with processing space-separated
+# arguments are excluded, pending an implementation that doesn't fail.
+args-and-targets.py
+multi-arg.py

--- a/test/AddOption/.exclude_tests
+++ b/test/AddOption/.exclude_tests
@@ -1,4 +1,4 @@
-# for now, thee tests showing problems with processing space-separated
+# for now, the tests showing problems with processing space-separated
 # arguments are excluded, pending an implementation that doesn't fail.
 args-and-targets.py
 multi-arg.py

--- a/test/AddOption/args-and-targets.py
+++ b/test/AddOption/args-and-targets.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Verify that when an option is specified which takes args,
+those do not end up treated as targets.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write(
+    'SConstruct',
+    """\
+env = Environment()
+AddOption(
+    '--extra',
+    nargs=1,
+    dest='extra',
+    action='store',
+    type='string',
+    metavar='ARG1',
+    default=(),
+    help='An argument to the option',
+)
+print(str(GetOption('extra')))
+print(COMMAND_LINE_TARGETS)
+""",
+)
+
+# arg using =
+test.run('-Q -q --extra=A TARG', status=1, stdout="A\n['TARG']\n")
+# arg not using =
+test.run('-Q -q --extra A TARG', status=1, stdout="A\n['TARG']\n")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/AddOption/multi-arg.py
+++ b/test/AddOption/multi-arg.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Verify that when an option is specified with nargs > 1,
+SCons consumes those correctly into the args.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+# First, test an option with nargs=2 and no others:
+test.write(
+    'SConstruct',
+    """\
+env = Environment()
+AddOption('--extras',
+          nargs=2,
+          dest='extras',
+          action='store',
+          type='string',
+          metavar='FILE1 FILE2',
+          default=(),
+          help='two extra files to install')
+print(str(GetOption('extras')))
+""",
+)
+
+# no args
+test.run('-Q -q .', stdout="()\n")
+# one arg, should fail
+test.run(
+    '-Q -q . --extras A',
+    status=2,
+    stderr="""\
+usage: scons [OPTION] [TARGET] ...
+
+SCons Error: --extras option requires 2 arguments
+""",
+)
+# two args
+test.run('-Q -q . --extras A B', status=1, stdout="('A', 'B')\n")
+# -- means the rest are not processed as args
+test.run('-Q -q . -- --extras A B', status=1, stdout="()\n")
+
+# Now test what has been a bug: another option is
+# also defined, this impacts the collection of args for the nargs>1 opt
+test.write(
+    'SConstruct',
+    """\
+env = Environment()
+AddOption(
+    '--prefix',
+    nargs=1,
+    dest='prefix',
+    action='store',
+    type='string',
+    metavar='DIR',
+    help='installation prefix',
+)
+AddOption(
+    '--extras',
+    nargs=2,
+    dest='extras',
+    action='store',
+    type='string',
+    metavar='FILE1 FILE2',
+    default=(),
+    help='two extra files to install',
+)
+print(str(GetOption('prefix')))
+print(str(GetOption('extras')))
+""",
+)
+
+# no options
+test.run('-Q -q .', stdout="None\n()\n")
+# one single-arg option
+test.run('-Q -q . --prefix=/home/foo', stdout="/home/foo\n()\n")
+# one two-arg option
+test.run('-Q -q . --extras A B', status=1, stdout="None\n('A', 'B')\n")
+# single-arg option followed by two-arg option
+test.run(
+    '-Q -q . --prefix=/home/foo --extras A B',
+    status=1,
+    stdout="/home/foo\n('A', 'B')\n",
+)
+# two-arg option followed by single-arg option
+test.run(
+    '-Q -q . --extras A B --prefix=/home/foo',
+    status=1,
+    stdout="/home/foo\n('A', 'B')\n",
+)
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
The two tests originally proposed in #3436, now withdrawn, are added along with a new `.exclude_tests` to not run them,  since they'd currently be in a failing state. These tests demonstrate several issues with the current option adding logic, mainly if space-separated arguments are used (--opt foo`, and worse with `nargs>1` like `--opt foo bar`).
    
Needed to fix `runtest.py`, wasn't completely correctly  processing `.exclude_tests` files.

This is a test-only change.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
