### PR TITLE
Fix tests to not hang on Windows with bad .py assoc

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,12 +14,16 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
         - Whatever John Doe did.
 
   From Mats Wichmann:
-    - Tweak definition of default site_scons paths on Windows to conform
-      to conventions, drop a Py2 workaround, and pick as better "system" path
-      (old one remains supported).
+    - Tweak the way default site_scons paths on Windows are expressed to
+      conform to conventions (what they actually resolve to is unchanged),
+      drop a Py2 workaround, and pick a better "system" path, old one
+      remains supported (%AllUsersProfile%\scons\site_scons vs old
+      %AllUsersProfile%\Application Data\scons\site_scons).
     - Fix testsuite to work on Windows systems where there is no usable
-      association for running .py files (there are five tests where we need
-      to do this for internal reasons, these are skipped now).
+      association for running .py files directly. There are a few tests where
+      we need to do this for internal reasons, those are skipped in that case.
+      Bad association could mean some other tool took it over (Visual
+      Studio Code is known to do this), or no association at all.
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,14 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
         - Whatever John Doe did.
 
+  From Mats Wichmann:
+    - Tweak definition of default site_scons paths on Windows to conform
+      to conventions, drop a Py2 workaround, and pick as better "system" path
+      (old one remains supported).
+    - Fix testsuite to work on Windows systems where there is no usable
+      assocation for running .py files (there are five tests where we need
+      to do this for internal reasons, these are skipped now).
+
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,7 +18,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       to conventions, drop a Py2 workaround, and pick as better "system" path
       (old one remains supported).
     - Fix testsuite to work on Windows systems where there is no usable
-      assocation for running .py files (there are five tests where we need
+      association for running .py files (there are five tests where we need
       to do this for internal reasons, these are skipped now).
 
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -22,6 +22,12 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - List modifications to existing features, where the previous behavior
   wouldn't actually be considered a bug
 
+- On Windows, %AllUsersProfile%\scons\site_scons is now the default "system"
+  location for a site_scons. %AllUsersProfile%\Application Data\scons\site_scons
+  will continue to work. There does not seem to be any convention to use
+  an "Application Data" subdirectory here.
+
+
 FIXES
 -----
 

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -381,7 +381,7 @@ def generate(env):
     # for SystemDrive because it's related.
     #
     # Weigh the impact carefully before adding other variables to this list.
-    import_env = ['SystemDrive', 'SystemRoot', 'TEMP', 'TMP' ]
+    import_env = ['SystemDrive', 'SystemRoot', 'TEMP', 'TMP', 'USERPROFILE']
     for var in import_env:
         v = os.environ.get(var)
         if v:

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -788,13 +788,12 @@ def _load_all_site_scons_dirs(topdir, verbose=False):
         return os.path.expanduser('~/'+d)
 
     if platform == 'win32' or platform == 'cygwin':
-        # Note we use $ here instead of %...% because older
-        # pythons (prior to 2.6?) didn't expand %...% on Windows.
-        # This set of dirs should work on XP, Vista, 7 and later.
         sysdirs=[
-            os.path.expandvars('$ALLUSERSPROFILE\\Application Data\\scons'),
-            os.path.expandvars('$USERPROFILE\\Local Settings\\Application Data\\scons')]
-        appdatadir = os.path.expandvars('$APPDATA\\scons')
+            os.path.expandvars('%AllUsersProfile%\\scons'),
+            # TODO older path, kept for compat
+            os.path.expandvars('%AllUsersProfile%\\Application Data\\scons'),
+            os.path.expandvars('%LocalAppData%\\scons')]
+        appdatadir = os.path.expandvars('%AppData%\\scons')
         if appdatadir not in sysdirs:
             sysdirs.append(appdatadir)
         sysdirs.append(homedir('.scons'))

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1729,27 +1729,28 @@ Also suppresses SCons status messages.</para>
   </varlistentry>
 
   <varlistentry id="opt-site-dir">
-  <term><option>--site-dir=<replaceable>dir</replaceable></option></term>
+  <term><option>--site-dir=<replaceable>path</replaceable></option></term>
   <listitem>
