### PR TITLE
build SCons packages with python tool 'build'

### DIFF
--- a/.github/workflows/scons-package.yml
+++ b/.github/workflows/scons-package.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel build
         #python -m pip install flake8 pytest
         if [ -f requirements-pkg.txt ]; then pip install -r requirements-pkg.txt; elif [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         sudo apt-get update

--- a/ReleaseConfig
+++ b/ReleaseConfig
@@ -27,9 +27,9 @@
 
 # The version tuple that will be used for the release.  The fields are
 # (major, minor, micro, type, patchlevel).  The release level is one of
-# 'alpha', 'beta', 'candidate', or 'final'.  If the release type is not
-# 'final', the patchlevel is set to the release date.  This value is
-# mandatory and must be present in this file.
+# 'a' (alpha), 'b' (beta), 'rc' (release candidate), or 'final'.
+# If the release type is not 'final', the patchlevel is set to the
+# release date.  This value is mandatory and must be present in this file.
 #version_tuple = (2, 2, 0, 'final', 0)
 version_tuple = (4, 5, 2, 'a', 0)
 

--- a/SConstruct
+++ b/SConstruct
@@ -209,10 +209,13 @@ wheel = env.Command(
     action='$PYTHON -m build --outdir $DISTDIR',
 )
 
-# Do we actually need this one?
-# zip_file = env.Command('$DISTDIR/SCons-${VERSION}.zip', ['setup.cfg', 'setup.py', 'SCons/__init__.py']+man_pages,
-#            #'$PYTHON setup.py sdist --format=zip')
-#            '$PYTHON setup.py sdist --format=zip')
+# TODO: this is built the old way, because "build" doesn't make zipfiles,
+# and it deletes its isolated env so we can't just zip that one up.
+zip_file = env.Command(
+    target='$DISTDIR/SCons-${VERSION}.zip',
+    source=['setup.cfg', 'setup.py', 'SCons/__init__.py'] + man_pages,
+    action='$PYTHON setup.py sdist --format=zip',
+)
 
 # Now set depends so the above run in a particular order
 # NOTE: 'build' with default options builds sdist, then whl from sdist,

--- a/SConstruct
+++ b/SConstruct
@@ -196,20 +196,28 @@ Export('command_line', 'env', 'whereis', 'revaction')
 SConscript('doc/SConscript')
 
 
-# Copy manpage's into base dir for inclusion in pypi packages
+# Copy manpages into base dir for inclusion in pypi packages
 man_pages = env.Install("#/", Glob("#/build/doc/man/*.1"))
 
-# Build packages for pypi
-wheel = env.Command('$DISTDIR/SCons-${VERSION}-py3-none-any.whl', ['setup.cfg', 'setup.py', 'SCons/__init__.py']+man_pages,
-            '$PYTHON setup.py bdist_wheel')
+# Build packages for pypi. 'build' makes sdist (tgz) + whl
+wheel = env.Command(
+    target=[
+        '$DISTDIR/SCons-${VERSION}-py3-none-any.whl',
+        '$DISTDIR/SCons-${VERSION}.tar.gz',
+    ],
+    source=['setup.cfg', 'setup.py', 'SCons/__init__.py'] + man_pages,
+    action='$PYTHON -m build --outdir $DISTDIR',
+)
 
-zip_file = env.Command('$DISTDIR/SCons-${VERSION}.zip', ['setup.cfg', 'setup.py', 'SCons/__init__.py']+man_pages,
-            '$PYTHON setup.py sdist --format=zip')
-tgz_file = env.Command('$DISTDIR/SCons-${VERSION}.tar.gz', ['setup.cfg', 'setup.py', 'SCons/__init__.py']+man_pages,
-            '$PYTHON setup.py sdist --format=gztar')
+# Do we actually need this one?
+# zip_file = env.Command('$DISTDIR/SCons-${VERSION}.zip', ['setup.cfg', 'setup.py', 'SCons/__init__.py']+man_pages,
+#            #'$PYTHON setup.py sdist --format=zip')
+#            '$PYTHON setup.py sdist --format=zip')
 
 # Now set depends so the above run in a particular order
-env.Depends(tgz_file, [zip_file, wheel])
+# NOTE: 'build' with default options builds sdist, then whl from sdist,
+# so it's already ordered.
+# env.Depends(tgz_file, [zip_file, wheel])
 
 # NOTE: Commenting this out as the manpages are expected to be in the base directory when manually
 # running setup.py from the base of the repo.

--- a/requirements-pkg.txt
+++ b/requirements-pkg.txt
@@ -11,3 +11,5 @@ readme-renderer
 sphinx < 6.0
 sphinx-book-theme
 rst2pdf
+
+build

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,10 @@ classifiers =
 [options]
 zip_safe = False
 python_requires = >=3.6
-install_requires =
+install_requires = setuptools
+setup_requires =
     setuptools
-
-setup_requires = setuptools
+    build
 include_package_data = True
 packages = find:
 


### PR DESCRIPTION
Pushed to see if the GH Action will build this way (works locally).  This an experiment to respond to the Py Packaging Authority's plea to "not call setup.py directly, use one of the tools".  Don't see how to build the .zip file of the package this way, so at the moment that's commented out, with a question of whether we need. Does build the zipfile of the portable version.  Updated: restored the old way of building the sdist-zipfile.

Update: this does seem to work, but I'll leave it as WIP, and it can be grabbed if wanted.

Changes only SCons' own build, not SCons itself, so no docs/tests/etc.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
