### PR TITLE
Deprecate qt tool and rearrange docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -93,8 +93,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       on version selection to docs.
       Update docs on JavaH tool in light of javah command dropped since 10.0. 
       Try to be better about preserving user's passed-in JAVA* construction vars.
-    - Depracate the qt tool, which refers to Qt3 (usupported since around
-      2006).
+    - Start the deprecation of the qt tool, which refers to Qt3 (usupported
+      since around 2006). There's a deprecation warning added, initially
+      defaulting to disabled.
 
   From Brian Quistorff:
     - Fix crash when scons is run from a python environement where a signal

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -93,6 +93,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       on version selection to docs.
       Update docs on JavaH tool in light of javah command dropped since 10.0. 
       Try to be better about preserving user's passed-in JAVA* construction vars.
+    - Depracate the qt tool, which refers to Qt3 (usupported since around
+      2006).
 
   From Brian Quistorff:
     - Fix crash when scons is run from a python environement where a signal

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -15,7 +15,8 @@ NEW FUNCTIONALITY
 DEPRECATED FUNCTIONALITY
 ------------------------
 
-- List anything that's been deprecated since the last release
+- The qt tool, which targets Qt version 3, is deprecated. Qt3 has been unsupported by
+  upstream for many years.  Qt4 and Qt5 tools are available from scons-contrib.
 
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------

--- a/SCons/Tool/qt.py
+++ b/SCons/Tool/qt.py
@@ -38,6 +38,7 @@ import SCons.Scanner
 import SCons.Tool
 import SCons.Util
 import SCons.Tool.cxx
+import SCons.Warnings
 cplusplus = SCons.Tool.cxx
 
 class ToolQtWarning(SCons.Warnings.SConsWarning):
@@ -269,6 +270,10 @@ def generate(env):
     CLVar = SCons.Util.CLVar
     Action = SCons.Action.Action
     Builder = SCons.Builder.Builder
