### PR TITLE
Update manpage "Extending SCons" section.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       we need to do this for internal reasons, those are skipped in that case.
       Bad association could mean some other tool took it over (Visual
       Studio Code is known to do this), or no association at all.
+    - logging code ("debug" call) in Tool/MSCommon now conforms to the
+      Python logging recommended "lazy interpolation" so instead of
+      debug("template %s" % text) it looks like debug("template %s", text)
+      so the logging system does the interpolation when/if needed.
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,10 +31,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       we need to do this for internal reasons, those are skipped in that case.
       Bad association could mean some other tool took it over (Visual
       Studio Code is known to do this), or no association at all.
-    - logging code ("debug" call) in Tool/MSCommon now conforms to the
-      Python logging recommended "lazy interpolation" so instead of
-      debug("template %s" % text) it looks like debug("template %s", text)
-      so the logging system does the interpolation when/if needed.
+    - Updated debug code in MSVC and MSVS tools to conform to the
+      suggested "lazy interpolation" use of the Python logging module.
+      Calls now look like 'debug("template %s", text)' rather than
+      'debug("template %s" % text)' so the logging system does the
+      interpolation only when/if needed (was a pylint warning).
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/SCons/Tool/MSCommon/__init__.py
+++ b/SCons/Tool/MSCommon/__init__.py
@@ -30,20 +30,23 @@ import SCons.Errors
 import SCons.Platform.win32
 import SCons.Util
 
-from SCons.Tool.MSCommon.sdk import mssdk_exists, \
-                                    mssdk_setup_env
+from SCons.Tool.MSCommon.sdk import mssdk_exists, mssdk_setup_env
 
-from SCons.Tool.MSCommon.vc import msvc_exists, \
-                                   msvc_setup_env, \
-                                   msvc_setup_env_once, \
-                                   msvc_version_to_maj_min, \
-                                   msvc_find_vswhere
+from SCons.Tool.MSCommon.vc import (
+    msvc_exists,
+    msvc_setup_env,
+    msvc_setup_env_once,
+    msvc_version_to_maj_min,
+    msvc_find_vswhere,
+)
 
-from SCons.Tool.MSCommon.vs import get_default_version, \
-                                   get_vs_by_version, \
-                                   merge_default_version, \
-                                   msvs_exists, \
-                                   query_versions
+from SCons.Tool.MSCommon.vs import (
+    get_default_version,
+    get_vs_by_version,
+    merge_default_version,
+    msvs_exists,
+    query_versions,
+)
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Tool/MSCommon/arch.py
+++ b/SCons/Tool/MSCommon/arch.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,11 +20,9 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """Module to define supported Windows chip architectures.
+"""
+MS compilers: Supported Windows chip architectures.
 """
 
 
@@ -40,22 +39,18 @@ SupportedArchitectureList = [
         'x86',
         ['i386', 'i486', 'i586', 'i686'],
     ),
-
     ArchDefinition(
         'x86_64',
         ['AMD64', 'amd64', 'em64t', 'EM64T', 'x86_64'],
     ),
-
     ArchDefinition(
         'ia64',
         ['IA64'],
     ),
-    
     ArchDefinition(
         'arm',
         ['ARM'],
     ),
-
 ]
 
 SupportedArchitectureMap = {}
@@ -64,3 +59,8 @@ for a in SupportedArchitectureList:
     for s in a.synonyms:
         SupportedArchitectureMap[s] = a
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -73,13 +73,13 @@ elif LOGFILE:
             return True
     logging.basicConfig(
         # This looks like:
-        #   00109ms:MSCommon/vc.py:find_vc_pdir#447:
+        #   00109ms:MSCommon/vc.py:find_vc_pdir#447:VC found '14.3'
         format=(
             '%(relativeCreated)05dms'
             ':%(relfilename)s'
             ':%(funcName)s'
             '#%(lineno)s'
-            ':%(message)s: '
+            ':%(message)s'
         ),
         filename=LOGFILE,
         level=logging.DEBUG)

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -1,8 +1,6 @@
-"""
-Common helper functions for working with the Microsoft tool chain.
-"""
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -22,8 +20,10 @@ Common helper functions for working with the Microsoft tool chain.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Common helper functions for working with the Microsoft tool chain.
+"""
 
 import copy
 import json
@@ -38,8 +38,12 @@ import SCons.Util
 # set to '-' to print to console, else set to filename to log to
 LOGFILE = os.environ.get('SCONS_MSCOMMON_DEBUG')
 if LOGFILE == '-':