-<para>Uses the named <replaceable>dir</replaceable> as the site directory
-rather than the default
-<filename>site_scons</filename>
-directories.  This directory will be prepended to
+<para>Use a specific <replaceable>path</replaceable> as the site directory
+rather than searching the list of default site directories.
+This directory will be prepended to
 <varname>sys.path</varname>,
 the module
-<filename><replaceable>dir</replaceable>/site_init.py</filename>
+<filename><replaceable>path</replaceable>/site_init.py</filename>
 will be loaded if it exists, and
-<filename><replaceable>dir</replaceable>/site_tools</filename>
+<filename><replaceable>path</replaceable>/site_tools</filename>
 will be added to the default toolpath.</para>
 
-<para>The default set of
-<filename>site_scons</filename>
-directories used when
+<para>The default set of site directories searched when
 <option>--site-dir</option>
 is not specified depends on the system platform, as follows.
+Users or system administrators can tune site-specific or
+project-specific &SCons; behavior by setting up a
+site directory in one or more of these locations.
 Directories are examined in the order given, from most
-generic to most specific, so the last-executed <filename>site_init.py</filename> file is
-the most specific one (which gives it the chance to override
+generic ("system" directories) to most specific (in the current project),
+so the last-executed <filename>site_init.py</filename> file is
+the most specific one, giving it the chance to override
 everything else), and the directories are prepended to the paths, again so
 the last directory examined comes first in the resulting path.</para>
 
@@ -1758,11 +1759,19 @@ the last directory examined comes first in the resulting path.</para>
       <term>Windows:</term>
       <listitem>
 <literallayout class="monospaced">
-%ALLUSERSPROFILE/Application Data/scons/site_scons
-%USERPROFILE%/Local Settings/Application Data/scons/site_scons
+%ALLUSERSPROFILE%/scons/site_scons
+%LOCALAPPDATA%/scons/site_scons
 %APPDATA%/scons/site_scons
-%HOME%/.scons/site_scons
+%USERPROFILE%/.scons/site_scons
 ./site_scons
+</literallayout>
+<para>
+Note earlier versions of the documentation listed a different
+path for the "system" site directory, this path is still checked
+but its use is discouraged:
+</para>
+<literallayout class="monospaced">
+%ALLUSERSPROFILE%/Application Data/scons/site_scons
 </literallayout>
       </listitem>
       </varlistentry>

--- a/runtest.py
+++ b/runtest.py
@@ -259,7 +259,7 @@ if args.output:
 
 # --- define helpers ----
 if sys.platform == 'win32':
-    # thanks to Brett Cannon for this recipe
+    # thanks to Eryk Sun for this recipe
     import ctypes
 
     shlwapi = ctypes.OleDLL('shlwapi')

--- a/runtest.py
+++ b/runtest.py
@@ -259,7 +259,7 @@ if args.output:
 
 # --- define helpers ----
 if sys.platform == 'win32':
-    # thanks to Bret Cannon for this recipe
+    # thanks to Brett Cannon for this recipe
     import ctypes
 
     shlwapi = ctypes.OleDLL('shlwapi')

--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -60,7 +60,7 @@ for arg in sys.argv[1:]:
     if arg.startswith('--profile='):
         profile = arg[10:]
         break
-print('my_python.py: %%s' %% profile)
+print('my_python.py: %s' % profile)
 """,
 )
 

--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -30,14 +30,14 @@ Verify specifying an alternate Python executable in a config file.
 import os
 
 import TestSCons_time
-from TestCmd import IS_WINDOWS
 
-_python_ = TestSCons_time._python_
+from TestCmd import NEED_HELPER
+from TestSCons_time import _python_
 
 test = TestSCons_time.TestSCons_time()
-if IS_WINDOWS:
-    # tests expect Windows file assoc to run my_python, not in our control.
-    test.skip_test("Skipping test on win32 due to launch problems.")
+
+if NEED_HELPER:
+    test.skip_test("Test host cannot directly execute scripts, skipping test\n")
 
 test.write_sample_project('foo.tar.gz')
 

--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -45,8 +45,8 @@ my_python_py = test.workpath('my_python.py')
 
 test.write(
     'config',
-    """\
-python = r'%(my_python_py)s'
+    f"""\
+python = f'{my_python_py}'
 """,
 )
 

