### PR TITLE
[WIP] Use only one NodeList definition

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Two unit tests had to be updated to make sure they're expecting the
       right string representation. Alias now returns a NodeList like other
       builders. Added some return type annotions.
+      The following public methods now explcitly return a NodeList,
+      where previously some did and some returned plain Python lists:
+      AddPreAction, AddPostAction, Alias, AlwaysBuild, Command, Depends,
+      NoClean, NoCache, Ignore, Precious, Pseudo, Requires, SideEffect.
 
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,15 +14,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix version tests to work with updated scons --version output. (Date format changed)
     
   From Mats Wichmann:
+    - Two small Python 3.10 fixes: one more docstring turned into raw
+      because it contained an escape; updated "helpful" syntax error message
+      from 3.10 was not expected by SubstTests.py and test/Subst/Syntax.py
     - Unify the NodeList definitions - there were two, and didn't need to be.
       Two unit tests had to be updated to make sure they're expecting the
       right string representation. Alias now returns a NodeList like other
       builders. Added some return type annotions.
-
-  From Mats Wichmann:
-    - Two small Python 3.10 fixes: one more docstring turned into raw
-      because it contained an escape; updated "helpful" syntax error message
-      from 3.10 was not expected by SubstTests.py and test/Subst/Syntax.py
 
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From William Deegan:
     - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
     - Fix version tests to work with updated scons --version output. (Date format changed)
+    
+  From Mats Wichmann:
+    - Unify the NodeList definitions - there were two, and didn't need to be.
+      Two unit tests had to be updated to make sure they're expecting the
+      right string representation. Alias now returns a NodeList like other
+      builders. Added some return type annotions.
 
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700

--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -270,13 +270,13 @@ class BuilderTestCase(unittest.TestCase):
         nnn2 = MyNode("nnn2")
         tlist = builder(env, target = [nnn1, nnn2], source = [])
         s = mystr(tlist)
-        assert s == "['nnn1', 'nnn2']", s
+        assert s == "nnn1 nnn2", s
         l = list(map(str, tlist))
         assert l == ['nnn1', 'nnn2'], l
 
         tlist = builder(env, target = 'n3', source = 'n4')
         s = mystr(tlist)
-        assert s == "['n3']", s
+        assert s == "n3", s
         target = tlist[0]
         l = list(map(str, tlist))
         assert l == ['n3'], l
@@ -285,7 +285,7 @@ class BuilderTestCase(unittest.TestCase):
 
         tlist = builder(env, target = 'n4 n5', source = ['n6 n7'])
         s = mystr(tlist)
-        assert s == "['n4 n5']", s
+        assert s == "n4 n5", s
         l = list(map(str, tlist))
         assert l == ['n4 n5'], l
         target = tlist[0]
@@ -294,7 +294,7 @@ class BuilderTestCase(unittest.TestCase):
 
         tlist = builder(env, target = ['n8 n9'], source = 'n10 n11')
         s = mystr(tlist)
-        assert s == "['n8 n9']", s
+        assert s == "n8 n9", s
         l = list(map(str, tlist))
         assert l == ['n8 n9'], l
         target = tlist[0]

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -36,6 +36,7 @@ import sys
 import re
 import shlex
 from collections import UserDict
+from typing import Optional
 
 import SCons.Action
 import SCons.Builder
@@ -1880,7 +1881,7 @@ class Base(SubstitutionEnvironment):
         tool(self)
         return tool
 
-    def WhereIs(self, prog, path=None, pathext=None, reject=None):
+    def WhereIs(self, prog, path=None, pathext=None, reject=None) -> Optional[str]:
         """Find prog in the path. """
         if not prog:  # nothing to search for, just give up
             return None
@@ -2006,7 +2007,7 @@ class Base(SubstitutionEnvironment):
         nkw = self.subst_kw(kw)
         return SCons.Builder.Builder(**nkw)
 
-    def CacheDir(self, path, custom_class=None):
+    def CacheDir(self, path, custom_class=None) -> None:
         if path is not None:
             path = self.subst(path)
         self._CacheDir_path = path
@@ -2021,7 +2022,7 @@ class Base(SubstitutionEnvironment):
             # multiple threads, but initializing it before the task walk starts
             self.get_CacheDir()
 
