### PR TITLE
Add Py3.10 test change missed in PR 3993

### DIFF
--- a/test/Subst/SyntaxError.py
+++ b/test/Subst/SyntaxError.py
@@ -34,7 +34,7 @@ import TestSCons
 test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 
-expect_build = r"""scons: \*\*\*%s SyntaxError `(invalid syntax|Unknown character)( \((<string>, )?line 1\))?' trying to evaluate `%s'
+expect_build = r"""scons: \*\*\*%s SyntaxError `invalid syntax( |\. Perhaps you forgot a comma\? )\(<string>, line 1\)?' trying to evaluate `%s'
 """
 
 expect_read = "\n" + expect_build + TestSCons.file_expr


### PR DESCRIPTION
This change to an e2e test was supposed to part of the fixes for the new "friendly" syntax error messages in Py3.10, but missed the commit somehow.

Change already covered in CHANGES.txt so no further change there.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
