### PR TITLE
Fix py unsupported 35

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,9 +9,10 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
+  From William Deegan:
 
-        - Whatever John Doe did.
+    - Fix check for unsupported Python version. It was broken. Also now the error message
+      will include what is the minimum supported version of Python
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -1,10 +1,10 @@
-A new SCons release, 4.1.0, is now available
+A new SCons release, 4.3.1, is now available
 on the SCons download page:
 
       https://scons.org/pages/download.html
 
 
-Here is a summary of the changes since 4.1.0:
+Here is a summary of the changes since 4.3.1:
 
 NEW FUNCTIONALITY
 -----------------
@@ -25,7 +25,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
-- List fixes of outright bugs
+    - Fix check for unsupported Python version. It was broken. Also now the error message
+      will include what is the minimum supported version of Python
 
 IMPROVEMENTS
 ------------

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -32,7 +32,7 @@ it goes here.
 """
 
 # these define the range of versions SCons supports
-unsupported_python_version = (3, 6, 0)
+minimum_python_version = (3, 6, 0)
 deprecated_python_version = (3, 6, 0)
 
 import SCons.compat
@@ -63,6 +63,8 @@ import SCons.Taskmaster
 import SCons.Util
 import SCons.Warnings
 import SCons.Script.Interactive
+
+from SCons import __version__ as SConsVersion
 
 # Global variables
 first_command_start = None
@@ -451,7 +453,7 @@ def python_version_string():
     return sys.version.split()[0]
 
 def python_version_unsupported(version=sys.version_info):
-    return version < unsupported_python_version
+    return version < minimum_python_version
 
 def python_version_deprecated(version=sys.version_info):
     return version < deprecated_python_version
@@ -1375,7 +1377,8 @@ def main():
     # disable that warning.
     if python_version_unsupported():
         msg = "scons: *** SCons version %s does not run under Python version %s.\n"
-        sys.stderr.write(msg % (SCons.__version__, python_version_string()))
+        sys.stderr.write(msg % (SConsVersion, python_version_string()))
+        sys.stderr.write("scons: *** Minimum Python version is %d.%d.%d\n" %minimum_python_version)
         sys.exit(1)
 
     parts = ["SCons by Steven Knight et al.:\n"]

--- a/SConstruct
+++ b/SConstruct
@@ -38,7 +38,7 @@ month_year = strftime('%B %Y')
 
 
 project = 'scons'
-default_version = '4.3.0'
+default_version = '4.3.1'
 copyright = "Copyright (c) %s The SCons Foundation" % copyright_years
 
 #

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -106,11 +106,11 @@ and a database of information about previous builds so
 details do not have to be recalculated each run.
 </para>
 
-<para>&scons; requires Python 3.5 or later to run;
+<para>&scons; requires Python 3.6 or later to run;
 there should be no other dependencies or requirements.
 <emphasis>
-Support for Python 3.5 is deprecated since
-&SCons; 4.2 and will be dropped in a future release.
+Support for Python 3.5 is removed since
+&SCons; 4.3.0.
 The CPython project has retired 3.5:
 <ulink url="https://www.python.org/dev/peps/pep-0478"/>.
 </emphasis></para>

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -55,7 +55,7 @@ from TestCmd import PIPE
 # here provides some independent verification that what we packaged
 # conforms to what we expect.
 
-default_version = '4.3.0ayyyymmdd'
+default_version = '4.3.1ayyyymmdd'
 
 # TODO: these need to be hand-edited when there are changes
 python_version_unsupported = (3, 6, 0)


### PR DESCRIPTION
Fix logic which checks if running SCons with unsupported python version.
Improved error message to include what is the minimum Python version required.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