--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -43,12 +43,17 @@ test.write_sample_project('foo.tar.gz')
 
 my_python_py = test.workpath('my_python.py')
 
-test.write('config', """\
+test.write(
+    'config',
+    """\
 python = r'%(my_python_py)s'
-""" % locals())
+""",
+)
 
-test.write(my_python_py, """\
-#!%(_python_)s
+test.write(
+    my_python_py,
+    f"""\
+#!{_python_}
 import sys
 profile = ''
 for arg in sys.argv[1:]:
@@ -56,7 +61,8 @@ for arg in sys.argv[1:]:
         profile = arg[10:]
         break
 print('my_python.py: %%s' %% profile)
-""" % locals())
+""",
+)
 
 os.chmod(my_python_py, 0o755)
 

--- a/test/scons-time/run/option/python.py
+++ b/test/scons-time/run/option/python.py
@@ -32,7 +32,6 @@ import os
 import TestSCons_time
 
 from TestCmd import NEED_HELPER
-from TestCmd import IS_WINDOWS
 from TestSCons_time import _python_
 
 test = TestSCons_time.TestSCons_time()
@@ -44,8 +43,10 @@ test.write_sample_project('foo.tar.gz')
 
 my_python_py = test.workpath('my_python.py')
 
-test.write(my_python_py, """\
-#!%(_python_)s
+test.write(
+    my_python_py,
+    f"""\
+#!{_python_}
 import sys
 profile = ''
 for arg in sys.argv[1:]:
@@ -53,7 +54,8 @@ for arg in sys.argv[1:]:
         profile = arg[10:]
         break
 sys.stdout.write('my_python.py: %%s\\n' %% profile)
-""" % locals())
+""",
+)
 
 os.chmod(my_python_py, 0o755)
 

--- a/test/scons-time/run/option/python.py
+++ b/test/scons-time/run/option/python.py
@@ -53,7 +53,7 @@ for arg in sys.argv[1:]:
     if arg.startswith('--profile='):
         profile = arg[10:]
         break
