### PR TITLE
Skip unusable javah tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,7 +80,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       if doing SUBST_RAW (issue #4037)
     - Update Util/NodeList implementation to get rid of a workaround for
       early Python 3 slicing issue that is no longer a problem.
-
+    - Rework some Java tests to skip rather than fail on CI systems, where
+      the working java is > v9, but a 1.8 or 9 was also found.
 
   From Brian Quistorff:
     - Fix crash when scons is run from a python environement where a signal

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       introduced by Aaron Franke (listed below) were merged.
     - Further PCH updates. It's now recommended that env['PCH'] should always be a File node.
       Either via return value from env.PCH() or by explicitly using File('StdAfx.pch').
+    - Added --no-ignore-skips to runtest.py. Changed default to ignore skips when setting
+      runtest.py's exit status. Previously would exit 2 if any tests were skipped.
+      Now will only exit 2 if user specifies --no-ignore-skips and some tests were skipped.
 
   From Ryan Egesdahl:
     - Small fix to ensure CLVar default value is an empty list.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -71,7 +71,9 @@ DOCUMENTATION
 DEVELOPMENT
 -----------
 
-- List visible changes in the way SCons is developed
+- Added --no-ignore-skips to runtest.py. Changed default to ignore skips when setting
+  runtest.py's exit status. Previously would exit 2 if any tests were skipped.
+  Now will only exit 2 if user specifies --no-ignore-skips and some tests were skipped.
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/SCons/Tool/javac.py
+++ b/SCons/Tool/javac.py
@@ -1,15 +1,6 @@
-"""SCons.Tool.javac
-
-Tool-specific initialization for javac.
-
-There normally shouldn't be any need to import this module directly.
-It will usually be imported through the generic SCons.Tool.Tool()
-selection method.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -30,7 +21,16 @@ selection method.
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""SCons.Tool.javac
+
+Tool-specific initialization for javac.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+
+"""
+
 
 import os
 import os.path

--- a/SCons/Tool/javah.py
+++ b/SCons/Tool/javah.py
@@ -1,15 +1,6 @@
-"""SCons.Tool.javah
-
-Tool-specific initialization for javah.
-
-There normally shouldn't be any need to import this module directly.
-It will usually be imported through the generic SCons.Tool.Tool()
-selection method.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -29,9 +20,16 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+"""SCons.Tool.javah
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+Tool-specific initialization for javah.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+
+"""
+
 
 import os.path
 

--- a/runtest.py
+++ b/runtest.py
@@ -858,7 +858,6 @@ if args.output:
     if isinstance(sys.stderr, Tee):
         sys.stderr.file.close()
 
-import pdb; pdb.set_trace()
 if fail:
     sys.exit(1)
 elif no_result and args.dont_ignore_skips:

--- a/runtest.py
+++ b/runtest.py
@@ -110,9 +110,9 @@ parser.add_argument('--no-faillog', dest='error_log',
                     default='failed_tests.log',
                     help="Do not log failed tests to a file")
 
-parser.add_argument('--no-ignore-skips', dest='ignore_skips',
-                    action='store_false',
-                    default=True,
+parser.add_argument('--no-ignore-skips', dest='dont_ignore_skips',
+                    action='store_true',
+                    default=False,
                     help="If any tests are skipped, exit status 2")
 
 outctl = parser.add_argument_group(description='Output control options:')
@@ -858,9 +858,10 @@ if args.output:
     if isinstance(sys.stderr, Tee):
         sys.stderr.file.close()
 
+import pdb; pdb.set_trace()
 if fail:
     sys.exit(1)
-elif no_result and args.ignore_skips:
+elif no_result and args.dont_ignore_skips:
     # if no fails, but skips were found
     sys.exit(2)
 else:

--- a/runtest.py
+++ b/runtest.py
@@ -110,6 +110,11 @@ parser.add_argument('--no-faillog', dest='error_log',
                     default='failed_tests.log',
                     help="Do not log failed tests to a file")
 
+parser.add_argument('--no-ignore-skips', dest='ignore_skips',
+                    action='store_false',
+                    default=True,
+                    help="If any tests are skipped, exit status 2")
+
 outctl = parser.add_argument_group(description='Output control options:')
 outctl.add_argument('-k', '--no-progress', action='store_false',
                     dest='print_progress',
@@ -855,7 +860,7 @@ if args.output:
 
 if fail:
     sys.exit(1)
-elif no_result:
+elif no_result and args.ignore_skips:
     # if no fails, but skips were found
     sys.exit(2)
 else:

--- a/test/Java/DerivedSourceTest.py
+++ b/test/Java/DerivedSourceTest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test of javac.py when building java code from derived sources.

--- a/test/Java/JAR.py
+++ b/test/Java/JAR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import TestSCons

--- a/test/Java/JARCHDIR.py
+++ b/test/Java/JARCHDIR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that when JARCHDIR that our command to create .jar files

--- a/test/Java/JARCOM.py
+++ b/test/Java/JARCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $JARCOM construction variable.

--- a/test/Java/JARCOMSTR.py
+++ b/test/Java/JARCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $JARCOMSTR construction variable allows you to configure

--- a/test/Java/JARFLAGS.py
+++ b/test/Java/JARFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,10 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 
 import TestSCons
 

--- a/test/Java/JAVABOOTCLASSPATH.py
+++ b/test/Java/JAVABOOTCLASSPATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that use of $JAVABOOTCLASSPATH sets the -bootclasspath option
@@ -33,19 +32,15 @@ import os
 
 import TestSCons
 
-_python_ = TestSCons._python_
-
 test = TestSCons.TestSCons()
 
 where_javac, java_version = test.java_where_javac()
-where_javah = test.java_where_javah()
 
 test.write('SConstruct', """
-env = Environment(tools = ['javac', 'javah'],
-                  JAVABOOTCLASSPATH = ['dir1', 'dir2'])
-j1 = env.Java(target = 'class', source = 'com/Example1.java')
-j2 = env.Java(target = 'class', source = 'com/Example2.java')
-""" % locals())
+env = Environment(tools=['javac'], JAVABOOTCLASSPATH=['dir1', 'dir2'])
+j1 = env.Java(target='class', source='com/Example1.java')
+j2 = env.Java(target='class', source='com/Example2.java')
+""")
 
 test.subdir('com')
 

