### PR TITLE
Clean up lint complaints in MSCommon

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       we need to do this for internal reasons, those are skipped in that case.
       Bad association could mean some other tool took it over (Visual
       Studio Code is known to do this), or no association at all.
+    - logging code ("debug" call) in Tool/MSCommon now conforms to the
+      Python logging recommended "lazy interpolation" so instead of
+      debug("template %s" % text) it looks like debug("template %s", text)
+      so the logging system does the interpolation when/if needed.
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,10 +31,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       we need to do this for internal reasons, those are skipped in that case.
       Bad association could mean some other tool took it over (Visual
       Studio Code is known to do this), or no association at all.
-    - logging code ("debug" call) in Tool/MSCommon now conforms to the
-      Python logging recommended "lazy interpolation" so instead of
-      debug("template %s" % text) it looks like debug("template %s", text)
-      so the logging system does the interpolation when/if needed.
+    - Updated debug code in MSVC and MSVS tools to conform to the
+      suggested "lazy interpolation" use of the Python logging module.
+      Calls now look like 'debug("template %s", text)' rather than
+      'debug("template %s" % text)' so the logging system does the
+      interpolation only when/if needed (was a pylint warning).
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/SCons/Tool/MSCommon/__init__.py
+++ b/SCons/Tool/MSCommon/__init__.py
@@ -30,20 +30,23 @@ import SCons.Errors
 import SCons.Platform.win32
 import SCons.Util
 
-from SCons.Tool.MSCommon.sdk import mssdk_exists, \
-                                    mssdk_setup_env
+from SCons.Tool.MSCommon.sdk import mssdk_exists, mssdk_setup_env
 
-from SCons.Tool.MSCommon.vc import msvc_exists, \
-                                   msvc_setup_env, \
-                                   msvc_setup_env_once, \
-                                   msvc_version_to_maj_min, \
-                                   msvc_find_vswhere
+from SCons.Tool.MSCommon.vc import (
+    msvc_exists,
+    msvc_setup_env,
+    msvc_setup_env_once,
+    msvc_version_to_maj_min,
+    msvc_find_vswhere,
+)
 
-from SCons.Tool.MSCommon.vs import get_default_version, \
-                                   get_vs_by_version, \
-                                   merge_default_version, \
-                                   msvs_exists, \
-                                   query_versions
+from SCons.Tool.MSCommon.vs import (
+    get_default_version,
+    get_vs_by_version,
+    merge_default_version,
+    msvs_exists,
+    query_versions,
+)
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Tool/MSCommon/arch.py
+++ b/SCons/Tool/MSCommon/arch.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,11 +20,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """Module to define supported Windows chip architectures.
+"""
+MS compilers: Supported Windows chip architectures.
 """
 
 
@@ -40,22 +39,18 @@ SupportedArchitectureList = [
         'x86',
         ['i386', 'i486', 'i586', 'i686'],
     ),
-
     ArchDefinition(
         'x86_64',
         ['AMD64', 'amd64', 'em64t', 'EM64T', 'x86_64'],
     ),
-
     ArchDefinition(
         'ia64',
         ['IA64'],
     ),
-    
     ArchDefinition(
         'arm',
         ['ARM'],
     ),
-
 ]
 
 SupportedArchitectureMap = {}
@@ -64,3 +59,8 @@ for a in SupportedArchitectureList:
     for s in a.synonyms:
         SupportedArchitectureMap[s] = a
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -73,13 +73,13 @@ elif LOGFILE:
             return True
     logging.basicConfig(
         # This looks like:
-        #   00109ms:MSCommon/vc.py:find_vc_pdir#447:
+        #   00109ms:MSCommon/vc.py:find_vc_pdir#447:VC found '14.3'
         format=(
             '%(relativeCreated)05dms'
             ':%(relfilename)s'
             ':%(funcName)s'
             '#%(lineno)s'
-            ':%(message)s: '
+            ':%(message)s'
         ),
         filename=LOGFILE,
         level=logging.DEBUG)

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -1,8 +1,6 @@
-"""
-Common helper functions for working with the Microsoft tool chain.
-"""
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -22,8 +20,10 @@ Common helper functions for working with the Microsoft tool chain.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Common helper functions for working with the Microsoft tool chain.
+"""
 
 import copy
 import json
