### PR TITLE
Simplified PCH fix to support PCH containing value which needs to be subst()'d

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From William Deegan:
     - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
     - Fix version tests to work with updated scons --version output. (Date format changed)
+    - Further PCH updates. It's now recommended that env['PCH'] should always be a File node.
+      Either via return value from env.PCH() or by explicitly using File('StdAfx.pch').
 
   From Ryan Egesdahl:
     - Small fix to ensure CLVar default value is an empty list.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,9 +13,19 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
     - Fix version tests to work with updated scons --version output. (Date format changed)
 
+  From Ryan Egesdahl:
+    - Small fix to ensure CLVar default value is an empty list.
+      See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
+      Code contributed by MongoDB.
+
+  From Aaron Franke:
+    - Define HOST_OS and HOST_ARCH in the environment for all platforms.
+      Before this change, these were only defined for Win32 and OS/2.
+
   From Daniel Moody:
     - Fix ninja tool to never use for_sig substitution because ninja does not use signatures. This
       issue affected CommandGeneratorAction function actions specifically.
+    - Added support for the PCH environment variable to support subst generators. 
 
   From Mats Wichmann:
     - Two small Python 3.10 fixes: one more docstring turned into raw
@@ -23,15 +33,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       from 3.10 was not expected by SubstTests.py and test/Subst/Syntax.py
     - EmitterProxy rich comparison set is completed (checker warning).
       Added __le__, __gt__, __ge__.
-
-  From Aaron Franke:
-    - Define HOST_OS and HOST_ARCH in the environment for all platforms.
-      Before this change, these were only defined for Win32 and OS/2.
-
-  From Ryan Egesdahl:
-    - Small fix to ensure CLVar default value is an empty list.
-      See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
-      Code contributed by MongoDB.
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -1,10 +1,10 @@
-A new SCons release, 4.1.0, is now available
+A new SCons release, 4.2.0, is now available
 on the SCons download page:
 
       https://scons.org/pages/download.html
 
 
-Here is a summary of the changes since 4.1.0:
+Here is a summary of the changes since 4.2.0:
 
 NEW FUNCTIONALITY
 -----------------
@@ -19,8 +19,8 @@ DEPRECATED FUNCTIONALITY
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 
-- List modifications to existing features, where the previous behavior
-  wouldn't actually be considered a bug
+- Further PCH updates. It's now recommended that env['PCH'] should always be a File node.
+  Either via return value from env.PCH() or by explicitly using File('StdAfx.pch').
 
 FIXES
 -----

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -31,6 +31,8 @@ FIXES
   Code contributed by MongoDB.
 - Fix ninja tool to never use for_sig substitution because ninja does not use signatures. This
   issue affected CommandGeneratorAction function actions specifically.
