### PR TITLE
Switch Windows CI builds to VS2022 and Py3.10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,14 @@
 #version: '3.0.1.{build}'
+#
+# When planning updates here, check availability at:
+# https://www.appveyor.com/docs/windows-images-software/
+# This is slow, try to keep the number of builds as low as makes sense.
 
 image:
   # linux builds done in Travis CI for now
-  - Visual Studio 2015
   - Visual Studio 2017
   - Visual Studio 2019
+  - Visual Studio 2022
 
 cache:
   - downloads -> appveyor.yml
@@ -21,9 +25,6 @@ install:
 # split builds into sets of four jobs due to appveyor per-job time limit
 environment:
   matrix:
-    - WINPYTHON: "Python35"
-      COVERAGE: 0
-
     - WINPYTHON: "Python36"
       COVERAGE: 1
 
@@ -33,18 +34,14 @@ environment:
     - WINPYTHON: "Python38"
       COVERAGE: 0
 
+    - WINPYTHON: "Python310"
+      COVERAGE: 0
+
+
 # remove sets of build jobs based on criteria below
 # to fine tune the number and platforms tested
 matrix:
   exclude:
-    # test python 3.5 on Visual Studio 2015 image
-    - image: Visual Studio 2015
-      WINPYTHON: "Python36"
-    - image: Visual Studio 2015
-      WINPYTHON: "Python37"
-    - image: Visual Studio 2015
-      WINPYTHON: "Python38"
-
     # test python 3.8 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python35"
@@ -58,6 +55,14 @@ matrix:
       WINPYTHON: "Python35"
     - image: Visual Studio 2019
       WINPYTHON: "Python36"
+
+    # test python 3.10 on Visual Studio 2022 image
+    - image: Visual Studio 2022
+      WINPYTHON: "Python36"
+    - image: Visual Studio 2022
+      WINPYTHON: "Python37"
+    - image: Visual Studio 2022
+      WINPYTHON: "Python38"
 
 # remove some binaries we don't want to be found
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,7 @@ matrix:
   exclude:
     # test python 3.8 on Visual Studio 2017 image
     - image: Visual Studio 2017
-      WINPYTHON: "Python35"
+      WINPYTHON: "Python310"
     - image: Visual Studio 2017
       WINPYTHON: "Python37"
     - image: Visual Studio 2017
@@ -52,7 +52,7 @@ matrix:
 
     # test python 3.7 on Visual Studio 2019 image
     - image: Visual Studio 2019
-      WINPYTHON: "Python35"
+      WINPYTHON: "Python310"
     - image: Visual Studio 2019
       WINPYTHON: "Python36"
 


### PR DESCRIPTION
Replacing the build with 3.5 and VS2015

This is CI only, no changes to SCons itself.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