--- a/test/Java/JAVAC.py
+++ b/test/Java/JAVAC.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test setting the JAVAC variable.

--- a/test/Java/JAVACCOM.py
+++ b/test/Java/JAVACCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $JAVACCOM construction variable.

--- a/test/Java/JAVACCOMSTR.py
+++ b/test/Java/JAVACCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $JAVACCOMSTR construction variable allows you to configure

--- a/test/Java/JAVACFLAGS.py
+++ b/test/Java/JAVACFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 

--- a/test/Java/JAVACLASSPATH.py
+++ b/test/Java/JAVACLASSPATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that use of $JAVASOURCEPATH allows finding Java .class

--- a/test/Java/JAVACLASSPATH.py
+++ b/test/Java/JAVACLASSPATH.py
@@ -29,6 +29,8 @@ files in alternate locations by adding the -classpath option
 to the javac command line.
 """
 
+import pathlib
+
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -39,11 +41,17 @@ where_javac, java_version = test.java_where_javac()
 where_javah = test.java_where_javah()
 
 # TODO rework for 'javac -h', for now skip
-# The logical test would be:
-# if float(java_version) > 9:
-# but java_where_javac() lies on a multi-java system
+# The logical test would be:  if java_version > 9:
+# but java_where_javah() roots around and will find from an older version
 if not test.Environment().WhereIs('javah'):
     test.skip_test("No Java javah for version > 9, skipping test.\n")
+
+# On some systems, the alternatives system does not remove javah even if the
+# preferred Java doesn't have it, so try another check
+javacdir = pathlib.Path(where_javac).parent
+javahdir = pathlib.Path(where_javah).parent
+if javacdir != javahdir:
+    test.skip_test("Cannot find Java javah matching javac, skipping test.\n")
 
 test.write('SConstruct', """
 env = Environment(tools=['javac', 'javah'])