+- Fix PCH not being evaluated by subst() where necessary.
+
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/MSCommon/__init__.py
+++ b/SCons/Tool/MSCommon/__init__.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,11 +20,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """
+"""
 Common functions for Microsoft Visual Studio and Visual C/C++.
 """
 

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -346,6 +346,21 @@ def parse_output(output, keep=KEEPLIST):
 
     return dkeep
 
+def get_pch_node(env, target, source):
+    """
+    Get the actual PCH file node
+    """
+    pch_subst = env.get('PCH', False) and env.subst('$PCH',target=target, source=source, conv=lambda x:x)
+
+    if not pch_subst:
+        return ""
+
+    if SCons.Util.is_String(pch_subst):
+        pch_subst = target[0].dir.File(pch_subst)
+
+    return pch_subst
+
+
 # Local Variables:
 # tab-width:4
 # indent-tabs-mode:nil

--- a/SCons/Tool/mslink.py
+++ b/SCons/Tool/mslink.py
@@ -128,7 +128,7 @@ def _dllEmitter(target, source, env, paramtp):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    if version_num >= 11.0:
+    if version_num >= 11.0 and env.get('PCH', False):
         pch_subst = env.subst('$PCH',target=target, source=source)
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.
@@ -187,7 +187,7 @@ def prog_emitter(target, source, env):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    if version_num >= 11.0:
+    if version_num >= 11.0 and env.get('PCH', False):
         pch_subst = env.subst('$PCH',target=target, source=source)
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.

--- a/SCons/Tool/mslink.py
+++ b/SCons/Tool/mslink.py
@@ -128,8 +128,8 @@ def _dllEmitter(target, source, env, paramtp):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    if version_num >= 11.0 and env.get('PCH', False):
-        pch_subst = env.subst('$PCH',target=target, source=source)
+    pch_subst = env.get('PCH', False) and env.subst('$PCH',target=target, source=source)
+    if version_num >= 11.0 and pch_subst:
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.
         pchobj = SCons.Util.splitext(pch_subst)[0] + '.obj'
@@ -187,8 +187,8 @@ def prog_emitter(target, source, env):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    if version_num >= 11.0 and env.get('PCH', False):
-        pch_subst = env.subst('$PCH',target=target, source=source)
+    pch_subst = env.get('PCH', False) and env.subst('$PCH',target=target, source=source)
+    if version_num >= 11.0 and pch_subst:
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.
         pchobj = SCons.Util.splitext(pch_subst)[0] + '.obj'

--- a/SCons/Tool/mslink.py
+++ b/SCons/Tool/mslink.py
@@ -44,6 +44,7 @@ import SCons.Tool.msvs
 import SCons.Util
 
 from .MSCommon import msvc_setup_env_once, msvc_exists
+from .MSCommon.common import get_pch_node
 
 def pdbGenerator(env, target, source, for_signature):
     try:
@@ -128,11 +129,11 @@ def _dllEmitter(target, source, env, paramtp):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    pch_subst = env.get('PCH', False) and env.subst('$PCH',target=target, source=source)
-    if version_num >= 11.0 and pch_subst:
+    pch_node = get_pch_node(env, target, source)
+    if version_num >= 11.0 and pch_node:
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.
-        pchobj = SCons.Util.splitext(pch_subst)[0] + '.obj'
+        pchobj = SCons.Util.splitext(str(pch_node))[0] + '.obj'
         # print "prog_emitter, version %s, appending pchobj %s"%(version_num, pchobj)
         if pchobj not in extrasources:
             extrasources.append(pchobj)
@@ -187,11 +188,11 @@ def prog_emitter(target, source, env):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    pch_subst = env.get('PCH', False) and env.subst('$PCH',target=target, source=source)
-    if version_num >= 11.0 and pch_subst:
+    pch_node = get_pch_node(env, target, source)
+    if version_num >= 11.0 and pch_node:
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.
-        pchobj = SCons.Util.splitext(pch_subst)[0] + '.obj'
+        pchobj = SCons.Util.splitext(str(pch_node))[0] + '.obj'
         # print "prog_emitter, version %s, appending pchobj %s"%(version_num, pchobj)
         if pchobj not in extrasources:
             extrasources.append(pchobj)

--- a/SCons/Tool/mslink.py
+++ b/SCons/Tool/mslink.py
@@ -1,13 +1,6 @@
-"""SCons.Tool.mslink
-
-Tool-specific initialization for the Microsoft linker.
-
-There normally shouldn't be any need to import this module directly.
-It will usually be imported through the generic SCons.Tool.Tool()
-selection method.
-
-"""
-
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,7 +20,16 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
+"""SCons.Tool.mslink
+
+Tool-specific initialization for the Microsoft linker.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+
+"""
 
 import os
 import os.path
@@ -126,10 +128,11 @@ def _dllEmitter(target, source, env, paramtp):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    if version_num >= 11.0 and env.get('PCH', 0):
+    if version_num >= 11.0:
+        pch_subst = env.subst('$PCH',target=target, source=source)
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.
-        pchobj = SCons.Util.splitext(str(env['PCH']))[0] + '.obj'
+        pchobj = SCons.Util.splitext(pch_subst)[0] + '.obj'
         # print "prog_emitter, version %s, appending pchobj %s"%(version_num, pchobj)
         if pchobj not in extrasources:
             extrasources.append(pchobj)
@@ -184,11 +187,12 @@ def prog_emitter(target, source, env):
         extratargets.append(pdb)
         target[0].attributes.pdb = pdb
 
-    if version_num >= 11.0 and env.get('PCH', 0):
+    if version_num >= 11.0:
+        pch_subst = env.subst('$PCH',target=target, source=source)
         # MSVC 11 and above need the PCH object file to be added to the link line,
         # otherwise you get link error LNK2011.
-        pchobj = SCons.Util.splitext(str(env['PCH']))[0] + '.obj'
-        # print("prog_emitter, version %s, appending pchobj %s"%(version_num, pchobj))
+        pchobj = SCons.Util.splitext(pch_subst)[0] + '.obj'
+        # print "prog_emitter, version %s, appending pchobj %s"%(version_num, pchobj)
         if pchobj not in extrasources:
             extrasources.append(pchobj)
 

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -224,7 +224,7 @@ def gen_ccpchflags(env, target, source, for_signature):
     if SCons.Util.is_String(pch_subst):
         pch_subst = target.dir.File(pch_subst)
 
-    return SCons.Util.CLVar(["/Yu$PCHSTOP","/Fp%s"%pch_subst])
+    return SCons.Util.CLVar(["/Yu$PCHSTOP", "/Fp%s" % pch_subst])
 
 def generate(env):
     """Add Builders and construction variables for MSVC++ to an Environment."""

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -1,15 +1,6 @@
-"""SCons.Tool.msvc
-
-Tool-specific initialization for Microsoft Visual C/C++.
-
-There normally shouldn't be any need to import this module directly.
-It will usually be imported through the generic SCons.Tool.Tool()
-selection method.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -29,9 +20,16 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""SCons.Tool.msvc
+
+Tool-specific initialization for Microsoft Visual C/C++.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+
+"""
 
 import os.path
 import os
@@ -112,8 +110,8 @@ def object_emitter(target, source, env, parent_emitter):
     # See issue #2505 for a discussion of what to do if it turns
     # out this assumption causes trouble in the wild:
     # https://github.com/SCons/scons/issues/2505
-    if 'PCH' in env:
-        pch = env['PCH']
+    pch=env.subst("$PCH", target=target, source=source)
+    if pch:
         if str(target[0]) != SCons.Util.splitext(str(pch))[0] + '.obj':
             env.Depends(target, pch)
 
@@ -236,7 +234,7 @@ def generate(env):
         shared_obj.add_emitter(suffix, shared_object_emitter)
 
     env['CCPDBFLAGS'] = SCons.Util.CLVar(['${(PDB and "/Z7") or ""}'])
-    env['CCPCHFLAGS'] = SCons.Util.CLVar(['${(PCH and "/Yu%s \\\"/Fp%s\\\""%(PCHSTOP or "",File(PCH))) or ""}'])
+    env['CCPCHFLAGS'] = SCons.Util.CLVar(['${(PCH and "/Yu%s \\\"/Fp%s\\\""%(PCHSTOP or "",File(PCH(env,target,source, for_signature)))) or ""}'])
     env['_MSVC_OUTPUT_FLAG'] = msvc_output_flag
     env['_CCCOMCOM']  = '$CPPFLAGS $_CPPDEFFLAGS $_CPPINCFLAGS $CCPCHFLAGS $CCPDBFLAGS'
     env['CC']         = 'cl'

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -221,9 +221,10 @@ def gen_ccpchflags(env, target, source, for_signature):
     if not pch_subst:
         return ""
 
-    pch_file = env.File(pch_subst)
+    if SCons.Util.is_String(pch_subst):
+        pch_subst = target.dir.File(pch_subst)
 
-    return SCons.Util.CLVar(["/Yu$PCHSTOP","\"/Fp%s\""%str(pch_file)])
+    return SCons.Util.CLVar(["/Yu$PCHSTOP","/Fp%s"%pch_subst])
 
 def generate(env):
     """Add Builders and construction variables for MSVC++ to an Environment."""

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -110,7 +110,7 @@ def object_emitter(target, source, env, parent_emitter):
     # See issue #2505 for a discussion of what to do if it turns
     # out this assumption causes trouble in the wild:
     # https://github.com/SCons/scons/issues/2505
-    pch=env.subst("$PCH", target=target, source=source)
+    pch=env.get('PCH', False) and env.subst("$PCH", target=target, source=source)
     if pch:
         if str(target[0]) != SCons.Util.splitext(str(pch))[0] + '.obj':
             env.Depends(target, pch)
@@ -234,7 +234,7 @@ def generate(env):
         shared_obj.add_emitter(suffix, shared_object_emitter)
 
     env['CCPDBFLAGS'] = SCons.Util.CLVar(['${(PDB and "/Z7") or ""}'])
-    env['CCPCHFLAGS'] = SCons.Util.CLVar(['${(PCH and "/Yu%s \\\"/Fp%s\\\""%(PCHSTOP or "",File(PCH(env,target,source, for_signature)))) or ""}'])
+    env['CCPCHFLAGS'] = SCons.Util.CLVar(['${(PCH and "/Yu%s \\\"/Fp%s\\\""%(PCHSTOP or "",File(callable(PCH) and PCH(env,target,source,for_signature) or PCH))) or ""}'])
     env['_MSVC_OUTPUT_FLAG'] = msvc_output_flag
     env['_CCCOMCOM']  = '$CPPFLAGS $_CPPDEFFLAGS $_CPPINCFLAGS $CCPCHFLAGS $CCPDBFLAGS'
     env['CC']         = 'cl'

--- a/SCons/Tool/msvc.xml
+++ b/SCons/Tool/msvc.xml
@@ -210,7 +210,7 @@ Example:
 </para>
 
 <example_commands>
-env['PCH'] = 'StdAfx.pch'
+env['PCH'] = File('StdAfx.pch')
 </example_commands>
 </summary>
 </cvar>

--- a/test/Libs/LIBS.py
+++ b/test/Libs/LIBS.py
@@ -26,7 +26,11 @@
 import sys
 
 import TestSCons
-from TestSCons import _exe, lib_, _lib
+
+# Leave below to resolve sider complaints
+_exe = TestSCons._exe
+lib_ = TestSCons.lib_
+_lib = TestSCons._lib
 
 if sys.platform == 'win32':
     import SCons.Tool.MSCommon as msc

--- a/test/MSVC/hierarchical.py
+++ b/test/MSVC/hierarchical.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of Visual Studio with a hierarchical build.
@@ -46,7 +45,7 @@ test.write('src/SConscript',"""
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
 env = Environment(tools=['mssdk', 'msvc', 'mslink'])
