### PR TITLE
Define `HOST_OS` and `HOST_ARCH` in the environment for all platforms

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       because it contained an escape; updated "helpful" syntax error message
       from 3.10 was not expected by SubstTests.py and test/Subst/Syntax.py
 
+  From Aaron Franke:
+    - Define HOST_OS and HOST_ARCH in the environment for all platforms.
+      Before this change, these were only defined for Win32 and OS/2.
+
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
 

--- a/SCons/Platform/Platform.xml
+++ b/SCons/Platform/Platform.xml
@@ -126,7 +126,6 @@ else:
         that Platform's logic will handle setting this value.
         This value is immutable, and should not be changed by the user after
         the Environment is initialized.
-        Currently only set for Win32.
 </para>
     </summary>
 </cvar>
@@ -139,7 +138,6 @@ else:
         that Platform's logic will handle setting this value.
         This value is immutable, and should not be changed by the user after
         the Environment is initialized.
-        Currently only set for Win32.
 </para>
     </summary>
 </cvar>

--- a/SCons/Platform/PlatformTests.py
+++ b/SCons/Platform/PlatformTests.py
@@ -50,6 +50,8 @@ class PlatformTestCase(unittest.TestCase):
         assert env['PROGSUFFIX'] == '.exe', env
         assert env['LIBSUFFIX'] == '.a', env
         assert env['SHELL'] == 'sh', env
+        assert env['HOST_OS'] == 'cygwin', env
+        assert env['HOST_ARCH'] != '', env
 
         p = SCons.Platform.Platform('os2')
         assert str(p) == 'os2', p
@@ -57,6 +59,8 @@ class PlatformTestCase(unittest.TestCase):
         p(env)
         assert env['PROGSUFFIX'] == '.exe', env
         assert env['LIBSUFFIX'] == '.lib', env
+        assert env['HOST_OS'] == 'os2', env
+        assert env['HOST_ARCH'] != '', env
 
         p = SCons.Platform.Platform('posix')
         assert str(p) == 'posix', p
@@ -65,6 +69,8 @@ class PlatformTestCase(unittest.TestCase):
         assert env['PROGSUFFIX'] == '', env
         assert env['LIBSUFFIX'] == '.a', env
         assert env['SHELL'] == 'sh', env
+        assert env['HOST_OS'] == 'posix', env
+        assert env['HOST_ARCH'] != '', env
 
         p = SCons.Platform.Platform('irix')
         assert str(p) == 'irix', p
@@ -73,6 +79,8 @@ class PlatformTestCase(unittest.TestCase):
         assert env['PROGSUFFIX'] == '', env
         assert env['LIBSUFFIX'] == '.a', env
         assert env['SHELL'] == 'sh', env
+        assert env['HOST_OS'] == 'irix', env
+        assert env['HOST_ARCH'] != '', env
 
         p = SCons.Platform.Platform('aix')
         assert str(p) == 'aix', p
@@ -81,6 +89,8 @@ class PlatformTestCase(unittest.TestCase):
         assert env['PROGSUFFIX'] == '', env
         assert env['LIBSUFFIX'] == '.a', env
         assert env['SHELL'] == 'sh', env
+        assert env['HOST_OS'] == 'aix', env
+        assert env['HOST_ARCH'] != '', env
 
         p = SCons.Platform.Platform('sunos')
         assert str(p) == 'sunos', p
@@ -89,6 +99,8 @@ class PlatformTestCase(unittest.TestCase):
         assert env['PROGSUFFIX'] == '', env
         assert env['LIBSUFFIX'] == '.a', env
         assert env['SHELL'] == 'sh', env
+        assert env['HOST_OS'] == 'sunos', env
+        assert env['HOST_ARCH'] != '', env
 
         p = SCons.Platform.Platform('hpux')
         assert str(p) == 'hpux', p
@@ -97,6 +109,8 @@ class PlatformTestCase(unittest.TestCase):
         assert env['PROGSUFFIX'] == '', env
         assert env['LIBSUFFIX'] == '.a', env
         assert env['SHELL'] == 'sh', env
+        assert env['HOST_OS'] == 'hpux', env
+        assert env['HOST_ARCH'] != '', env
 
         p = SCons.Platform.Platform('win32')
         assert str(p) == 'win32', p
@@ -104,6 +118,8 @@ class PlatformTestCase(unittest.TestCase):
         p(env)
         assert env['PROGSUFFIX'] == '.exe', env
         assert env['LIBSUFFIX'] == '.lib', env