-sys.stdout.write('my_python.py: %%s\\n' %% profile)
+sys.stdout.write('my_python.py: %s\\n' % profile)
 """,
 )
 

--- a/test/scons-time/run/option/python.py
+++ b/test/scons-time/run/option/python.py
@@ -30,14 +30,15 @@ Verify the run --python option to specify an alternatie Python executable.
 import os
 
 import TestSCons_time
-from TestCmd import IS_WINDOWS
 
-_python_ = TestSCons_time._python_
+from TestCmd import NEED_HELPER
+from TestCmd import IS_WINDOWS
+from TestSCons_time import _python_
 
 test = TestSCons_time.TestSCons_time()
-if IS_WINDOWS:
-    # tests expect Windows file assoc to run my_python, not in our control.
-    test.skip_test("Skipping test on win32 due to launch problems.")
+
+if NEED_HELPER:
+    test.skip_test("Test host cannot directly execute scripts, skipping test\n")
 
 test.write_sample_project('foo.tar.gz')
 

--- a/test/sconsign/script/SConsignFile.py
+++ b/test/sconsign/script/SConsignFile.py
@@ -44,7 +44,9 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, fr"""#!{_python_}
+test.write(
+    fake_cc_py,
+    fr"""#!{_python_}
 import os
 import re
 import sys
@@ -75,10 +77,12 @@ with open(sys.argv[2], 'w') as outf, open(sys.argv[3], 'r') as ifp:
     process(ifp, outf)
 
 sys.exit(0)
-"""
+""",
 )
 
-test.write(fake_link_py, fr"""#!{_python_}
+test.write(
+    fake_link_py,
+    fr"""#!{_python_}
 import sys
 
 with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
@@ -86,7 +90,7 @@ with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
     outf.write(ifp.read())
 
 sys.exit(0)
-"""
+""",
 )
 
 test.chmod(fake_cc_py, 0o755)
@@ -103,7 +107,9 @@ sub2_hello_obj  = 'sub2/hello.obj'
 sub2_inc1_h     = 'sub2/inc1.h'
 sub2_inc2_h     = 'sub2/inc2.h'
 
-test.write(['SConstruct'], f"""\
+test.write(
+    ['SConstruct'],
+    f"""\
 SConsignFile()
 env1 = Environment(
     PROGSUFFIX='.exe',
@@ -115,7 +121,7 @@ env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
 env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
-"""
+""",
 )
 # TODO in the above, we would normally want to run a python program
 # using "our python" like this:

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -62,7 +62,9 @@ test.subdir('sub1', 'sub2')
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, fr"""#!{_python_}
+test.write(
+    fake_cc_py,
+    fr"""#!{_python_}
 import os
 import re
 import sys
@@ -93,10 +95,12 @@ with open(sys.argv[2], 'w') as outf, open(sys.argv[3], 'r') as ifp:
     process(ifp, outf)
 
 sys.exit(0)
-"""
+""",
 )
 
-test.write(fake_link_py, fr"""#!{_python_}
+test.write(
+    fake_link_py,
+    fr"""#!{_python_}
 import sys
 
 with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
@@ -104,13 +108,15 @@ with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
     outf.write(ifp.read())
 
 sys.exit(0)
-"""
+""",
 )
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)
 
-test.write('SConstruct', f"""
+test.write(
+    'SConstruct',
+    f"""
 SConsignFile(None)
 Decider('timestamp-newer')
 env1 = Environment(
@@ -126,7 +132,7 @@ env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
 env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
-"""
+""",
 )
 # TODO in the above, we would normally want to run a python program
 # using "our python" like this:

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -56,7 +56,9 @@ database_name = test.get_sconsignname()
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, fr"""#!{_python_}
+test.write(
+    fake_cc_py,
+    fr"""#!{_python_}
 import os
 import re
 import sys
@@ -87,10 +89,12 @@ with open(sys.argv[2], 'w') as outf, open(sys.argv[3], 'r') as ifp:
     process(ifp, outf)
 
 sys.exit(0)
-"""
+""",
 )
 
-test.write(fake_link_py, fr"""#!{_python_}
+test.write(
+    fake_link_py,
+    fr"""#!{_python_}
 import sys
 
 with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
@@ -98,7 +102,7 @@ with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
     outf.write(ifp.read())
 
 sys.exit(0)
-"""
+""",
 )
 
 test.chmod(fake_cc_py, 0o755)
@@ -115,7 +119,9 @@ sub2_hello_obj  = 'sub2/hello.obj'
 sub2_inc1_h     = 'sub2/inc1.h'
 sub2_inc2_h     = 'sub2/inc2.h'
 
-test.write(['SConstruct'], f"""
+test.write(
+    ['SConstruct'],
+    f"""
 SConsignFile(None)
 env1 = Environment(
     PROGSUFFIX='.exe',
@@ -130,7 +136,7 @@ env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
 env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
-"""
+""",
 )
 # TODO in the above, we would normally want to run a python program
 # using "our python" like this:

--- a/test/sconsign/script/no-SConsignFile.py
+++ b/test/sconsign/script/no-SConsignFile.py
@@ -22,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the sconsign script works when using an individual
@@ -34,9 +31,13 @@ Verify that the sconsign script works when using an individual
 import TestSCons
 import TestSConsign
 
-_python_ = TestSCons._python_
+from TestSCons import _python_
+from TestCmd import NEED_HELPER
 
 test = TestSConsign.TestSConsign(match = TestSConsign.match_re)
+
+if NEED_HELPER:
+    test.skip_test("Test host cannot directly execute scripts, skipping test\n")
 
 test.subdir('sub1', 'sub2')
 
@@ -55,7 +56,7 @@ database_name = test.get_sconsignname()
 fake_cc_py = test.workpath('fake_cc.py')
 fake_link_py = test.workpath('fake_link.py')
 
-test.write(fake_cc_py, r"""#!%(_python_)s
+test.write(fake_cc_py, fr"""#!{_python_}
 import os
 import re
 import sys
@@ -82,21 +83,23 @@ def process(infp, outfp):
             outfp.write(line)
 
 with open(sys.argv[2], 'w') as outf, open(sys.argv[3], 'r') as ifp:
-    outf.write('fake_cc.py:  %%s\n' %% sys.argv)
+    outf.write('fake_cc.py:  %s\n' % sys.argv)
     process(ifp, outf)
 
 sys.exit(0)
-""" % locals())
+"""
+)
 
-test.write(fake_link_py, r"""#!%(_python_)s
+test.write(fake_link_py, fr"""#!{_python_}
 import sys
 
 with open(sys.argv[1], 'w') as outf, open(sys.argv[2], 'r') as ifp:
-    outf.write('fake_link.py:  %%s\n' %% sys.argv)
+    outf.write('fake_link.py:  %s\n' % sys.argv)
     outf.write(ifp.read())
 
 sys.exit(0)
-""" % locals())
+"""
+)
 
 test.chmod(fake_cc_py, 0o755)
 test.chmod(fake_link_py, 0o755)
@@ -112,7 +115,7 @@ sub2_hello_obj  = 'sub2/hello.obj'
 sub2_inc1_h     = 'sub2/inc1.h'
 sub2_inc2_h     = 'sub2/inc2.h'
 
-test.write(['SConstruct'], """
+test.write(['SConstruct'], f"""
 SConsignFile(None)
 env1 = Environment(
     PROGSUFFIX='.exe',
@@ -120,35 +123,38 @@ env1 = Environment(
     # Specify the command lines with lists-of-lists so
     # finding the implicit dependencies works even with
     # spaces in the fake_*_py path names.
-    CCCOM=[[r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-    LINKCOM=[[r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
+    CCCOM=[[r'{fake_cc_py}', 'sub2', '$TARGET', '$SOURCE']],
+    LINKCOM=[[r'{fake_link_py}', '$TARGET', '$SOURCE']],
 )
 env1.PrependENVPath('PATHEXT', '.PY')
 env1.Program('sub1/hello.c')
 env2 = env1.Clone(CPPPATH=['sub2'])
 env2.Program('sub2/hello.c')
-""" % locals())
+"""
+)
 # TODO in the above, we would normally want to run a python program
-# using "our python" as in:
-#    CCCOM=[[r'%(_python_)s', r'%(fake_cc_py)s', 'sub2', '$TARGET', '$SOURCE']],
-#    LINKCOM=[[r'%(_python_)s', r'%(fake_link_py)s', '$TARGET', '$SOURCE']],
-# however we're looking at dependencies with sconsign, so that breaks things
+# using "our python" like this:
+#    CCCOM=[[r'{_python_}', r'{fake_cc_py}', 'sub2', '$TARGET', '$SOURCE']],
+#    LINKCOM=[[r'{_python_}', r'{fake_link_py}', '$TARGET', '$SOURCE']],
+# however we're looking at dependencies with sconsign, so that breaks things.
+# It still breaks things on Windows if something else is registered as the
+# handler for .py files, as Visual Studio Code installs itself.
 
-test.write(['sub1', 'hello.c'], r"""\
+test.write(['sub1', 'hello.c'], r"""
 sub1/hello.c
 """)
 
-test.write(['sub2', 'hello.c'], r"""\
+test.write(['sub2', 'hello.c'], r"""
 #include <inc1.h>
 #include <inc2.h>
 sub2/hello.c
 """)
 
-test.write(['sub2', 'inc1.h'], r"""\
+test.write(['sub2', 'inc1.h'], r"""
 #define STRING1 "inc1.h"
 """)
 
-test.write(['sub2', 'inc2.h'], r"""\
+test.write(['sub2', 'inc2.h'], r"""
 #define STRING2 "inc2.h"
 """)
 
@@ -167,9 +173,9 @@ hello.obj: %(sig_re)s \d+ \d+
         %(sig_re)s \[.*\]
 """ % locals()
 
-test.run_sconsign(arguments = "sub1/{}".format(database_name), stdout=expect)
+test.run_sconsign(arguments = f"sub1/{database_name}", stdout=expect)
 
-test.run_sconsign(arguments = "--raw sub1/{}".format(database_name),
+test.run_sconsign(arguments = f"--raw sub1/{database_name}",
          stdout = r"""hello.c: {'csig': '%(sig_re)s', 'timestamp': \d+L?, 'size': \d+L?, '_version_id': 2}
 hello.exe: {'csig': '%(sig_re)s', 'timestamp': \d+L?, 'size': \d+L?, '_version_id': 2}
         %(sub1_hello_obj)s: {'csig': '%(sig_re)s', 'timestamp': \d+L?, 'size': \d+L?, '_version_id': 2}
@@ -181,7 +187,7 @@ hello.obj: {'csig': '%(sig_re)s', 'timestamp': \d+L?, 'size': \d+L?, '_version_i
         %(sig_re)s \[.*\]
 """ % locals())
 
-test.run_sconsign(arguments = "-v sub1/{}".format(database_name),
+test.run_sconsign(arguments = f"-v sub1/{database_name}",
          stdout = r"""hello.c:
     csig: %(sig_re)s
     timestamp: \d+
@@ -216,7 +222,7 @@ hello.obj:
     action: %(sig_re)s \[.*\]
 """ % locals())
 
-test.run_sconsign(arguments = "-c -v sub1/{}".format(database_name),
+test.run_sconsign(arguments = f"-c -v sub1/{database_name}",
          stdout = r"""hello.c:
     csig: %(sig_re)s
 hello.exe:
@@ -225,7 +231,7 @@ hello.obj:
     csig: %(sig_re)s
 """ % locals())
 
-test.run_sconsign(arguments = "-s -v sub1/{}".format(database_name),
+test.run_sconsign(arguments = f"-s -v sub1/{database_name}",
          stdout = r"""hello.c:
     size: \d+
 hello.exe:
@@ -234,7 +240,7 @@ hello.obj:
     size: \d+
 """ % locals())
 
-test.run_sconsign(arguments = "-t -v sub1/{}".format(database_name),
+test.run_sconsign(arguments = f"-t -v sub1/{database_name}",
          stdout = r"""hello.c:
     timestamp: \d+
 hello.exe:
@@ -243,14 +249,14 @@ hello.obj:
     timestamp: \d+
 """ % locals())
 
-test.run_sconsign(arguments = "-e hello.obj sub1/{}".format(database_name),
+test.run_sconsign(arguments = f"-e hello.obj sub1/{database_name}",
          stdout = r"""hello.obj: %(sig_re)s \d+ \d+
         %(sub1_hello_c)s: %(sig_re)s \d+ \d+
         fake_cc\.py: %(sig_re)s \d+ \d+
         %(sig_re)s \[.*\]
 """ % locals())
 
-test.run_sconsign(arguments = "-e hello.obj -e hello.exe -e hello.obj sub1/{}".format(database_name),
+test.run_sconsign(arguments = f"-e hello.obj -e hello.exe -e hello.obj sub1/{database_name}",
          stdout = r"""hello.obj: %(sig_re)s \d+ \d+
         %(sub1_hello_c)s: %(sig_re)s \d+ \d+
         fake_cc\.py: %(sig_re)s \d+ \d+
@@ -265,7 +271,7 @@ hello.obj: %(sig_re)s \d+ \d+
         %(sig_re)s \[.*\]
 """ % locals())
 
-test.run_sconsign(arguments = "sub2/{}".format(database_name),
+test.run_sconsign(arguments = f"sub2/{database_name}",
          stdout = r"""hello.c: %(sig_re)s \d+ \d+
 hello.exe: %(sig_re)s \d+ \d+
         %(sub2_hello_obj)s: %(sig_re)s \d+ \d+
@@ -293,7 +299,7 @@ inc2.h: %(sig_re)s \d+ \d+
 #        inc2.h: %(sig_re)s \d+ \d+
 #""" % locals())
 
-test.run_sconsign(arguments = "-e hello.obj sub2/{} sub1/{}".format(database_name, database_name),
+test.run_sconsign(arguments = f"-e hello.obj sub2/{database_name} sub1/{database_name}",
          stdout = r"""hello.obj: %(sig_re)s \d+ \d+
         %(sub2_hello_c)s: %(sig_re)s \d+ \d+
         %(sub2_inc1_h)s: %(sig_re)s \d+ \d+

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -312,16 +312,14 @@ import traceback
 from collections import UserList, UserString
 from subprocess import PIPE, STDOUT
 
-
 IS_WINDOWS = sys.platform == 'win32'
 IS_MACOS = sys.platform == 'darwin'
 IS_64_BIT = sys.maxsize > 2**32
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
-
+NEED_HELPER = os.environ.get('SCONS_NO_DIRECT_SCRIPT')
 
 # sentinel for cases where None won't do
 _Null = object()
-
 
 __all__ = [
     'diff_re',

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -307,8 +307,6 @@ class TestSCons(TestCommon):
                 kw['program'] = os.path.join(self.orig_cwd, kw['program'])
         if 'interpreter' not in kw and not os.environ.get('SCONS_EXEC'):
             kw['interpreter'] = [python, ]
-            if sys.version_info[0] < 3:
-                kw['interpreter'].append('-tt')
         if 'match' not in kw:
             kw['match'] = match_exact
         if 'workdir' not in kw:

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -763,8 +763,7 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
         return result
 
     def get_vs_host_arch(self):
-        """ Get an MSVS, SDK , and/or MSVS acceptable platform arch
-        """
+        """ Returns an MSVS, SDK , and/or MSVS acceptable platform arch. """
 
         # Dict to 'canonalize' the arch
         _ARCH_TO_CANONICAL = {
@@ -778,11 +777,6 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions()))
         }
 
         host_platform = platform.machine()
-        # TODO(2.5):  the native Python platform.machine() function returns
-        # '' on all Python versions before 2.6, after which it also uses
-        # PROCESSOR_ARCHITECTURE.
-        if not host_platform:
-            host_platform = os.environ.get('PROCESSOR_ARCHITECTURE', '')
 
         try:
             host = _ARCH_TO_CANONICAL[host_platform]


### PR DESCRIPTION
For systems where the association for .py files is not to an actual Python interpreter, those few cases where we need to run a Python script directly as a program don't work.  This could be because the association was never set up, or because some other program (e.g. Visual Studio Code) has taken it over. In some cases may appear to "hang" because the alternate program is waiting for user interaction

`runtest.py` now has a mechanism to check (thanks to Brett Cannon for providing this incantation). It isn't super precise (looks for the substring "py" in the queried association), but should work out.  It sets an environment variable which the test framework can read and as a result set a flag which individual tests can read.

Two tests in scons-time which had previously been set to skip-if-win32 now look at this flag instead.  Three tests in sconsign now also look at this flag. This allows a clean run on my dev box with VS Code having taken over the .py association.

Various things can break if the environment used to fire off Windows processes doesn't contain `%UserProfile%`. Added this to the short list of passthrough env vars.  Apparently an environment without this value is now considered invalid (it blew up the erroneously launched VS Code, but we've apparently been lucky it hasn't blown up more things - believe there was also a report of a problem with the Visual Studio setup scripts).

A little extra cleanup:
- a couple of Py2-isms were cleaned out (`Script/Main.py` and in the test framework)
- The paths to look for site-scons were rewritten (part of this was another Py2-ism), and the system path changed a bit - the old path is still checked, and the manpage updated to reflect this.
- `runtest.py` dropped the unused whereis functions.
- the three sconsign tests now use f-string formatting, mostly as an experiment to see how easy it is to convert.

Fixes #4053

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
