### PR TITLE
Moved CacheDir permissions update code behind atomic rename operation.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -65,6 +65,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Update BuildTask to pass all targets to the progress object fixing an issue
       where multi-target build nodes only got the first target passed to the progress
       object.
+    - Fix a potential race condition in shared cache environments where the permissions are
+      not writeable for a moment after the file has been renamed and other builds (users) will copy
+      it out of the cacheSmall reorganization of logic to copy files from cachedir. Moved CacheDir 
+      writeable permission code for copy to cache behind the atomic rename operation.
+
 
   From Mats Wichmann:
     - Initial support in tests for Python 3.10 - expected bytecode and

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -67,6 +67,10 @@ FIXES
       that regressed as of 4.0.0.
     - Fix issue #3790: Generators in CPPDEFINES now have access to populated source
       and target lists
+    - Fix a potential race condition in shared cache environments where the permissions are
+      not writeable for a moment after the file has been renamed and other builds (users) will copy
+      it out of the cacheSmall reorganization of logic to copy files from cachedir. Moved CacheDir 
+      writeable permission code for copy to cache behind the atomic rename operation.
 
 
 IMPROVEMENTS

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -117,8 +117,7 @@ def CachePushFunc(target, source, env):
         else:
             cd.copy_to_cache(env, t.get_internal_path(), tempfile)
         fs.rename(tempfile, cachefile)
-        st = fs.stat(t.get_internal_path())
-        fs.chmod(cachefile, stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
+
     except EnvironmentError:
         # It's possible someone else tried writing the file at the
         # same time we did, or else that there was some problem like
@@ -220,7 +219,11 @@ class CacheDir:
     @classmethod
     def copy_to_cache(cls, env, src, dst):
         try:
-            return env.fs.copy2(src, dst)
+            result = env.fs.copy2(src, dst)
+            fs = env.File(src).fs
+            st = fs.stat(src)
+            fs.chmod(dst, stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
+            return result
         except AttributeError as ex:
             raise EnvironmentError from ex
 


### PR DESCRIPTION
Moved CacheDir writeable permission code for copy to cache behind the atomic rename operation.

This fixes a potential race condition in shared cache environments where the permissions are
not writeable for a moment after the file has been renamed and other builds (users) will copy
it out of the cache.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