+        assert env['HOST_OS'] == 'win32', env
+        assert env['HOST_ARCH'] != '', env
 
         exc_caught = None
         try:

--- a/SCons/Platform/aix.py
+++ b/SCons/Platform/aix.py
@@ -72,6 +72,7 @@ def generate(env):
     #Based on AIX 5.2: ARG_MAX=24576 - 3000 for environment expansion
     env['MAXLINELENGTH']  = 21576
     env['SHLIBSUFFIX'] = '.a'
+    env['HOST_OS'] = 'aix'
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Platform/cygwin.py
+++ b/SCons/Platform/cygwin.py
@@ -52,6 +52,7 @@ def generate(env):
     env['TEMPFILE']    = TempFileMunge
     env['TEMPFILEPREFIX'] = '@'
     env['MAXLINELENGTH']  = 2048
+    env['HOST_OS'] = 'cygwin'
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Platform/darwin.py
+++ b/SCons/Platform/darwin.py
@@ -34,6 +34,7 @@ import os
 def generate(env):
     posix.generate(env)
     env['SHLIBSUFFIX'] = '.dylib'
+    env['HOST_OS'] = 'darwin'
     # put macports paths at front to override Apple's versions, fink path is after
     # For now let people who want Macports or Fink tools specify it!
     # env['ENV']['PATH'] = '/opt/local/bin:/opt/local/sbin:' + env['ENV']['PATH'] + ':/sw/bin'

--- a/SCons/Platform/hpux.py
+++ b/SCons/Platform/hpux.py
@@ -36,6 +36,7 @@ def generate(env):
     env['MAXLINELENGTH']  = 2045000
 
     env['SHLIBSUFFIX'] = '.sl'
+    env['HOST_OS'] = 'hpux'
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Platform/irix.py
+++ b/SCons/Platform/irix.py
@@ -32,6 +32,7 @@ from . import posix
 
 def generate(env):
     posix.generate(env)
+    env['HOST_OS'] = 'irix'
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Platform/posix.py
+++ b/SCons/Platform/posix.py
@@ -28,6 +28,7 @@ will usually be imported through the generic SCons.Platform.Platform()
 selection method.
 """
 
+import platform
 import subprocess
 
 from SCons.Platform import TempFileMunge
@@ -94,6 +95,8 @@ def generate(env):
     env['SHLIBSUFFIX']    = '.so'
     env['LIBPREFIXES']    = [ '$LIBPREFIX' ]
     env['LIBSUFFIXES']    = [ '$LIBSUFFIX', '$SHLIBSUFFIX' ]
+    env['HOST_OS']        = 'posix'
+    env['HOST_ARCH']      = platform.machine()
     env['PSPAWN']         = pspawn
     env['SPAWN']          = spawn
     env['SHELL']          = 'sh'

--- a/SCons/Platform/sunos.py
+++ b/SCons/Platform/sunos.py
@@ -38,6 +38,7 @@ def generate(env):
     env['PKGINFO'] = 'pkginfo'
     env['PKGCHK'] = '/usr/sbin/pkgchk'
     env['ENV']['PATH'] = env['ENV']['PATH'] + ':/opt/SUNWspro/bin:/usr/ccs/bin'
+    env['HOST_OS'] = 'sunos'
 
 # Local Variables:
 # tab-width:4

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -3097,7 +3097,6 @@ is <quote><literal>-dNOPAUSE -dBATCH -sDEVICE=pdfwrite</literal></quote>
         that Platform's logic will handle setting this value.
         This value is immutable, and should not be changed by the user after
         the Environment is initialized.
-        Currently only set for Win32.
 </para>
     <para>
 Sets the host architecture for the Visual C++ compiler. If not set,
@@ -3127,7 +3126,6 @@ used on other OSes as well.
         that Platform's logic will handle setting this value.
         This value is immutable, and should not be changed by the user after
         the Environment is initialized.
-        Currently only set for Win32.
 </para>
     </listitem>
   </varlistentry>


### PR DESCRIPTION
Before this commit, these were only defined for Win32 and OS/2.

Note that the title says all platforms but I don't know what `virtualenv` is and I didn't implement this for that.

Note that the call to `platform.machine()` only needs to be present in POSIX, since every other platform that this PR modifies calls the `generate(env)` method for POSIX and then builds on top of that.

Note that for the platform tests, the architecture depends on what architecture the test was executed on, so I just made the test check that the architecture isn't an empty string.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality. 
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
