### PR TITLE
Skip two scons-time tests on Windows

### DIFF
--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,15 +27,17 @@
 Verify specifying an alternate Python executable in a config file.
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 import os
 
 import TestSCons_time
+from TestCmd import IS_WINDOWS
 
 _python_ = TestSCons_time._python_
 
 test = TestSCons_time.TestSCons_time()
+if IS_WINDOWS:
+    # tests expect Windows file assoc to run my_python, not in our control.
+    test.skip_test("Skipping test on win32 due to launch problems.")
 
 test.write_sample_project('foo.tar.gz')
 

--- a/test/scons-time/run/option/python.py
+++ b/test/scons-time/run/option/python.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the run --python option to specify an alternatie Python executable.
@@ -31,10 +30,14 @@ Verify the run --python option to specify an alternatie Python executable.
 import os
 
 import TestSCons_time
+from TestCmd import IS_WINDOWS
 
 _python_ = TestSCons_time._python_
 
 test = TestSCons_time.TestSCons_time()
+if IS_WINDOWS:
+    # tests expect Windows file assoc to run my_python, not in our control.
+    test.skip_test("Skipping test on win32 due to launch problems.")
 
 test.write_sample_project('foo.tar.gz')
 


### PR DESCRIPTION
The `scons-time` tests trying to test the "run" subcommand of `scons-time` substitute a dummy script named `my_python.py` for Python. In order for this to work on Windows, the file association chain for `.py` files has to lead back to a Python interpreter, but we cannot control this - for example, systems with VS Code installed often steals this association in ways that are aren't easy to pre-detect.

Note that `scons-time` itself carfully uses the Python interpreter to launch things so it's not affected by this, it's just the test
that tries to mock part of this scheme that has problems.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
