### PR TITLE
Change SCons.Scanner.Base to ScannerBase

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -51,6 +51,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       and code formatting.  Docstring for scanner Base moved from
       init-method to class-level so it's picked up by Sphinx.
       Added new sconsign filenames to skip_entry_list in Scanner/Dir.py
+    - Change SCons.Scanner.Base to ScannerBase. Old name kept as an alias
+      but is now unused in SCons itself.
 
 
 RELEASE 4.2.0 - Sat, 31 Jul 2021 18:12:46 -0700

--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -863,7 +863,7 @@ class BuilderTestCase(unittest.TestCase):
         def func(self):
             pass
 
-        scanner = SCons.Scanner.Base(func, name='fooscan')
+        scanner = SCons.Scanner.ScannerBase(func, name='fooscan')
 
         b1 = SCons.Builder.Builder(action='bld', target_scanner=scanner)
         b2 = SCons.Builder.Builder(action='bld', target_scanner=scanner)

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2250,7 +2250,7 @@ class Base(SubstitutionEnvironment):
                 arg = self.subst(arg)
             nargs.append(arg)
         nkw = self.subst_kw(kw)
-        return SCons.Scanner.Base(*nargs, **nkw)
+        return SCons.Scanner.ScannerBase(*nargs, **nkw)
 
     def SConsignFile(self, name=".sconsign", dbm_module=None):
         if name is not None:

--- a/SCons/Scanner/Dir.py
+++ b/SCons/Scanner/Dir.py
@@ -22,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import SCons.Node.FS
-from . import Base
+from . import ScannerBase
 
 def only_dirs(nodes):
     is_Dir = lambda n: isinstance(n.disambiguate(), SCons.Node.FS.Dir)
@@ -33,14 +33,14 @@ def DirScanner(**kwargs):
     directories for on-disk files"""
     kwargs['node_factory'] = SCons.Node.FS.Entry
     kwargs['recursive'] = only_dirs
-    return Base(scan_on_disk, "DirScanner", **kwargs)
+    return ScannerBase(scan_on_disk, "DirScanner", **kwargs)
 
 def DirEntryScanner(**kwargs):
     """Return a prototype Scanner instance for "scanning"
     directory Nodes for their in-memory entries"""
     kwargs['node_factory'] = SCons.Node.FS.Entry
     kwargs['recursive'] = None
-    return Base(scan_in_memory, "DirEntryScanner", **kwargs)
+    return ScannerBase(scan_in_memory, "DirEntryScanner", **kwargs)
 
 skip_entry = {}
 

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -29,7 +29,7 @@ import re
 import SCons.Node.FS
 import SCons.Util
 import SCons.Warnings
-from . import Base, FindPathDirs
+from . import ScannerBase, FindPathDirs
 
 # list of graphics file extensions for TeX and LaTeX
 TexGraphics   = ['.eps', '.ps']
@@ -119,7 +119,7 @@ def PDFLaTeXScanner():
     return ds
 
 
-class LaTeX(Base):
+class LaTeX(ScannerBase):
     """Class for scanning LaTeX files for included files.
 
     Unlike most scanners, which use regular expressions that just

--- a/SCons/Scanner/Prog.py
+++ b/SCons/Scanner/Prog.py
@@ -26,7 +26,7 @@
 import SCons.Node
 import SCons.Node.FS
 import SCons.Util
-from . import Base, FindPathDirs
+from . import ScannerBase, FindPathDirs
 
 # global, set by --debug=findlibs
 print_find_libs = None
@@ -35,7 +35,7 @@ def ProgramScanner(**kwargs):
     """Return a prototype Scanner instance for scanning executable
     files for static-lib dependencies"""
     kwargs['path_function'] = FindPathDirs('LIBPATH')
-    ps = Base(scan, "ProgramScanner", **kwargs)
+    ps = ScannerBase(scan, "ProgramScanner", **kwargs)
     return ps
 
 def _subst_libs(env, libs):

--- a/SCons/Scanner/Python.py
+++ b/SCons/Scanner/Python.py
@@ -38,7 +38,7 @@ import re
 
 import SCons.Node.FS
 import SCons.Util
-from . import Base
+from . import ScannerBase
 
 # Capture python "from a import b" and "import a" statements.
 from_cre = re.compile(r'^\s*from\s+([^\s]+)\s+import\s+(.*)', re.M)
