### PR TITLE
tests: use framework for platform-specific defines

### DIFF
--- a/test/Libs/LIBPREFIXES.py
+++ b/test/Libs/LIBPREFIXES.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,21 +22,17 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import sys
+
 import TestSCons
+from TestSCons import _lib
 
 if sys.platform == 'win32':
-    _lib = '.lib'
     import SCons.Tool.MSCommon as msc
     if not msc.msvc_exists():
         _lib = '.a'
-else:
-    _lib = '.a'
 
 test = TestSCons.TestSCons()
 

--- a/test/Libs/LIBS.py
+++ b/test/Libs/LIBS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,22 +22,18 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-import TestSCons
 import sys
 
+import TestSCons
+from TestSCons import _exe, lib_, _lib
+
 if sys.platform == 'win32':
-    _exe = '.exe'
-    bar_lib = 'bar.lib'
     import SCons.Tool.MSCommon as msc
     if not msc.msvc_exists():
-        bar_lib = 'libbar.a'
-else:
-    _exe = ''
-    bar_lib = 'libbar.a'
+        _lib = '.a'
+        lib_ = 'lib'
+bar_lib = lib_ + 'bar' + _lib
 
 test = TestSCons.TestSCons()
 

--- a/test/NodeOps.py
+++ b/test/NodeOps.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,29 +22,23 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""
+This test is used to verify that the Buildability of a set of nodes
+is unaffected by various querying operations on those nodes:
 
-# This test is used to verify that the Buildability of a set of nodes
-# is unaffected by various querying operations on those nodes:
-#
-# 1) Calling exists() on a Node (e.g. from find_file) in a VariantDir
-#    will cause that node to be duplicated into the builddir.
-#    However, this should *not* occur during a dryrun (-n).  When not
-#    performed during a dryrun, this should not affect buildability.
-# 2) Calling is_derived() should not affect buildability.
+1) Calling exists() on a Node (e.g. from find_file) in a VariantDir
+   will cause that node to be duplicated into the builddir.
+   However, this should *not* occur during a dryrun (-n).  When not
+   performed during a dryrun, this should not affect buildability.
+2) Calling is_derived() should not affect buildability.
+"""
 
 import sys
-import TestSCons
 import os
 
-_exe = TestSCons._exe
-lib_ = TestSCons.lib_
-_lib = TestSCons._lib
-_obj = TestSCons._obj
-dll_ = TestSCons.dll_
-_dll = TestSCons._dll
+import TestSCons
+from TestSCons import _exe, lib_, _lib, _obj, dll_, _dll
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'

--- a/test/Repository/CPPPATH.py
+++ b/test/Repository/CPPPATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,19 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import TestSCons
+from TestSCons import TestSCons, _exe
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
-
-test = TestSCons.TestSCons()
+test = TestSCons()
 
 test.subdir('repository',
             ['repository', 'include1'],
@@ -43,7 +37,6 @@ work_foo = test.workpath('work', 'foo')
 
 opts = '-Y ' + test.workpath('repository')
 
-#
 test.write(['repository', 'include1', 'foo.h'], r"""
 #define STRING  "repository/include1/foo.h"
 """)

--- a/test/Repository/Program.py
+++ b/test/Repository/Program.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,21 +22,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import TestSCons
-
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
 for implicit_deps in ['0', '1', '2', '\"all\"']:
     # First, test a single repository.
-    test = TestSCons.TestSCons()
+    test = TestSCons()
     test.subdir('repository', 'work1')
     repository = test.workpath('repository')
     repository_foo_c = test.workpath('repository', 'foo.c')

--- a/test/Repository/SConscript.py
+++ b/test/Repository/SConscript.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,25 +22,16 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test how we handle SConscript calls when using a Repository.
 """
 
 import sys
-import TestSCons
+from TestSCons import TestSCons, _exe
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+test = TestSCons()
 
