### PR TITLE
Remove -prerelease for MSVC 2022

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Joseph Brill:
     - Fix MSVS tests (vs-N.N-exec.py) for MSVS 6.0, 7.0, and 7.1 (import missing module).
-    - Add support for Visual Studio 2022 (release and prerelease).
+    - Add support for Visual Studio 2022.
 
   From William Deegan:
     - Fix reproducible builds. Restore logic respecting SOURCE_DATE_EPOCH when set.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -10,7 +10,6 @@ NEW FUNCTIONALITY
 -----------------
 
 - Add support for Visual Studio 2022.
-- Add support for pre-release versions of Visual Studio 2022 via an environment variable.
 - Added ninja API 'NINJA_FORCE_SCONS_BUILD' to force a node to callback to scons.
 
 DEPRECATED FUNCTIONALITY

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -228,10 +228,6 @@ def get_host_target(env):
 
     return (host, target, req_target_platform)
 
-# Enable prerelease version(s) via vswhere query argument.
-# When enabled, an installed prerelease version will likely be the default msvc version.
-_MSVC_CHECK_PRERELEASE = os.environ.get('MSVC_CHECK_PRERELEASE') in ('1', 'true', 'True')
-
 # If you update this, update SupportedVSList in Tool/MSCommon/vs.py, and the
 # MSVC_VERSION documentation in Tool/msvc.xml.
 _VCVER = [
@@ -252,22 +248,18 @@ _VCVER = [
 _VCVER_TO_VSWHERE_VER = {
     '14.3': [
         ["-version", "[17.0, 18.0)"], # default: Enterprise, Professional, Community  (order unpredictable?)
-        ["-version", "[17.0, 18.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"], # BuildTools
-        ] + [
-        # TODO: remove after VS 2022 is released
-        ["-prerelease", "-version", "[17.0, 18.0)"], # default: Enterprise, Professional, Community  (order unpredictable?)
-        ["-prerelease", "-version", "[17.0, 18.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"], # BuildTools
-        ] if _MSVC_CHECK_PRERELEASE else [],
+        ["-version", "[17.0, 18.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
+        ],
     '14.2': [
         ["-version", "[16.0, 17.0)"], # default: Enterprise, Professional, Community  (order unpredictable?)
-        ["-version", "[16.0, 17.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"], # BuildTools
+        ["-version", "[16.0, 17.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
         ],
     '14.1':    [
         ["-version", "[15.0, 16.0)"], # default: Enterprise, Professional, Community (order unpredictable?)
-        ["-version", "[15.0, 16.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"], # BuildTools
+        ["-version", "[15.0, 16.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
         ],
     '14.1Exp': [
-        ["-version", "[15.0, 16.0)", "-products", "Microsoft.VisualStudio.Product.WDExpress"], # Express
+        ["-version", "[15.0, 16.0)", "-products", "Microsoft.VisualStudio.Product.WDExpress"],  # Express
         ],
 }
 


### PR DESCRIPTION
Remove prerelease flag for MSVC 2022 in prep for SCons 4.3 release and MSVC 2022 release.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