@@ -201,7 +201,7 @@ def scan(node, env, path=()):
 
 
 PythonSuffixes = ['.py']
-PythonScanner = Base(
+PythonScanner = ScannerBase(
     scan,
     name='PythonScanner',
     skeys=PythonSuffixes,

--- a/SCons/Scanner/ScannerTests.py
+++ b/SCons/Scanner/ScannerTests.py
@@ -66,6 +66,10 @@ class DummyNode:
 
     def Rfindalldirs(self, pathlist):
         return self.search_result + pathlist
+    def __repr__(self):
+        return self.name
+    def __eq__(self, other):
+        return self.name == other.name
 
     def __repr__(self):
         return self.name

--- a/SCons/Scanner/ScannerTests.py
+++ b/SCons/Scanner/ScannerTests.py
@@ -28,6 +28,7 @@ import TestUnit
 
 import SCons.compat
 import SCons.Scanner
+from SCons.Scanner import ScannerBase, Selector, Classic, ClassicCPP, Current, FindPathDirs
 
 class DummyFS:
     def File(self, name):
@@ -86,7 +87,7 @@ class FindPathDirsTestCase(unittest.TestCase):
         env.fs._cwd = DummyNode('cwd')
 
         dir = DummyNode('dir', ['xxx'])
-        fpd = SCons.Scanner.FindPathDirs('LIBPATH')
+        fpd = FindPathDirs('LIBPATH')
         result = fpd(env)
         assert str(result) == "('foo',)", result
         result = fpd(env, dir)
@@ -98,25 +99,25 @@ class ScannerTestCase(unittest.TestCase):
         """Test creation of Scanner objects"""
         def func(self):
             pass
-        s = SCons.Scanner.Base(func)
-        assert isinstance(s, SCons.Scanner.Base), s
-        s = SCons.Scanner.Base({})
-        assert isinstance(s, SCons.Scanner.Base), s
+        s = ScannerBase(func)
+        assert isinstance(s, ScannerBase), s
+        s = ScannerBase({})
+        assert isinstance(s, ScannerBase), s
 
-        s = SCons.Scanner.Base(func, name='fooscan')
+        s = ScannerBase(func, name='fooscan')
         assert str(s) == 'fooscan', str(s)
-        s = SCons.Scanner.Base({}, name='barscan')
+        s = ScannerBase({}, name='barscan')
         assert str(s) == 'barscan', str(s)
 
-        s = SCons.Scanner.Base(func, name='fooscan', argument=9)
+        s = ScannerBase(func, name='fooscan', argument=9)
         assert str(s) == 'fooscan', str(s)
         assert s.argument == 9, s.argument
-        s = SCons.Scanner.Base({}, name='fooscan', argument=888)
+        s = ScannerBase({}, name='fooscan', argument=888)
         assert str(s) == 'fooscan', str(s)
         assert s.argument == 888, s.argument
 
 
-class BaseTestCase(unittest.TestCase):
+class ScannerBaseTestCase(unittest.TestCase):
 
     class skey_node:
         def __init__(self, key):
@@ -154,7 +155,7 @@ class BaseTestCase(unittest.TestCase):
             self.assertFalse(hasattr(self, "arg"), "an argument was given when it shouldn't have been")
 
     def test___call__dict(self):
-        """Test calling Scanner.Base objects with a dictionary"""
+        """Test calling ScannerBase objects with a dictionary"""
         called = []
         def s1func(node, env, path, called=called):
             called.append('s1func')
@@ -164,9 +165,9 @@ class BaseTestCase(unittest.TestCase):
             called.append('s2func')
             called.append(node)
             return []
-        s1 = SCons.Scanner.Base(s1func)
-        s2 = SCons.Scanner.Base(s2func)
-        selector = SCons.Scanner.Base({'.x' : s1, '.y' : s2})
+        s1 = ScannerBase(s1func)
+        s2 = ScannerBase(s2func)
+        selector = ScannerBase({'.x' : s1, '.y' : s2})
         nx = self.skey_node('.x')
         env = DummyEnvironment()
         selector(nx, env, [])
@@ -177,7 +178,7 @@ class BaseTestCase(unittest.TestCase):
         assert called == ['s2func', ny], called
 
     def test_path(self):
-        """Test the Scanner.Base path() method"""
+        """Test the ScannerBase path() method"""
         def pf(env, cwd, target, source, argument=None):
             return "pf: %s %s %s %s %s" % \
                         (env.VARIABLE, cwd, target[0], source[0], argument)
@@ -187,17 +188,17 @@ class BaseTestCase(unittest.TestCase):
         target = DummyNode('target')
         source = DummyNode('source')
 
-        s = SCons.Scanner.Base(self.func, path_function=pf)
+        s = ScannerBase(self.func, path_function=pf)
         p = s.path(env, 'here', [target], [source])
         assert p == "pf: v1 here target source None", p
 
-        s = SCons.Scanner.Base(self.func, path_function=pf, argument="xyz")
+        s = ScannerBase(self.func, path_function=pf, argument="xyz")
         p = s.path(env, 'here', [target], [source])
         assert p == "pf: v1 here target source xyz", p
 
     def test_positional(self):
-        """Test the Scanner.Base class using positional arguments"""
-        s = SCons.Scanner.Base(self.func, "Pos")
+        """Test the ScannerBase class using positional arguments"""
+        s = ScannerBase(self.func, "Pos")
         env = DummyEnvironment()
         env.VARIABLE = "var1"
         self.test(s, env, DummyNode('f1.cpp'), ['f1.h', 'f1.hpp'])
@@ -207,8 +208,8 @@ class BaseTestCase(unittest.TestCase):
         self.test(s, env, DummyNode('i1.cpp'), ['i1.h', 'i1.hpp'])
 
     def test_keywords(self):
-        """Test the Scanner.Base class using keyword arguments"""
-        s = SCons.Scanner.Base(function = self.func, name = "Key")
+        """Test the ScannerBase class using keyword arguments"""
+        s = ScannerBase(function = self.func, name = "Key")
         env = DummyEnvironment()
         env.VARIABLE = "var2"
         self.test(s, env, DummyNode('f2.cpp'), ['f2.h', 'f2.hpp'])
@@ -219,9 +220,9 @@ class BaseTestCase(unittest.TestCase):
         self.test(s, env, DummyNode('i2.cpp'), ['i2.h', 'i2.hpp'])
 
     def test_pos_opt(self):
-        """Test the Scanner.Base class using both position and optional arguments"""
+        """Test the ScannerBase class using both position and optional arguments"""
         arg = "this is the argument"
-        s = SCons.Scanner.Base(self.func, "PosArg", arg)
+        s = ScannerBase(self.func, "PosArg", arg)
         env = DummyEnvironment()
         env.VARIABLE = "var3"
         self.test(s, env, DummyNode('f3.cpp'), ['f3.h', 'f3.hpp'], arg)
@@ -231,10 +232,9 @@ class BaseTestCase(unittest.TestCase):
         self.test(s, env, DummyNode('i3.cpp'), ['i3.h', 'i3.hpp'], arg)
 
     def test_key_opt(self):
-        """Test the Scanner.Base class using both keyword and optional arguments"""
+        """Test the ScannerBase class using both keyword and optional arguments"""
         arg = "this is another argument"
-        s = SCons.Scanner.Base(function = self.func, name = "KeyArg",
-                               argument = arg)
+        s = ScannerBase(function = self.func, name = "KeyArg", argument = arg)
         env = DummyEnvironment()
         env.VARIABLE = "var4"
         self.test(s, env, DummyNode('f4.cpp'), ['f4.h', 'f4.hpp'], arg)
@@ -244,13 +244,13 @@ class BaseTestCase(unittest.TestCase):
         self.test(s, env, DummyNode('i4.cpp'), ['i4.h', 'i4.hpp'], arg)
 
     def test___cmp__(self):
-        """Test the Scanner.Base class __cmp__() method"""
-        s = SCons.Scanner.Base(self.func, "Cmp")
+        """Test the ScannerBase class __cmp__() method"""
+        s = ScannerBase(self.func, "Cmp")
         assert s is not None
 
     def test_hash(self):
-        """Test the Scanner.Base class __hash__() method"""
-        s = SCons.Scanner.Base(self.func, "Hash")
+        """Test the ScannerBase class __hash__() method"""
+        s = ScannerBase(self.func, "Hash")
         mapping = {}
         mapping[s] = 777
         i = hash(id(s))
@@ -259,14 +259,14 @@ class BaseTestCase(unittest.TestCase):
                         "hash Scanner base class expected %s, got %s" % (i, h))
 
     def test_scan_check(self):
-        """Test the Scanner.Base class scan_check() method"""
+        """Test the ScannerBase class scan_check() method"""
         def my_scan(filename, env, target, *args):
             return []
         def check(node, env, s=self):
             s.checked[str(node)] = 1
             return 1
         env = DummyEnvironment()
-        s = SCons.Scanner.Base(my_scan, "Check", scan_check = check)
+        s = ScannerBase(my_scan, "Check", scan_check = check)
         self.checked = {}
         path = s.path(env)
         scanned = s(DummyNode('x'), env, path)
@@ -274,56 +274,49 @@ class BaseTestCase(unittest.TestCase):
                         "did not call check function")
 
     def test_recursive(self):
