### PR TITLE
Make sure TEMPFILEPREFIX can be set to empty string

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -120,6 +120,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Tool() has done.
     - Change SConscript() missing SConscript behavior - if must_exist=False,
       the warning is suppressed.
+    - Make sure TEMPFILEPREFIX can be set to an empty string (issue 3964)
 
   From Dillan Mills:
     - Add support for the (TARGET,SOURCE,TARGETS,SOURCES,CHANGED_TARGETS,CHANGED_SOURCES}.relpath property.

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -257,8 +257,9 @@ class TempFileMunge:
             # Windows path names.
             rm = 'del'
 
-        prefix = env.subst('$TEMPFILEPREFIX')
-        if not prefix:
+        if 'TEMPFILEPREFIX' in env:
+            prefix = env.subst('$TEMPFILEPREFIX')
+        else:
             prefix = '@'
 
         tempfile_esc_func = env.get('TEMPFILEARGESCFUNC', SCons.Subst.quote_spaces)
@@ -294,7 +295,7 @@ class TempFileMunge:
                     str(cmd[0]) + " " + " ".join(args))
                 self._print_cmd_str(target, source, env, cmdstr)
 
-        cmdlist = [ cmd[0], prefix + native_tmp + '\n' + rm, native_tmp ]
+        cmdlist = [cmd[0], prefix + native_tmp + '\n' + rm, native_tmp]
 
         # Store the temporary file command list into the target Node.attributes
         # to avoid creating two temporary files one for print and one for execute.
@@ -304,7 +305,7 @@ class TempFileMunge:
                 # $TEMPFILE{} fixes issue raised in PR #3140 and #3553
                 node.attributes.tempfile_cmdlist[cmdlist_key] = cmdlist
             except AttributeError:
-                node.attributes.tempfile_cmdlist = {cmdlist_key:cmdlist}
+                node.attributes.tempfile_cmdlist = {cmdlist_key: cmdlist}
 
         return cmdlist
 

--- a/test/TEMPFILE/TEMPFILEPREFIX.py
+++ b/test/TEMPFILE/TEMPFILEPREFIX.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 #
+# MIT License
+#
+# Copyright The SCons Foundation
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -25,17 +29,17 @@ it to appear at the front of name of the generated tempfile
 used for long command lines.
 """
 
-
 import TestSCons
 
-test = TestSCons.TestSCons(match = TestSCons.match_re)
+test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 test.write('SConstruct', """
 import os
+
 env = Environment(
-    BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
-    MAXLINELENGTH = 16,
-    TEMPFILEPREFIX = '-via',
+    BUILDCOM='${TEMPFILE("xxx.py $TARGET $SOURCES")}',
+    MAXLINELENGTH=16,
+    TEMPFILEPREFIX='-via',
 )
 env.AppendENVPath('PATH', os.curdir)
 env.Command('foo.out', 'foo.in', '$BUILDCOM')
@@ -43,8 +47,9 @@ env.Command('foo.out', 'foo.in', '$BUILDCOM')
 
 test.write('foo.in', "foo.in\n")
 
