### PR TITLE
Followon test fix for PR #4067

### DIFF
--- a/test/scons-time/run/config/python.py
+++ b/test/scons-time/run/config/python.py
@@ -46,14 +46,13 @@ my_python_py = test.workpath('my_python.py')
 test.write(
     'config',
     f"""\
-python = f'{my_python_py}'
+python = r'{my_python_py}'
 """,
 )
 
 test.write(
     my_python_py,
-    f"""\
-#!{_python_}
+    fr"""#!{_python_}
 import sys
 profile = ''
 for arg in sys.argv[1:]:
@@ -66,7 +65,7 @@ print('my_python.py: %s' % profile)
 
 os.chmod(my_python_py, 0o755)
 
-test.run(arguments = 'run -f config foo.tar.gz')
+test.run(arguments='run -f config foo.tar.gz')
 
 prof0 = test.workpath('foo-000-0.prof')
 prof1 = test.workpath('foo-000-1.prof')

--- a/test/scons-time/run/option/python.py
+++ b/test/scons-time/run/option/python.py
@@ -45,21 +45,20 @@ my_python_py = test.workpath('my_python.py')
 
 test.write(
     my_python_py,
-    f"""\
-#!{_python_}
+    fr"""#!{_python_}
 import sys
 profile = ''
 for arg in sys.argv[1:]:
     if arg.startswith('--profile='):
         profile = arg[10:]
         break
-sys.stdout.write('my_python.py: %s\\n' % profile)
+print('my_python.py: %s' % profile)
 """,
 )
 
 os.chmod(my_python_py, 0o755)
 
-test.run(arguments = 'run --python %s foo.tar.gz' % my_python_py)
+test.run(arguments='run --python %s foo.tar.gz' % my_python_py)
 
 prof0 = test.workpath('foo-000-0.prof')
 prof1 = test.workpath('foo-000-1.prof')


### PR DESCRIPTION
There was another hole in the tests after updating them, which was missed locally because the local test machines took the "skip for external reasons" path, and didn't actually run the test that failed.  *Any* SCons test path starts with the value of `%TEMP%`, which by default is "`C:\Users\something\AppData\Local\Temp`".  If not entered as a raw string, that's a unicode escape starting with the 3rd char, and leads to a decode error.  I somehow uncovered one of those that wasn't protected as a rawstring.

This is test-only.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
