### PR TITLE
Added cache-debug messages for cache push failures.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix check for unsupported Python version. It was broken. Also now the error message
       will include what is the minimum supported version of Python
 
+  From Daniel Moody:
+    - Add cache-debug messages for push failures.
+
   From Mats Wichmann:
     - Tweak the way default site_scons paths on Windows are expressed to
       conform to conventions (what they actually resolve to is unchanged),
@@ -63,7 +66,7 @@ RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700
     - Small fix to ensure CLVar default value is an empty list.
       See MongoDB bug report: https://jira.mongodb.org/browse/SERVER-59656
       Code contributed by MongoDB.
-    - Ninja - Fixed an issue where if you control-c and/or killed ninja while it was running scons to 
+    - Ninja - Fixed an issue where if you control-c and/or killed ninja while it was running scons to
       regenerate build.ninja you would end up with no build.ninja file and have to rerun scons from scratch.
       Code contributed by MongoDB.
 
@@ -75,12 +78,12 @@ RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700
     - Fix ninja tool to never use for_sig substitution because ninja does not use signatures. This
       issue affected CommandGeneratorAction function actions specifically.
     - Expanded ninja Mkdir to also support Mkdir actions.
-    - Added support for the PCH environment variable to support subst generators. 
+    - Added support for the PCH environment variable to support subst generators.
     - Fix command line escaping for ninja dollar sign escape. Without escaping ninja properly,
       the ninja file scons regenerate and callback invocations will lose the $ characters used in
       the scons command line which ninja uses itself for escaping. For Example:
           scons BUILD=xyz OTHERVAR=$BUILD
-      Prior to this fix, it would cause ninja to fail to escape the dollar sign, leading to the 
+      Prior to this fix, it would cause ninja to fail to escape the dollar sign, leading to the
       single dollar sign being used as a ninja escape character in the ninja file.
 
   From Daniel Moody:
@@ -122,7 +125,7 @@ RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700
     - Java updates: on Windows, detect more default JDK install locations.
       On all platforms, more Java versions (up to 17.0 now).  Add more information
       on version selection to docs.
-      Update docs on JavaH tool in light of javah command dropped since 10.0. 
+      Update docs on JavaH tool in light of javah command dropped since 10.0.
       Try to be better about preserving user's passed-in JAVA* construction vars.
     - Start the deprecation of the qt tool, which refers to Qt3 (usupported
       since around 2006). There's a deprecation warning added, initially

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -39,6 +39,7 @@ IMPROVEMENTS
 
 - Verify that a user specified msvc script (via MSVC_USE_SCRIPT) exists and raise an
   exception immediately when the user specified msvc script does not exist.
+- Add cache-debug messages for push failures.
 
 PACKAGING
 ---------

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -124,7 +124,8 @@ def CachePushFunc(target, source, env):
         # the CacheDir being on a separate file system that's full.
         # In any case, inability to push a file to cache doesn't affect
         # the correctness of the build, so just print a warning.
-        msg = errfmt % (str(target), cachefile)
+        msg = errfmt % (str(t), cachefile)
+        cd.CacheDebug(errfmt, str(t), cachefile)
         SCons.Warnings.warn(SCons.Warnings.CacheWriteErrorWarning, msg)
 
 CachePush = SCons.Action.Action(CachePushFunc, None)


### PR DESCRIPTION
MongoDB has seen cases were left over ".tmp" cache files were found. It's suspected that the silent exception here:
https://github.com/SCons/scons/blob/966a897d02d48b2834fd444ba4c5b2ea84cc4f42/SCons/CacheDir.py#L121-L128
is related.

Adding a debug message will make it more visible as to what happened.

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