-        """Test the Scanner.Base class recursive flag"""
+        """Test the ScannerBase class recursive flag"""
         nodes = [1, 2, 3, 4]
 
-        s = SCons.Scanner.Base(function = self.func)
+        s = ScannerBase(function = self.func)
         n = s.recurse_nodes(nodes)
-        self.assertTrue(n == [],
-                        "default behavior returned nodes: %s" % n)
+        self.assertTrue(n == [], "default behavior returned nodes: %s" % n)
 
-        s = SCons.Scanner.Base(function = self.func, recursive = None)
+        s = ScannerBase(function = self.func, recursive = None)
         n = s.recurse_nodes(nodes)
-        self.assertTrue(n == [],
-                        "recursive = None returned nodes: %s" % n)
+        self.assertTrue(n == [], "recursive = None returned nodes: %s" % n)
 
-        s = SCons.Scanner.Base(function = self.func, recursive = 1)
+        s = ScannerBase(function = self.func, recursive = 1)
         n = s.recurse_nodes(nodes)
-        self.assertTrue(n == n,
-                        "recursive = 1 didn't return all nodes: %s" % n)
+        self.assertTrue(n == n, "recursive = 1 didn't return all nodes: %s" % n)
 
         def odd_only(nodes):
             return [n for n in nodes if n % 2]