@@ -38,8 +38,12 @@ import SCons.Util
 # set to '-' to print to console, else set to filename to log to
 LOGFILE = os.environ.get('SCONS_MSCOMMON_DEBUG')
 if LOGFILE == '-':
-    def debug(message):
-        print(message)
+    def debug(message, *args):
+        if args:
+            print(message % args)
+        else:
+            print(message)
+
 elif LOGFILE:
     import logging
     modulelist = (
@@ -83,7 +87,8 @@ elif LOGFILE:
     logger.addFilter(_Debug_Filter())
     debug = logger.debug
 else:
-    def debug(x): return None
+    def debug(x, *args):
+        return None
 
 
 # SCONS_CACHE_MSVC_CONFIG is public, and is documented.
@@ -214,7 +219,7 @@ def normalize_env(env, keys, force=False):
     if sys32_ps_dir not in normenv['PATH']:
         normenv['PATH'] = normenv['PATH'] + os.pathsep + sys32_ps_dir
 
-    debug("PATH: %s" % normenv['PATH'])
+    debug("PATH: %s", normenv['PATH'])
     return normenv
 
 
@@ -256,14 +261,14 @@ def get_output(vcbat, args=None, env=None):
     env['ENV'] = normalize_env(env['ENV'], vs_vc_vars, force=False)
 
     if args:
-        debug("Calling '%s %s'" % (vcbat, args))
+        debug("Calling '%s %s'", vcbat, args)
         popen = SCons.Action._subproc(env,
                                       '"%s" %s & set' % (vcbat, args),
                                       stdin='devnull',
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE)
     else:
-        debug("Calling '%s'" % vcbat)
+        debug("Calling '%s'", vcbat)
         popen = SCons.Action._subproc(env,
                                       '"%s" & set' % vcbat,
                                       stdin='devnull',
@@ -279,8 +284,8 @@ def get_output(vcbat, args=None, env=None):
         stderr = popen.stderr.read()
 
     # Extra debug logic, uncomment if necessary
-    # debug('stdout:%s' % stdout)
-    # debug('stderr:%s' % stderr)
+    # debug('stdout:%s', stdout)
+    # debug('stderr:%s', stderr)
 
     # Ongoing problems getting non-corrupted text led to this
     # changing to "oem" from "mbcs" - the scripts run presumably
@@ -321,7 +326,7 @@ def parse_output(output, keep=KEEPLIST):
 
     # dkeep is a dict associating key: path_list, where key is one item from
     # keep, and path_list the associated list of paths
-    dkeep = dict([(i, []) for i in keep])
+    dkeep = {i: [] for i in keep}
 
     # rdk will  keep the regex to match the .bat file output line starts
     rdk = {}

--- a/SCons/Tool/MSCommon/netframework.py
+++ b/SCons/Tool/MSCommon/netframework.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,14 +21,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """
+"""
+MS Compilers: .Net Framework support
 """
 
 import os
 import re
-import SCons.Util
 
 from .common import read_reg, debug
 
@@ -40,13 +39,13 @@ def find_framework_root():
     # XXX: find it from environment (FrameworkDir)
     try:
         froot = read_reg(_FRAMEWORKDIR_HKEY_ROOT)
-        debug("Found framework install root in registry: {}".format(froot))
+        debug("Found framework install root in registry: %s", froot)
     except OSError:
-        debug("Could not read reg key {}".format(_FRAMEWORKDIR_HKEY_ROOT))
+        debug("Could not read reg key %s", _FRAMEWORKDIR_HKEY_ROOT)
         return None
 
     if not os.path.exists(froot):
-        debug("{} not found on fs".format(froot))
+        debug("%s not found on fs", froot)
         return None
 
     return froot

--- a/SCons/Tool/MSCommon/sdk.py
+++ b/SCons/Tool/MSCommon/sdk.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,10 +21,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """Module to detect the Platform/Windows SDK
+"""
+MS Compilers: detect the Platform/Windows SDK
 
 PSDK 2003 R1 is the earliest version detected.
 """
@@ -74,23 +73,23 @@ class SDKDefinition:
             return None
 
         hkey = self.HKEY_FMT % self.hkey_data
-        debug('find_sdk_dir(): checking registry:{}'.format(hkey))
+        debug('find_sdk_dir(): checking registry: %s', hkey)
 
         try:
             sdk_dir = read_reg(hkey)
         except OSError:
-            debug('find_sdk_dir(): no SDK registry key {}'.format(repr(hkey)))
+            debug('find_sdk_dir(): no SDK registry key %s', hkey)
             return None
 
-        debug('find_sdk_dir(): Trying SDK Dir: {}'.format(sdk_dir))
+        debug('find_sdk_dir(): Trying SDK Dir: %s', sdk_dir)
 
         if not os.path.exists(sdk_dir):
-            debug('find_sdk_dir():  {} not on file system'.format(sdk_dir))
+            debug('find_sdk_dir(): %s not on file system', sdk_dir)
             return None
 
         ftc = os.path.join(sdk_dir, self.sanity_check_file)
         if not os.path.exists(ftc):
-            debug("find_sdk_dir(): sanity check {} not found".format(ftc))
+            debug("find_sdk_dir(): sanity check %s not found", ftc)
             return None
 
         return sdk_dir
@@ -116,11 +115,14 @@ class SDKDefinition:
         if host_arch != target_arch:
             arch_string='%s_%s'%(host_arch,target_arch)
 
-        debug("get_sdk_vc_script():arch_string:%s host_arch:%s target_arch:%s"%(arch_string,
-                                                           host_arch,
-                                                           target_arch))
-        file=self.vc_setup_scripts.get(arch_string,None)
-        debug("get_sdk_vc_script():file:%s"%file)
+        debug(
+            "get_sdk_vc_script():arch_string:%s host_arch:%s target_arch:%s",
+            arch_string,
+            host_arch,
+            target_arch,
+        )
+        file = self.vc_setup_scripts.get(arch_string, None)
+        debug("get_sdk_vc_script():file:%s", file)
         return file
 
 class WindowsSDK(SDKDefinition):
@@ -289,9 +291,9 @@ def get_installed_sdks():
         InstalledSDKList = []
         InstalledSDKMap = {}
         for sdk in SupportedSDKList:
-            debug('trying to find SDK %s' % sdk.version)
+            debug('trying to find SDK %s', sdk.version)
             if sdk.get_sdk_dir():
-                debug('found SDK %s' % sdk.version)
+                debug('found SDK %s', sdk.version)
                 InstalledSDKList.append(sdk)
                 InstalledSDKMap[sdk.version] = sdk
     return InstalledSDKList
@@ -306,7 +308,7 @@ SDKEnvironmentUpdates = {}
 
 def set_sdk_by_directory(env, sdk_dir):
     global SDKEnvironmentUpdates
-    debug('set_sdk_by_directory: Using dir:%s'%sdk_dir)
+    debug('set_sdk_by_directory: Using dir:%s', sdk_dir)
     try:
         env_tuple_list = SDKEnvironmentUpdates[sdk_dir]
     except KeyError:
@@ -350,7 +352,7 @@ def mssdk_setup_env(env):
         if sdk_dir is None:
             return
         sdk_dir = env.subst(sdk_dir)
-        debug('mssdk_setup_env: Using MSSDK_DIR:{}'.format(sdk_dir))
+        debug('mssdk_setup_env: Using MSSDK_DIR:%s', sdk_dir)
     elif 'MSSDK_VERSION' in env:
         sdk_version = env['MSSDK_VERSION']
         if sdk_version is None:
@@ -362,22 +364,22 @@ def mssdk_setup_env(env):
             msg = "SDK version %s is not installed" % sdk_version
             raise SCons.Errors.UserError(msg)
         sdk_dir = mssdk.get_sdk_dir()
-        debug('mssdk_setup_env: Using MSSDK_VERSION:%s'%sdk_dir)
+        debug('mssdk_setup_env: Using MSSDK_VERSION:%s', sdk_dir)
     elif 'MSVS_VERSION' in env:
         msvs_version = env['MSVS_VERSION']
-        debug('mssdk_setup_env:Getting MSVS_VERSION from env:%s'%msvs_version)
+        debug('mssdk_setup_env:Getting MSVS_VERSION from env:%s', msvs_version)
         if msvs_version is None:
             debug('mssdk_setup_env thinks msvs_version is None')
             return
         msvs_version = env.subst(msvs_version)
         from . import vs
         msvs = vs.get_vs_by_version(msvs_version)
-        debug('mssdk_setup_env:msvs is :%s'%msvs)
+        debug('mssdk_setup_env:msvs is :%s', msvs)
         if not msvs:
-            debug('mssdk_setup_env: no VS version detected, bailingout:%s'%msvs)
+            debug('mssdk_setup_env: no VS version detected, bailingout:%s', msvs)
             return
         sdk_version = msvs.sdk_version
-        debug('msvs.sdk_version is %s'%sdk_version)
+        debug('msvs.sdk_version is %s', sdk_version)
         if not sdk_version:
             return
         mssdk = get_sdk_by_version(sdk_version)
@@ -386,13 +388,13 @@ def mssdk_setup_env(env):
             if not mssdk:
                 return
         sdk_dir = mssdk.get_sdk_dir()
-        debug('mssdk_setup_env: Using MSVS_VERSION:%s'%sdk_dir)
+        debug('mssdk_setup_env: Using MSVS_VERSION:%s', sdk_dir)
     else:
         mssdk = get_default_sdk()
         if not mssdk:
             return
         sdk_dir = mssdk.get_sdk_dir()
-        debug('mssdk_setup_env: not using any env values. sdk_dir:%s'%sdk_dir)
+        debug('mssdk_setup_env: not using any env values. sdk_dir:%s', sdk_dir)
 
     set_sdk_by_directory(env, sdk_dir)
 

--- a/SCons/Tool/MSCommon/vs.py
+++ b/SCons/Tool/MSCommon/vs.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,26 +20,26 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """Module to detect Visual Studio and/or Visual C/C++
+"""
+MS Compilers: detect Visual Studio and/or Visual C/C++
 """
 
 import os
 
 import SCons.Errors
+import SCons.Tool.MSCommon.vc
 import SCons.Util
 
-from .common import debug, \
-                   get_output, \
-                   is_win64, \
-                   normalize_env, \
-                   parse_output, \
-                   read_reg
+from .common import (
+    debug,
+    get_output,
+    is_win64,
+    normalize_env,
+    parse_output,
+    read_reg,
+)
 
-import SCons.Tool.MSCommon.vc
 
 class VisualStudio:
     """
@@ -60,14 +61,14 @@ class VisualStudio:
         batch_file = os.path.join(vs_dir, self.batch_file_path)
         batch_file = os.path.normpath(batch_file)
         if not os.path.isfile(batch_file):
-            debug('%s not on file system' % batch_file)
+            debug('%s not on file system', batch_file)
             return None
         return batch_file
 
     def find_vs_dir_by_vc(self, env):
         dir = SCons.Tool.MSCommon.vc.find_vc_pdir(env, self.vc_version)
         if not dir:
-            debug('no installed VC %s' % self.vc_version)
+            debug('no installed VC %s', self.vc_version)
             return None
         return os.path.abspath(os.path.join(dir, os.pardir))
 
@@ -83,9 +84,9 @@ class VisualStudio:
             try:
                 comps = read_reg(key)
             except OSError:
-                debug('no VS registry key {}'.format(repr(key)))
+                debug('no VS registry key %s', repr(key))
             else:
-                debug('found VS in registry: {}'.format(comps))
+                debug('found VS in registry: %s', comps)
                 return comps
         return None
 
@@ -94,21 +95,21 @@ class VisualStudio:
         First try to find by registry, and if that fails find via VC dir
         """
 
-        vs_dir=self.find_vs_dir_by_reg(env)
+        vs_dir = self.find_vs_dir_by_reg(env)
         if not vs_dir:
             vs_dir = self.find_vs_dir_by_vc(env)
-        debug('found VS in ' + str(vs_dir ))
+        debug('found VS in %s', str(vs_dir))
         return vs_dir
 
     def find_executable(self, env):
         vs_dir = self.get_vs_dir(env)
         if not vs_dir:
-            debug('no vs_dir ({})'.format(vs_dir))
+            debug('no vs_dir (%s)', vs_dir)
             return None
         executable = os.path.join(vs_dir, self.executable_path)
         executable = os.path.normpath(executable)
         if not os.path.isfile(executable):
-            debug('{} not on file system'.format(executable))
+            debug('%s not on file system', executable)
             return None
         return executable
 
@@ -122,15 +123,15 @@ class VisualStudio:
 
     def get_executable(self, env=None):
         try:
-            debug('using cache:%s'%self._cache['executable'])
+            debug('using cache:%s', self._cache['executable'])
             return self._cache['executable']
         except KeyError:
             executable = self.find_executable(env)
             self._cache['executable'] = executable
-            debug('not in cache:%s'%executable)
+            debug('not in cache:%s', executable)
             return executable
 
-    def get_vs_dir(self, env):
+    def get_vs_dir(self, env=None):
         try:
             return self._cache['vs_dir']
         except KeyError:
@@ -431,9 +432,9 @@ def get_installed_visual_studios(env=None):
         InstalledVSList = []
         InstalledVSMap = {}
         for vs in SupportedVSList:
-            debug('trying to find VS %s' % vs.version)
+            debug('trying to find VS %s', vs.version)
             if vs.get_executable(env):
-                debug('found VS %s' % vs.version)
+                debug('found VS %s', vs.version)
                 InstalledVSList.append(vs)
                 InstalledVSMap[vs.version] = vs
     return InstalledVSList
@@ -483,8 +484,8 @@ def reset_installed_visual_studios():
 #    for variable, directory in env_tuple_list:
 #        env.PrependENVPath(variable, directory)
 
-def msvs_exists(env=None):
-    return (len(get_installed_visual_studios(env)) > 0)
+def msvs_exists(env=None) -> bool:
+    return len(get_installed_visual_studios(env)) > 0
 
 def get_vs_by_version(msvs):
     global InstalledVSMap
@@ -496,8 +497,8 @@ def get_vs_by_version(msvs):
         raise SCons.Errors.UserError(msg)
     get_installed_visual_studios()
     vs = InstalledVSMap.get(msvs)
-    debug('InstalledVSMap:%s' % InstalledVSMap)
-    debug('found vs:%s' % vs)
+    debug('InstalledVSMap:%s', InstalledVSMap)
+    debug('found vs:%s', vs)
     # Some check like this would let us provide a useful error message
     # if they try to set a Visual Studio version that's not installed.
     # However, we also want to be able to run tests (like the unit
@@ -533,7 +534,8 @@ def get_default_version(env):
             env['MSVS_VERSION'] = versions[0] #use highest version by default
         else:
             debug('WARNING: no installed versions found, '
-                  'using first in SupportedVSList (%s)' % SupportedVSList[0].version)
+                  'using first in SupportedVSList (%s)',
+                  SupportedVSList[0].version)
             env['MSVS_VERSION'] = SupportedVSList[0].version
 
     env['MSVS']['VERSION'] = env['MSVS_VERSION']
@@ -566,11 +568,12 @@ def merge_default_version(env):
     version = get_default_version(env)
     arch = get_default_arch(env)
 
+# TODO: refers to versions and arch which aren't defined; called nowhere. Drop?
 def msvs_setup_env(env):
-    batfilename = msvs.get_batch_file()
     msvs = get_vs_by_version(version)
     if msvs is None:
         return
+    batfilename = msvs.get_batch_file()
 
     # XXX: I think this is broken. This will silently set a bogus tool instead
     # of failing, but there is no other way with the current scons tool


### PR DESCRIPTION
Largest change is lazy formatting in logging (debug).
```console
W1201: Use lazy % formatting in logging functions (logging-not-lazy)
W1202: Use lazy % formatting in logging functions (logging-format-interpolation)
```
This required minor rework to the two alternate definitions of `debug` which didn't use logging, to keep the signatures consistent.
```console
W1510: Using subprocess.run without explicitly set `check` is not recommended. (subprocess-run-check)
```

No doc impacts.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
