### PR TITLE
Fix gcc-version test for Windows

### DIFF
--- a/test/CC/gcc-non-utf8-fixture/gcc-non-utf8.py
+++ b/test/CC/gcc-non-utf8-fixture/gcc-non-utf8.py
@@ -1,7 +1,5 @@
 import sys
 
-print(f"In {sys.argv[0]}")
-
 if __name__ == '__main__':
     if '--version' in sys.argv:
         with open("data", "rb") as f:

--- a/test/CC/gcc-version.py
+++ b/test/CC/gcc-version.py
@@ -44,7 +44,7 @@ test.write(
 import sys
 
 DefaultEnvironment(tools=[])
-env = Environment(tools=[], CC="%(_python_)s gcc-non-utf8.py")
+env = Environment(tools=[], CC=r"%(_python_)s gcc-non-utf8.py")
 try:
     env.Tool('gcc')
 except UnicodeDecodeError:


### PR DESCRIPTION
A constructed string containing the Python path wasn't listed as a raw string, which led to a unicode error, because the
path string contained a \Users  which was misinterpreted as a Unicode escape.

Also had left a debug print in a script.

This is a test-only change, no SCons behavior touched.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