-        s = SCons.Scanner.Base(function = self.func, recursive = odd_only)
+        s = ScannerBase(function = self.func, recursive = odd_only)
         n = s.recurse_nodes(nodes)
-        self.assertTrue(n == [1, 3],
-                        "recursive = 1 didn't return all nodes: %s" % n)
+        self.assertTrue(n == [1, 3], "recursive = 1 didn't return all nodes: %s" % n)
 
     def test_get_skeys(self):
-        """Test the Scanner.Base get_skeys() method"""
-        s = SCons.Scanner.Base(function = self.func)
+        """Test the ScannerBase get_skeys() method"""
+        s = ScannerBase(function = self.func)
         sk = s.get_skeys()
-        self.assertTrue(sk == [],
-                        "did not initialize to expected []")
+        self.assertTrue(sk == [], "did not initialize to expected []")
 
-        s = SCons.Scanner.Base(function = self.func, skeys = ['.1', '.2'])
+        s = ScannerBase(function = self.func, skeys = ['.1', '.2'])
         sk = s.get_skeys()
-        self.assertTrue(sk == ['.1', '.2'],
-                        "sk was %s, not ['.1', '.2']")
+        self.assertTrue(sk == ['.1', '.2'], "sk was %s, not ['.1', '.2']")
 
-        s = SCons.Scanner.Base(function = self.func, skeys = '$LIST')
+        s = ScannerBase(function = self.func, skeys = '$LIST')
         env = DummyEnvironment(LIST = ['.3', '.4'])
         sk = s.get_skeys(env)
-        self.assertTrue(sk == ['.3', '.4'],
-                        "sk was %s, not ['.3', '.4']")
+        self.assertTrue(sk == ['.3', '.4'], "sk was %s, not ['.3', '.4']")
 
     def test_select(self):
-        """Test the Scanner.Base select() method"""
-        scanner = SCons.Scanner.Base(function = self.func)
+        """Test the ScannerBase select() method"""
+        scanner = ScannerBase(function = self.func)
         s = scanner.select('.x')
         assert s is scanner, s
 
-        selector = SCons.Scanner.Base({'.x' : 1, '.y' : 2})
+        selector = ScannerBase({'.x' : 1, '.y' : 2})
         s = selector.select(self.skey_node('.x'))
         assert s == 1, s
         s = selector.select(self.skey_node('.y'))