+
+    SCons.Warnings.warn(
+        SCons.Warnings.ToolQtDeprecatedWarning, "Tool module for Qt version 3 is deprecated"
+    )
 
     env.SetDefault(QTDIR  = _detect(env),
                    QT_BINPATH = os.path.join('$QTDIR', 'bin'),

--- a/SCons/Tool/qt.xml
+++ b/SCons/Tool/qt.xml
@@ -26,7 +26,91 @@ See its __doc__ string for a discussion of the format.
 <tool name="qt">
 <summary>
 <para>
-Sets construction variables for building Qt applications.
+Sets &consvars; for building Qt3 applications.
+</para>
+
+<note><para>
+This tool is only suitable for building targeted to Qt3,
+which is obsolete.
+There are contributed tools for Qt4 and Qt5,
+see
+<ulink url="https://github.com/SCons/scons/wiki/ToolsIndex">
+https://github.com/SCons/scons/wiki/ToolsIndex
+</ulink>.
+Qt4 has also passed end of life for standard support (in Dec 2015).
+</para></note>
+
+<para>
+Note paths for these &consvars; are assembled
+using the <function>os.path.join</function> method
+so they will have the appropriate separator at runtime,
+but are listed here in the various
+entries with the <literal>'/'</literal> separator
+for easier reading.
+</para>
+
+<para>
+In addition, the &consvars;
+&cv-link-CPPPATH;,
+&cv-link-LIBPATH; and
+&cv-link-LIBS; may be modified
+and the variables
+&cv-link-PROGEMITTER;, &cv-link-SHLIBEMITTER; and &cv-link-LIBEMITTER;
+are modified. Because the build-performance is affected when using this tool,
+you have to explicitly specify it at Environment creation:
+</para>
+
+<example_commands>
+Environment(tools=['default','qt'])
+</example_commands>
+
+<para>
+The &t-qt; tool supports the following operations:
+</para>
+
+<para>
+<emphasis role="strong">Automatic moc file generation from header files.</emphasis>
+You do not have to specify moc files explicitly, the tool does it for you.
+However, there are a few preconditions to do so: Your header file must have
+the same filebase as your implementation file and must stay in the same
+directory. It must have one of the suffixes
+<filename>.h</filename>,
+<filename>.hpp</filename>,
+<filename>.H</filename>,
+<filename>.hxx</filename>,
+<filename>.hh</filename>.
+You can turn off automatic moc file generation by setting
+&cv-link-QT_AUTOSCAN; to <constant>False</constant>.
+See also the corresponding
+&b-link-Moc; Builder.
+</para>
+
+<para>
+<emphasis role="strong">Automatic moc file generation from C++ files.</emphasis>
+As described in the Qt documentation, include the moc file at the end of
+the C++ file. Note that you have to include the file, which is generated
+by the transformation
+<literal>${QT_MOCCXXPREFIX}&lt;basename&gt;${QT_MOCCXXSUFFIX}</literal>, by default
+<filename>&lt;basename&gt;.mo</filename>. A warning is generated after building the moc file if you
+do not include the correct file. If you are using &f-link-VariantDir;, you may
+need to specify <parameter>duplicate=True</parameter>.
+You can turn off automatic moc file generation by setting &cv-QT_AUTOSCAN; to
+<literal>False</literal>. See also the corresponding
+&b-link-Moc; Builder.
+</para>
+
+<para>
+<emphasis role="strong">Automatic handling of .ui files.</emphasis>
+The implementation files generated from <filename>.ui</filename>
+files are handled much the same as yacc or lex files.
+Each <command>.ui</command> file given as a source of &b-link-Program;,
+&b-link-Library; or &b-link-SharedLibrary;
+will generate three files: the declaration file, the
+implementation file and a moc file. Because there are also generated headers,
+you may need to specify <parameter>duplicate=True</parameter> in calls to
+&f-link-VariantDir;.
+See also the corresponding
+&b-link-Uic; Builder.
 </para>
 </summary>
 <sets>
@@ -56,21 +140,23 @@ Sets construction variables for building Qt applications.
 <item>QT_MOCFROMCXXCOM</item>
 </sets>
 <uses>
+<item>QTDIR</item>
 </uses>
 </tool>
 
 <builder name="Moc">
 <summary>
 <para>
-Builds an output file from a moc input file. Moc input files are either
-header files or cxx files. This builder is only available after using the
-tool 'qt'. See the &cv-link-QTDIR; variable for more information.
+Builds an output file from a <command>moc</command> input file.
+<command>moc</command> input files are either header files or C++ files.
+This builder is only available after using the
+tool &t-link-qt;. See the &cv-link-QTDIR; variable for more information.
 Example:
 </para>
 
 <example_commands>
-env.Moc('foo.h') # generates moc_foo.cc
-env.Moc('foo.cpp') # generates foo.moc
+env.Moc('foo.h')  # generates moc_foo.cc
+env.Moc('foo.cpp')  # generates foo.moc
 </example_commands>
 </summary>
 </builder>
@@ -79,11 +165,11 @@ env.Moc('foo.cpp') # generates foo.moc
 <summary>
 <para>
 Builds a header file, an implementation file and a moc file from an ui file.
-and returns the corresponding nodes in the above order.
-This builder is only available after using the tool 'qt'. Note: you can
-specify <filename>.ui</filename> files directly as source
-files to the &b-Program;,
-&b-Library; and &b-SharedLibrary; builders
+and returns the corresponding nodes in the that order.
+This builder is only available after using the tool &t-link-qt;.
+Note: you can specify <filename>.ui</filename> files directly as source
+files to the &b-link-Program;,
+&b-link-Library; and &b-link-SharedLibrary; builders
 without using this builder. Using this builder lets you override the standard
 naming conventions (be careful: prefixes are always prepended to names of
 built files; if you don't want prefixes, you may set them to ``).
@@ -92,9 +178,11 @@ Example:
 </para>
 
 <example_commands>
-env.Uic('foo.ui') # -> ['foo.h', 'uic_foo.cc', 'moc_foo.cc']
-env.Uic(target = Split('include/foo.h gen/uicfoo.cc gen/mocfoo.cc'),
-        source = 'foo.ui') # -> ['include/foo.h', 'gen/uicfoo.cc', 'gen/mocfoo.cc']
+env.Uic('foo.ui')  # -> ['foo.h', 'uic_foo.cc', 'moc_foo.cc']
+env.Uic(
+    target=Split('include/foo.h gen/uicfoo.cc gen/mocfoo.cc'),
+    source='foo.ui'
+)  # -> ['include/foo.h', 'gen/uicfoo.cc', 'gen/mocfoo.cc']
 </example_commands>
 </summary>
 </builder>
@@ -102,66 +190,11 @@ env.Uic(target = Split('include/foo.h gen/uicfoo.cc gen/mocfoo.cc'),
 <cvar name="QTDIR">
 <summary>
 <para>
-The qt tool tries to take this from os.environ.
-It also initializes all QT_*
-construction variables listed below.
-(Note that all paths are constructed
-with python's os.path.join() method,
-but are listed here with the '/' separator
-for easier reading.)
-In addition, the construction environment
-variables &cv-link-CPPPATH;,
-&cv-link-LIBPATH; and
-&cv-link-LIBS; may be modified
-and the variables
-&cv-link-PROGEMITTER;, &cv-link-SHLIBEMITTER; and &cv-link-LIBEMITTER;
-are modified. Because the build-performance is affected when using this tool,
-you have to explicitly specify it at Environment creation:
-</para>
-
-<example_commands>
-Environment(tools=['default','qt'])
-</example_commands>
-
-<para>
-The qt tool supports the following operations:
-</para>
-
-<para>
-<emphasis role="strong">Automatic moc file generation from header files.</emphasis>
-You do not have to specify moc files explicitly, the tool does it for you.
-However, there are a few preconditions to do so: Your header file must have
-the same filebase as your implementation file and must stay in the same
-directory. It must have one of the suffixes .h, .hpp, .H, .hxx, .hh. You
-can turn off automatic moc file generation by setting QT_AUTOSCAN to 0.
-See also the corresponding
-&b-Moc;()
-builder method.
-</para>
-
-<para>
-<emphasis role="strong">Automatic moc file generation from cxx files.</emphasis>
-As stated in the qt documentation, include the moc file at the end of
-the cxx file. Note that you have to include the file, which is generated
-by the transformation ${QT_MOCCXXPREFIX}&lt;basename&gt;${QT_MOCCXXSUFFIX}, by default
-&lt;basename&gt;.moc. A warning is generated after building the moc file, if you
-do not include the correct file. If you are using VariantDir, you may
-need to specify duplicate=1. You can turn off automatic moc file generation
-by setting QT_AUTOSCAN to 0. See also the corresponding
-&b-Moc;
-builder method.
-</para>
-
-<para>
-<emphasis role="strong">Automatic handling of .ui files.</emphasis>
-The implementation files generated from .ui files are handled much the same
-as yacc or lex files. Each .ui file given as a source of Program, Library or
-SharedLibrary will generate three files, the declaration file, the
-implementation file and a moc file. Because there are also generated headers,
-you may need to specify duplicate=1 in calls to VariantDir.
-See also the corresponding
-&b-Uic;
-builder method.
+The path to the Qt installation to build against.
+If not already set,
+&t-link-qt; tool tries to obtain this from
+<varname>os.environ</varname>;
+if not found there, it tries to make a guess.
 </para>
 </summary>
 </cvar>
@@ -169,8 +202,8 @@ builder method.
 <cvar name="QT_AUTOSCAN">
 <summary>
 <para>
-Turn off scanning for mocable files. Use the Moc Builder to explicitly
-specify files to run moc on.
+Turn off scanning for mocable files. Use the &b-link-Moc; Builder to explicitly
+specify files to run <command>moc</command> on.
 </para>
 </summary>
 </cvar>
@@ -178,8 +211,8 @@ specify files to run moc on.
 <cvar name="QT_BINPATH">
 <summary>
 <para>
-The path where the qt binaries are installed.
-The default value is '&cv-link-QTDIR;/bin'.
+The path where the Qt binaries are installed.
+The default value is '&cv-link-QTDIR;<filename>/bin</filename>'.
 </para>
 </summary>
 </cvar>
@@ -187,9 +220,9 @@ The default value is '&cv-link-QTDIR;/bin'.
 <cvar name="QT_CPPPATH">
 <summary>
 <para>
-The path where the qt header files are installed.
+The path where the Qt header files are installed.
 The default value is '&cv-link-QTDIR;/include'.
-Note: If you set this variable to None,
+Note: If you set this variable to <constant>None</constant>,
 the tool won't change the &cv-link-CPPPATH;
 construction variable.
 </para>
@@ -207,8 +240,10 @@ Prints lots of debugging information while scanning for moc files.
 <cvar name="QT_LIB">
 <summary>
 <para>
-Default value is 'qt'. You may want to set this to 'qt-mt'. Note: If you set
-this variable to None, the tool won't change the &cv-link-LIBS; variable.
+Default value is <literal>'qt'</literal>.
+You may want to set this to <literal>'qt-mt'</literal>.
+Note: If you set this variable to <constant>None</constant>,
+the tool won't change the &cv-link-LIBS; variable.
 </para>
 </summary>
 </cvar>
@@ -216,9 +251,9 @@ this variable to None, the tool won't change the &cv-link-LIBS; variable.
 <cvar name="QT_LIBPATH">
 <summary>
 <para>
-The path where the qt libraries are installed.
-The default value is '&cv-link-QTDIR;/lib'.
-Note: If you set this variable to None,
+The path where the Qt libraries are installed.
+The default value is '&cv-link-QTDIR;<filename>/lib</filename>'.
+Note: If you set this variable to <constant>None</constant>,
 the tool won't change the &cv-link-LIBPATH;
 construction variable.
 </para>
@@ -228,7 +263,7 @@ construction variable.
 <cvar name="QT_MOC">
 <summary>
 <para>
-Default value is '&cv-link-QT_BINPATH;/moc'.
+Default value is '&cv-link-QT_BINPATH;<filename>/moc</filename>'.
 </para>
 </summary>
 </cvar>
@@ -236,7 +271,8 @@ Default value is '&cv-link-QT_BINPATH;/moc'.
 <cvar name="QT_MOCCXXPREFIX">
 <summary>
 <para>
-Default value is ''. Prefix for moc output files, when source is a cxx file.
+Default value is <literal>''</literal>.
+Prefix for <command>moc</command> output files when source is a C++ file.
 </para>
 </summary>
 </cvar>
@@ -244,8 +280,8 @@ Default value is ''. Prefix for moc output files, when source is a cxx file.
 <cvar name="QT_MOCCXXSUFFIX">
 <summary>
 <para>
-Default value is '.moc'. Suffix for moc output files, when source is a cxx
-file.
+Default value is <literal>'.moc'</literal>.
+Suffix for <command>moc</command> output files when source is a C++ file.
 </para>
 </summary>
 </cvar>
@@ -253,8 +289,8 @@ file.
 <cvar name="QT_MOCFROMCXXFLAGS">
 <summary>
 <para>
-Default value is '-i'. These flags are passed to moc, when moccing a
-C++ file.
+Default value is <literal>'-i'</literal>.
+These flags are passed to <command>moc</command> when moccing a C++ file.
 </para>
 </summary>
 </cvar>
@@ -262,7 +298,7 @@ C++ file.
 <cvar name="QT_MOCFROMCXXCOM">
 <summary>
 <para>
-Command to generate a moc file from a cpp file.
+Command to generate a moc file from a C++ file.
 </para>
 </summary>
 </cvar>
@@ -270,7 +306,7 @@ Command to generate a moc file from a cpp file.
 <cvar name="QT_MOCFROMCXXCOMSTR">
 <summary>
 <para>
-The string displayed when generating a moc file from a cpp file.
+The string displayed when generating a moc file from a C++ file.
 If this is not set, then &cv-link-QT_MOCFROMCXXCOM; (the command line) is displayed.
 </para>
 </summary>
@@ -287,7 +323,7 @@ Command to generate a moc file from a header.
 <cvar name="QT_MOCFROMHCOMSTR">
 <summary>
 <para>
-The string displayed when generating a moc file from a cpp file.
+The string displayed when generating a moc file from a C++ file.
 If this is not set, then &cv-link-QT_MOCFROMHCOM; (the command line) is displayed.
 </para>
 </summary>
@@ -296,8 +332,8 @@ If this is not set, then &cv-link-QT_MOCFROMHCOM; (the command line) is displaye
 <cvar name="QT_MOCFROMHFLAGS">
 <summary>
 <para>
-Default value is ''. These flags are passed to moc, when moccing a header
-file.
+Default value is <literal>''</literal>. These flags are passed to <command>moc</command>
+when moccing a header file.
 </para>
 </summary>
 </cvar>
@@ -305,7 +341,8 @@ file.
 <cvar name="QT_MOCHPREFIX">
 <summary>
 <para>
-Default value is 'moc_'. Prefix for moc output files, when source is a header.
+Default value is <literal>'moc_'</literal>.
+Prefix for <command>moc</command> output files when source is a header.
 </para>
 </summary>
 </cvar>
@@ -313,8 +350,8 @@ Default value is 'moc_'. Prefix for moc output files, when source is a header.
 <cvar name="QT_MOCHSUFFIX">
 <summary>
 <para>
-Default value is '&cv-link-CXXFILESUFFIX;'. Suffix for moc output files, when source is
-a header.
+Default value is '&cv-link-CXXFILESUFFIX;'.
+Suffix for moc output files when source is a header.
 </para>
 </summary>
 </cvar>
@@ -322,7 +359,7 @@ a header.
 <cvar name="QT_UIC">
 <summary>
 <para>
-Default value is '&cv-link-QT_BINPATH;/uic'.
+Default value is '&cv-link-QT_BINPATH;<filename>/uic</filename>'.
 </para>
 </summary>
 </cvar>
@@ -330,7 +367,7 @@ Default value is '&cv-link-QT_BINPATH;/uic'.
 <cvar name="QT_UICCOM">
 <summary>
 <para>
-Command to generate header files from .ui files.
+Command to generate header files from <filename>.ui</filename> files.
 </para>
 </summary>
 </cvar>
@@ -338,7 +375,7 @@ Command to generate header files from .ui files.
 <cvar name="QT_UICCOMSTR">
 <summary>
 <para>
-The string displayed when generating header files from .ui files.
+The string displayed when generating header files from <filename>.ui</filename> files.
 If this is not set, then &cv-link-QT_UICCOM; (the command line) is displayed.
 </para>
 </summary>
@@ -347,8 +384,8 @@ If this is not set, then &cv-link-QT_UICCOM; (the command line) is displayed.
 <cvar name="QT_UICDECLFLAGS">
 <summary>
 <para>
-Default value is ''. These flags are passed to uic, when creating a a h
-file from a .ui file.
+Default value is ''. These flags are passed to <command>uic</command>
+when creating a header file from a <filename>.ui</filename> file.
 </para>
 </summary>
 </cvar>
@@ -356,7 +393,8 @@ file from a .ui file.
 <cvar name="QT_UICDECLPREFIX">
 <summary>
 <para>
-Default value is ''. Prefix for uic generated header files.
+Default value is <literal>''</literal>.
+Prefix for <command>uic</command> generated header files.
 </para>
 </summary>
 </cvar>
@@ -364,7 +402,8 @@ Default value is ''. Prefix for uic generated header files.
 <cvar name="QT_UICDECLSUFFIX">
 <summary>
 <para>
-Default value is '.h'. Suffix for uic generated header files.
+Default value is <literal>'.h'</literal>.
+Suffix for <command>uic</command> generated header files.
 </para>
 </summary>
 </cvar>
@@ -372,8 +411,9 @@ Default value is '.h'. Suffix for uic generated header files.
 <cvar name="QT_UICIMPLFLAGS">
 <summary>
 <para>
-Default value is ''. These flags are passed to uic, when creating a cxx
-file from a .ui file.
+Default value is <literal>''</literal>.
+These flags are passed to <command>uic</command> when creating a C++
+file from a <filename>.ui</filename> file.
 </para>
 </summary>
 </cvar>
@@ -381,7 +421,8 @@ file from a .ui file.
 <cvar name="QT_UICIMPLPREFIX">
 <summary>
 <para>
-Default value is 'uic_'. Prefix for uic generated implementation files.
+Default value is <literal>'uic_'</literal>.
+Prefix for uic generated implementation files.
 </para>
 </summary>
 </cvar>
@@ -398,7 +439,8 @@ files.
 <cvar name="QT_UISUFFIX">
 <summary>
 <para>
-Default value is '.ui'. Suffix of designer input files.
+Default value is <literal>'.ui'</literal>.
+Suffix of designer input files.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/qt.xml
+++ b/SCons/Tool/qt.xml
@@ -31,12 +31,11 @@ Sets &consvars; for building Qt3 applications.
 
 <note><para>
 This tool is only suitable for building targeted to Qt3,
-which is obsolete.
-There are contributed tools for Qt4 and Qt5,
-see
-<ulink url="https://github.com/SCons/scons/wiki/ToolsIndex">
-https://github.com/SCons/scons/wiki/ToolsIndex
-</ulink>.
+which is obsolete
+(<emphasis>the tool is deprecated since 4.3</emphasis>).
+There are contributed tools for Qt4 and Qt5, see
+<ulink url="https://github.com/SCons/scons-contrib">
+https://github.com/SCons/scons-contrib</ulink>.
 Qt4 has also passed end of life for standard support (in Dec 2015).
 </para></note>
 
@@ -45,8 +44,8 @@ Note paths for these &consvars; are assembled
 using the <function>os.path.join</function> method
 so they will have the appropriate separator at runtime,
 but are listed here in the various
-entries with the <literal>'/'</literal> separator
-for easier reading.
+entries only with the <literal>'/'</literal> separator
+for simplicity.
 </para>
 
 <para>

--- a/SCons/Warnings.py
+++ b/SCons/Warnings.py
@@ -128,7 +128,7 @@ class DeprecatedDebugOptionsWarning(MandatoryDeprecatedWarning):
 class DeprecatedMissingSConscriptWarning(DeprecatedWarning):
     pass
 
-class ToolQtDeprecatedWarning(DeprecatedWarning):
+class ToolQtDeprecatedWarning(FutureDeprecatedWarning):
     pass
 
 # The below is a list of 2-tuples.  The first element is a class object.

--- a/SCons/Warnings.py
+++ b/SCons/Warnings.py
@@ -128,6 +128,8 @@ class DeprecatedDebugOptionsWarning(MandatoryDeprecatedWarning):
 class DeprecatedMissingSConscriptWarning(DeprecatedWarning):
     pass
 
+class ToolQtDeprecatedWarning(DeprecatedWarning):
+    pass
 
 # The below is a list of 2-tuples.  The first element is a class object.
 # The second element is true if that class is enabled, false if it is disabled.

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -7941,6 +7941,16 @@ and will silently revert to non-cached behavior in such cases.</para>
 <para><emphasis>Available since &scons; 3.1 (experimental)</emphasis>.</para>
     </listitem>
   </varlistentry>
+
+  <varlistentry>
+    <term><envar>QTDIR</envar></term>
+    <listitem>
+<para>If using the &t-link-qt; tool, this is the path to
+the Qt installation to build against. &SCons; respects this
+setting because it is a long-standing convention in the Qt world,
+where multiple Qt installations are possible.</para>
+    </listitem>
+  </varlistentry>
 </variablelist>
 </refsect1>
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1998,7 +1998,8 @@ after other processing.</para>
     <option>--warn=no-<replaceable>type</replaceable></option>
   </term>
   <listitem>
-<para>Enable or disable (with the no- prefix) warnings.
+<para>Enable or disable (with the prefix "no-") warnings
+(<option>--warning</option> is a synonym).
 <replaceable>type</replaceable>
 specifies the type of warnings to be enabled or disabled:</para>
 
@@ -2120,6 +2121,14 @@ singular form, even though
 and
 <parameter>source</parameter>
 can themselves refer to lists of names or nodes.</para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
+  <term><emphasis role="bold">tool-qt-deprecated</emphasis></term>
+  <listitem>
+<para>Warnings about the &t-link-qt; tool being deprecated.
+These warnings are enabled by default.</para>
   </listitem>
   </varlistentry>
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2128,7 +2128,11 @@ can themselves refer to lists of names or nodes.</para>
   <term><emphasis role="bold">tool-qt-deprecated</emphasis></term>
   <listitem>
 <para>Warnings about the &t-link-qt; tool being deprecated.
-These warnings are enabled by default.</para>
+These warnings are disabled by default for the first
+phase of deprecation. Enable to be reminded about use
+of this tool module.
+<emphasis>Available since &SCons; 4.3.</emphasis>
+</para>
   </listitem>
   </varlistentry>
 

--- a/runtest.py
+++ b/runtest.py
@@ -195,9 +195,10 @@ if args.excludelistfile:
         )
         sys.exit(1)
 
-if args.jobs > 1:
-    # don't let tests write stdout/stderr directly if multi-job,
-    # else outputs will interleave and be hard to read
+if args.jobs > 1 or args.output:
+    # 1. don't let tests write stdout/stderr directly if multi-job,
+    # else outputs will interleave and be hard to read.
+    # 2. If we're going to write a logfile, we also need to catch the output.
     catch_output = True
 
 if not args.printcommand:
@@ -236,7 +237,6 @@ sys.stderr = Unbuffered(sys.stderr)
 # print = functools.partial(print, flush)
 
 if args.output:
-    logfile = open(args.output, 'w')
     class Tee:
         def __init__(self, openfile, stream):
             self.file = openfile

--- a/runtest.py
+++ b/runtest.py
@@ -195,10 +195,9 @@ if args.excludelistfile:
         )
         sys.exit(1)
 
-if args.jobs > 1 or args.output:
-    # 1. don't let tests write stdout/stderr directly if multi-job,
-    # else outputs will interleave and be hard to read.
-    # 2. If we're going to write a logfile, we also need to catch the output.
+if args.jobs > 1:
+    # don't let tests write stdout/stderr directly if multi-job,
+    # else outputs will interleave and be hard to read
     catch_output = True
 
 if not args.printcommand:
@@ -237,6 +236,7 @@ sys.stderr = Unbuffered(sys.stderr)
 # print = functools.partial(print, flush)
 
 if args.output:
+    logfile = open(args.output, 'w')
     class Tee:
         def __init__(self, openfile, stream):
             self.file = openfile

--- a/test/QT/CPPPATH-appended.py
+++ b/test/QT/CPPPATH-appended.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that an appended relative CPPPATH works with generated files.
@@ -70,7 +69,7 @@ test.write(['sub', 'local_include', 'local_include.h'], r"""
 /* empty; just needs to be found */
 """)
 
-test.run(arguments = aaa_exe)
+test.run(arguments='--warn=no-tool-qt-deprecated ' + aaa_exe)
 
 test.pass_test()
 

--- a/test/QT/CPPPATH.py
+++ b/test/QT/CPPPATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that an overwritten CPPPATH works with generated files.
@@ -60,7 +59,7 @@ test.write(['local_include', 'local_include.h'], r"""
 /* empty; just needs to be found */
 """)
 
-test.run(arguments = aaa_exe)
+test.run(arguments='--warn=no-tool-qt-deprecated ' + aaa_exe)
 
 test.pass_test()
 

--- a/test/QT/QTFLAGS.py
+++ b/test/QT/QTFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Testing the configuration mechanisms of the 'qt' tool.
@@ -40,7 +39,7 @@ test.subdir('work1', 'work2')
 
 test.run(
     chdir=test.workpath('qt', 'lib'),
-    arguments='.',
+    arguments="--warn=no-tool-qt-deprecated .",
     stderr=TestSCons.noisy_ar,
     match=TestSCons.match_re_dotall,
 )
@@ -138,16 +137,18 @@ int main(void) {
 }
 """)
 
-test.run(chdir = 'work1', arguments = "mytest" + _exe)
+test.run(chdir='work1', arguments="--warn=no-tool-qt-deprecated mytest" + _exe)
 
-test.must_exist(['work1', 'mmmmocFromH.cxx'],
-                ['work1', 'mocmocFromCpp.inl'],
-                ['work1', 'an_ui_file.cxx'],
-                ['work1', 'uic-an_ui_file.hpp'],
-                ['work1', 'mmman_ui_file.cxx'],
-                ['work1', 'another_ui_file.cxx'],
-                ['work1', 'uic-another_ui_file.hpp'],
-                ['work1', 'mmmanother_ui_file.cxx'])
+test.must_exist(
+    ['work1', 'mmmmocFromH.cxx'],
+    ['work1', 'mocmocFromCpp.inl'],
+    ['work1', 'an_ui_file.cxx'],
+    ['work1', 'uic-an_ui_file.hpp'],
+    ['work1', 'mmman_ui_file.cxx'],
+    ['work1', 'another_ui_file.cxx'],
+    ['work1', 'uic-another_ui_file.hpp'],
+    ['work1', 'mmmanother_ui_file.cxx'],
+)
 
 def _flagTest(test,fileToContentsStart):
     for f,c in fileToContentsStart.items():
@@ -155,19 +156,29 @@ def _flagTest(test,fileToContentsStart):
             return 1
     return 0
 
-test.fail_test(_flagTest(test, {'mmmmocFromH.cxx':'/* mymoc.py -z */',
-                                'mocmocFromCpp.inl':'/* mymoc.py -w */',
-                                'an_ui_file.cxx':'/* myuic.py -x */',
-                                'uic-an_ui_file.hpp':'/* myuic.py -y */',
-                                'mmman_ui_file.cxx':'/* mymoc.py -z */'}))
+test.fail_test(
+    _flagTest(
+        test,
+        {
+            'mmmmocFromH.cxx': '/* mymoc.py -z */',
+            'mocmocFromCpp.inl': '/* mymoc.py -w */',
+            'an_ui_file.cxx': '/* myuic.py -x */',
+            'uic-an_ui_file.hpp': '/* myuic.py -y */',
+            'mmman_ui_file.cxx': '/* mymoc.py -z */',
+        },
+    )
+)
 
 test.write(['work2', 'SConstruct'], """
 import os.path
-env1 = Environment(tools=['qt'],
-                   QTDIR = r'%(QTDIR)s',
-                   QT_BINPATH='$QTDIR/bin64',
-                   QT_LIBPATH='$QTDIR/lib64',
-                   QT_CPPPATH='$QTDIR/h64')
+
+env1 = Environment(
+    tools=['qt'],
+    QTDIR=r'%(QTDIR)s',
+    QT_BINPATH='$QTDIR/bin64',
+    QT_LIBPATH='$QTDIR/lib64',
+    QT_CPPPATH='$QTDIR/h64',
+)
 
 cpppath = env1.subst('$CPPPATH')
 if os.path.normpath(cpppath) != os.path.join(r'%(QTDIR)s', 'h64'):
@@ -182,11 +193,9 @@ if os.path.normpath(qt_moc) != os.path.join(r'%(QTDIR)s', 'bin64', 'moc'):
     print(qt_moc)
     Exit(3)
 
-env2 = Environment(tools=['default', 'qt'],
-                   QTDIR = None,
-                   QT_LIB = None,
-                   QT_CPPPATH = None,
-                   QT_LIBPATH = None)
+env2 = Environment(
+    tools=['default', 'qt'], QTDIR=None, QT_LIB=None, QT_CPPPATH=None, QT_LIBPATH=None
+)
 
 env2.Program('main.cpp')
 """ % {'QTDIR':QT})
@@ -197,7 +206,7 @@ int main(void) { return 0; }
 
 # Ignore stderr, because if Qt is not installed,
 # there may be a warning about an empty QTDIR on stderr.
-test.run(chdir='work2', stderr=None)
+test.run(arguments="--warn=no-tool-qt-deprecated", chdir='work2', stderr=None)
 
 test.must_exist(['work2', 'main' + _exe])
 

--- a/test/QT/Tool.py
+++ b/test/QT/Tool.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -30,8 +32,6 @@ real-world configuration for lprof (lprof.sourceforge.net).  It's probably
 not completely minimal, but we're leaving it as-is since it represents a
 good real-world sanity check on the interaction of some key subsystems.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -145,7 +145,7 @@ if not config.CheckForQt():
 env.Tool('qt', ['$TOOL_PATH'])
 """)
 
