### PR TITLE
Minor tweak to Tools.xml - correct referrring text

### DIFF
--- a/SCons/Tool/Tool.xml
+++ b/SCons/Tool/Tool.xml
@@ -282,8 +282,8 @@ Note that the source files will be scanned
 according to the suffix mappings in the
 <classname>SourceFileScanner</classname>
 object.
-See the section "Scanner Objects,"
-below, for more information.
+See the manpage section "Scanner Objects"
+for more information.
 </para>
 </summary>
 </builder>
@@ -387,8 +387,8 @@ Note that the source files will be scanned
 according to the suffix mappings in the
 <classname>SourceFileScanner</classname>
 object.
-See the section "Scanner Objects,"
-below, for more information.
+See the manpage section "Scanner Objects"
+for more information.
 </para>
 </summary>
 </builder>


### PR DESCRIPTION
In two places a reference to a section is made using "below" implying the section is in same doc, but Tools.xml definitions are
distributed to both docs and this is incorrect for User Guide. Use "in manpage" instead.

Doc-only change (trivial)

Signed-off-by: Mats Wichmann <mats@linux.com>


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
