### PR TITLE
Fix SCons/Platform/PlatformTests.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix version tests to work with updated scons --version output. (Date format changed)
     - Fix issue #4021.  Change the way subst() is used in Textfile() to not evaluate '$$(' -> '$',
       but instead it should yield '$('.
+    - Change SCons.Platform.win32.get_architecture() to return platform.platform() when run in an
+      environment where neither: PROCESSOR_ARCHITEW6432 nor PROCESSOR_ARCHITECTURE is set.
+      This should fix platform tests which started failing when HOST_OS/HOST_ARCH changes
+      introduced by Aaron Franke (listed below) were merged.
 
   From Daniel Moody:
     - Fix ninja tool to never use for_sig substitution because ninja does not use signatures. This

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -19,8 +19,10 @@ DEPRECATED FUNCTIONALITY
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 
-- List modifications to existing features, where the previous behavior
-  wouldn't actually be considered a bug
+- Change SCons.Platform.win32.get_architecture() to return platform.platform() when run in an
+  environment where neither: PROCESSOR_ARCHITEW6432 nor PROCESSOR_ARCHITECTURE is set.
+  This should fix platform tests which started failing when HOST_OS/HOST_ARCH changes
+  introduced by Aaron Franke (listed below) were merged.
 
 FIXES
 -----

--- a/SCons/Platform/PlatformTests.py
+++ b/SCons/Platform/PlatformTests.py
@@ -132,6 +132,36 @@ class PlatformTestCase(unittest.TestCase):
         SCons.Platform.Platform()(env)
         assert env != {}, env
 
+    def test_win32_no_arch_shell_variables(self):
+        """
+        Test that a usable HOST_ARCH is available when
+        neither: PROCESSOR_ARCHITEW6432 nor PROCESSOR_ARCHITECTURE
+        is set for SCons.Platform.win32.get_architecture()
+        """
+
+        # Save values if defined
+        PA_6432 = os.environ.get('PROCESSOR_ARCHITEW6432')
+        PA = os.environ.get('PROCESSOR_ARCHITECTURE')
+        if PA_6432:
+            del(os.environ['PROCESSOR_ARCHITEW6432'])
+        if PA:
+            del(os.environ['PROCESSOR_ARCHITECTURE'])
+
+        p = SCons.Platform.win32.get_architecture()
+
+        # restore values
+        if PA_6432:
+            os.environ['PROCESSOR_ARCHITEW6432']=PA_6432
+        if PA:
+            os.environ['PROCESSOR_ARCHITECTURE']=PA
+
+        assert p.arch != '', 'SCons.Platform.win32.get_architecture() not setting arch'
+        assert p.synonyms != '', 'SCons.Platform.win32.get_architecture() not setting synonyms'
+
+
+
+
+
 
 class TempFileMungeTestCase(unittest.TestCase):
     def test_MAXLINELENGTH(self):

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -30,6 +30,7 @@ selection method.
 
 import os
 import os.path
+import platform
 import sys
 import tempfile
 
@@ -321,7 +322,7 @@ def get_architecture(arch=None):
         arch = os.environ.get('PROCESSOR_ARCHITEW6432')
         if not arch:
             arch = os.environ.get('PROCESSOR_ARCHITECTURE')
-    return SupportedArchitectureMap.get(arch, ArchDefinition('', ['']))
+    return SupportedArchitectureMap.get(arch, ArchDefinition(platform.machine(), [platform.machine()]))
 
 
 def generate(env):


### PR DESCRIPTION
Add a reasonable ArchDefinition from win32 when PROCESSOR_ARCHITEW643…nor PROCESSOR_ARCHITECTURE are available. This should fix SCons/Platform/PlatformTests.py


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