-test.run(arguments = '.')
+test.run(arguments='--warn=no-tool-qt-deprecated .')
 
 test.pass_test()
 

--- a/test/QT/copied-env.py
+++ b/test/QT/copied-env.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -24,8 +26,6 @@
 """
 Test Qt with a copied construction environment.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -63,7 +63,7 @@ test.write('MyForm.ui', r"""
 void aaa(void)
 """)
 
-test.run()
+test.run(arguments="--warn=no-tool-qt-deprecated")
 
 moc_MyForm = [x for x in test.stdout().split('\n') if x.find('moc_MyForm') != -1]
 

--- a/test/QT/empty-env.py
+++ b/test/QT/empty-env.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test Qt creation from a copied empty environment.
@@ -62,11 +61,14 @@ foo6(void)
 
 # we can receive warnings about a non detected qt (empty QTDIR)
 # these are not critical, but may be annoying.
-test.run(stderr=None)
+test.run(stderr=None, arguments='--warn=no-tool-qt-deprecated')
 
-test.run(program = test.workpath('main' + TestSCons._exe),
-         stderr = None,
-         stdout = 'qt/include/foo6.h\n')
+test.run(
+    program=test.workpath('main' + TestSCons._exe),
+    arguments='--warn=no-tool-qt-deprecated',
+    stderr=None,
+    stdout='qt/include/foo6.h\n',
+)
 
 test.pass_test()
 

--- a/test/QT/generated-ui.py
+++ b/test/QT/generated-ui.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the UI scanning logic correctly picks up scansG
@@ -120,11 +119,13 @@ test.write(['layer', 'aclock', 'qt_bug', 'migraform.ui'], """\
 </UI>
 """)
 
-test.run(arguments = '.',
-         stderr = TestSCons.noisy_ar,
-         match = TestSCons.match_re_dotall)
+test.run(
+    arguments='--warn=no-tool-qt-deprecated',
+    stderr=TestSCons.noisy_ar,
+    match=TestSCons.match_re_dotall,
+)
 
-test.up_to_date(arguments = '.')
+test.up_to_date(options="--warn=no-tool-qt-deprecated", arguments=".")
 
 test.pass_test()
 

--- a/test/QT/installed.py
+++ b/test/QT/installed.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Look if qt is installed, and try out all builders.
@@ -173,13 +172,15 @@ int main(int argc, char **argv) {
 }
 """)
 