-env['PCH'] = 'StdAfx.pch'
+env['PCH'] = File('StdAfx.pch')
 env['PDB'] = '#out/test.pdb'
 env['PCHSTOP'] = 'StdAfx.h'
 env.PCH('StdAfx.cpp')

--- a/test/MSVC/hierarchical.py
+++ b/test/MSVC/hierarchical.py
@@ -37,17 +37,15 @@ test.skip_if_not_msvc()
 test.subdir('src', 'build', 'out')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 VariantDir('build', 'src', duplicate=0)
 SConscript('build/SConscript')
 """)
 
 test.write('src/SConscript',"""
-import os
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
 env = Environment(tools=['mssdk', 'msvc', 'mslink'])
-env.Append(CPPPATH=os.environ.get('INCLUDE', ''),
-           LIBPATH=os.environ.get('LIB', ''))
 env['PCH'] = 'StdAfx.pch'
 env['PDB'] = '#out/test.pdb'
 env['PCHSTOP'] = 'StdAfx.h'

--- a/test/MSVC/msvc.py
+++ b/test/MSVC/msvc.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,7 +28,6 @@ Verify basic invocation of Microsoft Visual C/C++, including use
 of a precompiled header with the $CCFLAGS variable.
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import time
 
@@ -36,70 +37,10 @@ test = TestSCons.TestSCons(match = TestSCons.match_re)
 
 test.skip_if_not_msvc()
 
