### PR TITLE
fix ninja tool to never user for_sig substitution.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
     - Fix version tests to work with updated scons --version output. (Date format changed)
 
+  From Daniel Moody:
+    - Fix ninja tool to never use for_sig substitution because ninja does not use signatures. This
+      issue affected CommandGeneratorAction function actions specifically.
+
   From Mats Wichmann:
     - Two small Python 3.10 fixes: one more docstring turned into raw
       because it contained an escape; updated "helpful" syntax error message
@@ -61,7 +65,7 @@ RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
     - Fix #3955 - _LIBDIRFLAGS leaving $( and $) in *COMSTR output.  Added affect_signature flag to
       _concat function.  If set to False, it will prepend and append $( and $). That way the various
       Environment variables can use that rather than "$( _concat(...) $)".
-    - Fix issue with exparimental ninja tool which would fail on windows or when ninja package wasn't 
+    - Fix issue with exparimental ninja tool which would fail on windows or when ninja package wasn't
       installed but --experimental=ninja was specified.
     - As part of experimental ninja tool, allow SetOption() to set both disable_execute_ninja and
       disable_ninja.
@@ -94,9 +98,9 @@ RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
       object.
     - Fix a potential race condition in shared cache environments where the permissions are
       not writeable for a moment after the file has been renamed and other builds (users) will copy
-      it out of the cache. Small reorganization of logic to copy files from cachedir. Moved CacheDir 
+      it out of the cache. Small reorganization of logic to copy files from cachedir. Moved CacheDir
       writeable permission code for copy to cache behind the atomic rename operation.
-    - Added marking of intermediate and and multi target nodes generated from SConf tests so that 
+    - Added marking of intermediate and and multi target nodes generated from SConf tests so that
       is_conftest() is more accurate.
     - Added test for configure check failing to ensure it didn't break generating and running ninja.
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -25,10 +25,12 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
-    - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
-    - Small fix to ensure CLVar default value is an empty list.
-      See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
-      Code contributed by MongoDB.
+- Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.
+- Small fix to ensure CLVar default value is an empty list.
+  See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
+  Code contributed by MongoDB.
+- Fix ninja tool to never use for_sig substitution because ninja does not use signatures. This
+  issue affected CommandGeneratorAction function actions specifically.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/ninja/Methods.py
+++ b/SCons/Tool/ninja/Methods.py
@@ -26,6 +26,7 @@ import shlex
 import textwrap
 
 import SCons
+from SCons.Subst import SUBST_CMD
 from SCons.Tool.ninja import NINJA_CUSTOM_HANDLERS, NINJA_RULES, NINJA_POOLS
 from SCons.Tool.ninja.Globals import __NINJA_RULE_MAPPING
 from SCons.Tool.ninja.Utils import get_targets_sources, get_dependencies, get_order_only, get_outputs, get_inputs, \
@@ -129,7 +130,7 @@ def get_command(env, node, action):  # pylint: disable=too-many-branches
     # Generate a real CommandAction
     if isinstance(action, SCons.Action.CommandGeneratorAction):
         # pylint: disable=protected-access
-        action = action._generate(tlist, slist, sub_env, 0, executor=executor)
+        action = action._generate(tlist, slist, sub_env, SUBST_CMD, executor=executor)
 
     variables = {}
 

--- a/SCons/Tool/ninja/Methods.py
+++ b/SCons/Tool/ninja/Methods.py
@@ -129,7 +129,7 @@ def get_command(env, node, action):  # pylint: disable=too-many-branches
     # Generate a real CommandAction
     if isinstance(action, SCons.Action.CommandGeneratorAction):
         # pylint: disable=protected-access
-        action = action._generate(tlist, slist, sub_env, 1, executor=executor)
+        action = action._generate(tlist, slist, sub_env, 0, executor=executor)
 
     variables = {}
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_no_for_sig_subst
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_no_for_sig_subst
@@ -3,7 +3,7 @@ import SCons
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 
-env = Environment()
+env = Environment(tools=[])
 env.Tool('ninja')
 
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_no_for_sig_subst
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_no_for_sig_subst
@@ -1,0 +1,24 @@
+import SCons
+
+SetOption('experimental','ninja')
+DefaultEnvironment(tools=[])
+
+env = Environment()
+env.Tool('ninja')
+
+
+def test_subst_func(env, target, source, for_signature):
+    cmd = 'echo test > '
+    if not for_signature:
+        cmd += 'out.txt'
+    return cmd
+
+bld = SCons.Builder.Builder(
+        action=SCons.Action.CommandGeneratorAction(
+            test_subst_func,
+            {}
+        )
+    )
+
+env['BUILDERS']['TestBld'] = bld
+env.TestBld(target='out.txt', source='foo.c')

--- a/test/ninja/no_for_sig_subst.py
+++ b/test/ninja/no_for_sig_subst.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import os
+
+import TestSCons
+from TestCmd import IS_WINDOWS
+
+test = TestSCons.TestSCons()
+
+try:
+    import ninja
+except ImportError:
+    test.skip_test("Could not find module in python")
+
+_python_ = TestSCons._python_
+_exe = TestSCons._exe
+
+ninja_bin = os.path.abspath(os.path.join(
+    ninja.__file__,
+    os.pardir,
+    'data',
+    'bin',
+    'ninja' + _exe))
+
+test.dir_fixture('ninja-fixture')
+
+test.file_fixture('ninja_test_sconscripts/sconstruct_no_for_sig_subst', 'SConstruct')
+
+# generate simple build
+test.run(stdout=None)
+test.must_contain_all_lines(test.stdout(), ['Generating: build.ninja'])
+test.must_contain_all(test.stdout(), 'Executing:')
+test.must_contain_all(test.stdout(), 'ninja%(_exe)s -f' % locals())
+test.must_exist([test.workpath('out.txt')])
+
+# clean build and ninja files
+test.run(arguments='-c', stdout=None)
+test.must_contain_all_lines(test.stdout(), [
+    'Removed out.txt',
+    'Removed build.ninja'])
+
+# only generate the ninja file
+test.run(arguments='--disable-execute-ninja', stdout=None)
+test.must_contain_all_lines(test.stdout(), ['Generating: build.ninja'])
+test.must_not_exist(test.workpath('out.txt'))
+
+# run ninja independently
+program = test.workpath('run_ninja_env.bat') if IS_WINDOWS else ninja_bin
+test.run(program=program, stdout=None)
+test.must_exist([test.workpath('out.txt')])
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
originally this bug was found downstream in mongo build: https://github.com/mongodb/mongo/commit/0f3cd5391f1b67f0f2ed23c77a8bd217b407d8a2

There are cases where creating a CommandGeneratorAction would cause ninja to use for_signature substitution and generate invalid command lines into the ninja file. Since ninja does not use signatures in any way, it should never use that kind of substitution.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