--- a/test/Java/JAVAH-mock.py
+++ b/test/Java/JAVAH-mock.py
@@ -24,10 +24,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Verify that use of $JAVASOURCEPATH allows finding Java .class
-files in alternate locations by adding the -classpath option
-to the javac command line.
+Test JavaH without calling the tool
+Split from rest of test to allow these to run if real javah skipped.
 """
+
+import os
 
 import TestSCons
 
@@ -35,62 +36,60 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-where_javac, java_version = test.java_where_javac()
-where_javah = test.java_where_javah()
-
-# TODO rework for 'javac -h', for now skip
-# The logical test would be:
-# if float(java_version) > 9:
-# but java_where_javac() lies on a multi-java system
-if not test.Environment().WhereIs('javah'):
-    test.skip_test("No Java javah for version > 9, skipping test.\n")
+test.write('myjavah.py', r"""
+import sys
+args = sys.argv[1:]
+while args:
+    a = args[0]
+    if a == '-d':
+        outdir = args[1]
+        args = args[1:]
+    elif a == '-o':
+        outfile = open(args[1], 'w')
+        args = args[1:]
+    elif a == '-classpath':
+        args = args[1:]
+    elif a == '-sourcepath':
+        args = args[1:]
+    else:
+        break
+    args = args[1:]
+for file in args:
+    infile = open(file, 'r')
+    for l in infile.readlines():
+        if l[:9] != '/*javah*/':
+            outfile.write(l)
+sys.exit(0)
+""")
 
 test.write('SConstruct', """
-env = Environment(tools=['javac', 'javah'])
-j1 = env.Java(target='class1', source='com.1/Example1.java')
-j2 = env.Java(target='class2', source='com.2/Example2.java')
-env.JavaH(target='outdir', source=[j1, j2], JAVACLASSPATH='class2')
+env = Environment(tools=['javah'], JAVAH=r'%(_python_)s myjavah.py')
+env.JavaH(target=File('test1.h'), source='test1.java')
 """ % locals())
 
-test.subdir('com.1', 'com.2')
-
-test.write(['com.1', 'Example1.java'], """\
-package com;
-
-public class Example1
-{
-
-     public static void main(String[] args)
-     {
-
-     }
-
-}
+test.write('test1.java', """\
+test1.java
+/*javah*/
+line 3
 """)
 
-test.write(['com.2', 'Example2.java'], """\
-package com;
+test.run(arguments='.', stderr=None)
+test.must_match('test1.h', "test1.java\nline 3\n", mode='r')
 
-public class Example2
-{
+if os.path.normcase('.java') == os.path.normcase('.JAVA'):
+    test.write('SConstruct', """\
+env = Environment(tools=['javah'], JAVAH=r'%(_python_)s myjavah.py')
+env.JavaH(target=File('test2.h'), source='test2.JAVA')
+""" % locals())
 
-     public static void main(String[] args)
-     {
-
-     }
-
-}
+    test.write('test2.JAVA', """\
+test2.JAVA
+/*javah*/
+line 3
 """)
 
-test.run(arguments = '.')
-
-test.must_exist(['class1', 'com', 'Example1.class'])
-test.must_exist(['class2', 'com', 'Example2.class'])
-
-test.must_exist(['outdir', 'com_Example1.h'])
-test.must_exist(['outdir', 'com_Example2.h'])
-
-test.up_to_date(arguments = '.')
+    test.run(arguments='.', stderr=None)
+    test.must_match('test2.h', "test2.JAVA\nline 3\n", mode='r')
 
 test.pass_test()
 

--- a/test/Java/JAVAH.py
+++ b/test/Java/JAVAH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 

--- a/test/Java/JAVAHCOM.py
+++ b/test/Java/JAVAHCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $JAVAHCOM construction variable.
@@ -37,11 +36,13 @@ test = TestSCons.TestSCons()
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(TOOLS = ['default', 'javah'],
-                  JAVAHCOM = r'%(_python_)s mycompile.py javah $TARGET $SOURCES')
-env.JavaH(target = 'out', source = 'file1.class')
-env.JavaH(target = 'out', source = 'file2.class')
-env.JavaH(target = 'out', source = 'file3.class')
+env = Environment(
+    TOOLS=['default', 'javah'],
+    JAVAHCOM=r'%(_python_)s mycompile.py javah $TARGET $SOURCES',
+)
+env.JavaH(target='out', source='file1.class')
+env.JavaH(target='out', source='file2.class')
+env.JavaH(target='out', source='file3.class')
 """ % locals())
 
 test.write('file1.class', "file1.class\n/*javah*/\n")