-test.run(arguments="bld/test_realqt" + TestSCons._exe)
+test.run(arguments="--warn=no-tool-qt-deprecated bld/test_realqt" + TestSCons._exe)
 
-
-test.run(program=test.workpath("bld", "test_realqt"),
-         stdout=None,
-         status=None,
-         stderr=None)
+test.run(
+    program=test.workpath("bld", "test_realqt"),
+    arguments="--warn=no-tool-qt-deprecated",
+    stdout=None,
+    status=None,
+    stderr=None,
+)
 
 if test.stdout() != "Hello World\n" or test.stderr() != '' or test.status:
     sys.stdout.write(test.stdout())
@@ -191,23 +192,24 @@ if test.stdout() != "Hello World\n" or test.stderr() != '' or test.status:
     expect = 'cannot connect to X server'
     test.fail_test(test.stdout())
     test.fail_test(expect not in test.stderr())
-    if test.status != 1 and (test.status>>8) != 1:
+    if test.status != 1 and (test.status >> 8) != 1:
         sys.stdout.write('test_realqt returned status %s\n' % test.status)
         test.fail_test()
 
 QTDIR = os.environ['QTDIR']
 PATH = os.environ['PATH']
-os.environ['QTDIR']=''
-os.environ['PATH']='.'
+os.environ['QTDIR'] = ''
+os.environ['PATH'] = '.'
 