-test = TestSCons.TestSCons()
-
-#
 test.subdir('work',
             ['work', 'src'],
             'rep1',
@@ -48,11 +41,9 @@ test.subdir('work',
             ['rep2', 'src'],
             ['rep2', 'src', 'sub'])
 
-#
 workpath_rep1 = test.workpath('rep1')
 workpath_rep2 = test.workpath('rep2')
 
-#
 test.write(['work', 'SConstruct'], """
 Repository(r'%s')
 SConscript('src/SConscript')

--- a/test/Repository/absolute-path.py
+++ b/test/Repository/absolute-path.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,20 +22,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import sys
-import TestSCons
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
-test = TestSCons.TestSCons()
+test = TestSCons()
 
 test.subdir('repository',
             ['repository', 'src'],
@@ -46,7 +41,6 @@ work_src_foo = test.workpath('work', 'src', 'foo' + _exe)
 
 opts = "-Y " + test.workpath('repository')
 
-#
 test.write(['repository', 'SConstruct'], r"""
 SConscript(r'%s')
 """ % src_SConscript)

--- a/test/Repository/include.py
+++ b/test/Repository/include.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,19 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import TestSCons
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
-test = TestSCons.TestSCons()
+test = TestSCons()
 
 test.subdir('repository', 'work')
 

--- a/test/Repository/link-object.py
+++ b/test/Repository/link-object.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,31 +22,19 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import TestSCons
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
+test = TestSCons()
 
-
-test = TestSCons.TestSCons()
-
-#
 test.subdir('repository', 'work')
 
-#
 workpath_repository = test.workpath('repository')
 repository_foo = test.workpath('repository', 'foo' + _exe)
 work_foo = test.workpath('work', 'foo' + _exe)
 
-#
 test.write(['repository', 'SConstruct'], """
 Repository(r'%s')
 env = Environment()

--- a/test/Repository/multi-dir.py
+++ b/test/Repository/multi-dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,23 +22,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import TestSCons
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
+test = TestSCons()
 
-
-test = TestSCons.TestSCons()
-
-#
 test.subdir('work',
             ['work', 'src'],
             ['work', 'include'],
@@ -44,7 +36,6 @@ test.subdir('work',
             ['repository', 'src'],
             ['repository', 'include'])
 
-#
 workpath_repository = test.workpath('repository')
 work_include_my_string_h = test.workpath('work', 'include', 'my_string.h')
 work_src_xxx = test.workpath('work', 'src', 'xxx')
@@ -52,7 +43,6 @@ repository_src_xxx = test.workpath('repository', 'src', 'xxx')
 
 opts = "-Y " + workpath_repository
 
-#
 test.write(['repository', 'SConstruct'], """
 env = Environment(CPPPATH = ['#src', '#include'])
 SConscript('src/SConscript', "env")

--- a/test/Repository/no-repository.py
+++ b/test/Repository/no-repository.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,22 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 
-import TestSCons
+from TestSCons import TestSCons, _exe
 
-python = TestSCons.python
-
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
-
-test = TestSCons.TestSCons()
+test = TestSCons()
 
 test.subdir('work')
 

--- a/test/Repository/top-level-path.py
+++ b/test/Repository/top-level-path.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,20 +22,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import sys
-import TestSCons
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
-test = TestSCons.TestSCons()
+test = TestSCons()
 
 test.subdir('repository',
             ['repository', 'src'],
@@ -45,7 +40,6 @@ work_src_foo = test.workpath('work', 'src', 'foo' + _exe)
 
 opts = "-Y " + test.workpath('repository')
 
-#
 test.write(['repository', 'SConstruct'], r"""
 SConscript(r'%s')
 """ % src_SConscript)

--- a/test/Repository/variants.py
+++ b/test/Repository/variants.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,23 +22,14 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import sys
 import time
-import TestSCons
 
-if sys.platform == 'win32':
-    _obj = '.obj'
-    _exe = '.exe'
-else:
-    _obj = '.o'
-    _exe = ''
+from TestSCons import TestSCons, _exe, _obj
 
-test = TestSCons.TestSCons()
+test = TestSCons()
 
 test.subdir('repository',
             ['repository', 'src1'],

--- a/test/Repository/within-repository.py
+++ b/test/Repository/within-repository.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,31 +22,19 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import TestSCons
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
+test = TestSCons()
 
-
-test = TestSCons.TestSCons()
-
-#
 test.subdir('repository', ['repository', 'src'])
 
-#
 workpath_repository = test.workpath('repository')
 repository_foo = test.workpath('repository', 'foo' + _exe)
 repository_src_bar = test.workpath('repository', 'src', 'bar' + _exe)
 
-#
 test.write(['repository', 'SConstruct'], """
 Repository(r'%s')
 SConscript('src/SConscript')

--- a/test/option/option--Y.py
+++ b/test/option/option--Y.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,21 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
-import TestSCons
 
-if sys.platform == 'win32':
-    _exe = '.exe'
-else:
-    _exe = ''
+from TestSCons import TestSCons, _exe
 
-
-
-test = TestSCons.TestSCons()
+test = TestSCons()
 
 test.subdir('repository', 'work1')
 


### PR DESCRIPTION
Tweaked some tests which directly set values for `_exe`, `_obj`, etc. which are available from the framework. Done for consistency, none of these were doing these wrong.

This is a test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
