### PR TITLE
Add rest of comparison ops to EmitterProxy

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Two small Python 3.10 fixes: one more docstring turned into raw
       because it contained an escape; updated "helpful" syntax error message
       from 3.10 was not expected by SubstTests.py and test/Subst/Syntax.py
+    - EmitterProxy rich comparison set is completed (checker warning).
+      Added __le__, __gt__, __ge__.
 
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -353,12 +353,20 @@ class EmitterProxy:
 
         return (target, source)
 
-
     def __eq__(self, other):
         return self.var == other.var
 
     def __lt__(self, other):
         return self.var < other.var
+
+    def __le__(self, other):
+        return self.var <= other.var
+
+    def __gt__(self, other):
+        return self.var > other.var
+
+    def __ge__(self, other):
+        return self.var >= other.var
 
 class BuilderBase:
     """Base class for Builders, objects that create output


### PR DESCRIPTION
Python 3 expects that a full set of rich comparison operators be implemented if any of them are.  A checker complained that `__lt__` existed but the class was incomplete because `__le__`, `__gt__` and `__ge__` did not.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