-    def Clean(self, targets, files):
+    def Clean(self, targets, files) -> None:
         global CleanTargets
         tlist = self.arg2nodes(targets, self.fs.Entry)
         flist = self.arg2nodes(files, self.fs.Entry)
@@ -2043,7 +2044,7 @@ class Base(SubstitutionEnvironment):
             pass
         return SCons.SConf.SConf(*nargs, **nkw)
 
-    def Command(self, target, source, action, **kw):
+    def Command(self, target, source, action, **kw) -> NodeList:
         """Builds the supplied target files from the supplied
         source files using the supplied action.  Action may
         be any type that the Builder constructor will accept

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -428,24 +428,40 @@ file into an object file.
 <summary>
 <para>
 Creates one or more phony targets that
-expand to one or more other targets.
+expand to one or more other <parameter>targets</parameter>.
 An optional
 <parameter>action</parameter>
 (command)
 or list of actions
 can be specified that will be executed
-whenever the any of the alias targets are out-of-date.
-Returns the Node object representing the alias,
-which exists outside of any file system.
-This Node object, or the alias name,
+whenever the any of the alias <parameter>targets</parameter> are out-of-date.
+</para>
+<para>
+Since it creates target Nodes, even though those nodes
+do not represent file system objects,
+&Alias; is actually a Builder, and like other builders,
+returns a list of Nodes (more precisely,
+a <classname>NodeList</classname> object).
+Either the alias name or the
+returned <classname>NodeList</classname> object
 may be used as a dependency of any other target,
 including another alias.
-&f-Alias;
+</para>
+<para>
+&Alias;
 can be called multiple times for the same
-alias to add additional targets to the alias,
-or additional actions to the list for this alias.
+alias to add additional <parameter>targets</parameter> to the alias,
+or additional <parameter>action</parameter> descriptions
+to the list for this alias.
 Aliases are global even if set through
 the construction environment method.
+</para>
+<para>
+When nesting aliases, order matters: the subjects
+(<parameter>targets</parameter>) of the &Alias;
+call need to have already
+been declared to &SCons; or the relationship will
+not be as expected.
 </para>
 
 <para>

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -262,6 +262,7 @@ class SubstitutionTestCase(unittest.TestCase):
             return dict[name]
 
         nodes = env.arg2nodes("Util.py UtilTests.py", Factory)
+        assert isinstance(nodes, SCons.Util.NodeList), type(nodes)
         assert len(nodes) == 1, nodes
         assert isinstance(nodes[0], X)
         assert nodes[0].name == "Util.py UtilTests.py", nodes[0].name
@@ -2680,7 +2681,10 @@ def generate(env):
         """Test the Alias() method"""
         env = self.TestEnvironment(FOO='kkk', BAR='lll', EA='export_alias')
 
-        tgt = env.Alias('new_alias')[0]
+        tlist = env.Alias('new_alias')
+        assert isinstance(tlist, SCons.Util.NodeList), type(tlist)
+        tgt = tlist[0]
+        assert isinstance(tgt, SCons.Node.Alias.Alias), type(tgt)
         assert str(tgt) == 'new_alias', tgt
         assert tgt.sources == [], tgt.sources
         assert not hasattr(tgt, 'builder'), tgt.builder

--- a/SCons/Node/AliasTests.py
+++ b/SCons/Node/AliasTests.py
@@ -29,14 +29,12 @@ import SCons.Node.Alias
 class AliasTestCase(unittest.TestCase):
 
     def test_AliasNameSpace(self):
-        """Test creating an Alias name space
-        """
+        """Test creating an Alias name space."""
         ans = SCons.Node.Alias.AliasNameSpace()
         assert ans is not None, ans
 
     def test_ANS_Alias(self):
-        """Test the Alias() factory
-        """
+        """Test the Alias() factory."""
         ans = SCons.Node.Alias.AliasNameSpace()
 
         a1 = ans.Alias('a1')
@@ -46,8 +44,7 @@ class AliasTestCase(unittest.TestCase):
         assert a1 is a2, (a1, a2)
 
     def test_get_contents(self):
-        """Test the get_contents() method
-        """
+        """Test the get_contents() method."""
         class DummyNode:
             def __init__(self, contents):
                 self.contents = contents
@@ -67,8 +64,7 @@ class AliasTestCase(unittest.TestCase):
         assert c == 'onetwothree', c
 
     def test_lookup(self):
-        """Test the lookup() method
-        """
+        """Test the lookup() method."""
         ans = SCons.Node.Alias.AliasNameSpace()
 
         ans.Alias('a1')
@@ -82,8 +78,7 @@ class AliasTestCase(unittest.TestCase):
         assert a is None, a
 
     def test_Alias(self):
-        """Test creating an Alias() object
-        """
+        """Test creating an Alias() object."""
         a1 = SCons.Node.Alias.Alias('a')
         assert a1.name == 'a', a1.name
 

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -3350,7 +3350,7 @@ class File(Base):
 
         # For an "empty" binfo properties like bsources
         # do not exist: check this to avoid exception.
-        if not any ((binfo.bsourcesigs, binfo.bdependsigs, binfo.bimplicitsigs)):
+        if not any((binfo.bsourcesigs, binfo.bdependsigs, binfo.bimplicitsigs)):
             return {}
 
         binfo.dependency_map = {

--- a/SCons/Node/NodeTests.py
+++ b/SCons/Node/NodeTests.py
@@ -1346,18 +1346,19 @@ class NodeTestCase(unittest.TestCase):
         assert r == 0, r
 
 
+#TODO: no more Node.Nodelist, merge this to UtilTests (or drop?)
 class NodeListTestCase(unittest.TestCase):
     def test___str__(self):
         """Test"""
         n1 = MyNode("n1")
         n2 = MyNode("n2")
         n3 = MyNode("n3")
-        nl = SCons.Node.NodeList([n3, n2, n1])
+        nl = SCons.Util.NodeList([n3, n2, n1])
 
         l = [1]
         ul = collections.UserList([2])
         s = str(nl)
-        assert s == "['n3', 'n2', 'n1']", s
+        assert s == "n3 n2 n1", s
 
         r = repr(nl)
         r = re.sub(r'at (0[xX])?[0-9a-fA-F]+', 'at 0x', r)

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -1709,13 +1709,14 @@ class Node(object, metaclass=NoSlotsPyPy):
             lines = ["%s:\n" % preamble] + lines
             return ( ' '*11).join(lines)
 
-class NodeList(collections.UserList):
-    def __str__(self):
-        return str(list(map(str, self.data)))
+def get_children(node, parent):
+    return node.children()
 
-def get_children(node, parent): return node.children()
-def ignore_cycle(node, stack): pass
-def do_nothing(node, parent): pass
+def ignore_cycle(node, stack):
+    pass
+
+def do_nothing(node, parent):
+    pass
 
 class Walker:
     """An iterator for walking a Node tree.

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -390,14 +390,13 @@ del name
 SConscript = _SConscript.DefaultEnvironmentCall('SConscript')
 
 # Make SConscript look enough like the module it used to be so