-    def debug(message):
-        print(message)
+    def debug(message, *args):
+        if args:
+            print(message % args)
+        else:
+            print(message)
+
 elif LOGFILE:
     import logging
     modulelist = (
@@ -83,7 +87,8 @@ elif LOGFILE:
     logger.addFilter(_Debug_Filter())
     debug = logger.debug
 else:
-    def debug(x): return None
+    def debug(x, *args):
+        return None
 
 
 # SCONS_CACHE_MSVC_CONFIG is public, and is documented.
@@ -214,7 +219,7 @@ def normalize_env(env, keys, force=False):
     if sys32_ps_dir not in normenv['PATH']:
         normenv['PATH'] = normenv['PATH'] + os.pathsep + sys32_ps_dir
 
-    debug("PATH: %s" % normenv['PATH'])
+    debug("PATH: %s", normenv['PATH'])
     return normenv
 
 
@@ -256,14 +261,14 @@ def get_output(vcbat, args=None, env=None):
     env['ENV'] = normalize_env(env['ENV'], vs_vc_vars, force=False)
 
     if args:
-        debug("Calling '%s %s'" % (vcbat, args))
+        debug("Calling '%s %s'", vcbat, args)
         popen = SCons.Action._subproc(env,
                                       '"%s" %s & set' % (vcbat, args),
                                       stdin='devnull',
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE)
     else:
-        debug("Calling '%s'" % vcbat)
+        debug("Calling '%s'", vcbat)
         popen = SCons.Action._subproc(env,
                                       '"%s" & set' % vcbat,
                                       stdin='devnull',
@@ -279,8 +284,8 @@ def get_output(vcbat, args=None, env=None):
         stderr = popen.stderr.read()
 
     # Extra debug logic, uncomment if necessary
-    # debug('stdout:%s' % stdout)
-    # debug('stderr:%s' % stderr)
+    # debug('stdout:%s', stdout)
+    # debug('stderr:%s', stderr)
 
     # Ongoing problems getting non-corrupted text led to this
     # changing to "oem" from "mbcs" - the scripts run presumably
@@ -321,7 +326,7 @@ def parse_output(output, keep=KEEPLIST):
 
     # dkeep is a dict associating key: path_list, where key is one item from
     # keep, and path_list the associated list of paths
-    dkeep = dict([(i, []) for i in keep])
+    dkeep = {i: [] for i in keep}
 
     # rdk will  keep the regex to match the .bat file output line starts
     rdk = {}

--- a/SCons/Tool/MSCommon/netframework.py
+++ b/SCons/Tool/MSCommon/netframework.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,14 +21,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """
+"""
+MS Compilers: .Net Framework support
 """
 
 import os
 import re
-import SCons.Util
 
 from .common import read_reg, debug
 
@@ -40,13 +39,13 @@ def find_framework_root():
     # XXX: find it from environment (FrameworkDir)
     try:
         froot = read_reg(_FRAMEWORKDIR_HKEY_ROOT)
-        debug("Found framework install root in registry: {}".format(froot))
+        debug("Found framework install root in registry: %s", froot)
     except OSError:
-        debug("Could not read reg key {}".format(_FRAMEWORKDIR_HKEY_ROOT))
+        debug("Could not read reg key %s", _FRAMEWORKDIR_HKEY_ROOT)
         return None
 
     if not os.path.exists(froot):
-        debug("{} not found on fs".format(froot))
+        debug("%s not found on fs", froot)
         return None
 
     return froot

--- a/SCons/Tool/MSCommon/sdk.py
+++ b/SCons/Tool/MSCommon/sdk.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,10 +21,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """Module to detect the Platform/Windows SDK
+"""
+MS Compilers: detect the Platform/Windows SDK
 
 PSDK 2003 R1 is the earliest version detected.
 """
@@ -74,23 +73,23 @@ class SDKDefinition:
             return None
 
         hkey = self.HKEY_FMT % self.hkey_data
-        debug('find_sdk_dir(): checking registry:{}'.format(hkey))
+        debug('find_sdk_dir(): checking registry: %s', hkey)
 
         try:
             sdk_dir = read_reg(hkey)
         except OSError:
-            debug('find_sdk_dir(): no SDK registry key {}'.format(repr(hkey)))
+            debug('find_sdk_dir(): no SDK registry key %s', hkey)
             return None
 
-        debug('find_sdk_dir(): Trying SDK Dir: {}'.format(sdk_dir))
+        debug('find_sdk_dir(): Trying SDK Dir: %s', sdk_dir)
 
         if not os.path.exists(sdk_dir):
-            debug('find_sdk_dir():  {} not on file system'.format(sdk_dir))
+            debug('find_sdk_dir(): %s not on file system', sdk_dir)
             return None
 
         ftc = os.path.join(sdk_dir, self.sanity_check_file)
         if not os.path.exists(ftc):
-            debug("find_sdk_dir(): sanity check {} not found".format(ftc))
+            debug("find_sdk_dir(): sanity check %s not found", ftc)
             return None
 
         return sdk_dir
@@ -116,11 +115,14 @@ class SDKDefinition:
         if host_arch != target_arch:
             arch_string='%s_%s'%(host_arch,target_arch)
 
-        debug("get_sdk_vc_script():arch_string:%s host_arch:%s target_arch:%s"%(arch_string,
-                                                           host_arch,
-                                                           target_arch))
-        file=self.vc_setup_scripts.get(arch_string,None)
-        debug("get_sdk_vc_script():file:%s"%file)
+        debug(
+            "get_sdk_vc_script():arch_string:%s host_arch:%s target_arch:%s",
+            arch_string,
+            host_arch,
+            target_arch,
+        )
+        file = self.vc_setup_scripts.get(arch_string, None)
+        debug("get_sdk_vc_script():file:%s", file)
         return file
 
 class WindowsSDK(SDKDefinition):
@@ -289,9 +291,9 @@ def get_installed_sdks():
         InstalledSDKList = []
         InstalledSDKMap = {}
         for sdk in SupportedSDKList:
-            debug('trying to find SDK %s' % sdk.version)
+            debug('trying to find SDK %s', sdk.version)
             if sdk.get_sdk_dir():
-                debug('found SDK %s' % sdk.version)
+                debug('found SDK %s', sdk.version)
                 InstalledSDKList.append(sdk)
                 InstalledSDKMap[sdk.version] = sdk
     return InstalledSDKList
@@ -306,7 +308,7 @@ SDKEnvironmentUpdates = {}
 
 def set_sdk_by_directory(env, sdk_dir):
     global SDKEnvironmentUpdates
-    debug('set_sdk_by_directory: Using dir:%s'%sdk_dir)
+    debug('set_sdk_by_directory: Using dir:%s', sdk_dir)
     try:
         env_tuple_list = SDKEnvironmentUpdates[sdk_dir]
     except KeyError:
@@ -350,7 +352,7 @@ def mssdk_setup_env(env):
         if sdk_dir is None:
             return
         sdk_dir = env.subst(sdk_dir)
-        debug('mssdk_setup_env: Using MSSDK_DIR:{}'.format(sdk_dir))
+        debug('mssdk_setup_env: Using MSSDK_DIR:%s', sdk_dir)
     elif 'MSSDK_VERSION' in env:
         sdk_version = env['MSSDK_VERSION']
         if sdk_version is None:
@@ -362,22 +364,22 @@ def mssdk_setup_env(env):
             msg = "SDK version %s is not installed" % sdk_version
             raise SCons.Errors.UserError(msg)
         sdk_dir = mssdk.get_sdk_dir()
-        debug('mssdk_setup_env: Using MSSDK_VERSION:%s'%sdk_dir)
+        debug('mssdk_setup_env: Using MSSDK_VERSION:%s', sdk_dir)
     elif 'MSVS_VERSION' in env:
         msvs_version = env['MSVS_VERSION']
-        debug('mssdk_setup_env:Getting MSVS_VERSION from env:%s'%msvs_version)
+        debug('mssdk_setup_env:Getting MSVS_VERSION from env:%s', msvs_version)
         if msvs_version is None:
             debug('mssdk_setup_env thinks msvs_version is None')
             return
         msvs_version = env.subst(msvs_version)
         from . import vs
         msvs = vs.get_vs_by_version(msvs_version)
-        debug('mssdk_setup_env:msvs is :%s'%msvs)
+        debug('mssdk_setup_env:msvs is :%s', msvs)
         if not msvs:
-            debug('mssdk_setup_env: no VS version detected, bailingout:%s'%msvs)
+            debug('mssdk_setup_env: no VS version detected, bailingout:%s', msvs)
             return
         sdk_version = msvs.sdk_version
-        debug('msvs.sdk_version is %s'%sdk_version)
+        debug('msvs.sdk_version is %s', sdk_version)
         if not sdk_version:
             return
         mssdk = get_sdk_by_version(sdk_version)
@@ -386,13 +388,13 @@ def mssdk_setup_env(env):
             if not mssdk:
                 return
         sdk_dir = mssdk.get_sdk_dir()
-        debug('mssdk_setup_env: Using MSVS_VERSION:%s'%sdk_dir)
+        debug('mssdk_setup_env: Using MSVS_VERSION:%s', sdk_dir)
     else:
         mssdk = get_default_sdk()
         if not mssdk:
             return
         sdk_dir = mssdk.get_sdk_dir()
-        debug('mssdk_setup_env: not using any env values. sdk_dir:%s'%sdk_dir)
+        debug('mssdk_setup_env: not using any env values. sdk_dir:%s', sdk_dir)
 
     set_sdk_by_directory(env, sdk_dir)
 

--- a/SCons/Tool/MSCommon/vs.py
+++ b/SCons/Tool/MSCommon/vs.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,26 +20,26 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-__doc__ = """Module to detect Visual Studio and/or Visual C/C++
+"""
+MS Compilers: detect Visual Studio and/or Visual C/C++
 """
 
 import os
 
 import SCons.Errors
+import SCons.Tool.MSCommon.vc
 import SCons.Util
 
-from .common import debug, \
-                   get_output, \
-                   is_win64, \
-                   normalize_env, \
-                   parse_output, \
-                   read_reg
+from .common import (
+    debug,
+    get_output,
+    is_win64,
+    normalize_env,
+    parse_output,
+    read_reg,
+)
 
-import SCons.Tool.MSCommon.vc
 
 class VisualStudio:
     """
@@ -60,14 +61,14 @@ class VisualStudio:
         batch_file = os.path.join(vs_dir, self.batch_file_path)
         batch_file = os.path.normpath(batch_file)
         if not os.path.isfile(batch_file):
-            debug('%s not on file system' % batch_file)
+            debug('%s not on file system', batch_file)
             return None
         return batch_file
 
     def find_vs_dir_by_vc(self, env):
         dir = SCons.Tool.MSCommon.vc.find_vc_pdir(env, self.vc_version)
         if not dir:
-            debug('no installed VC %s' % self.vc_version)
+            debug('no installed VC %s', self.vc_version)
             return None
         return os.path.abspath(os.path.join(dir, os.pardir))
 
@@ -83,9 +84,9 @@ class VisualStudio:
             try:
                 comps = read_reg(key)
             except OSError:
-                debug('no VS registry key {}'.format(repr(key)))
+                debug('no VS registry key %s', repr(key))
             else:
-                debug('found VS in registry: {}'.format(comps))
+                debug('found VS in registry: %s', comps)
                 return comps
         return None
 
@@ -94,21 +95,21 @@ class VisualStudio:
         First try to find by registry, and if that fails find via VC dir
         """
 
-        vs_dir=self.find_vs_dir_by_reg(env)
+        vs_dir = self.find_vs_dir_by_reg(env)
         if not vs_dir:
             vs_dir = self.find_vs_dir_by_vc(env)
-        debug('found VS in ' + str(vs_dir ))
+        debug('found VS in %s', str(vs_dir))
         return vs_dir
 
     def find_executable(self, env):
         vs_dir = self.get_vs_dir(env)
         if not vs_dir:
-            debug('no vs_dir ({})'.format(vs_dir))
+            debug('no vs_dir (%s)', vs_dir)
             return None
         executable = os.path.join(vs_dir, self.executable_path)
         executable = os.path.normpath(executable)
         if not os.path.isfile(executable):
-            debug('{} not on file system'.format(executable))
+            debug('%s not on file system', executable)
             return None
         return executable
 
@@ -122,15 +123,15 @@ class VisualStudio:
 
     def get_executable(self, env=None):
         try:
-            debug('using cache:%s'%self._cache['executable'])
+            debug('using cache:%s', self._cache['executable'])
             return self._cache['executable']
         except KeyError:
             executable = self.find_executable(env)
             self._cache['executable'] = executable
-            debug('not in cache:%s'%executable)
+            debug('not in cache:%s', executable)
             return executable
 
-    def get_vs_dir(self, env):
+    def get_vs_dir(self, env=None):
         try:
             return self._cache['vs_dir']
         except KeyError:
@@ -431,9 +432,9 @@ def get_installed_visual_studios(env=None):
         InstalledVSList = []
         InstalledVSMap = {}
         for vs in SupportedVSList:
-            debug('trying to find VS %s' % vs.version)
+            debug('trying to find VS %s', vs.version)
             if vs.get_executable(env):
-                debug('found VS %s' % vs.version)
+                debug('found VS %s', vs.version)
                 InstalledVSList.append(vs)
                 InstalledVSMap[vs.version] = vs
     return InstalledVSList
@@ -483,8 +484,8 @@ def reset_installed_visual_studios():
 #    for variable, directory in env_tuple_list:
 #        env.PrependENVPath(variable, directory)
 
-def msvs_exists(env=None):
-    return (len(get_installed_visual_studios(env)) > 0)
+def msvs_exists(env=None) -> bool:
+    return len(get_installed_visual_studios(env)) > 0
 
 def get_vs_by_version(msvs):
     global InstalledVSMap
@@ -496,8 +497,8 @@ def get_vs_by_version(msvs):
         raise SCons.Errors.UserError(msg)
     get_installed_visual_studios()
     vs = InstalledVSMap.get(msvs)
-    debug('InstalledVSMap:%s' % InstalledVSMap)
-    debug('found vs:%s' % vs)
+    debug('InstalledVSMap:%s', InstalledVSMap)
+    debug('found vs:%s', vs)
     # Some check like this would let us provide a useful error message
     # if they try to set a Visual Studio version that's not installed.
     # However, we also want to be able to run tests (like the unit
@@ -533,7 +534,8 @@ def get_default_version(env):
             env['MSVS_VERSION'] = versions[0] #use highest version by default
         else:
             debug('WARNING: no installed versions found, '
-                  'using first in SupportedVSList (%s)' % SupportedVSList[0].version)
+                  'using first in SupportedVSList (%s)',
+                  SupportedVSList[0].version)
             env['MSVS_VERSION'] = SupportedVSList[0].version
 
     env['MSVS']['VERSION'] = env['MSVS_VERSION']
@@ -566,11 +568,12 @@ def merge_default_version(env):
     version = get_default_version(env)
     arch = get_default_arch(env)
 
+# TODO: refers to versions and arch which aren't defined; called nowhere. Drop?
 def msvs_setup_env(env):
-    batfilename = msvs.get_batch_file()
     msvs = get_vs_by_version(version)
     if msvs is None:
         return
+    batfilename = msvs.get_batch_file()
 
     # XXX: I think this is broken. This will silently set a bogus tool instead
     # of failing, but there is no other way with the current scons tool

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -12,10 +12,10 @@ without limitation the rights to use, copy, modify, merge, publish,
 distribute, sublicense, and/or sell copies of the Software, and to
 permit persons to whom the Software is furnished to do so, subject to
 the following conditions:
-#
+
 The above copyright notice and this permission notice shall be included
 in all copies or substantial portions of the Software.
-#
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
 KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -145,7 +145,7 @@ to support additional input file types.
 
 <para>Information about files involved in the build,
 including a cryptographic hash of the contents,
-is cached for later reuse, 
+is cached for later reuse,
 By default content hashes are used to determine if a file
 has changed since the last build,
 but this can be controlled by selecting an appropriate
@@ -4126,7 +4126,7 @@ actually two bytes.</para>
 <para>Checks whether the C compiler
 (as defined by the &cv-link-CC; &consvar;) works,
 by trying to compile a small source file.
-This provides a more rigorous check: 
+This provides a more rigorous check:
 by default, &SCons; itself only detects if there is a program
 with the correct name, not if it is a functioning compiler.
 Returns a boolean indicating success or failure.</para>
@@ -4146,7 +4146,7 @@ be accepted or rejected by the compiler.
 <para>Checks whether the C++ compiler
 (as defined by the &cv-link-CXX; &consvar;) works,
 by trying to compile a small source file.
-This provides a more rigorous check: 
+This provides a more rigorous check:
 by default, &SCons; itself only detects if there is a program
 with the correct name, not if it is a functioning compiler.
 Returns a boolean indicating success or failure.</para>
@@ -4166,7 +4166,7 @@ be accepted or rejected by the compiler.
 <para>Checks whether the shared-object C compiler (as defined by the
 &cv-link-SHCC; &consvar;) works
 by trying to compile a small source file.
-This provides a more rigorous check: 
+This provides a more rigorous check:
 by default, &SCons; itself only detects if there is a program
 with the correct name, not if it is a functioning compiler.
 Returns a boolean indicating success or failure.</para>
@@ -4188,7 +4188,7 @@ be created.
 <para>Checks whether the shared-object C++ compiler (as defined by the
 &cv-link-SHCXX; &consvar;)
 works by trying to compile a small source file.
-This provides a more rigorous check: 
+This provides a more rigorous check:
 by default, &SCons; itself only detects if there is a program
 with the correct name, not if it is a functioning compiler.
 Returns a boolean indicating success or failure.</para>
@@ -4207,7 +4207,7 @@ be created.
   <varlistentry>
   <term><replaceable>context</replaceable>.<methodname>CheckProg</methodname>(<parameter>prog_name</parameter>)</term>
   <listitem>
-<para>Checks if 
+<para>Checks if
 <parameter>prog_name</parameter>
 exists in the path &SCons; will use at build time.
 (<replaceable>context</replaceable>.<varname>env['ENV']['PATH']</varname>).
@@ -4243,7 +4243,7 @@ it will be be used as the macro replacement value.
 If <parameter>value</parameter> is a string and needs to
 display with quotes, the quotes need to be included,
 as in <literal>'"string"'</literal>
-If the optional 
+If the optional
 <parameter>comment</parameter> is given,
 it is inserted as a comment above the macro definition
 (suitable comment marks will be added automatically).
@@ -5083,20 +5083,53 @@ vars.AddVariables(
 </refsect2>
 
 <refsect2 id='node_objects'>
+<title>Node Objects</title>
+
+<para>
+&SCons; represents objects that are the sources or targets of
+build operations as <firstterm>Nodes</firstterm>,
+which are internal data structures.
+There are a number of user-visible types of nodes:
+File Nodes, Directory Nodes, Value Nodes and Alias Nodes.
+Some of the node types have visible attributes and methods,
+described below. Each of the node types has a global function
+and a matching environment method to create instances:
+&f-link-File;, &f-link-Dir;, &f-link-Value; and &f-link-Alias;.
+</para>
+
+<refsect3 id='file_and_directory_nodes'>
 <title>File and Directory Nodes</title>
 
 <para>
 The &f-link-File; and &f-link-Dir;
 functions/methods return
 File and Directory Nodes, respectively.
-Such nodes are Python objects with
-several user-visible attributes
-and methods that are often useful to access
-in SConscript files:</para>
+File and Directory Nodes
+(collectively, filesystem Nodes)
+describe build participants that correspond to entries
+in the computer's filesystem, whether or not such an entry exists
+at the time the Node is created.
+It is usually not necessary to explicitly create filesystem Nodes yourself:
+when you supply a string as a target or source of a Builder,
+&SCons; will create the Nodes as needed,
+and Builders return the target Node(s) in the form of a list.
+However, since filesystem Nodes have some useful
+public attributes and methods
+you can use in SConscript files,
+it is sometimes appropriate to create them
+outside the regular context of a Builder call.
+</para>
+<para>
+There are also times when you may need to refer to an entry
+in a filesystem without knowing in advance whether it's a
+file or a directory. For those situations, &SCons; also supports
+an <function>Entry</function> function,
+which returns a Node that can represent either a file or a directory.
+</para>
 
 <variablelist>
   <varlistentry>
-  <term><replaceable>n</replaceable>.<varname>path</varname></term>
+  <term><replaceable>node</replaceable>.<varname>path</varname></term>
   <listitem>
 <para>The build path
 of the given
@@ -5110,21 +5143,21 @@ is not being used.</para>
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>n</replaceable>.<varname>abspath</varname></term>
+  <term><replaceable>node</replaceable>.<varname>abspath</varname></term>
   <listitem>
 <para>The absolute build path of the given file or directory.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>n</replaceable>.<varname>relpath</varname></term>
+  <term><replaceable>node</replaceable>.<varname>relpath</varname></term>
   <listitem>
 <para>The build path of the given file or directory relative to the root SConstruct file's directory.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>n</replaceable>.<function>srcnode</function>()</term>
+  <term><replaceable>node</replaceable>.<function>srcnode</function>()</term>
   <listitem>
 <para>The
 <function>srcnode</function>
@@ -5137,61 +5170,61 @@ File or Directory Node.
   </varlistentry>
 </variablelist>
 
-<para>For example:</para>
+<para>Examples:</para>
 
 <programlisting language="python">
 # Get the current build dir's path, relative to top.
 Dir('.').path
+
 # Current dir's absolute path
 Dir('.').abspath
+
 # Current dir's path relative to the root SConstruct file's directory
 Dir('.').relpath
+
 # Next line is always '.', because it is the top dir's path relative to itself.
 Dir('#.').path
 File('foo.c').srcnode().path   # source path of the given source file.
 
-# Builders also return File objects:
+# Builders return lists of File objects:
 foo = env.Program('foo.c')
-print("foo will be built in", foo.path)
+print("foo will be built in", foo[0].path)
 </programlisting>
 
 <para>
-File and Directory Node objects have methods to create
-File and Directory Nodes relative to the original Node.
-</para>
-
-<para>
+Filesystem Node objects have methods to create new
+filesystem Nodes relative to the original Node.
 If the object is a Directory Node,
-these methods will place the the new Node within the directory
-the Node represents:
+these methods will place the new Node within the directory
+the original Node represents:
 </para>
 
 <variablelist>
   <varlistentry>
-  <term><replaceable>d</replaceable>.<function>Dir</function>(<parameter>name</parameter>)</term>
+  <term><replaceable>node</replaceable>.<function>Dir</function>(<parameter>name</parameter>)</term>
   <listitem>
 <para>Returns a directory Node for a subdirectory of
-<replaceable>d</replaceable>
+<replaceable>node</replaceable>
 named
 <parameter>name</parameter>.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>d</replaceable>.<function>File</function>(<parameter>name</parameter>)</term>
+  <term><replaceable>node</replaceable>.<function>File</function>(<parameter>name</parameter>)</term>
   <listitem>
 <para>Returns a file Node for a file within
-<replaceable>d</replaceable>
+<replaceable>node</replaceable>
 named
 <parameter>name</parameter>.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>d</replaceable>.<function>Entry</function>(<parameter>name</parameter>)</term>
+  <term><replaceable>node</replaceable>.<function>Entry</function>(<parameter>name</parameter>)</term>
   <listitem>
 <para>Returns an unresolved Node within
-<replaceable>d</replaceable>
+<replaceable>node</replaceable>
 named
 <parameter>name</parameter>.</para>
   </listitem>
@@ -5206,32 +5239,32 @@ directory as the one the Node represents:
 
 <variablelist>
   <varlistentry>
-  <term><replaceable>f</replaceable>.<function>Dir</function>(<parameter>name</parameter>)</term>
+  <term><replaceable>node</replaceable>.<function>Dir</function>(<parameter>name</parameter>)</term>
   <listitem>
-<para>Returns a directory named
+<para>Returns a Node for a directory named
 <parameter>name</parameter>
 within the parent directory of
-<replaceable>f</replaceable>.</para>
+<replaceable>node</replaceable>.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>f</replaceable>.<function>File</function>(<parameter>name</parameter>)</term>
+  <term><replaceable>node</replaceable>.<function>File</function>(<parameter>name</parameter>)</term>
   <listitem>
-<para>Returns a file named
+<para>Returns a Node for a file named
 <parameter>name</parameter>
 within the parent directory of
-<replaceable>f</replaceable>.</para>
+<replaceable>node</replaceable>.</para>
   </listitem>
   </varlistentry>
 
   <varlistentry>
-  <term><replaceable>f</replaceable>.<function>Entry</function>(<parameter>name</parameter>)</term>
+  <term><replaceable>node</replaceable>.<function>Entry</function>(<parameter>name</parameter>)</term>
   <listitem>
 <para>Returns an unresolved Node named
 <parameter>name</parameter>
 within the parent directory of
-<replaceable>f</replaceable>.</para>
+<replaceable>node</replaceable>.</para>
   </listitem>
   </varlistentry>
 </variablelist>
@@ -5257,6 +5290,54 @@ html = docs.Dir('html')
 index = html.File('index.html')
 css = index.File('app.css')
 </programlisting>
+</refsect3>
+
+<refsect3 id='value_and_alias_nodes'>
+<title>Value and Alias Nodes</title>
+
+<para>
+&SCons; provides two other Node types to describe
+items that will not have an equivalent filesystem entry.
+Such Nodes always need to be created explicitly.
+</para>
+
+<para>
+The &f-link-Alias; method returns an Alias Node.
+Aliases are virtual objects - they will not themselves result
+in physical objects being constructed, but are entered into
+the dependency graph related to their sources.
+An alias is checked for up to date by checking if
+its sources are up to date.
+An alias is built by making sure its sources have been built,
+and applying any optional actions that are part of the alias.
+</para>
+
+<para>
+An &f-link-Alias; call creates an entry in the alias namespace,
+which is used for disambiguation.
+If an alias source has a string valued name,
+it will be resolved to a filesystem entry Node,
+unless it is found in the alias namespace,
+in which case it it resolved to the matching alias Node.
+As a result, the order of &f-Alias; calls is signifcant.
+An alias can refer to another alias, but only if the
+other alias has already been created.
+</para>
+
+<para>
+The &f-link-Value; method returns a Value Node.
+Value nodes are often used for generated data that
+will not have any corresponding filesystem entry,
+but will be used to determine whether a build target is out of date,
+or to include as part of a build Action.
+Common examples are timestamp strings, git revision strings and
+other run-time generated strings.
+</para>
+
+<para>
+A Value Node can also be the target of a builder.
+</para>
+</refsect3>
 
 </refsect2>
 </refsect1>
@@ -7020,7 +7101,7 @@ is optional, the default is no <parameter>arg</parameter>.
 <para>
 The function can use use
 <function>str</function>(<parameter>node</parameter>)
-to fetch the name of the file, 
+to fetch the name of the file,
 <replaceable>node</replaceable>.<function>dir</function>
 to fetch the directory the file is in,
 <replaceable>node</replaceable>.<function>get_contents</function>()
@@ -7041,7 +7122,7 @@ in order to build Nodes with correct paths.
 Using &f-link-FindPathDirs; with an argument of <literal>CPPPATH</literal>
 as the <parameter>path_function</parameter> in the &f-Scanner; call
 means the scanner function will be called with the paths extracted
-from &cv-CPPPATH; in the environment <parameter>env</parameter> 
+from &cv-CPPPATH; in the environment <parameter>env</parameter>
 passed as the <parameter>paths</parameter> parameter.
 </para>
 <para>
@@ -7375,8 +7456,8 @@ arguments to itself, not to &scons;:</para>
 </screen>
 
 <para>Second, the Cygwin shell does not
-reognize typing <userinput>scons</userinput>
-at the command line prompt as referring to this weapper.
+recognize typing <userinput>scons</userinput>
+at the command line prompt as referring to this wrapper.
 You can work around this either by executing
 <userinput>scons.bat</userinput>
 (including the extension)

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1202,11 +1202,11 @@ database with name <filename>.sconsign_sha256.dblite</filename>.</para>
 <para>If this option is not specified, a the first supported hash format found
 is selected. Typically this is MD5, however, if you are on a FIPS-compliant system
 and using a version of Python less than 3.9, SHA1 or SHA256 will be chosen as the default.
-Python 3.9 and onwards clients will always default to MD5, even in FIPS mode, unless 
+Python 3.9 and onwards clients will always default to MD5, even in FIPS mode, unless
 otherwise specified with the <option>--hash-format</option> option.</para>
 
-<para>For MD5 databases (either explicitly specified with <option>--hash-format=md5</option> or 
-defaulted), the SConsign database is<filename>.sconsign.dblite</filename>. The newer SHA1 and 
+<para>For MD5 databases (either explicitly specified with <option>--hash-format=md5</option> or
+defaulted), the SConsign database is<filename>.sconsign.dblite</filename>. The newer SHA1 and
 SHA256 selections meanwhile store their databases to <filename>.sconsign_algorithmname.dblite</filename></para>
 
 <para><emphasis>Available since &scons; 4.2.</emphasis></para>
@@ -2519,11 +2519,11 @@ See <xref linkend="commandline_construction_variables"/> for details.
 <title>Tools</title>
 
 <para>
-&SCons; has a large number of predefined tools
-(more properly, <firstterm>tool specifications</firstterm>)
+&SCons; has a large number of predefined tool modules
+(more properly, <firstterm>tool specification modules</firstterm>)
 which are used to help initialize the &consenv;.
 An &SCons; tool is only responsible for setup.
-For example, if the &SConscript; file declares
+For example, if an SConscript file declares
 the need to construct an object file from
 a C-language source file by calling the
 &b-link-Object; builder, then a tool representing
@@ -2531,8 +2531,8 @@ an available C compiler needs to have run first,
 to set up that builder and all the &consvars;
 it needs in the associated &consenv;; the tool itself
 is not called in the process of the build. Normally this
-happens invisibly: &scons; has per-platform
-lists of default tools, and it runs through those tools,
+happens invisibly as &scons; has per-platform
+lists of default tools, and it steps through those tools,
 calling the ones which are actually applicable,
 skipping those where necessary programs are not
 installed on the build system, or other preconditions are not met.
@@ -2582,152 +2582,10 @@ Changing the <varname>PATH</varname>
 variable after the &consenv; is constructed will not cause the tools to
 be re-detected.</para>
 
-<para>
-Additional tools can be added to a project either by
-placing them in a <filename>site_tools</filename> subdirectory
-of a site directory, or in a custom location specified to
-&scons; by giving the
-<parameter>toolpath</parameter> keyword argument.
-<parameter>toolpath</parameter> also takes a list as its value:
+<para>Additional tools can be added, see the
+<link linkend='extending_scons'>Extending SCons</link> section
+and specifically <link linkend='tool_modules'>Tool Modules</link>.
 </para>
-
-<programlisting language="python">
-env = Environment(tools=['default', 'foo'], toolpath=['tools'])
-</programlisting>
-
-<para>
-This looks for a tool specification module <filename>foo.py</filename>
-in directory <filename>tools</filename> and in the standard locations,
-as well as using the ordinary default tools for the platform.
-</para>
-
-<para>
-Directories specified via <parameter>toolpath</parameter> are prepended
-to the existing tool path. The default tool path is any <filename>site_tools</filename>
-directories, so tools in a specified <parameter>toolpath</parameter>
-take priority,
-followed by tools in a <filename>site_tools</filename> directory,
-followed by built-in tools.  For example, adding
-a tool specification module <filename>gcc.py</filename> to the toolpath
-directory would override the built-in &t-link-gcc; tool.
-The tool path is
-stored in the environment and will be
-used by subsequent calls to the &f-link-Tool; method,
-as well as by &f-link-env-Clone;.
-</para>
-
-<programlisting language="python">
-base = Environment(toolpath=['custom_path'])
-derived = base.Clone(tools=['custom_tool'])
-derived.CustomBuilder()
-</programlisting>
-
-<para>
-A tool specification module must include two functions:
-</para>
-
-<variablelist>
-  <varlistentry>
-    <term><function>generate</function>(<parameter>env, **kwargs</parameter>)</term>
-    <listitem>
-<para>Modifies the environment referenced by <parameter>env</parameter>
-to set up variables so that the facilities represented by
-the tool can be executed.
-It may use any keyword arguments
-that the user supplies in <parameter>kwargs</parameter>
-to vary its initialization.</para>
-    </listitem>
-  </varlistentry>
-  <varlistentry>
-    <term><function>exists</function>(<parameter>env</parameter>)</term>
-    <listitem>
-<para>Return <constant>True</constant> if the tool can
-be called in the context of <parameter>env</parameter>.
-Usually this means looking up one or more
-known programs using the <envar>PATH</envar> from the
-supplied <parameter>env</parameter>, but the tool can
-make the "exists" decision in any way it chooses.
-</para>
-    </listitem>
-  </varlistentry>
-</variablelist>
-
-<note>
-<para>
-At the moment, user-added tools do not automatically have their
-<function>exists</function> function called.
-As a result, it is recommended that the <function>generate</function>
-function be defensively coded - that is, do not rely on any
-necessary existence checks already having been performed.
-This is expected to be a temporary limitation,
-and the <function>exists</function> function should still be provided.
-</para>
-</note>
-
-<para>The elements of the <parameter>tools</parameter> list may also
-be functions or callable objects,
-in which case the &Environment; method
-will call those objects
-to update the new &consenv; (see &f-link-Tool; for more details):</para>
-
-<programlisting language="python">
-def my_tool(env):
-    env['XYZZY'] = 'xyzzy'
-
-env = Environment(tools=[my_tool])
-</programlisting>
-
-<para>The individual elements of the <parameter>tools</parameter> list
-may also themselves be lists or tuples of the form
-(<varname>toolname</varname>, <varname>kw_dict</varname>).
-SCons searches for the
-<parameter>toolname</parameter>
-specification file as described above, and
-passes
-<parameter>kw_dict</parameter>,
-which must be a dictionary, as keyword arguments to the tool's
-<function>generate</function>
-function.
-The
-<function>generate</function>
-function can use the arguments to modify the tool's behavior
-by setting up the environment in different ways
-or otherwise changing its initialization.</para>
-
-<programlisting language="python">
-# in tools/my_tool.py:
-def generate(env, **kwargs):
-  # Sets MY_TOOL to the value of keyword 'arg1' '1' if not supplied
-  env['MY_TOOL'] = kwargs.get('arg1', '1')
-
-def exists(env):
-  return True
-
-# in SConstruct:
-env = Environment(tools=['default', ('my_tool', {'arg1': 'abc'})],
-                  toolpath=['tools'])
-</programlisting>
-
-<para>The tool specification (<function>my_tool</function> in the example)
-can use the
-<envar>PLATFORM</envar> variable from
-the &consenv; it is passed to customize the tool for different platforms.</para>
-
-<para>Tools can be "nested" - that is, they
-can be located within a subdirectory in the toolpath.
-A nested tool name uses a dot to represent a directory separator</para>
-
-<programlisting language="python">
-# namespaced builder
-env = Environment(ENV=os.environ.copy(), tools=['SubDir1.SubDir2.SomeTool'])
-env.SomeTool(targets, sources)
-
-# Search Paths
-# SCons\Tool\SubDir1\SubDir2\SomeTool.py
-# SCons\Tool\SubDir1\SubDir2\SomeTool\__init__.py
-# .\site_scons\site_tools\SubDir1\SubDir2\SomeTool.py
-# .\site_scons\site_tools\SubDir1\SubDir2\SomeTool\__init__.py
-</programlisting>
 
 <para>SCons supports the following tool specifications out of the box:</para>
 
@@ -5345,6 +5203,30 @@ A Value Node can also be the target of a builder.
 <refsect1 id='extending_scons'>
 <title>EXTENDING SCONS</title>
 
+<para>
+&SCons; is designed to be extensible through provided facilities,
+so changing the code of &SCons; itself is only rarely needed
+to customize its behavior.
+A number of the main operations use callable objects
+which can be supplemented by writing your own.
+Builders, Scanners and Tools each use a kind of plugin system,
+allowing you to seamlessly drop in new ones.
+Information about creating
+<link linkend='builder_objects'>Builder Objects</link> and
+<link linkend='scanner_objects'>Scanner Objects</link>
+appear in the following sections.
+The instructions &SCons; actually uses to make things are called
+Actions, and it is easy to create Action Objects and hand them
+to the objects that need to know about those actions
+(besides Builders, see &f-link-AddPostAction;,
+&f-link-AddPreAction; and &f-link-Alias; for some examples
+of other places that take Actions).
+<link linkend='action_objects'>Action Objects</link>
+are also described below.
+Adding new Tool modules is described in
+<link linkend='tool_modules'>Tool Modules</link>
+</para>
+
 <refsect2 id='builder_objects'>
 <title>Builder Objects</title>
 
@@ -5373,7 +5255,10 @@ factory function.
 Once created, a builder is added to an environment
 by entering it in the &cv-link-BUILDERS; dictionary
 in that environment (some of the examples
-in this section illustrate that). </para>
+in this section illustrate this).
+Doing so automatically triggers &SCons; to add a method
+with the name of the builder to the environment.
+</para>
 
 <para>
 The
@@ -5396,7 +5281,7 @@ any combination of command line strings
 (if the builder should accept multiple source file extensions),
 a Python function,
 an Action object
-(see <xref linkend="action_objects"/>)
+(see <link linkend='action_objects'>Action Objects</link>)
 or a list of any of the above.</para>
 
 <para>An action function must accept three arguments:
@@ -5624,7 +5509,7 @@ env.Collect('archive', ['directory_name', 'file_name'])
   </listitem>
   </varlistentry>
 
-  <varlistentry>
+  <varlistentry id="emitter_function">
   <term><parameter>emitter</parameter></term>
   <listitem>
 <para>A function or list of functions to manipulate the target and source
@@ -5721,7 +5606,7 @@ used to call the Builder for the target file.)</para>
   </listitem>
   </varlistentry>
 
-  <varlistentry>
+  <varlistentry id="generator_function">
   <term><parameter>generator</parameter></term>
   <listitem>
 <para>A function that returns a list of actions that will be executed to build
@@ -5940,9 +5825,11 @@ result of the call).</para>
 
 <para>These extra keyword arguments are passed to the
 following functions:
-command generator functions,
-function Actions,
-and emitter functions.</para>
+<link linkend='generator_function'>command generator functions</link>,
+<link linkend='miscellaneous_action_functions'>function Actions</link>,
+and
+<link linkend='emitter_function'>emitter functions</link>.
+</para>
 
 </refsect2>
 
@@ -6129,7 +6016,7 @@ with the same interpretation as for a callable
   </listitem>
 
   <listitem>
-<para>If <parameter>output</parameter>is  <constant>None</constant>,
+<para>If <parameter>output</parameter>is <constant>None</constant>,
 output is suppressed entirely.</para>
   </listitem>
 </itemizedlist>
@@ -6369,9 +6256,8 @@ a = Action('build $CHANGED_SOURCES', batch_key=batch_key)
   </listitem>
   </varlistentry>
 </variablelist>
-</refsect2>
 
-<refsect2 id='miscellaneous_action_functions'>
+<refsect3 id='miscellaneous_action_functions'>
 <title>Miscellaneous Action Functions</title>
 
 <para>&SCons;
@@ -6600,9 +6486,9 @@ env.Command('marker', 'input_file', action=[MyBuildAction, Touch('$TARGET')])
   </listitem>
   </varlistentry>
 </variablelist>
-</refsect2>
+</refsect3>
 
-<refsect2 id='variable_substitution'>
+<refsect3 id='variable_substitution'>
 <title>Variable Substitution</title>
 
 <para>Before executing a command,
@@ -6839,7 +6725,7 @@ All text between
 and
 <emphasis role="bold">$)</emphasis>
 will be removed from the command line
-before it is added to the build (action) signature,
+before it is added to the build action signature,
 and the
 <emphasis role="bold">$(</emphasis>
 and
@@ -6930,9 +6816,9 @@ class foo:
 # Will expand $BAR to "my argument bar baz"
 env=Environment(FOO=foo, BAR="${FOO('my argument')} baz")
 </programlisting>
-</refsect2>
+</refsect3>
 
-<refsect2 id='python_code_substitution'>
+<refsect3 id='python_code_substitution'>
 <title>Python Code Substitution</title>
 
 <para>
@@ -7052,6 +6938,7 @@ Although &SCons; makes use of it in a somewhat restricted context,
 you should be aware of this issue when using the
 <literal>${python-expression-for-subst}</literal> form.
 </para></note>
+</refsect3>
 </refsect2>
 
 <refsect2 id='scanner_objects'>
@@ -7065,8 +6952,8 @@ that cause other files to be included during processing.
 &SCons; has a number of pre-built Scanner objects,
 so it is usually only necessary to set up Scanners for new file types.
 You do this by calling the &f-link-Scanner; factory function.
-&f-Scanner; accepts the following arguments,
-only <parameter>function</parameter> is required,
+&f-Scanner; accepts the following arguments.
+Only <parameter>function</parameter> is required;
 the rest are optional:
 </para>
 
@@ -7281,15 +7168,21 @@ Nodes for additional scanning.</para>
   </listitem>
   </varlistentry>
 </variablelist>
-<para>Note that
-&scons;
-has a global
+
+<para>
+Once created, a Scanner can added to an environment
+by setting it in the &cv-link-SCANNERS; list,
+which automatically triggers &SCons; to also add it
+to the environment as a method.
+However, usually a scanner is not truly standalone, but needs to
+be plugged in to the existing selection mechanism for
+deciding how to scan source files based on filename extensions.
+For this, &SCons; has a global
 <classname>SourceFileScanner</classname>
 object that is used by
 the &b-link-Object;, &b-link-SharedObject; and &b-link-StaticObject;
 builders to decide
-which scanner should be used
-for different file extensions.
+which scanner should be used.
 You can use the
 <methodname>SourceFileScanner.add_scanner()</methodname>
 method to add your own Scanner object
@@ -7310,6 +7203,169 @@ XYZScanner = Scanner(xyz_scan)
 SourceFileScanner.add_scanner('.xyz', XYZScanner)
 
 env.Program('my_prog', ['file1.c', 'file2.f', 'file3.xyz'])
+</programlisting>
+
+</refsect2>
+
+<refsect2 id='tool_modules'>
+<title>Tool Modules</title>
+
+<para>
+Additional tools can be added to a project either by
+placing them in a <filename>site_tools</filename> subdirectory
+of a site directory, or in a custom location specified to
+&scons; by giving the
+<parameter>toolpath</parameter> keyword argument to &f-link-Environment;.
+A tool module is a form of Python module, invoked internally
+using the Python import mechanism, so a tool can consist either
+of a single source file taking the name of the tool
+(e.g. <filename>mytool.py</filename>) or a directory taking
+the name of the tool (e.g. <filename>mytool/</filename>)
+which contains at least an <filename>__init__.py</filename> file.
+</para>
+
+<para>
+The <parameter>toolpath</parameter> parameter
+takes a list as its value:
+</para>
+
+<programlisting language="python">
+env = Environment(tools=['default', 'foo'], toolpath=['tools'])
+</programlisting>
+
+<para>
+This looks for a tool specification module (<filename>mytool.py</filename>,
+or directory <filename>mytool</filename>)
+in directory <filename>tools</filename> and in the standard locations,
+as well as using the ordinary default tools for the platform.
+</para>
+
+<para>
+Directories specified via <parameter>toolpath</parameter> are prepended
+to the existing tool path.
+The default tool path is any <filename>site_tools</filename> directories,
+so tools in a specified <parameter>toolpath</parameter> take priority,
+followed by tools in a <filename>site_tools</filename> directory,
+followed by built-in tools.  For example, adding
+a tool specification module <filename>gcc.py</filename> to the toolpath
+directory would override the built-in &t-link-gcc; tool.
+The tool path is stored in the environment and will be
+used by subsequent calls to the &f-link-Tool; method,
+as well as by &f-link-env-Clone;.
+</para>
+
+<programlisting language="python">
+base = Environment(toolpath=['custom_path'])
+derived = base.Clone(tools=['custom_tool'])
+derived.CustomBuilder()
+</programlisting>
+
+<para>
+A tool specification module must include two functions:
+</para>
+
+<variablelist>
+  <varlistentry>
+    <term><function>generate</function>(<parameter>env, **kwargs</parameter>)</term>
+    <listitem>
+<para>Modifies the &consenv; <parameter>env</parameter>
+to set up necessary &consvars; so that the facilities represented by
+the tool can be executed.
+It may use any keyword arguments
+that the user supplies in <parameter>kwargs</parameter>
+to vary its initialization.</para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term><function>exists</function>(<parameter>env</parameter>)</term>
+    <listitem>
+<para>Returns <constant>True</constant> if the tool can
+be called in the context of <parameter>env</parameter>.
+Usually this means looking up one or more
+known programs using the <envar>PATH</envar> from the
+supplied <parameter>env</parameter>, but the tool can
+make the "exists" decision in any way it chooses.
+</para>
+    </listitem>
+  </varlistentry>
+</variablelist>
+
+<note>
+<para>
+At the moment, user-added tools do not automatically have their
+<function>exists</function> function called.
+As a result, it is recommended that the <function>generate</function>
+function be defensively coded - that is, do not rely on any
+necessary existence checks already having been performed.
+This is expected to be a temporary limitation,
+and the <function>exists</function> function should still be provided.
+</para>
+</note>
+
+<para>The elements of the <parameter>tools</parameter> list may also
+be functions or callable objects,
+in which case the &Environment; method
+will call those objects
+to update the new &consenv; (see &f-link-Tool; for more details):</para>
+
+<programlisting language="python">
+def my_tool(env):
+    env['XYZZY'] = 'xyzzy'
+
+env = Environment(tools=[my_tool])
+</programlisting>
+
+<para>The individual elements of the <parameter>tools</parameter> list
+may also themselves be lists or tuples of the form
+<literal>(toolname, kw_dict)</literal>.
+SCons searches for the
+<parameter>toolname</parameter>
+specification file as described above, and
+passes
+<parameter>kw_dict</parameter>,
+which must be a dictionary, as keyword arguments to the tool's
+<function>generate</function>
+function.
+The
+<function>generate</function>
+function can use the arguments to modify the tool's behavior
+by setting up the environment in different ways
+or otherwise changing its initialization.</para>
+
+<programlisting language="python">
+# in tools/my_tool.py:
+def generate(env, **kwargs):
+  # Sets MY_TOOL to the value of keyword 'arg1' '1' if not supplied
+  env['MY_TOOL'] = kwargs.get('arg1', '1')
+
+def exists(env):
+  return True
+
+# in SConstruct:
+env = Environment(tools=['default', ('my_tool', {'arg1': 'abc'})],
+                  toolpath=['tools'])
+</programlisting>
+
+<para>The tool specification (<function>my_tool</function> in the example)
+can use the
+&cv-link-PLATFORM; variable from
+the &consenv; it is passed to customize the tool for different platforms.
+</para>
+
+<para>Tools can be "nested" - that is, they
+can be located within a subdirectory in the toolpath.
+A nested tool name uses a dot to represent a directory separator</para>
+
+<programlisting language="python">
+# namespaced builder
+env = Environment(ENV=os.environ.copy(), tools=['SubDir1.SubDir2.SomeTool'])
+env.SomeTool(targets, sources)
+
+# Search Paths
+# SCons\Tool\SubDir1\SubDir2\SomeTool.py
+# SCons\Tool\SubDir1\SubDir2\SomeTool\__init__.py
+# .\site_scons\site_tools\SubDir1\SubDir2\SomeTool.py
+# .\site_scons\site_tools\SubDir1\SubDir2\SomeTool\__init__.py
 </programlisting>
 
 </refsect2>
@@ -7413,7 +7469,7 @@ such as the python.org and ActiveState versions,
 do not have the Cygwin path name semantics.
 This means that using a native Windows version of Python
 to build compiled programs using Cygwin tools
-(such as &gcc;, &bison; and <application>flex</application>)
+(such as &gcc;, &bison; and &flex;)
 may yield unpredictable results.
 "Mixing and matching" in this way
 can be made to work,

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -62,6 +62,7 @@
 <!ENTITY f77            "<application xmlns='http://www.scons.org/dbxsd/v1.0'>f77</application>">
 <!ENTITY f90            "<application xmlns='http://www.scons.org/dbxsd/v1.0'>f90</application>">
 <!ENTITY f95            "<application xmlns='http://www.scons.org/dbxsd/v1.0'>f95</application>">
+<!ENTITY flex           "<application xmlns='http://www.scons.org/dbxsd/v1.0'>flex</application>">
 <!ENTITY gas            "<application xmlns='http://www.scons.org/dbxsd/v1.0'>gas</application>">
 <!ENTITY gcc            "<application xmlns='http://www.scons.org/dbxsd/v1.0'>gcc</application>">
 <!ENTITY g77            "<application xmlns='http://www.scons.org/dbxsd/v1.0'>g77</application>">


### PR DESCRIPTION
Now organized into four sections: Builder Objects, Action Objects, Scanner Objects, Tool Modules, with the latter (new) section getting a lot of the material that was in the Tools section (which users dodn't need just to select an existing tool).
    
Adds a bit of commentary to the beginning of the section, and to Builder and Scanner.

Doc-only change.
    
Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