-test.run(stderr=None, arguments="-c bld/test_realqt" + TestSCons._exe)
+test.run(
+    stderr=None,
+    arguments="--warn=no-tool-qt-deprecated -c bld/test_realqt" + TestSCons._exe,
+)
 
 expect1 = "scons: warning: Could not detect qt, using empty QTDIR"
 expect2 = "scons: warning: Could not detect qt, using moc executable as a hint"
 
-test.fail_test(expect1 not in test.stderr() and
-               expect2 not in test.stderr())
-
+test.fail_test(expect1 not in test.stderr() and expect2 not in test.stderr())
 
 test.pass_test()
 

--- a/test/QT/manual.py
+++ b/test/QT/manual.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the manual QT builder calls.
@@ -124,7 +123,7 @@ int main(void) {
 }
 """)
 
-test.run(arguments = aaa_exe)
+test.run(arguments="--warn=no-tool-qt-deprecated " + aaa_exe)
 
 # normal invocation
 test.must_exist(test.workpath('include', 'moc_aaa.cc'))

--- a/test/QT/moc-from-cpp.py
+++ b/test/QT/moc-from-cpp.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Create a moc file from a cpp file.
@@ -64,11 +63,13 @@ void useit() {
 }
 """)
 
-test.run(arguments=lib_aaa,
-         stderr=TestSCons.noisy_ar,
-         match=TestSCons.match_re_dotall)
+test.run(
+    arguments="--warn=no-tool-qt-deprecated " + lib_aaa,
+    stderr=TestSCons.noisy_ar,
+    match=TestSCons.match_re_dotall,
+)
 