-# that pychecker doesn't barf.
-SConscript.__name__ = 'SConscript'
-
-SConscript.Arguments = ARGUMENTS
-SConscript.ArgList = ARGLIST
-SConscript.BuildTargets = BUILD_TARGETS
-SConscript.CommandLineTargets = COMMAND_LINE_TARGETS
-SConscript.DefaultTargets = DEFAULT_TARGETS
+# that pychecker and mypy don't barf.
+setattr(SConscript, "__name__", "SConscript")
+setattr(SConscript, "Arguments", ARGUMENTS)
+setattr(SConscript, "ArgList", ARGLIST)
+setattr(SConscript, "BuildTargets", BUILD_TARGETS)
+setattr(SConscript, "CommandLineTargets", COMMAND_LINE_TARGETS)
+setattr(SConscript, "DefaultTargets", DEFAULT_TARGETS)
 
 # The global Command() function must be handled differently than the
 # global functions for other construction environment methods because

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -28,7 +28,8 @@ import re
 from inspect import signature, Parameter
 
 import SCons.Errors
-from SCons.Util import is_String, is_Sequence
+import SCons.Util
+from SCons.Util import is_String, is_Sequence, NodeList
 
 # Indexed by the SUBST_* constants below.
 _strconv = [
@@ -183,9 +184,11 @@ class NLWrapper:
     def __init__(self, list, func):
         self.list = list
         self.func = func
-    def _return_nodelist(self):
+
+    def _return_nodelist(self) -> NodeList:
         return self.nodelist
-    def _gen_nodelist(self):
+
+    def _gen_nodelist(self) -> NodeList:
         mylist = self.list
         if mylist is None:
             mylist = []
@@ -193,9 +196,11 @@ class NLWrapper:
             mylist = [mylist]
         # The map(self.func) call is what actually turns
         # a list into appropriate proxies.
-        self.nodelist = SCons.Util.NodeList(list(map(self.func, mylist)))
+        nfunc = self.func
+        self.nodelist = NodeList([nfunc(n) for n in mylist])
         self._create_nodelist = self._return_nodelist
         return self.nodelist
+
     _create_nodelist = _gen_nodelist
 
 

--- a/SCons/TaskmasterTests.py
+++ b/SCons/TaskmasterTests.py
@@ -219,17 +219,22 @@ class Node:
             class Executor:
                 def prepare(self):
                     pass
+
                 def get_action_targets(self):
                     return self.targets
+
                 def get_all_targets(self):
                     return self.targets
+
                 def get_all_children(self) -> UniqueList:
                     result = UniqueList()
                     for node in self.targets:
                         result.extend(node.children())
                     return result
+
                 def get_all_prerequisites(self) -> UniqueList:
                     return UniqueList()
+
                 def get_action_side_effects(self) -> UniqueList:
                     return UniqueList()
 
@@ -678,6 +683,7 @@ class TaskmasterTestCase(unittest.TestCase):
         class StopNode(Node):
             def children(self):
                 raise SCons.Errors.StopError("stop!")
+
         class ExitNode(Node):
             def children(self):
                 sys.exit(77)
@@ -899,15 +905,19 @@ class TaskmasterTestCase(unittest.TestCase):
         class ExceptionExecutor:
             def prepare(self):
                 raise Exception("Executor.prepare() exception")
+
             def get_all_targets(self):
                 return self.nodes
+
             def get_all_children(self) -> UniqueList:
                 result = UniqueList()
                 for node in self.nodes:
                     result.extend(node.children())
                 return result
+
             def get_all_prerequisites(self) -> UniqueList:
                 return UniqueList()
+
             def get_action_side_effects(self) -> UniqueList:
                 return UniqueList()
 

--- a/SCons/TaskmasterTests.py
+++ b/SCons/TaskmasterTests.py
@@ -29,6 +29,7 @@ import unittest
 
 import SCons.Taskmaster
 import SCons.Errors
+from SCons.Util import UniqueList
 
 
 built_text = None
@@ -222,15 +223,16 @@ class Node:
                     return self.targets
                 def get_all_targets(self):
                     return self.targets
-                def get_all_children(self):
-                    result = []
+                def get_all_children(self) -> UniqueList:
+                    result = UniqueList()
                     for node in self.targets:
                         result.extend(node.children())
                     return result
-                def get_all_prerequisites(self):
-                    return []
-                def get_action_side_effects(self):
-                    return []
+                def get_all_prerequisites(self) -> UniqueList:
+                    return UniqueList()
+                def get_action_side_effects(self) -> UniqueList:
+                    return UniqueList()
+
             self.executor = Executor()
             self.executor.targets = self.targets
         return self.executor
@@ -899,15 +901,15 @@ class TaskmasterTestCase(unittest.TestCase):
                 raise Exception("Executor.prepare() exception")
             def get_all_targets(self):
                 return self.nodes
-            def get_all_children(self):
-                result = []
+            def get_all_children(self) -> UniqueList:
+                result = UniqueList()
                 for node in self.nodes:
                     result.extend(node.children())
                 return result
-            def get_all_prerequisites(self):
-                return []
-            def get_action_side_effects(self):
-                return []
+            def get_all_prerequisites(self) -> UniqueList:
+                return UniqueList()
+            def get_action_side_effects(self) -> UniqueList:
+                return UniqueList()
 
         n11 = Node("n11")
         n11.executor = ExceptionExecutor()

--- a/SCons/Tool/GettextCommon.py
+++ b/SCons/Tool/GettextCommon.py
@@ -231,17 +231,18 @@ class _POFileBuilder(BuilderBase):
                 target = linguas
         if not target:
             # Let the SCons.BuilderBase to handle this patologic situation
-            return BuilderBase._execute(self, env, target, source, *args, **kw)
+            return super()._execute(env, target, source, *args, **kw)
+
         # The rest is ours
         if not SCons.Util.is_List(target):
             target = [target]
-        result = []
+        result = NodeList()
         for tgt in target:
-            r = BuilderBase._execute(self, env, [tgt], source, *args, **kw)
+            r = super()._execute(env, [tgt], source, *args, **kw)
             result.extend(r)
         if linguas_files is not None:
             env['LINGUAS_FILE'] = linguas_files
-        return NodeList(result)
+        return result
 
 
 def _translate(env, target=None, source=SCons.Environment._null, *args, **kw):

--- a/SCons/Tool/GettextCommon.py
+++ b/SCons/Tool/GettextCommon.py
@@ -206,7 +206,7 @@ class _POFileBuilder(BuilderBase):
             del kw['target_alias']
         if 'target_factory' not in kw:
             kw['target_factory'] = _POTargetFactory(env, alias=alias).File
-        BuilderBase.__init__(self, **kw)
+        super().__init__(**kw)
 
     def _execute(self, env, target, source, *args, **kw) -> NodeList:
         """ Execute builder's actions.

--- a/SCons/Tool/msgfmt.py
+++ b/SCons/Tool/msgfmt.py
@@ -28,7 +28,6 @@ import os
 
 import SCons.Action
 import SCons.Tool
-import SCons.Util
 import SCons.Warnings
 from SCons.Builder import BuilderBase
 from SCons.Errors import StopError
@@ -40,6 +39,7 @@ from SCons.Tool.GettextCommon import (
     # MsgfmtToolWarning,
     _read_linguas_from_files,
 )
+from SCons.Util import CLVar, NodeList
 
 class _MOFileBuilder(BuilderBase):
     """The builder class for `MO` files.
@@ -50,7 +50,7 @@ class _MOFileBuilder(BuilderBase):
     here).
     """
 
-    def _execute(self, env, target, source, *args, **kw):
+    def _execute(self, env, target, source, *args, **kw) -> NodeList:
         # Here we add support for 'LINGUAS_FILE' keyword. Emitter is not suitable
         # in this case, as it is called too late (after multiple sources
         # are handled single_source builder.
@@ -68,9 +68,10 @@ class _MOFileBuilder(BuilderBase):
                 source = [source] + linguas
             else:
                 source = linguas
-        result = BuilderBase._execute(self, env, target, source, *args, **kw)
+        result = super()._execute(env, target, source, *args, **kw)
         if linguas_files is not None:
             env['LINGUAS_FILE'] = linguas_files
+
         return result
 
 
@@ -108,7 +109,7 @@ def generate(env, **kw):
     except StopError:
         env['MSGFMT'] = 'msgfmt'
     env.SetDefault(
-        MSGFMTFLAGS=[SCons.Util.CLVar('-c')],
+        MSGFMTFLAGS=[CLVar('-c')],
         MSGFMTCOM='$MSGFMT $MSGFMTFLAGS -o $TARGET $SOURCE',
         MSGFMTCOMSTR='',
         MOSUFFIX=['.mo'],

--- a/SCons/Tool/packaging/__init__.py
+++ b/SCons/Tool/packaging/__init__.py
@@ -30,7 +30,7 @@ import SCons.Defaults
 import SCons.Environment
 from SCons.Errors import UserError, SConsEnvironmentError
 from SCons.Script import AddOption, GetOption
-from SCons.Util import is_List, make_path_relative
+from SCons.Util import is_List, make_path_relative, NodeList
 from SCons.Variables import EnumVariable
 from SCons.Warnings import warn, SConsWarning
 
@@ -85,9 +85,8 @@ def Tag(env, target, source, *more_tags, **kw_tags):
                 k = 'PACKAGING_' + k
             t.Tag(k, v)
 
-def Package(env, target=None, source=None, **kw):
-    """ Entry point for the package tool.
-    """
+def Package(env, target=None, source=None, **kw) -> NodeList:
+    """ Entry point for the package tool."""
     # check if we need to find the source files ourselves
     if not source:
         source = env.FindInstalledFiles()
@@ -192,7 +191,7 @@ def Package(env, target=None, source=None, **kw):
     target = env.arg2nodes(target, env.fs.Entry)
     #XXX: target set above unused... what was the intent?
     targets.extend(env.Alias('package', targets))
-    return targets
+    return NodeList(targets)
 
 #
 # SCons tool initialization functions
@@ -218,7 +217,7 @@ def generate(env):
         env['BUILDERS']['Tag'] = Tag
 
 def exists(env):
-    return 1
+    return True
 
 # XXX
 def options(opts):

--- a/SCons/Tool/xgettext.py
+++ b/SCons/Tool/xgettext.py
@@ -159,14 +159,15 @@ def _update_pot_file(target, source, env):
 
 
 class _POTBuilder(BuilderBase):
-    def _execute(self, env, target, source, *args):
+    def _execute(self, env, target, source, *args) -> SCons.Util.NodeList:
         if not target:
             if 'POTDOMAIN' in env and env['POTDOMAIN']:
                 domain = env['POTDOMAIN']
             else:
                 domain = 'messages'
             target = [domain]
-        return BuilderBase._execute(self, env, target, source, *args)
+
+        return super()._execute(env, target, source, *args)
 
 
 def _scan_xgettext_from_files(target, source, env, files=None, path=None):

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -46,7 +46,7 @@ PYPY = hasattr(sys, 'pypy_translation_info')
 
 # this string will be hashed if a Node refers to a file that doesn't exist
 # in order to distinguish from a file that exists but is empty.
-NOFILE = "SCONS_MAGIC_MISSING_FILE_STRING"
+NOFILE = b"SCONS_MAGIC_MISSING_FILE_STRING"
 
 # unused?
 def dictify(keys, values, result=None) -> dict:
@@ -146,23 +146,14 @@ class NodeList(UserList):
         result = [getattr(x, name) for x in self.data]
         return self.__class__(result)
 
-    def __getitem__(self, index):
-        """
-        This comes for free on py2,
-        but py3 slices of NodeList are returning a list
-        breaking slicing nodelist and refering to
-        properties and methods on contained object
-        """
-#        return self.__class__(self.data[index])
-
-        if isinstance(index, slice):
-            # Expand the slice object using range()
-            # limited by number of items in self.data
-            indices = index.indices(len(self.data))
-            return self.__class__([self[x] for x in range(*indices)])
-
-        # Return one item of the tart
-        return self.data[index]
+    # obs: previous versions had a custom __getitem__ method for Py3 with the
+    # following comment in the docstring, which seems to no longer be true.
+    # If it needs to be retrieved, rel_4.2.0 in git has the last version.
+    #
+    #    This comes for free on py2,
+    #    but py3 slices of NodeList are returning a list
+    #    breaking slicing nodelist and refering to
+    #    properties and methods on contained object
 
 
 _get_env_var = re.compile(r'^\$([_a-zA-Z]\w*|{[_a-zA-Z]\w*})$')
@@ -1400,7 +1391,7 @@ def uniquer(seq, idfun=None):
 # idfun() argument and function-call overhead by assuming that all
 # items in the sequence are hashable.  Order-preserving.
 
-def uniquer_hashables(seq):
+def uniquer_hashables(seq) -> list:
     seen = {}
     result = []
     result_append = result.append  # perf: avoid repeated method lookups

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -698,6 +698,12 @@ class UtilTestCase(unittest.TestCase):
         assert f.data == ['aa', 'bb', 'cc', 'dd'], f.data
         assert str(f) == 'aa bb cc dd', str(f)
 
+        # test slicing: Py3 < 3.7 had a bug
+        f = CLVar(['aa', 'bb', 'cc', 'dd'])
+        s = f[1:-1]
+        assert isinstance(s, CLVar), type(s)
+        assert s.data == ['bb', 'cc'], s.data
+
 
     def test_Selector(self):
         """Test the Selector class"""
@@ -871,8 +877,9 @@ class NodeListTestCase(unittest.TestCase):
 
         nl = NodeList([t1, t2, t3])
         assert nl.bar == ['t1', 't2', 't3'], nl.bar
-        assert nl[0:2].child.bar == ['t1child', 't2child'], \
-            nl[0:2].child.bar
+        sl = nl[0:2]
+        assert isinstance(sl, NodeList), type(sl)
+        assert sl.child.bar == ['t1child', 't2child'], sl.child.bar
 
     def test_callable_attributes(self):
         """Test callable attributes of a NodeList class"""

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -903,7 +903,7 @@ class NodeListTestCase(unittest.TestCase):
 
     def test_null(self):
         """Test a null NodeList"""
-        nl = NodeList([])
+        nl = NodeList()
         r = str(nl)
         assert r == '', r
         for node in nl:

--- a/SCons/__init__.py
+++ b/SCons/__init__.py
@@ -1,9 +1,9 @@
 __version__="4.2.0"
 __copyright__="Copyright (c) 2001 - 2021 The SCons Foundation"
-__developer__="bdbaddog"
-__date__="Sat, 31 Jul 2021 18:12:46 -0700"
-__buildsys__="ProDog2020"
-__revision__="fcdadeef19fe5fead09fa7544a27502be65312be"
-__build__="fcdadeef19fe5fead09fa7544a27502be65312be"
+__developer__="mats"
+__date__="Wed, 11 Aug 2021 09:38:35 -0600"
+__buildsys__="boulder"
+__revision__="dfffcf43437514981ca267fab1f4cdea190aa551"
+__build__="dfffcf43437514981ca267fab1f4cdea190aa551"
 # make sure compatibility is always in place
 import SCons.compat # noqa

--- a/doc/user/alias.xml
+++ b/doc/user/alias.xml
@@ -47,8 +47,8 @@
 
   <para>
 
-  We've already seen how you can use the &Alias;
-  function to create a target named <literal>install</literal>:
+  We've already seen how you can use &f-Alias;
+  to create a target named <literal>install</literal>:
 
   </para>
 
@@ -77,10 +77,10 @@ int main() { printf("Hello, world!\n"); }
 
   <para>
 
-  Like other &Builder; methods, though,
-  the &Alias; method returns an object
+  Like other &Builder; methods
+  &Alias; returns an object
   representing the alias being built.
-  You can then use this object as input to anothother &Builder;.
+  You can use this object as input to another &Builder;.
   This is especially useful if you use such an object
   as input to another call to the &Alias; &Builder;,
   allowing you to create a hierarchy


### PR DESCRIPTION
The two definitions of `NodeList` are collapsed to one, keeping the `SCons.Util` version and dumping the `SCons.Node` one.  Two unit tests that were expecting the `__str__` behavior of `SCons.Node.NodeList` were adjusted to match the behavior of `SCons.Util.NodeList`.

`Alias()` now returns `NodeList`. This brings it into line with the claim "builders return a nodelist".

Some type annotation added re: `NodeLists`, and based on running `mypy`, some other adjustments made.

## Edited:
The Node `NodeList` `__str__` method produces a string which begins and ends with brackets, the Util one does not. I don't have a strong opinion which is better, but the unit tests of course expect a very specific behavior. It's unclear if the str change affects anything else (investigate).

This code changes the `_execute` method to return a `SCons.Util.NodeList` instead of an `SCons.Node.NodeList`.  The main one is in `BuilderBase`, but some derived classes define their own, which are currently `_PDFFileBuilder` in `GettextCommon.py`, `_POTBuilder` in `xgettext.py` and `_MDFileBuilder` in `msgfmt.py`.

The following public methods now explcitly return a `NodeList`, where previously some did and some returned plain Python lists: `AddPreAction`, `AddPostAction`, `Alias`, `AlwaysBuild`, `Command`, `Depends`, `NoClean`, `NoCache`, `Ignore`, `Precious`, `Pseudo`, `Requires`, `SideEffect`.

These internal methods methods now return a `NodeList` where they previously returned a Python list: `arg2nodes`, `_create_nodes`.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
