### PR TITLE
Calling Split(None) Split() with no arguments should raise an exception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Small fix to ensure CLVar default value is an empty list.
       See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
       Code contributed by MongoDB.
+    - Change Split() so it raises a TypeError when passed no arguments
+      or `None`. This reinforces the intended purpose of the function
+      and makes it easier to catch errors.
+      Code contributed by MongoDB.
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,10 @@ FIXES
     - Small fix to ensure CLVar default value is an empty list.
       See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
       Code contributed by MongoDB.
+    - Change Split() so it raises a TypeError when passed no arguments
+      or `None`. This reinforces the intended purpose of the function
+      and makes it easier to catch errors.
+      Code contributed by MongoDB.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1162,18 +1162,25 @@ system object.  For other platforms, `path` is unchanged.
 display = DisplayEngine()
 
 def Split(arg) -> list:
-    """Returns a list of file names or other objects.
+    """Return a list of file names or other objects.
 
     If `arg` is a string, it will be split on strings of white-space
     characters within the string.  If `arg` is already a list, the list
     will be returned untouched. If `arg` is any other type of object,
-    it will be returned as a list containing just the object.
+    except for None, it will be returned as a list containing just the
+    object.
+
+    Raises:
+        TypeError: if `arg` is None.
 
     >>> print(Split(" this  is  a  string  "))
     ['this', 'is', 'a', 'string']
     >>> print(Split(["stringlist", " preserving ", " spaces "]))
     ['stringlist', ' preserving ', ' spaces ']
     """
+    if arg is None:
+        raise TypeError("Split() needs an argument")
+
     if is_List(arg) or is_Tuple(arg):
         return arg
 

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -41,6 +41,7 @@ from SCons.Util import (
     PrependPath,
     Proxy,
     Selector,
+    Split,
     WhereIs,
     adjustixes,
     containsAll,
@@ -581,6 +582,48 @@ class UtilTestCase(unittest.TestCase):
         assert env_dict['BLAT'] == [os.path.normpath('/baz/foo'),
                                     os.path.normpath('/foo/bar'),
                                     os.path.normpath('/baz/blat')], env_dict['BLAT']
+
+
+    def test_Split(self):
+        """Test the Split() function."""
+        
+        # None or no arguments should raise a TypeError
+        with self.assertRaises(TypeError):
+            Split()
+        with self.assertRaises(TypeError):
+            Split(None)
+
+        # Single objects should be returned as a single-item list
+        f = 'abc'
+        assert is_List(Split(f)), type(Split(f))
+        assert Split(f) == ['abc'], Split(f)
+
+        f = 123
+        assert is_List(Split(f)), type(Split(f))
+        assert Split(f) == [123], Split(f)
+
+        # Any other non-string object should be returned as-is
+        f = []
+        assert is_List(Split(f)), type(Split(f))
+        assert Split(f) == [], Split(f)
+
+        f = ()
+        assert is_Tuple(Split(f)), type(Split(f))
+        assert Split(f) == (), Split(f)
+
+        f = ['abc', 123]
+        assert is_List(Split(f)), type(Split(f))
+        assert Split(f) == ['abc', 123], Split(f)
+
+        f = ('abc', 123)
+        assert is_Tuple(Split(f)), type(Split(f))
+        assert Split(f) == ('abc', 123), Split(f)
+
+        # Strings should be split on spaces
+        f = ' this is a string    '
+        assert is_List(Split(f)), type(Split(f))
+        assert Split(f) == ['this', 'is', 'a', 'string'], Split(f)
+
 
     def test_CLVar(self):
         """Test the command-line construction variable class"""


### PR DESCRIPTION
Calling Split() with no arguments should raise an exception, since it
doesn't make any sense at all to split nothing. This mirrors the
behavior of Python's `str.split()`, which would raise a TypeError.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
