### PR TITLE
Fix initialization of CLVar

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Define HOST_OS and HOST_ARCH in the environment for all platforms.
       Before this change, these were only defined for Win32 and OS/2.
 
+  From Ryan Egesdahl:
+    - Small fix to ensure CLVar default value is an empty list.
+      See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
+      Code contributed by MongoDB.
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -26,6 +26,9 @@ FIXES
 -----
 
     - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
+    - Small fix to ensure CLVar default value is an empty list.
+      See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
+      Code contributed by MongoDB.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1213,7 +1213,7 @@ class CLVar(UserList):
     """
 
     def __init__(self, initlist=None):
-        super().__init__(Split(initlist))
+        super().__init__(Split(initlist if initlist is not None else []))
 
     def __add__(self, other):
         return super().__add__(CLVar(other))

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -585,6 +585,12 @@ class UtilTestCase(unittest.TestCase):
     def test_CLVar(self):
         """Test the command-line construction variable class"""
 
+        # the default value should be an empty list
+        d = CLVar()
+        assert isinstance(d, CLVar), type(d)
+        assert d.data == [], d.data
+        assert str(d) == '', str(d)
+
         # input to CLVar is a string - should be split
         f = CLVar('aa bb')
 


### PR DESCRIPTION
Prior to commit 69dcebbd, CLVar could be initialized with no
arguments, which would set its default value to an empty list.
After that commit, the default value is a list with a single
`None` element. This commit reverts CLVar back to the previous
default value while preserving the intent of the original commit.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
