### PR TITLE
Bug install scons copytree recursion

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,12 @@ NOTE: The 4.2.0 Release of SCons will drop Python 3.5 Support
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Byron Platt:
+    - Fix Install() issue when copytree recursion gives bad arguments that can
+      lead to install side-effects including keeping dangling symlinks and
+      silently failing to copy directorys (and their subdirectories) when the
+      directory already exists in the target.
+
   From Joseph Brill:
     - Internal MSVS update: Remove unnecessary calls to find all installed versions of msvc
       when constructing the installed visual studios list.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,7 +12,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Byron Platt:
     - Fix Install() issue when copytree recursion gives bad arguments that can
       lead to install side-effects including keeping dangling symlinks and
-      silently failing to copy directorys (and their subdirectories) when the
+      silently failing to copy directories (and their subdirectories) when the
       directory already exists in the target.
 
   From Joseph Brill:

--- a/SCons/Tool/install.py
+++ b/SCons/Tool/install.py
@@ -122,12 +122,17 @@ def scons_copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
                         continue
                     # otherwise let the copy occurs. copy2 will raise an error
                     if os.path.isdir(srcname):
-                        scons_copytree(srcname, dstname, symlinks, ignore,
-                                       copy_function, dirs_exist_ok)
+                        scons_copytree(srcname, dstname, symlinks=symlinks,
+                                       ignore=ignore, copy_function=copy_function,
+                                       ignore_dangling_symlinks=ignore_dangling_symlinks,
+                                       dirs_exist_ok=dirs_exist_ok)
                     else:
                         copy_function(srcname, dstname)
             elif os.path.isdir(srcname):
-                scons_copytree(srcname, dstname, symlinks, ignore, copy_function, dirs_exist_ok)
+                scons_copytree(srcname, dstname, symlinks=symlinks,
+                               ignore=ignore, copy_function=copy_function,
+                               ignore_dangling_symlinks=ignore_dangling_symlinks,
+                               dirs_exist_ok=dirs_exist_ok)
             else:
                 # Will raise a SpecialFileError for unsupported file types
                 copy_function(srcname, dstname)

--- a/test/Install/rec-sub-dir.py
+++ b/test/Install/rec-sub-dir.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#
+# MIT Licenxe
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test using Install() on directory that contains existing subdirectories
+causing copytree recursion where the directory already exists.
+"""
+
+import os.path
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+Execute(Mkdir('a/b/c'))
+Execute(Mkdir('b/c/d'))
+Install('z', 'a')
+Install('z/a', 'b')
+""")
+
+expect="""\
+Mkdir("a/b/c")
+Mkdir("b/c/d")
+Install directory: "a" as "z%sa"
+Install directory: "b" as "z%sa%sb"
+"""%(os.sep,os.sep,os.sep)
+test.run(arguments=["-Q"], stdout=expect)
+
+test.must_exist(test.workpath('a', 'b', 'c'))
+test.must_exist(test.workpath('b', 'c', 'd'))
+test.must_exist(test.workpath('z', 'a', 'b', 'c', 'd'))
+
+# this run used to fail on Windows with an OS error before the copytree fix
+test.run(arguments=["-Q"])
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Install/rec-sub-dir.py
+++ b/test/Install/rec-sub-dir.py
@@ -47,7 +47,7 @@ Mkdir("a/b/c")
 Mkdir("b/c/d")
 Install directory: "a" as "z%sa"
 Install directory: "b" as "z%sa%sb"
-"""%(os.sep,os.sep,os.sep)
+""" % (os.sep, os.sep, os.sep)
 test.run(arguments=["-Q"], stdout=expect)
 
 test.must_exist(test.workpath('a', 'b', 'c'))


### PR DESCRIPTION
When scons_copytree() in install.py is called recursively the dirs_exist_ok
parameter is passed in the wrong position.

This may modify the value of ignore_dangling_symlinks and causes
dirs_exist_ok to take on the default value of False.

The install will 'silently' fail if the destination directory exists when this
happens, and there can obviously be unintended side effects if
ignore_dangling_symlinks is changed.

The fix simply fixes the arguments in the recursive call, and also uses keyword
arguments.