+test.dir_fixture('msvc_fixture')
+
 #####
 # Test the basics
-
-test.write('SConstruct',"""
-import os
-DefaultEnvironment(tools=[])
-# TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
-# and ideally we shouldn't need to specify the tools= list anyway.
-env = Environment(tools=['mssdk', 'msvc', 'mslink'])
-env.Append(CPPPATH=os.environ.get('INCLUDE', ''),
-           LIBPATH=os.environ.get('LIB', ''),
-           CCFLAGS='/DPCHDEF')
-env['PDB'] = File('test.pdb')
-env['PCHSTOP'] = 'StdAfx.h'
-env['PCH'] = env.PCH('StdAfx.cpp')[0]
-env.Program('test', ['test.cpp', env.RES('test.rc')], LIBS=['user32'])
-
-env.Object('fast', 'foo.cpp')
-env.Object('slow', 'foo.cpp', PCH=0)
-""")
-
-test.write('test.cpp', '''
-#include "StdAfx.h"
-#include "resource.h"
-
-int main(void) 
-{ 
-    char test[1024];
-    LoadString(GetModuleHandle(NULL), IDS_TEST, test, sizeof(test));
-    printf("%d %s\\n", IDS_TEST, test);
-    return 0;
-}
-''')
-
-test.write('test.rc', '''
-#include "resource.h"
-
-STRINGTABLE DISCARDABLE 
-BEGIN
-    IDS_TEST "test 1"
-END
-''')
-
-test.write('resource.h', '''
-#define IDS_TEST 2001
-''')
-
-
-test.write('foo.cpp', '''
-#include "StdAfx.h"
-''')
-
-test.write('StdAfx.h', '''
-#include <windows.h>
-#include <stdio.h>
-#include "resource.h"
-''')
-
-test.write('StdAfx.cpp', '''
-#include "StdAfx.h"
-#ifndef PCHDEF
-this line generates an error if PCHDEF is not defined!
-#endif
-''')
 
 #  Visual Studio 8 has deprecated the /Yd option and prints warnings
 #  about it, so ignore stderr when running SCons.