-test.run(arguments = '-n -Q .',
-         stdout = """\
+test.run(
+    arguments='-n -Q .',
+    stdout="""\
 Using tempfile \\S+ for command line:
 xxx.py foo.out foo.in
 xxx.py -via\\S+
@@ -66,37 +71,65 @@ env.AppendENVPath('PATH', os.curdir)
 env.Command('foo.out', 'foo.in', '$BUILDCOM')
 """)
 
-test.run(arguments = '-n -Q .',
-         stdout = """""")
+test.run(arguments='-n -Q .', stdout="")
 
 test.write('SConstruct', """
 import os
 from SCons.Platform import TempFileMunge
 
 class TestTempFileMunge(TempFileMunge):
-
-    def __init__(self, cmd, cmdstr = None):
-        super(TestTempFileMunge, self).__init__(cmd, cmdstr)
+    def __init__(self, cmd, cmdstr=None):
+        super().__init__(cmd, cmdstr)
 
     def _print_cmd_str(self, target, source, env, cmdstr):
-        super(TestTempFileMunge, self)._print_cmd_str(target, source, None, cmdstr)
+        super()._print_cmd_str(target, source, None, cmdstr)
 
 env = Environment(
-    TEMPFILE = TestTempFileMunge,
-    BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
-    MAXLINELENGTH = 16,
-    TEMPFILEPREFIX = '-via',
-
+    TEMPFILE=TestTempFileMunge,
+    BUILDCOM='${TEMPFILE("xxx.py $TARGET $SOURCES")}',
+    MAXLINELENGTH=16,
+    TEMPFILEPREFIX='-via',
 )
 env.AppendENVPath('PATH', os.curdir)
 env.Command('foo.out', 'foo.in', '$BUILDCOM')
 """)
 
-test.run(arguments = '-n -Q .',
-         stdout = """\
+test.run(
+    arguments='-n -Q .',
+    stdout="""\
 Using tempfile \\S+ for command line:
 xxx.py foo.out foo.in
 xxx.py -via\\S+
+""")
+
+# make sure an empty prefix works too
+test.write('SConstruct', """
+import os
+from SCons.Platform import TempFileMunge
+
+class TestTempFileMunge(TempFileMunge):
+    def __init__(self, cmd, cmdstr=None):
+        super().__init__(cmd, cmdstr)
+
+    def _print_cmd_str(self, target, source, env, cmdstr):
+        super()._print_cmd_str(target, source, None, cmdstr)
+
+env = Environment(
+    TEMPFILE=TestTempFileMunge,
+    BUILDCOM='${TEMPFILE("xxx.py $TARGET $SOURCES")}',
+    MAXLINELENGTH=16,
+    TEMPFILEPREFIX='',
+)
+env.AppendENVPath('PATH', os.curdir)
+env.Command('foo.out', 'foo.in', '$BUILDCOM')
+""")
+
+test.run(
+    arguments='-n -Q .',
+    stdout="""\
+Using tempfile \\S+ for command line:
+xxx.py foo.out foo.in
+xxx.py [^@]\\S+
 """)
 
 test.pass_test()

--- a/test/TEMPFILE/TEMPFILESUFFIX.py
+++ b/test/TEMPFILE/TEMPFILESUFFIX.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 #
+# MIT License
+#
+# Copyright The SCons Foundation
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -32,19 +36,20 @@ test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 test.write('SConstruct', """
 import os
+
 env = Environment(
-    BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
-    MAXLINELENGTH = 16,
-    TEMPFILESUFFIX = '.foo',
+    BUILDCOM='${TEMPFILE("xxx.py $TARGET $SOURCES")}',
+    MAXLINELENGTH=16,
+    TEMPFILESUFFIX='.foo',
 )
 env.AppendENVPath('PATH', os.curdir)
 env.Command('foo.out', 'foo.in', '$BUILDCOM')
 """)
 
 test.write('foo.in', "foo.in\n")
-
-test.run(arguments = '-n -Q .',
-         stdout = """\
+test.run(
+    arguments='-n -Q .',
+    stdout="""\
 Using tempfile \\S+ for command line:
 xxx.py foo.out foo.in
 xxx.py \\S+
@@ -57,10 +62,10 @@ def print_cmd_line(s, targets, sources, env):
     pass
 
 env = Environment(
-    BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
-    MAXLINELENGTH = 16,
-    TEMPFILESUFFIX = '.foo',
-    PRINT_CMD_LINE_FUNC=print_cmd_line
+    BUILDCOM='${TEMPFILE("xxx.py $TARGET $SOURCES")}',
+    MAXLINELENGTH=16,
+    TEMPFILESUFFIX='.foo',
+    PRINT_CMD_LINE_FUNC=print_cmd_line,
 )
 env.AppendENVPath('PATH', os.curdir)
 env.Command('foo.out', 'foo.in', '$BUILDCOM')
@@ -74,26 +79,25 @@ import os
 from SCons.Platform import TempFileMunge
 
 class TestTempFileMunge(TempFileMunge):
-
-    def __init__(self, cmd, cmdstr = None):
-        super(TestTempFileMunge, self).__init__(cmd, cmdstr)
+    def __init__(self, cmd, cmdstr=None):
+        super().__init__(cmd, cmdstr)
 
     def _print_cmd_str(self, target, source, env, cmdstr):
-        super(TestTempFileMunge, self)._print_cmd_str(target, source, None, cmdstr)
+        super()._print_cmd_str(target, source, None, cmdstr)
 
 env = Environment(
-    TEMPFILE = TestTempFileMunge,
-    BUILDCOM = '${TEMPFILE("xxx.py $TARGET $SOURCES")}',
-    MAXLINELENGTH = 16,
-    TEMPFILESUFFIX = '.foo',
-
+    TEMPFILE=TestTempFileMunge,
+    BUILDCOM='${TEMPFILE("xxx.py $TARGET $SOURCES")}',
+    MAXLINELENGTH=16,
+    TEMPFILESUFFIX='.foo',
 )
 env.AppendENVPath('PATH', os.curdir)
 env.Command('foo.out', 'foo.in', '$BUILDCOM')
 """)
 
-test.run(arguments = '-n -Q .',
-         stdout = """\
+test.run(
+    arguments='-n -Q .',
+    stdout="""\
 Using tempfile \\S+ for command line:
 xxx.py foo.out foo.in
 xxx.py \\S+


### PR DESCRIPTION
Use the same logic as for `TEMPFILESUFFIX`: if `TEMPFILEPREFIX` is set in the env, use it (after subst), only if not set use the default.

Added a test for `TEMPFILEPREFIX=''`.

Reformatted the tests and made license header changes. `TEMPFILESUFFIX.py` had no functional change.

Fixes #3964

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
