### PR TITLE
Update manpage mentions of for_signature

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -5622,11 +5622,14 @@ must accept four arguments:
 <parameter>source</parameter> is a list of source nodes,
 <parameter>target</parameter> is a list of target nodes,
 <parameter>env</parameter> is the &consenv; to use for context,
-<parameter>for_signature</parameter> is
-a Boolean value that specifies
-whether the generator is being called
-for generating a build signature
+and <parameter>for_signature</parameter> is
+a Boolean value that tells the function
+if it is being called for the purpose of generating a build signature
 (as opposed to actually executing the command).
+Since the build signature is used for rebuild determination,
+the function should omit those elements
+that do not affect whether a rebuild should be triggered
+if <parameter>for_signature</parameter> is true.
 </para>
 
 <para>Example:</para>
@@ -6703,70 +6706,6 @@ to enclose a Python expression to be evaluated.
 See <xref linkend='python_code_substitution'/> below
 for a description.</para>
 
-<para>A variable name
-may also be a Python function
-associated with a
-&consvar; in the environment.
-The function should
-accept four arguments:
-</para>
-<simplelist>
-  <member><parameter>target</parameter> - a list of target nodes</member>
-  <member><parameter>source</parameter> - a list of source nodes</member>
-  <member><parameter>env</parameter> - the &consenv;</member>
-  <member><parameter>for_signature</parameter> -
-    a Boolean value that specifies
-    whether the function is being called
-    for generating a build signature.
-  </member>
-</simplelist>
-
-<para>
-SCons will insert whatever
-the called function returns
-into the expanded string:
-</para>
-
-<programlisting language="python">
-def foo(target, source, env, for_signature):
-    return "bar"
-
-# Will expand $BAR to "bar baz"
-env=Environment(FOO=foo, BAR="$FOO baz")
-</programlisting>
-
-<para>As a reminder, this evaluation happens when
-<literal>$BAR</literal> is actually used in a
-builder action.  The value of <literal>env['BAR']</literal>
-will be exactly as it was set: <literal>"$FOO baz"</literal>.
-</para>
-
-<para>You can use this feature to pass arguments to a
-Python function by creating a callable class
-that stores one or more arguments in an object,
-and then uses them when the
-<methodname>__call__()</methodname>
-method is called.
-Note that in this case,
-the entire variable expansion must
-be enclosed by curly braces
-so that the arguments will
-be associated with the
-instantiation of the class:</para>
-
-<programlisting language="python">
-class foo:
-    def __init__(self, arg):
-        self.arg = arg
-
-    def __call__(self, target, source, env, for_signature):
-        return self.arg + " bar"
-
-# Will expand $BAR to "my argument bar baz"
-env=Environment(FOO=foo, BAR="${FOO('my argument')} baz")
-</programlisting>
-
-
 <para>The special pseudo-variables
 <emphasis role="bold">$(</emphasis>
 and
@@ -6806,6 +6745,72 @@ echo Last build occurred $TODAY. &gt; $TARGET
 echo Last build occurred  . &gt; $TARGET
 </screen>
 
+<para>A variable name may also be the name
+of a &consvar; which refers to a &Python; function
+called to perform the variable substitution.
+Such a function must accept four arguments:
+<parameter>target</parameter>,
+<parameter>source</parameter>,
+<parameter>env</parameter> and
+<parameter>for_signature</parameter>.
+<parameter>source</parameter> is a list of source nodes,
+<parameter>target</parameter> is a list of target nodes,
+<parameter>env</parameter> is the &consenv; to use for context,
+and <parameter>for_signature</parameter> is
+a Boolean value that tells the function
+if it is being called for the purpose of generating a build signature.
+Since the build signature is used for rebuild determination,
+the function should omit variable elements
+that do not affect whether a rebuild should be triggered
+(see <emphasis role="bold">$(</emphasis>
+and <emphasis role="bold">$)</emphasis>
+above) if <parameter>for_signature</parameter> is true.
+</para>
+
+<para>
+SCons will insert whatever
+the called function returns
+into the expanded string:
+</para>
+
+<programlisting language="python">
+def foo(target, source, env, for_signature):
+    return "bar"
+
+# Will expand $BAR to "bar baz"
+env = Environment(FOO=foo, BAR="$FOO baz")
+</programlisting>
+
+<para>As a reminder, substitution evaluation happens when
+<literal>$BAR</literal> is actually used in a
+builder action.  The value of <literal>env['BAR']</literal>
+will be exactly as it was set: <literal>"$FOO baz"</literal>.
+</para>
+
+<para>You can use this feature to pass arguments to a
+Python function by creating a callable class
+that stores one or more arguments in an object,
+and then uses them when the
+<methodname>__call__()</methodname>
+method is called.
+Note that in this case,
+the entire variable expansion must
+be enclosed by curly braces
+so that the arguments will
+be associated with the
+instantiation of the class:</para>
+
+<programlisting language="python">
+class foo:
+    def __init__(self, arg):
+        self.arg = arg
+
+    def __call__(self, target, source, env, for_signature):
+        return self.arg + " bar"
+
+# Will expand $BAR to "my argument bar baz"
+env=Environment(FOO=foo, BAR="${FOO('my argument')} baz")
+</programlisting>
 </refsect2>
 
 <refsect2 id='python_code_substitution'>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -6706,7 +6706,7 @@ to enclose a Python expression to be evaluated.
 See <xref linkend='python_code_substitution'/> below
 for a description.</para>
 
-<para>The special pseudo-variables
+<para>The special escape sequences
 <emphasis role="bold">$(</emphasis>
 and
 <emphasis role="bold">$)</emphasis>
@@ -6721,7 +6721,7 @@ All text between
 and
 <emphasis role="bold">$)</emphasis>
 will be removed from the command line
-before it is added to file signatures,
+before it is added to the action signature,
 and the
 <emphasis role="bold">$(</emphasis>
 and
@@ -6745,9 +6745,10 @@ echo Last build occurred $TODAY. &gt; $TARGET
 echo Last build occurred  . &gt; $TARGET
 </screen>
 
-<para>A variable name may also be the name
-of a &consvar; which refers to a &Python; function
-called to perform the variable substitution.
+<para>While &consvars; are normally directly substituted,
+if a variable refers to a &consvar;
+whose value is a &Python; function,
+that function is called during substitution.
 Such a function must accept four arguments:
 <parameter>target</parameter>,
 <parameter>source</parameter>,
@@ -6768,7 +6769,7 @@ above) if <parameter>for_signature</parameter> is true.
 </para>
 
 <para>
-SCons will insert whatever
+&SCons; will insert whatever
 the called function returns
 into the expanded string:
 </para>
@@ -6781,7 +6782,7 @@ def foo(target, source, env, for_signature):
 env = Environment(FOO=foo, BAR="$FOO baz")
 </programlisting>
 
-<para>As a reminder, substitution evaluation happens when
+<para>As a reminder, substitution happens when
 <literal>$BAR</literal> is actually used in a
 builder action.  The value of <literal>env['BAR']</literal>
 will be exactly as it was set: <literal>"$FOO baz"</literal>.


### PR DESCRIPTION
Fills in some incomplete information, based on some user confusion reported quite a while back.

In the Builder Objects section, under generator, just add a note about omitting pieces that don't affect rebuilds if `for_signature` is true.

In the Variable Substitution section, the same is added for a variable referring to a function, but a little more wording added,
and since the new info kind of depends on the `$( $)` construct, which came just below it in the section, that chunk is moved up to make the reference a little more natural.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

Doc-only change.

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
