### PR TITLE
Tweak doc of experimental option

### DIFF
--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -729,7 +729,7 @@ def Parser(version):
         if ',' in value:
             value = value.split(',')
         else:
-            value = [value, ]
+            value = [value]
 
         for v in value:
             if v == 'none':
@@ -737,13 +737,15 @@ def Parser(version):
             elif v == 'all':
                 experimental = experimental_features
             elif v not in experimental_features:
-                raise OptionValueError("option --experimental: invalid choice: '%s' (choose from 'all','none',%s)" % (
-                                       v, ','.join(["'%s'" % e for e in sorted(experimental_features)])))
+                raise OptionValueError(
+                    "option --experimental: invalid choice: '%s' "
+                    "(choose from 'all','none',%s)"
+                    % (v, ','.join(["'%s'" % e for e in sorted(experimental_features)]))
+                )
             else:
                 experimental |= {v}
 
         setattr(parser.values, option.dest, experimental)
-
 
 
     op.add_option('--experimental',

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1126,16 +1126,21 @@ the mechanisms in the specified order.</para>
 
   <varlistentry id="opt-experimental">
     <term>
-      <option>--experimental=<replaceable>all</replaceable></option>,
-      <option>--experimental=<replaceable>none</replaceable></option>
+      <option>--experimental=<replaceable>feature</replaceable></option>
     </term>
     <listitem>
-      <para>Enable experimental features and/or tools. <emphasis role="strong">No Support offered for any features or tools enabled by this flag</emphasis></para>
-      <para>The default setting is none.</para>
+      <para>Enable experimental features and/or tools.
+        <replaceable>feature</replaceable> can be an available feature name or
+        the special tokens <literal>all</literal> or <literal>none</literal>.
+        A comma-separated string can be used to select multiple features.
+        The default setting is <literal>none</literal>.</para>
+      <para>Current available features are: <literal>ninja</literal>.</para>
+      <caution><para>
+        No Support offered for any features or tools enabled by this flag.
+      </para></caution>
       <para><emphasis>Available since &scons; 4.2.</emphasis></para>
     </listitem>
   </varlistentry>
-
 
   <varlistentry id="opt-f">
     <term>


### PR DESCRIPTION
Twiddled the way the `--experimenta`l option is described, and listed ninja as the available feature.

Also reformatted the exception call in the code for unknown feature, behavior was not changed.

Essentially, this is a doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
