### PR TITLE
Two small tweaks for Py3.10 support.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
     - Fix version tests to work with updated scons --version output. (Date format changed)
 
+  From Mats Wichmann:
+    - Two small Python 3.10 fixes: one more docstring turned into raw
+      because it contained an escape; updated "helpful" syntax error message
+      from 3.10 was not expected by SubstTests.py and test/Subst/Syntax.py
+
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
 

--- a/SCons/Platform/__init__.py
+++ b/SCons/Platform/__init__.py
@@ -53,7 +53,7 @@ import SCons.Tool
 
 
 def platform_default():
-    """Return the platform string for our execution environment.
+    r"""Return the platform string for our execution environment.
 
     The returned value should map to one of the SCons/Platform/\*.py
     files.  Since scons is architecture independent, though, we don't

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -597,8 +597,10 @@ class scons_subst_TestCase(SubstTestCase):
             scons_subst('$foo.bar.3.0', env)
         except SCons.Errors.UserError as e:
             expect = [
-                # Python 2.5 and later
+                # Python 2.5 to 3.9
                 "SyntaxError `invalid syntax (<string>, line 1)' trying to evaluate `$foo.bar.3.0'",
+                # Python 3.10 and later
+                "SyntaxError `invalid syntax. Perhaps you forgot a comma? (<string>, line 1)' trying to evaluate `$foo.bar.3.0'",
             ]
             assert str(e) in expect, e
         else:
@@ -1054,9 +1056,10 @@ class scons_subst_list_TestCase(SubstTestCase):
             scons_subst_list('$foo.bar.3.0', env)
         except SCons.Errors.UserError as e:
             expect = [
-                "SyntaxError `invalid syntax' trying to evaluate `$foo.bar.3.0'",
-                "SyntaxError `invalid syntax (line 1)' trying to evaluate `$foo.bar.3.0'",
+                # Python 2.5 to 3.9
                 "SyntaxError `invalid syntax (<string>, line 1)' trying to evaluate `$foo.bar.3.0'",
+                # Python 3.10 and later
+                "SyntaxError `invalid syntax. Perhaps you forgot a comma? (<string>, line 1)' trying to evaluate `$foo.bar.3.0'",
             ]
             assert str(e) in expect, e
         else:


### PR DESCRIPTION
Python 3.10 has added "friendlier" messages in some cases, if you have a syntax error it tries to suggest what might be wrong.  Two test files were not expecting the new text, but they already have mechanisms for dealing with several formats, so added the new message - and deleted cases that were from Pythons older than 3.5

One docstring containing a non-python escape (`\*.py`) was turned into a raw string to avoid a deprecation warning.

No scons changes: tests and a docstring only.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