--- a/test/Java/JAVAHCOMSTR.py
+++ b/test/Java/JAVAHCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $JAVAHCOMSTR construction variable allows you to configure
@@ -46,12 +45,14 @@ out_file3_h = os.path.join('out', 'file3.h')
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(TOOLS = ['default', 'javah'],
-                  JAVAHCOM = r'%(_python_)s mycompile.py javah $TARGET $SOURCES',
-                  JAVAHCOMSTR = 'Building javah $TARGET from $SOURCES')
-env.JavaH(target = 'out', source = 'file1.class')
-env.JavaH(target = 'out', source = 'file2.class')
-env.JavaH(target = 'out', source = 'file3.class')
+env = Environment(
+    TOOLS=['default', 'javah'],
+    JAVAHCOM=r'%(_python_)s mycompile.py javah $TARGET $SOURCES',
+    JAVAHCOMSTR='Building javah $TARGET from $SOURCES',
+)
+env.JavaH(target='out', source='file1.class')
+env.JavaH(target='out', source='file2.class')
+env.JavaH(target='out', source='file3.class')
 """ % locals())
 
 test.write('file1.class', "file1.class\n/*javah*/\n")

--- a/test/Java/JAVASOURCEPATH.py
+++ b/test/Java/JAVASOURCEPATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that use of $JAVASOURCEPATH allows finding source .java
@@ -32,18 +31,16 @@ to the javac command line.
 
 import TestSCons
 
-_python_ = TestSCons._python_
-
 test = TestSCons.TestSCons()
 
 where_javac, java_version = test.java_where_javac()
 
 test.write('SConstruct', """