-test.up_to_date(options = '-n', arguments = lib_aaa)
+test.up_to_date(options='-n --warn=no-tool-qt-deprecated', arguments=lib_aaa)
 
 test.write('aaa.cpp', r"""
 #include "my_qobject.h"
@@ -77,22 +78,30 @@ void aaa(void) Q_OBJECT
 #include "%s"
 """ % moc)
 
-test.not_up_to_date(options = '-n', arguments = moc)
+test.not_up_to_date(options='-n --warn=no-tool-qt-deprecated', arguments=moc)
 
-test.run(options = '-c', arguments = lib_aaa)
+test.run(options="--warn=no-tool-qt-deprecated -c", arguments=lib_aaa)
 
-test.run(arguments = "variant_dir=1 " + test.workpath('build', lib_aaa),
-         stderr=TestSCons.noisy_ar,
-         match=TestSCons.match_re_dotall)
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 "
+    + test.workpath('build', lib_aaa),
+    stderr=TestSCons.noisy_ar,
+    match=TestSCons.match_re_dotall,
+)
 
-test.run(arguments = "variant_dir=1 chdir=1 " + test.workpath('build', lib_aaa))
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 chdir=1 "
+    + test.workpath('build', lib_aaa)
+)
 
 test.must_exist(test.workpath('build', moc))
 