@@ -332,8 +325,8 @@ class BaseTestCase(unittest.TestCase):
         assert s is None, s
 
     def test_add_scanner(self):
-        """Test the Scanner.Base add_scanner() method"""
-        selector = SCons.Scanner.Base({'.x' : 1, '.y' : 2})
+        """Test the ScannerBase add_scanner() method"""
+        selector = ScannerBase({'.x' : 1, '.y' : 2})
         s = selector.select(self.skey_node('.z'))
         assert s is None, s
         selector.add_scanner('.z', 3)
@@ -341,11 +334,11 @@ class BaseTestCase(unittest.TestCase):
         assert s == 3, s
 
     def test___str__(self):
-        """Test the Scanner.Base __str__() method"""
-        scanner = SCons.Scanner.Base(function = self.func)
+        """Test the ScannerBase __str__() method"""
+        scanner = ScannerBase(function = self.func)
         s = str(scanner)
         assert s == 'NONE', s
-        scanner = SCons.Scanner.Base(function = self.func, name = 'xyzzy')
+        scanner = ScannerBase(function = self.func, name = 'xyzzy')
         s = str(scanner)
         assert s == 'xyzzy', s
 
@@ -360,8 +353,8 @@ class SelectorTestCase(unittest.TestCase):
 
     def test___init__(self):
         """Test creation of Scanner.Selector object"""
-        s = SCons.Scanner.Selector({})
-        assert isinstance(s, SCons.Scanner.Selector), s
+        s = Selector({})
+        assert isinstance(s, Selector), s
         assert s.mapping == {}, s.mapping
 
     def test___call__(self):
@@ -375,9 +368,9 @@ class SelectorTestCase(unittest.TestCase):
             called.append('s2func')
             called.append(node)
             return []
-        s1 = SCons.Scanner.Base(s1func)
-        s2 = SCons.Scanner.Base(s2func)
-        selector = SCons.Scanner.Selector({'.x' : s1, '.y' : s2})
+        s1 = ScannerBase(s1func)
+        s2 = ScannerBase(s2func)
+        selector = Selector({'.x' : s1, '.y' : s2})
         nx = self.skey_node('.x')
         env = DummyEnvironment()
         selector(nx, env, [])
@@ -389,7 +382,7 @@ class SelectorTestCase(unittest.TestCase):
 
     def test_select(self):
         """Test the Scanner.Selector select() method"""
-        selector = SCons.Scanner.Selector({'.x' : 1, '.y' : 2})
+        selector = Selector({'.x' : 1, '.y' : 2})
         s = selector.select(self.skey_node('.x'))
         assert s == 1, s
         s = selector.select(self.skey_node('.y'))
@@ -399,7 +392,7 @@ class SelectorTestCase(unittest.TestCase):
 
     def test_add_scanner(self):
         """Test the Scanner.Selector add_scanner() method"""
-        selector = SCons.Scanner.Selector({'.x' : 1, '.y' : 2})
+        selector = Selector({'.x' : 1, '.y' : 2})
         s = selector.select(self.skey_node('.z'))
         assert s is None, s
         selector.add_scanner('.z', 3)
@@ -438,7 +431,7 @@ class CurrentTestCase(unittest.TestCase):
             node.func_called = 1
             return []
         env = DummyEnvironment()
-        s = SCons.Scanner.Current(func)
+        s = Current(func)
         path = s.path(env)
         hnb = HasNoBuilder()
         s(hnb, env, path)
@@ -471,7 +464,7 @@ class ClassicTestCase(unittest.TestCase):
     def test_find_include(self):
         """Test the Scanner.Classic find_include() method"""
         env = DummyEnvironment()
-        s = SCons.Scanner.Classic("t", ['.suf'], 'MYPATH', r'^my_inc (\S+)')
+        s = Classic("t", ['.suf'], 'MYPATH', r'^my_inc (\S+)')
 
         def _find_file(filename, paths):
             return paths[0]+'/'+filename
@@ -489,7 +482,7 @@ class ClassicTestCase(unittest.TestCase):
 
     def test_name(self):
         """Test setting the Scanner.Classic name"""
-        s = SCons.Scanner.Classic("my_name", ['.s'], 'MYPATH', r'^my_inc (\S+)')
+        s = Classic("my_name", ['.s'], 'MYPATH', r'^my_inc (\S+)')
         assert s.name == "my_name", s.name
 
     def test_scan(self):
