### PR TITLE
make multi target and intermediate SConf files marked is_conftest

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -68,8 +68,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       object.
     - Fix a potential race condition in shared cache environments where the permissions are
       not writeable for a moment after the file has been renamed and other builds (users) will copy
-      it out of the cacheSmall reorganization of logic to copy files from cachedir. Moved CacheDir 
+      it out of the cache. Small reorganization of logic to copy files from cachedir. Moved CacheDir 
       writeable permission code for copy to cache behind the atomic rename operation.
+    - Added marking of intermediate and and multi target nodes generated from SConf tests so that 
+      is_conftest() is more accurate.
 
 
   From Mats Wichmann:

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -76,6 +76,8 @@ FIXES
       not writeable for a moment after the file has been renamed and other builds (users) will copy
       it out of the cacheSmall reorganization of logic to copy files from cachedir. Moved CacheDir 
       writeable permission code for copy to cache behind the atomic rename operation.
+    - Fixed intermediate and and multi target nodes generated from SConf tests not being marked
+      as is_conftest().
 
 
 IMPROVEMENTS

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -613,6 +613,10 @@ class BuilderBase:
             t.set_executor(executor)
             t.set_explicit(self.is_explicit)
 
+        if env.get("SCONF_NODE"):
+            for node in tlist + slist:
+                node.attributes.conftest_node = 1
+
         return SCons.Node.NodeList(tlist)
 
     def __call__(self, env, target=None, source=None, chdir=_null, **kw):

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -614,7 +614,7 @@ class BuilderBase:
             t.set_explicit(self.is_explicit)
 
         if env.get("SCONF_NODE"):
-            for node in tlist + slist:
+            for node in tlist:
                 node.attributes.conftest_node = 1
 
         return SCons.Node.NodeList(tlist)

--- a/SCons/SConfTests.py
+++ b/SCons/SConfTests.py
@@ -168,7 +168,7 @@ class SConfTestCase(unittest.TestCase):
                 # need action because temporary file name uses hash of actions get_contents()
                 self.action = MyAction()
 
-            def __call__(self, env, target, source):
+            def __call__(self, env, target, source, *args, **kw):
                 class MyNode:
                     def __init__(self, name):
                         self.name = name

--- a/test/Configure/is_conftest/fixture/SConstruct
+++ b/test/Configure/is_conftest/fixture/SConstruct
@@ -17,7 +17,7 @@ if not conf.TryRun("int main( int argc, char* argv[] ){return 0;}", '.c'):
 
 env = conf.Finish()
 
-for node in env.Glob('.sconf_temp/*'):
+for node in env.Glob(conf.confdir.path + '/*'):
     if not node.is_conftest():
         print("FAIL")
 

--- a/test/Configure/is_conftest/fixture/SConstruct
+++ b/test/Configure/is_conftest/fixture/SConstruct
@@ -1,0 +1,24 @@
+"""
+Test the nodes are created as conftest nodes in configure tests.
+"""
+import sys
+DefaultEnvironment(tools=[])
+
+env = Environment()
+
+conf = Configure(env)
+if sys.platform == "win32":
+    conf.env.Append(
+        CCFLAGS="/DEBUG /Z7 /INCREMENTAL:NO",
+        LINKFLAGS="/DEBUG /INCREMENTAL:NO",
+        PDB='${TARGET.base}.pdb')
+if not conf.TryRun("int main( int argc, char* argv[] ){return 0;}", '.c'):
+    print("FAIL")
+
+env = conf.Finish()
+
+for node in env.Glob('.sconf_temp/*'):
+    if not node.is_conftest():
+        print("FAIL")
+
+

--- a/test/Configure/is_conftest/is_conftest.py
+++ b/test/Configure/is_conftest/is_conftest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,12 +22,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Verify is_conftest is marking nodes.
+Verify is_conftest is marking nodes, even for intermediate files.
 """
 
 import TestSCons

--- a/test/Configure/is_conftest/is_conftest.py
+++ b/test/Configure/is_conftest/is_conftest.py
@@ -37,7 +37,7 @@ test.file_fixture('./fixture/SConstruct')
 test.run('-Q --silent')
 
 if "FAIL" in test.stdout():
-  test.fail_test()
+    test.fail_test()
 
 test.pass_test()
 

--- a/test/Configure/is_conftest/is_conftest.py
+++ b/test/Configure/is_conftest/is_conftest.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify is_conftest is marking nodes.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.file_fixture('./fixture/SConstruct')
+
+test.run('-Q --silent')
+
+if "FAIL" in test.stdout():
+  test.fail_test()
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Discovered some issues with is_conftest when testing mongo build with experimental ninja tool.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