--- a/test/MSVC/msvc_fixture/SConstruct
+++ b/test/MSVC/msvc_fixture/SConstruct
@@ -1,0 +1,15 @@
+import os
+DefaultEnvironment(tools=[])
+# TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
+# and ideally we shouldn't need to specify the tools= list anyway.
+env = Environment(tools=['mssdk', 'msvc', 'mslink'])
+env.Append(CPPPATH=os.environ.get('INCLUDE', ''),
+           LIBPATH=os.environ.get('LIB', ''),
+           CCFLAGS='/DPCHDEF')
+env['PDB'] = File('test.pdb')
+env['PCHSTOP'] = 'StdAfx.h'
+env['PCH'] = env.PCH('StdAfx.cpp')[0]
+env.Program('test', ['test.cpp', env.RES('test.rc')], LIBS=['user32'])
+
+env.Object('fast', 'foo.cpp')
+env.Object('slow', 'foo.cpp', PCH=0)

--- a/test/MSVC/msvc_fixture/SConstruct
+++ b/test/MSVC/msvc_fixture/SConstruct
@@ -1,11 +1,10 @@
-import os
+# msvc_fixture's SConstruct
+
 DefaultEnvironment(tools=[])
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
 env = Environment(tools=['mssdk', 'msvc', 'mslink'])
-env.Append(CPPPATH=os.environ.get('INCLUDE', ''),
-           LIBPATH=os.environ.get('LIB', ''),
-           CCFLAGS='/DPCHDEF')
+env.Append(CCFLAGS='/DPCHDEF')
 env['PDB'] = File('test.pdb')
 env['PCHSTOP'] = 'StdAfx.h'
 env['PCH'] = env.PCH('StdAfx.cpp')[0]

--- a/test/MSVC/msvc_fixture/StdAfx.cpp
+++ b/test/MSVC/msvc_fixture/StdAfx.cpp
@@ -1,0 +1,4 @@
+#include "StdAfx.h"
+#ifndef PCHDEF
+this line generates an error if PCHDEF is not defined!
+#endif

--- a/test/MSVC/msvc_fixture/StdAfx.h
+++ b/test/MSVC/msvc_fixture/StdAfx.h
@@ -1,0 +1,3 @@
+#include <windows.h>
+#include <stdio.h>
+#include "resource.h"

--- a/test/MSVC/msvc_fixture/foo.cpp
+++ b/test/MSVC/msvc_fixture/foo.cpp
@@ -1,0 +1,1 @@
+#include "StdAfx.h"

--- a/test/MSVC/msvc_fixture/resource.h
+++ b/test/MSVC/msvc_fixture/resource.h
@@ -1,0 +1,1 @@
+#define IDS_TEST 2001

--- a/test/MSVC/msvc_fixture/test.cpp
+++ b/test/MSVC/msvc_fixture/test.cpp
@@ -1,0 +1,10 @@
+#include "StdAfx.h"
+#include "resource.h"
+
+int main(void) 
+{ 
+    char test[1024];
+    LoadString(GetModuleHandle(NULL), IDS_TEST, test, sizeof(test));
+    printf("%d %s\n", IDS_TEST, test);
+    return 0;
+}

--- a/test/MSVC/msvc_fixture/test.rc
+++ b/test/MSVC/msvc_fixture/test.rc
@@ -1,0 +1,6 @@
+#include "resource.h"
+
+STRINGTABLE DISCARDABLE 
+BEGIN
+    IDS_TEST "test 1"
+END