@@ -510,7 +503,7 @@ class ClassicTestCase(unittest.TestCase):
             def get_dir(self):
                 return self._dir
 
-        class MyScanner(SCons.Scanner.Classic):
+        class MyScanner(Classic):
             def find_include(self, include, source_dir, path):
                 return include, include
 
@@ -574,7 +567,7 @@ class ClassicTestCase(unittest.TestCase):
         nodes = [1, 2, 3, 4]
 
 
-        s = SCons.Scanner.Classic("Test", [], None, "", function=self.func, recursive=1)
+        s = Classic("Test", [], None, "", function=self.func, recursive=1)
         n = s.recurse_nodes(nodes)
         self.assertTrue(n == n,
                         "recursive = 1 didn't return all nodes: %s" % n)
@@ -582,7 +575,7 @@ class ClassicTestCase(unittest.TestCase):
         def odd_only(nodes):
             return [n for n in nodes if n % 2]
 
-        s = SCons.Scanner.Classic("Test", [], None, "", function=self.func, recursive=odd_only)
+        s = Classic("Test", [], None, "", function=self.func, recursive=odd_only)
         n = s.recurse_nodes(nodes)
         self.assertTrue(n == [1, 3],
                         "recursive = 1 didn't return all nodes: %s" % n)
@@ -592,7 +585,7 @@ class ClassicCPPTestCase(unittest.TestCase):
     def test_find_include(self):
         """Test the Scanner.ClassicCPP find_include() method"""
         env = DummyEnvironment()
-        s = SCons.Scanner.ClassicCPP("Test", [], None, "")
+        s = ClassicCPP("Test", [], None, "")
 
         def _find_file(filename, paths):
             return paths[0]+'/'+filename
