### PR TITLE
Bjacklyn/fix keyerror when cloning override environment with boolean override GitHub

### DIFF
--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2381,6 +2381,9 @@ class OverrideEnvironment(Base):
 
     # Methods that make this class act like a proxy.
     def __getattr__(self, name):
+        if '__subject' not in self.__dict__:
+            setattr(self.__dict__, '__subject', {})
+
         attr = getattr(self.__dict__['__subject'], name)
         # Here we check if attr is one of the Wrapper classes. For
         # example when a pseudo-builder is being called from an
@@ -2396,6 +2399,9 @@ class OverrideEnvironment(Base):
             return attr
 
     def __setattr__(self, name, value):
+        if '__subject' not in self.__dict__:
+            setattr(self.__dict__, '__subject', {})
+
         setattr(self.__dict__['__subject'], name, value)
 
     # Methods that make this class act like a dictionary.

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -3887,6 +3887,17 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
         assert env['CPPDEFINES'] == 'FOO', env['CPPDEFINES']
         assert env2['CPPDEFINES'] == ['FOO','BAR'], env2['CPPDEFINES']
 
+    def test_Clone_with_boolean_override(self):
+        """Test cloning an instance of OverrideEnvironment"""
+        env = Environment()
+        env._dict = {'BOOLEAN': None}
+        env2 = OverrideEnvironment(env, {'BOOLEAN': True})
+        env3 = OverrideEnvironment(env2, {'BOOLEAN': False})
+
+        clone_env2 = env2.Clone(BOOLEAN=False)
+        assert clone_env2['BOOLEAN'] == False, clone_env2['BOOLEAN']
+        clone_env3 = env3.Clone(BOOLEAN=True)
+        assert clone_env3['BOOLEAN'] == True, clone_env3['BOOLEAN']
 
 
 class NoSubstitutionProxyTestCase(unittest.TestCase,TestEnvironmentFixture):


### PR DESCRIPTION
Added a test to demonstrate the issue in python3.
```console
$ python3 runtest.py SCons/EnvironmentTests.py
1/1 (100.00%) /usr/bin/python3 SCons/EnvironmentTests.py
...................................................................................E.............................................
======================================================================
ERROR: test_Clone_with_boolean_override (__main__.OverrideEnvironmentTestCase)
Test cloning an instance of OverrideEnvironment
----------------------------------------------------------------------
Traceback (most recent call last):
  File "SCons/EnvironmentTests.py", line 3897, in test_Clone_with_boolean_override
    clone_env2 = env2.Clone(BOOLEAN=False)
  File "/home/brandon/fw/releng/scons/SCons/Environment.py", line 1450, in Clone
    clone = copy.copy(self)
  File "/usr/lib/python3.5/copy.py", line 105, in copy
    return _reconstruct(x, rv, 0)
  File "/usr/lib/python3.5/copy.py", line 298, in _reconstruct
    if hasattr(y, '__setstate__'):
  File "/home/brandon/fw/releng/scons/SCons/Environment.py", line 2384, in __getattr__
    attr = getattr(self.__dict__['__subject'], name)
KeyError: '__subject'

----------------------------------------------------------------------
Ran 129 tests in 1.634s

FAILED (errors=1)
```
And added a commit to fix the bug.
```
$ python3 runtest.py SCons/EnvironmentTests.py
1/1 (100.00%) /usr/bin/python3 SCons/EnvironmentTests.py
.................................................................................................................................
----------------------------------------------------------------------
Ran 129 tests in 1.599s

OK
```

I'm not sure why this only happens in python3, but this change looks possibly related - https://github.com/python/cpython/commit/cbbec1c53f4b6fb88b4ae984e69db2d2951cd560
They added a change to `copy()` to fix how booleans were handled, change is _only_ 6 years old so might not be in python2 :upside_down_face: 