### PR TITLE
Add some info to User Guide on #/paths

### DIFF
--- a/doc/generated/examples/hierarchy_hash_1.xml
+++ b/doc/generated/examples/hierarchy_hash_1.xml
@@ -1,0 +1,5 @@
+<screen xmlns="http://www.scons.org/dbxsd/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">% <userinput>scons -Q</userinput>
+path = #/include
+force-interpreted path = include
+scons: `.' is up to date.
+</screen>

--- a/doc/user/hierarchy.xml
+++ b/doc/user/hierarchy.xml
@@ -303,8 +303,7 @@ SConscript(['display/SConscript',
 
     <scons_example name="hierarchy_ex1">
       <file name="SConstruct" printme="1">
-SConscript(['prog1/SConscript',
-            'prog2/SConscript'])
+SConscript(['prog1/SConscript', 'prog2/SConscript'])
       </file>
       <file name="prog1/SConscript">
 env = Environment()
@@ -384,7 +383,7 @@ x
   </section>
 
   <section>
-  <title>Top-Level Path Names in Subsidiary &SConscript; Files</title>
+  <title>Top-Relative Path Names in Subsidiary &SConscript; Files</title>
 
     <para>
 
@@ -397,8 +396,7 @@ x
     You can tell &SCons; to interpret a path name
     as relative to the top-level &SConstruct; directory,
     not the local directory of the &SConscript; file,
-    by appending a &hash; (hash mark)
-    to the beginning of the path name:
+    by prepending a &hash; (hash mark) in front of the path name:
 
     </para>
 
@@ -443,6 +441,52 @@ x
     See <xref linkend="chap-separate"></xref>, below,
     for information about
     how to build the object file in a different subdirectory.)
+
+    </para>
+
+    <para>
+
+    A couple of notes on top-relative paths:
+
+      <orderedlist>
+        <listitem><para>
+
+        &SCons; doesn't care whether you add a slash after the &hash;.
+        Some people consider <literal>'#/lib/foo1.c'</literal>
+        more readable than <literal>'#lib/foo1.c'</literal>,
+        but they're functionally equivalent.
+
+        </para></listitem>
+
+        <listitem><para>
+
+        The top-relative syntax is <emphasis>only</emphasis>
+        evaluated by &SCons;, the &Python; language itself does not
+        understand about it.  This becomes immediately obvious
+        if you like to use <function>print</function> for debugging,
+        or write a Python function that wants to evaluate a path.
+        You can force &SCons; to evaluate a top-relative path by
+        creating a Node object from it:
+
+        </para>
+
+        </listitem>
+      </orderedlist>
+
+      <scons_example name="hierarchy_hash">
+        <file name="SConstruct" printme="1">
+path = "#/include"
+
+print("path =", path)
+print("force-interpreted path =", Entry(path))
+        </file>
+      </scons_example>
+
+      Which shows:
+
+      <scons_output example="hierarchy_hash" suffix="1">
+         <scons_output_command>scons -Q</scons_output_command>
+      </scons_output>
 
     </para>
 

--- a/doc/user/separate.xml
+++ b/doc/user/separate.xml
@@ -55,12 +55,12 @@
   and header files differ.  If you build "Controller A" first,
   then "Controller B", on the second build everything would
   have to be rebuilt, because &SCons; sees that the build
-  instructions differ, and thus the targets that depend on those
-  different instructions are not valid for the current build.
+  instructions are different to the ones used to build the
+  existing targets,  and thus the existing targets are invalid.
   Now when you go back and build for "Controller A",
   things have to be rebuilt from scratch again for the same reason.
-  However, if you can separate the places the output files
-  go, this problem can be avoided.
+  However, if you can separate the places the output files go,
+  this problem can be avoided.
   You can even set up to do both builds in one invocation of &SCons;.
 
   </para>
@@ -69,8 +69,8 @@
 
   You can enable this separation by creating one or more
   <firstterm>variant directory</firstterm> trees
-  that are used to hold the built objects files, libraries,
-  and executable programs, etc.
+  that are used to perform the build in, and thus provide a unique
+  home for object files, libraries, and executable programs, etc.
   for a specific flavor, or variant, of build.
   &SCons; provides two ways to do this,
   one through the &f-link-SConscript; function that we've already seen,

--- a/doc/user/separate.xml
+++ b/doc/user/separate.xml
@@ -53,13 +53,14 @@
   lot of code, so it makes sense to keep them in the same
   source tree, but certain build options in the source code
   and header files differ.  If you build "Controller A" first,
-  then "Controller B", on the second build everything would
-  have to be rebuilt, because &SCons; sees that the build
-  instructions are different to the ones used to build the
-  existing targets,  and thus the existing targets are invalid.
+  then "Controller B", on the "Controller B" build everything would
+  have to be rebuilt, because &SCons; recognizes that the build
+  instructions are different from those used in the "Controller A"
+  build for each target - the build instructions are part of
+  &SCons;'s out-of-date calculation.
   Now when you go back and build for "Controller A",
   things have to be rebuilt from scratch again for the same reason.
-  However, if you can separate the places the output files go,
+  However, if you can separate the locations of the output files,
   this problem can be avoided.
   You can even set up to do both builds in one invocation of &SCons;.
 
@@ -67,11 +68,20 @@
 
   <para>
 
-  You can enable this separation by creating one or more
+  You can enable this separation by establishing one or more
   <firstterm>variant directory</firstterm> trees
   that are used to perform the build in, and thus provide a unique
   home for object files, libraries, and executable programs, etc.
-  for a specific flavor, or variant, of build.
+  for a specific flavor, or variant, of build. &SCons; tracks
+  targets by their path, so when the variant directory is included,
+  objects belonging to "Controller A" can have different
+  build instructions than those belonging to "Controller B" without
+  triggering ping-ponging rebuilds.
+
+  </para>
+
+  <para>
+
   &SCons; provides two ways to do this,
   one through the &f-link-SConscript; function that we've already seen,
   and the second through a more flexible &f-link-VariantDir; function.


### PR DESCRIPTION
Mention in User Guide that `#foo` and `#/foo` are equivalent.
Proviade a trivial example that shows that Python doesn't evaluate top-relative paths.

This is a doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