-test.run(arguments = "variant_dir=1 dup=0 " +
-                     test.workpath('build_dup0', lib_aaa),
-         stderr=TestSCons.noisy_ar,
-         match=TestSCons.match_re_dotall)
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 dup=0 "
+    + test.workpath('build_dup0', lib_aaa),
+    stderr=TestSCons.noisy_ar,
+    match=TestSCons.match_re_dotall,
+)
 
 test.must_exist(test.workpath('build_dup0', moc))
 

--- a/test/QT/moc-from-header.py
+++ b/test/QT/moc-from-header.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Create a moc file from a header file.
@@ -69,11 +68,8 @@ test.write('aaa.h', r"""
 void aaa(void) Q_OBJECT;
 """)
 
-test.run()
-
-test.up_to_date(options = '-n', arguments=aaa_exe)
-
-test.up_to_date(options = '-n', arguments = aaa_exe)
+test.run(arguments="--warn=no-tool-qt-deprecated")
+test.up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=aaa_exe)
 
 test.write('aaa.h', r"""
 /* a change */
@@ -81,18 +77,26 @@ test.write('aaa.h', r"""
 void aaa(void) Q_OBJECT;
 """)
 
-test.not_up_to_date(options='-n', arguments = moc)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=moc)
 
-test.run(program = test.workpath(aaa_exe), stdout = 'aaa.h\n')
+test.run(
+    arguments="--warn=no-tool-qt-deprecated",
+    program=test.workpath(aaa_exe),
+    stdout='aaa.h\n',
+)
 
-test.run(arguments = "variant_dir=1 " + build_aaa_exe)
+test.run(arguments="--warn=no-tool-qt-deprecated variant_dir=1 " + build_aaa_exe)
 
-test.run(arguments = "variant_dir=1 chdir=1 " + build_aaa_exe)
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 chdir=1 " + build_aaa_exe
+)
 
 test.must_exist(test.workpath('build', moc))
 
-test.run(arguments = "variant_dir=1 chdir=1 dup=0 " +
-                     test.workpath('build_dup0', aaa_exe) )
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 chdir=1 dup=0 "
+    + test.workpath('build_dup0', aaa_exe)
+)
 
 test.must_exist(['build_dup0', moc])
 

--- a/test/QT/qt_warnings.py
+++ b/test/QT/qt_warnings.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -24,8 +26,6 @@
 """
 Test the Qt tool warnings.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import re
@@ -51,7 +51,7 @@ import os
 env.StaticLibrary('aaa.cpp')
 """)
 
-test.run(stderr=None)
+test.run(arguments="--warn=no-tool-qt-deprecated", stderr=None)
 
 match12 = r"""
 scons: warning: Generated moc file 'aaa.moc' is not included by 'aaa.cpp'
@@ -64,7 +64,7 @@ if not re.search(match12, test.stderr()):
 
 os.environ['QTDIR'] = test.QT
 
-test.run(arguments='-n noqtdir=1')
+test.run(arguments='--warn=no-tool-qt-deprecated -n noqtdir=1')
 
 # We'd like to eliminate $QTDIR from the environment as follows:
 #       del os.environ['QTDIR']
@@ -74,7 +74,7 @@ test.run(arguments='-n noqtdir=1')
 # environment, so it only gets removed from the Python dictionary.
 # Consequently, we need to just wipe out its value as follows>
 os.environ['QTDIR'] = ''
-test.run(stderr=None, arguments='-n noqtdir=1')
+test.run(stderr=None, arguments='--warn=no-tool-qt-deprecated -n noqtdir=1')
 
 moc = test.where_is('moc')
 if moc:

--- a/test/QT/reentrant.py
+++ b/test/QT/reentrant.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test creation from a copied environment that already has QT variables.
@@ -59,11 +58,13 @@ test.write('main.cpp', r"""
 int main(void) { foo5(); return 0; }
 """)
 
-test.run()
+test.run(arguments="--warn=no-tool-qt-deprecated")
 
-test.run(program = test.workpath('main' + TestSCons._exe),
-         stdout = 'qt/include/foo5.h\n')
-
+test.run(
+    arguments='--warn=no-tool-qt-deprecated',
+    program=test.workpath('main' + TestSCons._exe),
+    stdout='qt/include/foo5.h\n',
+)
 test.pass_test()
 
 # Local Variables:

--- a/test/QT/source-from-ui.py
+++ b/test/QT/source-from-ui.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Create .cpp, .h, moc_....cpp from a .ui file.
@@ -68,9 +67,9 @@ void useit() {
 }
 """)
 
-test.run(arguments = aaa_dll)
+test.run(arguments="--warn=no-tool-qt-deprecated " + aaa_dll)
 
-test.up_to_date(options='-n', arguments = aaa_dll)
+test.up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=aaa_dll)
 
 test.write('aaa.ui', r"""
 /* a change */
@@ -82,11 +81,11 @@ test.write('aaa.ui', r"""
 DLLEXPORT void aaa(void)
 """)
 
-test.not_up_to_date(options = '-n', arguments = moc)
-test.not_up_to_date(options = '-n', arguments = cpp)
-test.not_up_to_date(options = '-n', arguments = h)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=moc)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=cpp)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=h)
 
