### PR TITLE
Two small test tweaks

### DIFF
--- a/SCons/cppTests.py
+++ b/SCons/cppTests.py
@@ -878,10 +878,9 @@ if __name__ == '__main__':
     for tclass in tclasses:
         names = unittest.getTestCaseNames(tclass, 'test_')
         try:
-            names = list(set(names))
+            names = sorted(set(names))
         except NameError:
             pass
-        names.sort()
         suite.addTests(list(map(tclass, names)))
     TestUnit.run(suite)
 

--- a/test/Libs/LIBS.py
+++ b/test/Libs/LIBS.py
@@ -97,6 +97,7 @@ test.write('foo5.c', foo_contents)
 
 test.write('sl.c', """\
 #include <stdio.h>
+
 void
 sl(void)
 {
@@ -105,7 +106,11 @@ sl(void)
 """)
 
 test.write('slprog.c', """\
+#include <stdlib.h>
 #include <stdio.h>
+
+void sl(void);
+
 int
 main(int argc, char *argv[])
 {


### PR DESCRIPTION
Modernize the C in test/Libs/LIBS.py to avoid clang errors (gcc and MSVC only warn here).

Change where test list is sorted in SCons/cppTests.py.

Signed-off-by: Mats Wichmann <mats@linux.com>

A test-only change.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
