### PR TITLE
Docs: Fix a typo and use more entities

### DIFF
--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -2882,7 +2882,7 @@ when all the directories in which SConscript files may be found
 don't necessarily exist locally.)
 You may enable and disable
 this ability by calling
-SConscriptChdir()
+&f-SConscriptChdir;
 multiple times.
 </para>
 

--- a/doc/user/troubleshoot.xml
+++ b/doc/user/troubleshoot.xml
@@ -261,13 +261,13 @@ file3.c
   </section>
 
   <section>
-  <title>What's in That Construction Environment?  the &Dump; Method</title>
+  <title>What's in That Construction Environment?  the &f-Dump; Method</title>
 
     <para>
 
-    When you create a construction environment,
+    When you create a &consenv;,
     &SCons; populates it
-    with construction variables that are set up
+    with &consvars; that are set up
     for various compilers, linkers and utilities
     that it finds on your system.
     Although this is usually helpful and what you want,
@@ -276,10 +276,10 @@ file3.c
     expect to be set.
     In situations like this,
     it's sometimes helpful to use the
-    construction environment &Dump; method
+    &consenv; &f-link-Dump; method
     to print all or some of
-    the construction variables.
-    Note that the &Dump; method
+    the &consvars;.
+    Note that the &f-Dump; method
     <emphasis>returns</emphasis>
     the representation of the variables
     in the environment
@@ -318,11 +318,11 @@ print(env.Dump())
 
     <para>
 
-    The construction environments in these examples have
+    The &consenvs; in these examples have
     actually been restricted to just gcc and Visual C++,
     respectively.
     In a real-life situation,
-    the construction environments will
+    the &consenvs; will
     likely contain a great many more variables.
     Also note that we've massaged the example output above
     to make the memory address of all objects a constant 0x700000.
@@ -336,7 +336,7 @@ print(env.Dump())
     To make it easier to see just what you're
     interested in,
     the &Dump; method allows you to
-    specify a specific constrcution variable
+    specify a specific &consvar;
     that you want to disply.
     For example,
     it's not unusual to want to verify


### PR DESCRIPTION
Fixes #4096 (thanks to @Vishwajith-K for reporting)
Changed references in this file to use `&consvar;` and `&consenv;` entities.
+ Use the entity for PATH as well.
+ Update the entity reference for DUMP.

Also fix unrelated missing-entity referring to `SConscriptChdir` method.

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
