### PR TITLE
Fix a doc typo introduced in PR 4009

### DIFF
--- a/doc/user/preface.xml
+++ b/doc/user/preface.xml
@@ -246,7 +246,7 @@
     as the User Guide does not attempt to provide every detail.
     While this Guide's Appendices A-D do duplicate information that appears
     in the man page (this is to allow intra-document links to
-    definitions of &convars;, builders, tools and environment methods
+    definitions of &consvars;, builders, tools and environment methods
     to work), the rest of the man page is unique content.
 
     </para>


### PR DESCRIPTION
docs no longer validated thanks to a typo in an entity name.  I forgot that `[ci skip]` now also skips the github action that does a sample docs (and package) build, when first introduced it didn't skip.  It's a one-character docs-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>




## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
