### PR TITLE
Added error message when failure to delete partial cache retrieval occurs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).
+    - Added error message to handle the case when SCons attempts to retrieve all the targets
+      for a specified builder from the CacheDir, fails to do so, and then runs into an error
+      when deleting the files which were retrieved. Previously if this happened there was no
+      errors or warnings.
 
   From Flaviu Tamas:
     - Added -fsanitize support to ParseFlags().  This will propagate to CCFLAGS and LINKFLAGS.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,7 +31,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added logic to help packagers enable reproducible builds into packaging/etc/. Please
       read packaging/etc/README.txt if you are interested.
 
-
+  From Daniel Moody:
+    - Add error message for failure to delete partial cache retrieval files.
 
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,14 +32,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       read packaging/etc/README.txt if you are interested.
 
   From Daniel Moody:
-    - Add error message for failure to delete partial cache retrieval files.
-
-  From Dan Mezhiborsky:
-    - Add newline to end of compilation db (compile_commands.json).
     - Added error message to handle the case when SCons attempts to retrieve all the targets
       for a specified builder from the CacheDir, fails to do so, and then runs into an error
       when deleting the files which were retrieved. Previously if this happened there was no
       errors or warnings.
+
+  From Dan Mezhiborsky:
+    - Add newline to end of compilation db (compile_commands.json).
 
   From Flaviu Tamas:
     - Added -fsanitize support to ParseFlags().  This will propagate to CCFLAGS and LINKFLAGS.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -66,7 +66,7 @@ IMPROVEMENTS
 - Add cache-debug messages for push failures.
 - Added error message to handle the case when SCons attempts to retrieve all the targets
   for a specified builder from the CacheDir, fails to do so, and then runs into an error
-  when deleting the files which were retrieved. Previously if this happened there was no
+  when deleting the files which were retrieved. Previously if this happened there were no
   errors or warnings.
 
 PACKAGING

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -58,6 +58,8 @@ IMPROVEMENTS
 ------------
 
 - Changed the Taskmaster trace logic to use python's logging module.
+- Add cache-debug messages for push failures.
+- Add error message for failure to delete partial cache retrieval files.
 
 PACKAGING
 ---------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -13,6 +13,11 @@ A new SCons release, 4.4.1, is now available on the SCons download page:
 
 Here is a summary of the changes since 4.4.0:
 
+NOTE: If you build with Python 3.10.0 and then rebuild with 3.10.1 (or higher), you may
+      see unexpected rebuilds. This is due to Python internals changing which changed
+      the signature of a Python Action Function.
+
+
 NEW FUNCTIONALITY
 -----------------
 
@@ -59,7 +64,10 @@ IMPROVEMENTS
 
 - Changed the Taskmaster trace logic to use python's logging module.
 - Add cache-debug messages for push failures.
-- Add error message for failure to delete partial cache retrieval files.
+- Added error message to handle the case when SCons attempts to retrieve all the targets
+  for a specified builder from the CacheDir, fails to do so, and then runs into an error
+  when deleting the files which were retrieved. Previously if this happened there was no
+  errors or warnings.
 
 PACKAGING
 ---------

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -65,6 +65,8 @@ NODE_UP_TO_DATE = SCons.Node.up_to_date
 NODE_EXECUTED = SCons.Node.executed
 NODE_FAILED = SCons.Node.failed
 
+display = SCons.Util.display
+
 print_prepare = False               # set by option --debug=prepare
 
 # A subsystem for recording stats about how different Nodes are handled by
@@ -241,8 +243,8 @@ class Task(ABC):
                 for t in cached_targets:
                     try:
                         t.fs.unlink(t.get_internal_path())
-                    except (IOError, OSError):
-                        pass
+                    except (IOError, OSError) as e:
+                        display("scons: failed to delete partial cache file %s: %s" % (t.get_internal_path(), e))
                 self.targets[0].build()
             else:
                 for t in cached_targets:

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -64,9 +64,6 @@ NODE_EXECUTING = SCons.Node.executing
 NODE_UP_TO_DATE = SCons.Node.up_to_date
 NODE_EXECUTED = SCons.Node.executed
 NODE_FAILED = SCons.Node.failed
-
-display = SCons.Util.display
-
 print_prepare = False               # set by option --debug=prepare
 
 # A subsystem for recording stats about how different Nodes are handled by
@@ -245,7 +242,7 @@ class Task(ABC):
                         t.fs.unlink(t.get_internal_path())
                     except (IOError, OSError) as e:
                         SCons.Warnings.warn(SCons.Warnings.CacheCleanupErrorWarning,
-                            "failed to delete partial cache file %s: %s" % (t.get_internal_path(), e))
+                            "Failed copying all target files from cache, Error while attempting to remove file %s retrieved from cache: %s" % (t.get_internal_path(), e))
                 self.targets[0].build()
             else:
                 for t in cached_targets:

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -244,7 +244,8 @@ class Task(ABC):
                     try:
                         t.fs.unlink(t.get_internal_path())
                     except (IOError, OSError) as e:
-                        display("scons: failed to delete partial cache file %s: %s" % (t.get_internal_path(), e))
+                        SCons.Warnings.warn(SCons.Warnings.CacheCleanupErrorWarning,
+                            "failed to delete partial cache file %s: %s" % (t.get_internal_path(), e))
                 self.targets[0].build()
             else:
                 for t in cached_targets:

--- a/SCons/Warnings.py
+++ b/SCons/Warnings.py
@@ -46,6 +46,9 @@ class CacheVersionWarning(WarningOnByDefault):
 class CacheWriteErrorWarning(SConsWarning):
     pass
 
+class CacheCleanupErrorWarning(SConsWarning):
+    pass
+
 class CorruptSConsignWarning(WarningOnByDefault):
     pass
 


### PR DESCRIPTION
Mongodb was running into cases where the partial cache file still existed in a bad state after a bad retrieval. The lack of any error message around the related code in this PR made it difficult to understand what was happening. This error message should give some more obvious insight into what took place and why the failed retrieval file still exists after a failed retrieval.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