--- a/test/MSVC/pch-spaces-subdir.py
+++ b/test/MSVC/pch-spaces-subdir.py
@@ -62,6 +62,7 @@ SConscript('SConscript', variant_dir='Release Output', duplicate=0)
 """)
 
 test.write('SConscript', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 
 env['PCHSTOP'] = 'Precompiled.h'

--- a/test/MSVC/pch_gen/fixture/SConstruct
+++ b/test/MSVC/pch_gen/fixture/SConstruct
@@ -9,9 +9,9 @@ env['PDB'] = File('test.pdb')
 env['PCHSTOP'] = 'StdAfx.h'
 
 def pch_gen(env, target, source, for_signature):
-    return 'StdAfx.pch'
+    return 'StdAfx-1.pch'
 env['PCH'] = pch_gen
-env.PCH('StdAfx.cpp')[0]
+env.PCH('StdAfx-1.pch', 'StdAfx.cpp')[0]
 env.Program('test', ['test.cpp', env.RES('test.rc')], LIBS=['user32'])
 
 env.Object('fast', 'foo.cpp')

--- a/test/MSVC/pch_gen/fixture/SConstruct
+++ b/test/MSVC/pch_gen/fixture/SConstruct
@@ -1,0 +1,19 @@
+import os
+DefaultEnvironment(tools=[])
+# TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
+# and ideally we shouldn't need to specify the tools= list anyway.
+env = Environment(tools=['mssdk', 'msvc', 'mslink'])
+env.Append(CPPPATH=os.environ.get('INCLUDE', ''),
+           LIBPATH=os.environ.get('LIB', ''),
+           CCFLAGS='/DPCHDEF')
+env['PDB'] = File('test.pdb')
+env['PCHSTOP'] = 'StdAfx.h'
+
+def pch_gen(env, target, source, for_signature):
+    return 'StdAfx.pch'
+env['PCH'] = pch_gen
+env.PCH('StdAfx.cpp')[0]
+env.Program('test', ['test.cpp', env.RES('test.rc')], LIBS=['user32'])
+
+env.Object('fast', 'foo.cpp')
+env.Object('slow', 'foo.cpp', PCH=0)

--- a/test/MSVC/pch_gen/fixture/SConstruct
+++ b/test/MSVC/pch_gen/fixture/SConstruct
@@ -1,11 +1,10 @@
-import os
+# pch_gen fixture's SConstruct
+
 DefaultEnvironment(tools=[])
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
 env = Environment(tools=['mssdk', 'msvc', 'mslink'])
-env.Append(CPPPATH=os.environ.get('INCLUDE', ''),
-           LIBPATH=os.environ.get('LIB', ''),
-           CCFLAGS='/DPCHDEF')
+env.Append(CCFLAGS='/DPCHDEF')
 env['PDB'] = File('test.pdb')
 env['PCHSTOP'] = 'StdAfx.h'
 

--- a/test/MSVC/pch_gen/fixture/SConstruct
+++ b/test/MSVC/pch_gen/fixture/SConstruct
@@ -5,6 +5,10 @@ DefaultEnvironment(tools=[])
 # and ideally we shouldn't need to specify the tools= list anyway.
 
 
+VariantDir('output1','src')
+VariantDir('output2','src')
+
+
 # Add flag to cause pch_gen to return empty string
 # This will enable testing that PCH if subst'd yields empty string will stop
 # PCH from being enabled.
@@ -14,7 +18,7 @@ vars.AddVariables(BoolVariable("DISABLE_PCH", help="Disable PCH functionality", 
 
 env = Environment(variables=vars, tools=["mssdk", "msvc", "mslink"])
 env.Append(CCFLAGS="/DPCHDEF")
-env["PDB"] = File("test.pdb")
+env["PDB"] = File("output1/test.pdb")
 env["PCHSTOP"] = "StdAfx.h"
 
 
@@ -26,8 +30,24 @@ def pch_gen(env, target, source, for_signature):
 
 
 env["PCH"] = pch_gen
-env.PCH("StdAfx-1.pch", "StdAfx.cpp")
-env.Program("test", ["test.cpp", env.RES("test.rc")], LIBS=["user32"])
+env.PCH("output1/StdAfx-1.pch", "output1/StdAfx.cpp")
+env.Program("output1/test", ["output1/test.cpp", env.RES("output1/test.rc")], LIBS=["user32"])
 
-env.Object("fast", "foo.cpp")
-env.Object("slow", "foo.cpp", PCH=0)
+env.Object("output1/fast", "output1/foo.cpp")
+env.Object("output1/slow", "output1/foo.cpp", PCH=0)
+
+
+
+env2 = env.Clone()
+
+def pch_gen2(env, target, source, for_signature):
+    if env['DISABLE_PCH']:
+        return ""
+    else:
+        return env.get('PCH_NODE')
+env2["PDB"] = File("output2/test.pdb")
+env2["PCHSTOP"] = "StdAfx.h"
+env2["PCH"] = pch_gen2
+env2['PCH_NODE'] = env2.PCH("output2/StdAfx-1.pch", "output2/StdAfx.cpp")[0]
+env2.Program("output2/test", ["output2/test.cpp", env.RES("output2/test.rc")], LIBS=["user32"])
+

--- a/test/MSVC/pch_gen/fixture/SConstruct
+++ b/test/MSVC/pch_gen/fixture/SConstruct
@@ -3,16 +3,31 @@
 DefaultEnvironment(tools=[])
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
-env = Environment(tools=['mssdk', 'msvc', 'mslink'])
-env.Append(CCFLAGS='/DPCHDEF')
-env['PDB'] = File('test.pdb')
-env['PCHSTOP'] = 'StdAfx.h'
+
+
+# Add flag to cause pch_gen to return empty string
+# This will enable testing that PCH if subst'd yields empty string will stop
+# PCH from being enabled.
+vars = Variables(None, ARGUMENTS)
+vars.AddVariables(BoolVariable("DISABLE_PCH", help="Disable PCH functionality", default=False))
+
+
+env = Environment(variables=vars, tools=["mssdk", "msvc", "mslink"])
+env.Append(CCFLAGS="/DPCHDEF")
+env["PDB"] = File("test.pdb")
+env["PCHSTOP"] = "StdAfx.h"
+
 
 def pch_gen(env, target, source, for_signature):
-    return 'StdAfx-1.pch'
-env['PCH'] = pch_gen
-env.PCH('StdAfx-1.pch', 'StdAfx.cpp')[0]
-env.Program('test', ['test.cpp', env.RES('test.rc')], LIBS=['user32'])
+    if env['DISABLE_PCH']:
+        return ""
+    else:
+        return "StdAfx-1.pch"
 
-env.Object('fast', 'foo.cpp')
-env.Object('slow', 'foo.cpp', PCH=0)
+
+env["PCH"] = pch_gen
+env.PCH("StdAfx-1.pch", "StdAfx.cpp")
+env.Program("test", ["test.cpp", env.RES("test.rc")], LIBS=["user32"])
+
+env.Object("fast", "foo.cpp")
+env.Object("slow", "foo.cpp", PCH=0)

--- a/test/MSVC/pch_gen/pch_gen.py
+++ b/test/MSVC/pch_gen/pch_gen.py
@@ -43,6 +43,13 @@ test.file_fixture('fixture/SConstruct',
 
 test.run(arguments='.')
 
+test.must_exist(test.workpath('test.exe'))
+test.must_exist(test.workpath('test.res'))
+test.must_exist(test.workpath('test.pdb'))
+test.must_exist(test.workpath('StdAfx-1.pch'))
+test.must_exist(test.workpath('StdAfx-1.obj'))
+
+
 test.pass_test()
 
 # Local Variables:

--- a/test/MSVC/pch_gen/pch_gen.py
+++ b/test/MSVC/pch_gen/pch_gen.py
@@ -34,8 +34,10 @@ test = TestSCons.TestSCons()
 
 test.skip_if_not_msvc()
 
+# include all of msvc_fixture's files
 test.dir_fixture('../msvc_fixture')
 
+# Then we'll replace the SConstruct with one specific to this test.
 test.file_fixture('fixture/SConstruct',
                   'SConstruct')
 

--- a/test/MSVC/pch_gen/pch_gen.py
+++ b/test/MSVC/pch_gen/pch_gen.py
@@ -49,6 +49,13 @@ test.must_exist(test.workpath('test.pdb'))
 test.must_exist(test.workpath('StdAfx-1.pch'))
 test.must_exist(test.workpath('StdAfx-1.obj'))
 
+test.run(arguments="-c .")
+test.run(arguments="DISABLE_PCH=1 .")
+
+test.must_exist(test.workpath('test.exe'))
+test.must_exist(test.workpath('test.res'))
+test.must_exist(test.workpath('test.pdb'))
+test.fail_test(condition = ('/YuStdAfx.h' in test.stdout()), message="Shouldn't have /YuStdAfx.h in compile line when PCH is disabled")
 
 test.pass_test()
 

--- a/test/MSVC/pch_gen/pch_gen.py
+++ b/test/MSVC/pch_gen/pch_gen.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Template for end-to-end test file.
+Replace this with a description of the test.
+"""
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.skip_if_not_msvc()
+
+test.dir_fixture('../msvc_fixture')
+
+test.file_fixture('fixture/SConstruct',
+                  'SConstruct')
+
+test.run(arguments='.')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/pch_gen/pch_gen.py
+++ b/test/MSVC/pch_gen/pch_gen.py
@@ -35,7 +35,7 @@ test = TestSCons.TestSCons()
 test.skip_if_not_msvc()
 
 # include all of msvc_fixture's files