-env = Environment(tools = ['javac', 'javah'])
-bar = env.Java(target = 'bar/classes',
-         source = 'bar/src/TestBar.java',
-         JAVASOURCEPATH = ['foo/src'])
-""" % locals())
+env = Environment(tools=['javac'])
+bar = env.Java(
+    target='bar/classes', source='bar/src/TestBar.java', JAVASOURCEPATH=['foo/src']
+)
+""")
 
 test.subdir('foo',
             ['foo', 'src'],

--- a/test/Java/Java-1.4.py
+++ b/test/Java/Java-1.4.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test Java compilation with a live Java 1.4 "javac" compiler.

--- a/test/Java/Java-1.5.py
+++ b/test/Java/Java-1.5.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test Java compilation with a live Java 1.5 "javac" compiler.

--- a/test/Java/Java-1.6.py
+++ b/test/Java/Java-1.6.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
-#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -20,8 +18,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test Java compilation with a live Java 1.6 "javac" compiler.

--- a/test/Java/Java-1.8.py
+++ b/test/Java/Java-1.8.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test Java compilation with a live Java 1.8 "javac" compiler.

--- a/test/Java/RMIC.py
+++ b/test/Java/RMIC.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 

--- a/test/Java/RMICCOM.py
+++ b/test/Java/RMICCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $RMICCOM construction variable.

--- a/test/Java/RMICCOMSTR.py
+++ b/test/Java/RMICCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $RMICCOMSTR construction variable allows you to configure

--- a/test/Java/jar_not_in_PATH.py
+++ b/test/Java/jar_not_in_PATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Ensures that the Tool gets initialized, even when jar is not directly

--- a/test/Java/multi-step.py
+++ b/test/Java/multi-step.py
@@ -26,6 +26,8 @@
 """
 Real-world test (courtesy Leanid Nazdrynau) of the multi-step
 capabilities of the various Java Builders.
+
+TODO: the whole Applet facility is deprecated, need a new test.
 """
 
 import os
@@ -50,27 +52,36 @@ if not swig:
 if test.javac_is_gcj:
     test.skip_test('Test not valid for gcj (gnu java); skipping test(s).\n')
 
-test.subdir(['src'],
-            ['src', 'HelloApplet'],
-            ['src', 'HelloApplet', 'com'],
-            ['src', 'javah'],
-            ['src', 'jni'],
-            ['src', 'server'],
-            ['src', 'server', 'JavaSource'],
-            ['src', 'server', 'JavaSource', 'com'],
-            ['src', 'server', 'JavaSource', 'com', 'gnu'],
-            ['src', 'server', 'JavaSource', 'com', 'gnu', 'scons'],
-            ['src', 'server', 'JavaSource', 'com', 'gnu', 'scons', 'web'],
-            ['src', 'server', 'JavaSource', 'com', 'gnu', 'scons', 'web', 'tools'],
-            ['src', 'server', 'WebContent'],
-            ['src', 'server', 'WebContent', 'META-INF'],
-            ['src', 'server', 'WebContent', 'WEB-INF'],
-            ['src', 'server', 'WebContent', 'WEB-INF', 'conf'],
-            ['src', 'server', 'WebContent', 'WEB-INF', 'lib'],
-            ['src', 'server', 'WebContent', 'theme'])
+# TODO rework for 'javac -h', for now skip
+# The logical test would be:
+# if float(java_version) > 9:
+# but java_where_javac() lies on a multi-java system
+if not test.Environment().WhereIs('javah'):
+    test.skip_test("No Java javah for version > 9, skipping test.\n")
+
+test.subdir(
+    ['src'],
+    ['src', 'HelloApplet'],
+    ['src', 'HelloApplet', 'com'],
+    ['src', 'javah'],
+    ['src', 'jni'],
+    ['src', 'server'],
+    ['src', 'server', 'JavaSource'],
+    ['src', 'server', 'JavaSource', 'com'],
+    ['src', 'server', 'JavaSource', 'com', 'gnu'],
+    ['src', 'server', 'JavaSource', 'com', 'gnu', 'scons'],
+    ['src', 'server', 'JavaSource', 'com', 'gnu', 'scons', 'web'],
+    ['src', 'server', 'JavaSource', 'com', 'gnu', 'scons', 'web', 'tools'],
+    ['src', 'server', 'WebContent'],
+    ['src', 'server', 'WebContent', 'META-INF'],
+    ['src', 'server', 'WebContent', 'WEB-INF'],
+    ['src', 'server', 'WebContent', 'WEB-INF', 'conf'],
+    ['src', 'server', 'WebContent', 'WEB-INF', 'lib'],
+    ['src', 'server', 'WebContent', 'theme'],
+)
 
 test.write(['SConstruct'], """\
-import os,sys
+import os, sys
 
 if sys.platform == 'win32':
     # Ensure tests don't pick up link from mingw or cygwin
@@ -78,31 +89,35 @@ if sys.platform == 'win32':
 else:
     tools = ['default', 'javac', 'javah', 'swig']
 
-env=Environment(tools = tools,
-                CPPPATH=["$JAVAINCLUDES"])
+env = Environment(tools=tools, CPPPATH=["$JAVAINCLUDES"])
 Export('env')
 # env.PrependENVPath('PATH',os.environ.get('PATH',[]))
-env['INCPREFIX']='-I'
-env.Append(SWIGFLAGS=['-c++','$_CPPINCFLAGS'])
+env['INCPREFIX'] = '-I'
+env.Append(SWIGFLAGS=['-c++', '$_CPPINCFLAGS'])
 
-#this is for JNI
-#env.Append(CCFLAGS=['/IN:/jdk/v1.3.1/include','/IN:/jdk/v1.3.1/include/win32'])
+# this is for JNI
+# env.Append(CCFLAGS=['/IN:/jdk/v1.3.1/include','/IN:/jdk/v1.3.1/include/win32'])
 
-#this for windows only C++ build
-#env.Append(CXXFLAGS='-GX')
+# this for windows only C++ build
+# env.Append(CXXFLAGS='-GX')
 
 env.Append(CPPPATH='.')
 
 env.VariantDir('buildout', 'src', duplicate=0)
 
-if sys.platform[:6]=='darwin':
-   env.Append(CPPPATH=['/System/Library/Frameworks/JavaVM.framework/Headers'])
+if sys.platform[:6] == 'darwin':
+    env.Append(CPPPATH=['/System/Library/Frameworks/JavaVM.framework/Headers'])
 
-#If you do not have swig on your system please remove 'buildout/jni/SConscript' line from next call
-env.SConscript(['buildout/server/JavaSource/SConscript',
-                'buildout/HelloApplet/SConscript',
-                'buildout/jni/SConscript',
-                'buildout/javah/SConscript'])
+# If you do not have swig on your system please remove
+# 'buildout/jni/SConscript' line from next call
+env.SConscript(
+    [
+        'buildout/server/JavaSource/SConscript',
+        'buildout/HelloApplet/SConscript',
+        'buildout/jni/SConscript',
+        'buildout/javah/SConscript',
+    ]
+)
 """ % locals())
 
 test.write(['src', 'HelloApplet', 'Hello.html'], """\
@@ -123,21 +138,20 @@ test.write(['src', 'HelloApplet', 'Hello.html'], """\
 
 test.write(['src', 'HelloApplet', 'SConscript'], """\
 import os
-Import ("env")
-denv=env.Clone()
-classes=denv.Java(target='classes',source=['com'])
-#set correct path for jar
-denv['JARCHDIR']=os.path.join(denv.Dir('.').get_abspath(),'classes')
-denv.Jar('HelloApplet',classes)
 
+Import("env")
+denv = env.Clone()
+classes = denv.Java(target='classes', source=['com'])
+# set correct path for jar
+denv['JARCHDIR'] = os.path.join(denv.Dir('.').get_abspath(), 'classes')
+denv.Jar('HelloApplet', classes)
 
-#To sign applet you have to create keystore before and made a calls like this
+# To sign applet you have to create keystore before and made a calls like this
 
-#keystore='/path/to/jarsignkey'
-#denv['JARSIGNFLAGS']='-keystore '+keystore+' -storepass pass -keypass passkey'
-#denv['JARSIGNALIAS']='ALIAS'
-#denv['JARCOM']=[denv['JARCOM'],'$JARSIGNCOM']
-
+# keystore='/path/to/jarsignkey'
+# denv['JARSIGNFLAGS']='-keystore '+keystore+' -storepass pass -keypass passkey'
+# denv['JARSIGNALIAS']='ALIAS'
+# denv['JARCOM']=[denv['JARCOM'],'$JARSIGNCOM']
 """)
 
 test.write(['src', 'HelloApplet', 'com', 'Hello.java'], """\
@@ -179,12 +193,11 @@ public class MyID
 
 test.write(['src', 'javah', 'SConscript'], """\
 Import('env')
-denv=env.Clone()
-denv['JARCHDIR']=denv.Dir('.').get_abspath()
-denv.Jar('myid','MyID.java')
-denv.JavaH(denv.Dir('.').get_abspath(),'MyID.java')
-denv.SharedLibrary('myid','MyID.cc')
-
+denv = env.Clone()
+denv['JARCHDIR'] = denv.Dir('.').get_abspath()
+denv.Jar('myid', 'MyID.java')
+denv.JavaH(denv.Dir('.').get_abspath(), 'MyID.java')
+denv.SharedLibrary('myid', 'MyID.cc')
 """)
 
 test.write(['src', 'jni', 'A.java'], """\
@@ -225,8 +238,6 @@ test.write(['src', 'jni', 'JniWrapper.cc'], """\
 
 #include "JniWrapper.h"
 
-
-
 JniWrapper::JniWrapper( JNIEnv *pEnv )
     : mpEnv( pEnv )
 {
@@ -239,7 +250,6 @@ JniWrapper::JniWrapper( const JniWrapper& rJniWrapper )
 
 JniWrapper::~JniWrapper()
 {
-
 }
 
 JniWrapper& JniWrapper::operator=( const JniWrapper& rJniWrapper )
@@ -373,13 +383,13 @@ private:
 """)
 
 test.write(['src', 'jni', 'SConscript'], """\
-Import ("env")
-denv=env.Clone()
+Import("env")
+denv = env.Clone()
 
 denv.Append(SWIGFLAGS=['-java'])
-denv.SharedLibrary('scons',['JniWrapper.cc','Sample.i'])
-denv['JARCHDIR']=denv.Dir('.').get_abspath()
-denv.Jar(['Sample.i','A.java'])
+denv.SharedLibrary('scons', ['JniWrapper.cc', 'Sample.i'])
+denv['JARCHDIR'] = denv.Dir('.').get_abspath()
+denv.Jar(['Sample.i', 'A.java'])
 """)
 
 test.write(['src', 'jni', 'Sample.h'], """\

--- a/test/Java/multi-step.py
+++ b/test/Java/multi-step.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,8 +27,6 @@
 Real-world test (courtesy Leanid Nazdrynau) of the multi-step
 capabilities of the various Java Builders.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 

--- a/test/Java/multi-step.py
+++ b/test/Java/multi-step.py
@@ -31,6 +31,7 @@ TODO: the whole Applet facility is deprecated, need a new test.
 """
 
 import os
+import pathlib
 
 import TestSCons
 
@@ -53,11 +54,17 @@ if test.javac_is_gcj:
     test.skip_test('Test not valid for gcj (gnu java); skipping test(s).\n')
 
 # TODO rework for 'javac -h', for now skip
-# The logical test would be:
-# if float(java_version) > 9:
-# but java_where_javac() lies on a multi-java system
+# The logical test would be:  if java_version > 9:
+# but java_where_javah() roots around and will find from an older version
 if not test.Environment().WhereIs('javah'):
     test.skip_test("No Java javah for version > 9, skipping test.\n")
+
+# On some systems, the alternatives system does not remove javah even if the
+# preferred Java doesn't have it, so try another check
+javacdir = pathlib.Path(where_javac).parent
+javahdir = pathlib.Path(where_javah).parent
+if javacdir != javahdir:
+    test.skip_test("Cannot find Java javah matching javac, skipping test.\n")
 
 test.subdir(
     ['src'],

--- a/test/Java/nested-classes.py
+++ b/test/Java/nested-classes.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,14 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test Java compilation with inner and anonymous classes (Issue 2087).
 """
-
 
 import TestSCons
 

--- a/test/Java/no-JARCHDIR.py
+++ b/test/Java/no-JARCHDIR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the Jar() behavior when we have no JARCHDIR set (it should

--- a/test/Java/rmic_not_in_PATH.py
+++ b/test/Java/rmic_not_in_PATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Ensures that the Tool gets initialized, even when rmic is not directly

--- a/test/Java/source-files.py
+++ b/test/Java/source-files.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can pass the Java() builder explicit lists of .java
@@ -31,8 +30,6 @@ files as sources.
 
 import TestSCons
 
-_python_ = TestSCons._python_
-
 test = TestSCons.TestSCons()
 
 # Keep this logic because it skips the test if javac or jar not found.
@@ -40,10 +37,10 @@ where_javac, java_version = test.java_where_javac()
 where_jar = test.java_where_jar()
 
 test.write('SConstruct', """
-env = Environment(tools = ['javac', 'javah'])
-env.Java(target = 'class1', source = 'com/Example1.java')
-env.Java(target = 'class2', source = ['com/Example2.java', 'com/Example3.java'])
-""" % locals())
+env = Environment(tools=['javac'])
+env.Java(target='class1', source='com/Example1.java')
+env.Java(target='class2', source=['com/Example2.java', 'com/Example3.java'])
+""")
 
 test.subdir('com', 'src')
 

--- a/test/Java/swig-dependencies.py
+++ b/test/Java/swig-dependencies.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that dependencies on SWIG-generated .java files work correctly.
@@ -39,8 +38,6 @@ if not swig:
     test.skip_test('Can not find installed "swig", skipping test.\n')
 
 where_javac, java_version = test.java_where_javac()
-where_javah = test.java_where_javah()
-
 where_java_include=test.java_where_includes()
 
 test.subdir(['foo'],
@@ -50,11 +47,11 @@ test.subdir(['foo'],
 test.write(['SConstruct'], """\
 import os
 
-env = Environment(ENV = os.environ)
+env = Environment(ENV=os.environ)
 if env['PLATFORM'] != 'win32':
-    env.Append(CPPFLAGS = ' -g -Wall')
-env['CPPPATH'] ='$JAVAINCLUDES'
-        
+    env.Append(CPPFLAGS=' -g -Wall')
+env['CPPPATH'] = '$JAVAINCLUDES'
+
 Export('env')
 
 SConscript('#foo/SConscript')

--- a/test/Repository/JavaH.py
+++ b/test/Repository/JavaH.py
@@ -28,6 +28,7 @@ Test building Java applications when using Repositories.
 """
 
 import os
+import pathlib
 
 import TestSCons
 
@@ -38,6 +39,13 @@ test = TestSCons.TestSCons()
 where_javac, java_version = test.java_where_javac()
 where_java = test.java_where_java()
 where_javah = test.java_where_javah()
+
+# On some systems, the alternatives system does not remove javah even if the
+# preferred Java doesn't have it, check the paths just in case.
+javacdir = pathlib.Path(where_javac).parent
+javahdir = pathlib.Path(where_javah).parent
+if javacdir != javahdir:
+    test.skip_test("Cannot find Java javah matching javac, skipping test.\n")
 
 java = where_java
 javac = where_javac
@@ -58,7 +66,7 @@ test.subdir(
     ['rep1', 'src'],
     'work1',
     'work2',
-    'work3'
+    'work3',
 )
 
 #

--- a/test/Repository/JavaH.py
+++ b/test/Repository/JavaH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test building Java applications when using Repositories.
@@ -44,13 +43,23 @@ java = where_java
 javac = where_javac
 javah = where_javah
 
+# TODO: javah no longer exists for Java > 9.  Other tests fail
+# on certain systems because the java_where_* routines are very greedy
+# and may indicate it's found even if the working java is > 9 if there
+# was a 1.8 insallation present - and then at runtime it's not found.
+# In this case we actually pass the javac/javah that's found by those,
+# which means the test will seem to work. We still need to rework this.
+
 ###############################################################################
 
 #
-test.subdir('rep1', ['rep1', 'src'],
-            'work1',
-            'work2',
-            'work3')
+test.subdir(
+    'rep1',
+    ['rep1', 'src'],
+    'work1',
+    'work2',
+    'work3'
+)
 
 #
 rep1_classes = test.workpath('rep1', 'classes')
@@ -62,11 +71,9 @@ opts = '-Y ' + test.workpath('rep1')
 
 #
 test.write(['rep1', 'SConstruct'], """
-env = Environment(tools = ['javac', 'javah'],
-                  JAVAC = r'"%s"',
-                  JAVAH = r'"%s"')
-classes = env.Java(target = 'classes', source = 'src')
-env.JavaH(target = 'outdir', source = classes)
+env = Environment(tools=['javac', 'javah'], JAVAC=r'"%s"', JAVAH=r'"%s"')
+classes = env.Java(target='classes', source='src')
+env.JavaH(target='outdir', source=classes)
 """ % (javac, javah))
 
 test.write(['rep1', 'src', 'Foo1.java'], """\
@@ -206,11 +213,9 @@ test.up_to_date(chdir = 'work2', options = opts, arguments = ".")
 
 #
 test.write(['work3', 'SConstruct'], """
-env = Environment(tools = ['javac', 'javah'],
-                  JAVAC = r'"%s"',
-                  JAVAH = r'"%s"')
-classes = env.Java(target = 'classes', source = 'src')
-hfiles = env.JavaH(target = 'outdir', source = classes)
+env = Environment(tools=['javac', 'javah'], JAVAC=r'"%s"', JAVAH=r'"%s"')
+classes = env.Java(target='classes', source='src')
+hfiles = env.JavaH(target='outdir', source=classes)
 Local(hfiles)
 """ % (javac, javah))
 

--- a/test/runtest/baseline/no_result.py
+++ b/test/runtest/baseline/no_result.py
@@ -48,10 +48,16 @@ expect_stderr = """\
 NO RESULT TEST STDERR
 """
 
-test.run(arguments='-k -b . test/no_result.py',
+test.run(arguments='--no-ignore-skips -k -b . test/no_result.py',
          status=2,
          stdout=expect_stdout,
          stderr=expect_stderr)
+
+test.run(arguments='-k -b . test/no_result.py',
+         status=0,
+         stdout=expect_stdout,
+         stderr=expect_stderr)
+
 
 test.pass_test()
 

--- a/test/runtest/simple/no_result.py
+++ b/test/runtest/simple/no_result.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test how we handle a no-results test specified on the command line.
@@ -48,10 +47,16 @@ expect_stderr = """\
 NO RESULT TEST STDERR
 """
 
-test.run(arguments='-k test/no_result.py',
+test.run(arguments='--no-ignore-skips -k test/no_result.py',
          status=2,
          stdout=expect_stdout,
          stderr=expect_stderr)
+
+test.run(arguments='-k test/no_result.py',
+         status=0,
+         stdout=expect_stdout,
+         stderr=expect_stderr)
+
 
 test.pass_test()
 


### PR DESCRIPTION
For the three tests which fail, skip if the command finder (`WhereIs`), which  is much less aggressive than the `java_where_j*` routines, doesn't find `javah`.
    
Split the `JAVAH` test file into two files, so that the part which doesn't call javah can run even if the rest is skipped.
    
Header cleanup and partial Black reformats (test SConstructs) for Java tests.
    
Leave a comment in the `Repository/JavaH` test, and do some reformatting there as well.  Test needs rework, but for now doesn't fail so leave alone.

Remove references to javah that were not used

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