@@ -621,7 +614,7 @@ def suite():
     tclasses = [
                  FindPathDirsTestCase,
                  ScannerTestCase,
-                 BaseTestCase,
+                 ScannerBaseTestCase,
                  SelectorTestCase,
                  CurrentTestCase,
                  ClassicTestCase,

--- a/SCons/Scanner/__init__.py
+++ b/SCons/Scanner/__init__.py
@@ -43,7 +43,7 @@ def Scanner(function, *args, **kwargs):
     Creates the appropriate Scanner based on the type of "function".
 
     TODO:  Deprecate this some day.  We've moved the functionality
-    inside the Base class and really don't need this factory function
+    inside the ScannerBase class and really don't need this factory function
     any more.  It was, however, used by some of our Tool modules, so
     the call probably ended up in various people's custom modules
     patterned on SCons code.
@@ -52,7 +52,7 @@ def Scanner(function, *args, **kwargs):
     if SCons.Util.is_Dict(function):
         return Selector(function, *args, **kwargs)
 
-    return Base(function, *args, **kwargs)
+    return ScannerBase(function, *args, **kwargs)
 
 
 class FindPathDirs:
@@ -73,8 +73,7 @@ class FindPathDirs:
         return tuple(dir.Rfindalldirs(path))
 
 
-
-class Base:
+class ScannerBase:
     """Base class for dependency scanners.
 
     Implements straightforward, single-pass scanning of a single file.
@@ -276,13 +275,18 @@ class Base:
         self.add_skey(skey)
 
 
-class Selector(Base):
+# keep the old name for a while in case external users are using.
+# there are no more internal uses of this class by the name "Base"
+Base = ScannerBase
+
+
+class Selector(ScannerBase):
     """
     A class for selecting a more specific scanner based on the
     :func:`scanner_key` (suffix) for a specific Node.
 
     TODO:  This functionality has been moved into the inner workings of
-    the Base class, and this class will be deprecated at some point.
+    the ScannerBase class, and this class will be deprecated at some point.
     (It was never exposed directly as part of the public interface,
     although it is used by the :func:`Scanner` factory function that was
     used by various Tool modules and therefore was likely a template
@@ -307,7 +311,7 @@ class Selector(Base):
         self.add_skey(skey)
 
 
-class Current(Base):
+class Current(ScannerBase):
     """
     A class for scanning files that are source files (have no builder)
     or are derived files and are current (which implies that they exist,

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -142,7 +142,7 @@ FindPathDirs            = SCons.Scanner.FindPathDirs
 Platform                = SCons.Platform.Platform
 Virtualenv              = SCons.Platform.virtualenv.Virtualenv
 Return                  = _SConscript.Return
-Scanner                 = SCons.Scanner.Base
+Scanner                 = SCons.Scanner.ScannerBase
 Tool                    = SCons.Tool.Tool
 WhereIs                 = SCons.Util.WhereIs
 

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -60,7 +60,7 @@ DScanner = SCons.Scanner.D.DScanner()
 LaTeXScanner = SCons.Scanner.LaTeX.LaTeXScanner()
 PDFLaTeXScanner = SCons.Scanner.LaTeX.PDFLaTeXScanner()
 ProgramScanner = SCons.Scanner.Prog.ProgramScanner()
-SourceFileScanner = SCons.Scanner.Base({}, name='SourceFileScanner')
+SourceFileScanner = SCons.Scanner.ScannerBase({}, name='SourceFileScanner')
 SWIGScanner = SCons.Scanner.SWIG.SWIGScanner()
 
 CSuffixes = [".c", ".C", ".cxx", ".cpp", ".c++", ".cc",

--- a/SCons/Tool/install.py
+++ b/SCons/Tool/install.py
@@ -453,9 +453,9 @@ def generate(env):
                               action         = install_action,
                               target_factory = target_factory.Entry,
                               source_factory = env.fs.Entry,
-                              multi          = 1,
+                              multi          = True,
                               emitter        = [ add_targets_to_INSTALLED_FILES, ],
-                              source_scanner = SCons.Scanner.Base( {}, name = 'Install', recursive = False ),
+                              source_scanner = SCons.Scanner.ScannerBase({}, name='Install', recursive=False),
                               name           = 'InstallBuilder')
 
     global BaseVersionedInstallBuilder
@@ -470,7 +470,7 @@ def generate(env):
                                        action         = installVerLib_action,
                                        target_factory = target_factory.Entry,
                                        source_factory = env.fs.Entry,
-                                       multi          = 1,
+                                       multi          = True,
                                        emitter        = [ add_versioned_targets_to_INSTALLED_FILES, ],
                                        name           = 'InstallVersionedBuilder')
 

--- a/SCons/Tool/qt.py
+++ b/SCons/Tool/qt.py
@@ -258,7 +258,7 @@ def uicScannerFunc(node, env, path):
             result.append(dep)
     return result
 
-uicScanner = SCons.Scanner.Base(uicScannerFunc,
+uicScanner = SCons.Scanner.ScannerBase(uicScannerFunc,
                                 name = "UicScanner",
                                 node_class = SCons.Node.FS.File,
                                 node_factory = SCons.Node.FS.File,

--- a/test/CacheDir/scanner-target.py
+++ b/test/CacheDir/scanner-target.py
@@ -53,11 +53,9 @@ def sillyScanner(node, env, dirs):
     print('This is never called (unless we build file.out)')
     return []
 
-SillyScanner = SCons.Scanner.Base(function = sillyScanner, skeys = ['.res'])
+SillyScanner = SCons.Scanner.ScannerBase(function=sillyScanner, skeys=['.res'])
 
-env = Environment(tools=[],
-                  SCANNERS = [SillyScanner],
-                  BUILDERS = {})
+env = Environment(tools=[], SCANNERS=[SillyScanner], BUILDERS={})
 
 r = env.Command('file.res', 'file.ma', docopy)
 

--- a/test/CacheDir/source-scanner.py
+++ b/test/CacheDir/source-scanner.py
@@ -57,11 +57,9 @@ def sillyScanner(node, env, dirs):
     print('This is never called (unless we build file.out)')
     return []
 
-SillyScanner = SCons.Scanner.Base(function = sillyScanner, skeys = ['.res'])
+SillyScanner = SCons.Scanner.ScannerBase(function=sillyScanner, skeys=['.res'])
 
-env = Environment(tools=[],
-                  SCANNERS = [SillyScanner],
-                  BUILDERS = {})
+env = Environment(tools=[], SCANNERS=[SillyScanner], BUILDERS={})
 
 r = env.Command('file.res', 'file.ma', docopy)
 


### PR DESCRIPTION
Maintenance: SCons has multiple classes named `Base`, which is a bit unfortunate.  Some already use a context-qualified name, like `BuilderBase`, which seems preferable.  Do that for `ScannerBase`, but leave the name `Base` in the `SCons.Scanner` package in case *external* users are depending on `SCons.Scanner.Base` working. SCons internally no longer uses that name.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