-test.dir_fixture('../msvc_fixture')
+test.dir_fixture('../msvc_fixture','src')
 
 # Then we'll replace the SConstruct with one specific to this test.
 test.file_fixture('fixture/SConstruct',
@@ -43,19 +43,19 @@ test.file_fixture('fixture/SConstruct',
 
 test.run(arguments='.')
 
-test.must_exist(test.workpath('test.exe'))
-test.must_exist(test.workpath('test.res'))
-test.must_exist(test.workpath('test.pdb'))
-test.must_exist(test.workpath('StdAfx-1.pch'))
-test.must_exist(test.workpath('StdAfx-1.obj'))
+test.must_exist(test.workpath('output1/test.exe'))
+test.must_exist(test.workpath('output1/test.res'))
+test.must_exist(test.workpath('output1/test.pdb'))
+test.must_exist(test.workpath('output1/StdAfx-1.pch'))
+test.must_exist(test.workpath('output1/StdAfx-1.obj'))
 
 test.run(arguments="-c .")
 test.run(arguments="DISABLE_PCH=1 .")
 
-test.must_exist(test.workpath('test.exe'))
-test.must_exist(test.workpath('test.res'))
-test.must_exist(test.workpath('test.pdb'))
-test.fail_test(condition = ('/YuStdAfx.h' in test.stdout()), message="Shouldn't have /YuStdAfx.h in compile line when PCH is disabled")
+test.must_exist(test.workpath('output1/test.exe'))
+test.must_exist(test.workpath('output1/test.res'))
+test.must_exist(test.workpath('output1/test.pdb'))
+test.fail_test(condition = ('/Yuoutput1/StdAfx.h' in test.stdout()), message="Shouldn't have output1/YuStdAfx.h in compile line when PCH is disabled")
 
 test.pass_test()
 

--- a/test/Repository/CPPPATH.py
+++ b/test/Repository/CPPPATH.py
@@ -24,7 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import sys
-from TestSCons import TestSCons, _exe
+from TestSCons import TestSCons
 
 test = TestSCons()
 

--- a/test/Repository/SConscript.py
+++ b/test/Repository/SConscript.py
@@ -28,7 +28,7 @@ Test how we handle SConscript calls when using a Repository.
 """
 
 import sys
-from TestSCons import TestSCons, _exe
+from TestSCons import TestSCons
 
 test = TestSCons()
 

--- a/test/Repository/multi-dir.py
+++ b/test/Repository/multi-dir.py
@@ -25,7 +25,7 @@
 
 import sys
 
-from TestSCons import TestSCons, _exe
+from TestSCons import TestSCons
 
 test = TestSCons()
 

--- a/test/ninja/build_libraries.py
+++ b/test/ninja/build_libraries.py
@@ -25,7 +25,7 @@ import os
 
 import TestSCons
 from TestCmd import IS_WINDOWS, IS_MACOS
-from TestSCons import _python_, _exe, _lib, lib_, _dll, dll_
+from TestSCons import _exe, _lib, lib_, _dll, dll_
 
 test = TestSCons.TestSCons()
 


### PR DESCRIPTION
Initial checkin of simplified support for PCH needing to be subst()'d to resolve. In particular when PCH evaluates to a generator

Possible alternative to PR #3984 Based of work done by @dmoody256 


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