-test.run(arguments = aaa_dll)
+test.run(arguments="--warn=no-tool-qt-deprecated " + aaa_dll)
 
 test.write('aaa.ui', r"""
 void aaa(void)
@@ -94,28 +93,30 @@ void aaa(void)
 """)
 
 # test that non-existant ui.h files are ignored (as uic does)
-test.run(arguments = aaa_dll)
+test.run(arguments="--warn=no-tool-qt-deprecated " + aaa_dll)
 
 test.write('aaa.ui.h', r"""
 /* test dependency to .ui.h */
 """)
 
-test.run(arguments = aaa_dll)
+test.run(arguments="--warn=no-tool-qt-deprecated " + aaa_dll)
 
 test.write('aaa.ui.h', r"""
 /* changed */
 """)
 
-test.not_up_to_date(options = '-n', arguments = obj)
-test.not_up_to_date(options = '-n', arguments = cpp)
-test.not_up_to_date(options = '-n', arguments = h)
-test.not_up_to_date(options = '-n', arguments = moc)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=obj)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=cpp)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=h)
+test.not_up_to_date(options='--warn=no-tool-qt-deprecated -n', arguments=moc)
 
 # clean up
-test.run(arguments = '-c ' + aaa_dll)
+test.run(arguments="--warn=no-tool-qt-deprecated -c " + aaa_dll)
 
-test.run(arguments = "variant_dir=1 " +
-                     test.workpath('build', aaa_dll) )
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 "
+    + test.workpath('build', aaa_dll)
+)
 
 test.must_exist(test.workpath('build', moc))
 test.must_exist(test.workpath('build', cpp))
@@ -127,8 +128,10 @@ test.must_not_exist(test.workpath(h))
 cppContents = test.read(test.workpath('build', cpp), mode='r')
 test.fail_test(cppContents.find('#include "aaa.ui.h"') == -1)
 
-test.run(arguments = "variant_dir=1 chdir=1 " +
-                     test.workpath('build', aaa_dll) )
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 chdir=1 "
+    + test.workpath('build', aaa_dll)
+)
 
 test.must_exist(test.workpath('build', moc))
 test.must_exist(test.workpath('build', cpp))
@@ -137,12 +140,14 @@ test.must_not_exist(test.workpath(moc))
 test.must_not_exist(test.workpath(cpp))
 test.must_not_exist(test.workpath(h))
 
-test.run(arguments = "variant_dir=1 chdir=1 dup=0 " +
-                     test.workpath('build_dup0', aaa_dll) )
+test.run(
+    arguments="--warn=no-tool-qt-deprecated variant_dir=1 chdir=1 dup=0 "
+    + test.workpath('build_dup0', aaa_dll)
+)
 
-test.must_exist(test.workpath('build_dup0',moc))
-test.must_exist(test.workpath('build_dup0',cpp))
-test.must_exist(test.workpath('build_dup0',h))
+test.must_exist(test.workpath('build_dup0', moc))
+test.must_exist(test.workpath('build_dup0', cpp))
+test.must_exist(test.workpath('build_dup0', h))
 test.must_not_exist(test.workpath(moc))
 test.must_not_exist(test.workpath(cpp))
 test.must_not_exist(test.workpath(h))

--- a/test/QT/up-to-date.py
+++ b/test/QT/up-to-date.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,8 +23,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Validate that a stripped-down real-world Qt configuation (thanks
@@ -128,14 +128,12 @@ test.write(['layer', 'aclock', 'qt_bug', 'my.cc'], """\
 #include <main.h>
 """)
 
-my_obj = 'layer/aclock/qt_bug/my'+_obj
+my_obj = 'layer/aclock/qt_bug/my' + _obj
 
-test.run(arguments = my_obj, stderr=None)
+test.run(arguments='--warn=no-tool-qt-deprecated ' + my_obj, stderr=None)
 
-expect = my_obj.replace( '/', os.sep )
-test.up_to_date(options = '--debug=explain',
-                arguments =expect,
-                stderr=None)
+expect = my_obj.replace('/', os.sep)
+test.up_to_date(options='--debug=explain', arguments=expect, stderr=None)
 
 test.pass_test()
 


### PR DESCRIPTION
* Deprecate the qt tool.
* Updates tests to disable the warning that this change enables.
* Fix runtest.py to make sure -o logging option captures all the output (not strictly related, but it caused lots of irritation in debugging the qt tests, so it seemed apt to include it).
* Fiddle Qt docs:
  * Add markup.
  * Move description of qt tool into entry for qt tool, itself, previously it was in the entry for the QTDIR variable.
  * Add QTDIR environment variable to the manpage, since scons will read this one if set.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
