### PR TITLE
Update ActionTests.py to work for python 3.10.1+

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From William Deegan:
     - Fix check for unsupported Python version. It was broken. Also now the error message
       will include what is the minimum supported version of Python
+    - Fix ActionTests to work with python 3.10.1 (and higher)
+    NOTE: If you build with Python 3.10.0 and then rebuild with 3.10.1 (or higher), you may
+          see unexpected rebuilds. This is due to Python internals changing which changed 
+          the signature of a Python Action Function.
 
   From Daniel Moody:
     - Add cache-debug messages for push failures.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -6,6 +6,11 @@ on the SCons download page:
 
 Here is a summary of the changes since 4.3.1:
 
+NOTE: If you build with Python 3.10.0 and then rebuild with 3.10.1 (or higher), you may
+      see unexpected rebuilds. This is due to Python internals changing which changed 
+      the signature of a Python Action Function.
+
+
 NEW FUNCTIONALITY
 -----------------
 
@@ -18,9 +23,6 @@ DEPRECATED FUNCTIONALITY
 
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
-
-- List modifications to existing features, where the previous behavior
-  wouldn't actually be considered a bug
 
 - On Windows, %AllUsersProfile%\scons\site_scons is now the default "system"
   location for a site_scons. %AllUsersProfile%\Application Data\scons\site_scons

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -2246,16 +2246,17 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (3, 5): bytearray(b'3, 3, 0, 0,(),(),(|\x00\x00S),(),()'),
-            (3, 6): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
-            (3, 7): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
-            (3, 8): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
-            (3, 9): bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),
-            (3, 10): bytearray(b'3, 3, 0, 0,(N.),(),(|\x00S\x00),(),()'),
+            (3, 5): (bytearray(b'3, 3, 0, 0,(),(),(|\x00\x00S),(),()')),
+            (3, 6): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()')),
+            (3, 7): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()')),
+            (3, 8): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()')),
+            (3, 9): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()')),
+            (3, 10): (bytearray(b'3, 3, 0, 0,(N.),(),(|\x00S\x00),(),()'),
+                      bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()')) # 3.10.1, 3.10.2
         }
 
         c = SCons.Action._function_contents(func1)
-        assert c == expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(
+        assert c in expected[sys.version_info[:2]], "Got\n" + repr(c) + "\nExpected \n" + "\n" + repr(
             expected[sys.version_info[:2]])
 
     def test_object_contents(self):


### PR DESCRIPTION
Update ActionTests.py to work with change in function signature for 3.10.1+ (it changed from 3.10.0)

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
