### PR TITLE
update ninja tool to support $ in scons command line args

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,7 +41,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Prior to this fix, it would cause ninja to fail to escape the dollar sign, leading to the 
       single dollar sign being used as a ninja escape character in the ninja file.
 
-
   From Mats Wichmann:
     - Two small Python 3.10 fixes: one more docstring turned into raw
       because it contained an escape; updated "helpful" syntax error message

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix ninja tool to never use for_sig substitution because ninja does not use signatures. This
       issue affected CommandGeneratorAction function actions specifically.
     - Added support for the PCH environment variable to support subst generators. 
+    - Fix command line escaping for ninja dollar sign escape. Without escaping ninja properly,
+      the ninja file scons regenerate and callback invocations will lose the $ characters used in
+      the scons command line which ninja uses itself for escaping. For Example:
+          scons BUILD=xyz OTHERVAR=$BUILD
+      Prior to this fix, it would cause ninja to fail to escape the dollar sign, leading to the 
+      single dollar sign being used as a ninja escape character in the ninja file.
+
 
   From Mats Wichmann:
     - Two small Python 3.10 fixes: one more docstring turned into raw

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -38,6 +38,12 @@ FIXES
 - Fix PCH not being evaluated by subst() where necessary.
 - Fix issue #4021.  Change the way subst() is used in Textfile() to not evaluate '$$(' -> '$',
   but instead it should yield '$('.
+- Fix command line escaping for ninja dollar sign escape. Without escaping ninja properly,
+  the ninja file scons regenerate and callback invocations will lose the $ characters used in
+  the scons command line which ninja uses itself for escaping. For Example:
+      scons BUILD=xyz OTHERVAR=$BUILD
+  Prior to this fix, it would cause ninja to fail to escape the dollar sign, leading to the 
+  single dollar sign being used as a ninja escape character in the ninja file.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/ninja/__init__.py
+++ b/SCons/Tool/ninja/__init__.py
@@ -383,7 +383,7 @@ def generate(env):
     ninja_syntax = importlib.import_module(".ninja_syntax", package='ninja')
 
     if NINJA_STATE is None:
-        NINJA_STATE = NinjaState(env, ninja_file[0], ninja_syntax.Writer)
+        NINJA_STATE = NinjaState(env, ninja_file[0], ninja_syntax)
 
     # TODO: this is hacking into scons, preferable if there were a less intrusive way
     # We will subvert the normal builder execute to make sure all the ninja file is dependent

--- a/test/ninja/ninja_command_line.py
+++ b/test/ninja/ninja_command_line.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import os
+
+import TestSCons
+from TestCmd import IS_WINDOWS
+
+test = TestSCons.TestSCons()
+
+try:
+    import ninja
+except ImportError:
+    test.skip_test("Could not find module in python")
+
+_python_ = TestSCons._python_
+_exe = TestSCons._exe
+
+ninja_bin = os.path.abspath(os.path.join(
+    ninja.__file__,
+    os.pardir,
+    'data',
+    'bin',
+    'ninja' + _exe))
+
+test.dir_fixture('ninja-fixture', 'src')
+
+test.file_fixture('ninja_test_sconscripts/sconstruct_ninja_command_line', 'SConstruct')
+
+# generate simple build
+test.run(arguments=['BUILD=build', 'OTHER_VAR=$BUILD'], stdout=None)
+test.must_contain_all_lines(test.stdout(), ['Generating: build.ninja'])
+test.must_contain_all(test.stdout(), 'Executing:')
+test.must_contain_all(test.stdout(), 'ninja%(_exe)s -f' % locals())
+test.run(program=test.workpath('foo' + _exe), stdout="foo.c")
+
+# clean build and ninja files
+test.run(arguments=['-c', 'BUILD=build', 'OTHER_VAR=$BUILD'], stdout=None)
+test.must_contain_all_lines(test.stdout(), [
+    'Removed build%sbar2.c' % os.sep,
+    'Removed build%sbar2.o' % os.sep,
+    'Removed foo',
+    'Removed build.ninja'])
+
+# only generate the ninja file
+test.run(arguments=['--disable-execute-ninja', 'BUILD=build', 'OTHER_VAR=$BUILD'], stdout=None)
+test.must_contain_all_lines(test.stdout(), ['Generating: build.ninja'])
+test.must_not_exist(test.workpath('foo' + _exe))
+
+# run ninja independently
+program = test.workpath('run_ninja_env.bat') if IS_WINDOWS else ninja_bin
+test.run(program=program, stdout=None)
+test.run(program=test.workpath('foo' + _exe), stdout="foo.c")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/ninja/ninja_test_sconscripts/sconstruct_ninja_command_line
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_ninja_command_line
@@ -1,0 +1,12 @@
+SetOption('experimental','ninja')
+DefaultEnvironment(tools=[])
+
+env_vars=Variables(args=ARGUMENTS)
+env_vars.Add('BUILD')
+env_vars.Add('OTHER_VAR')
+env = Environment(variables=env_vars)
+
+env.VariantDir(env['OTHER_VAR'], 'src')
+env.Tool('ninja')
+env.Textfile('$BUILD/bar2.c', open('src/foo.c').read())
+env.Program(target = 'foo', source = '$BUILD/bar2.c', CPPPATH='src')


### PR DESCRIPTION
from https://github.com/mongodb/mongo/commit/dee0f733cdb3cab7714326574efc8a1ae4ec750f

Without escaping ninja's dollar sign escape character properly, the ninja file scons regenerate and callback invocations will lose the $ characters used in the scons command line which ninja uses itself for escaping.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
