### PR TITLE
Add variable MSVC_USE_SCRIPT_ARGS to pass args to MSVC_USE_SCRIPT

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -52,7 +52,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       processors for testing threads.
 
   From Zhichang Yu:
-    - Define MSVC_SCRIPT_ARGS to pass arguments (whitespace separated) to MSVC_USE_SCRIPT.
+    - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -51,6 +51,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - runtest.py now accepts -j 0 to auto-detect number of usable
       processors for testing threads.
 
+  From Zhichang Yu:
+    - Define MSVC_SCRIPT_ARGS to pass arguments (whitespace separated) to MSVC_USE_SCRIPT.
+
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -15,6 +15,7 @@ NEW FUNCTIONALITY
 -----------------
 
 - List new features (presumably why a checkpoint is being released)
+- Define MSVC_SCRIPT_ARGS to pass arguments (whitespace separated) to MSVC_USE_SCRIPT.
 
 DEPRECATED FUNCTIONALITY
 ------------------------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -15,7 +15,7 @@ NEW FUNCTIONALITY
 -----------------
 
 - List new features (presumably why a checkpoint is being released)
-- Define MSVC_SCRIPT_ARGS to pass arguments (whitespace separated) to MSVC_USE_SCRIPT.
+- Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.
 
 DEPRECATED FUNCTIONALITY
 ------------------------

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -942,7 +942,7 @@ def msvc_setup_env(env):
         use_script = use_script.strip()
         if not os.path.exists(use_script):
             raise MSVCScriptNotFound('Script specified by MSVC_USE_SCRIPT not found: "{}"'.format(use_script))
-        args = env.get('MSVC_SCRIPT_ARGS', None)
+        args = env.subst('$MSVC_USE_SCRIPT_ARGS')
         debug('use_script 1 %s %s', repr(use_script), repr(args))
         d = script_env(use_script, args)
     elif use_script:

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -942,8 +942,9 @@ def msvc_setup_env(env):
         use_script = use_script.strip()
         if not os.path.exists(use_script):
             raise MSVCScriptNotFound('Script specified by MSVC_USE_SCRIPT not found: "{}"'.format(use_script))
-        debug('use_script 1 %s', repr(use_script))
-        d = script_env(use_script)
+        args = env.get('MSVC_SCRIPT_ARGS', None)
+        debug('use_script 1 %s %s', repr(use_script), repr(args))
+        d = script_env(use_script, args)
     elif use_script:
         d = msvc_find_valid_batch_script(env,version)
         debug('use_script 2 %s', d)

--- a/SCons/Tool/msvc.xml
+++ b/SCons/Tool/msvc.xml
@@ -395,7 +395,7 @@ and extract the relevant variables from the result (typically
 <envar>%PATH%</envar>) for supplying to the build.
 This can be useful to force the use of a compiler version that
 &SCons; does not detect.
-<literal>MSVC_SCRIPT_ARGS</literal> is the arguments (whitespace separated) passed to this script.
+&cv-MSVC_USE_SCRIPT_ARGS; privides arguments passed to this script.
 </para>
 
 <para>
@@ -413,10 +413,10 @@ you don't want &SCons; to change anything.
 </summary>
 </cvar>
 
-<cvar name="MSVC_SCRIPT_ARGS">
+<cvar name="MSVC_USE_SCRIPT_ARGS">
 <summary>
 <para>
-This is the arguments (whitespace separated) passed to the script <literal>MSVC_USE_SCRIPT</literal>.
+Provides arguments passed to the script &cv-MSVC_USE_SCRIPT;.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/msvc.xml
+++ b/SCons/Tool/msvc.xml
@@ -395,6 +395,7 @@ and extract the relevant variables from the result (typically
 <envar>%PATH%</envar>) for supplying to the build.
 This can be useful to force the use of a compiler version that
 &SCons; does not detect.
+<literal>MSVC_SCRIPT_ARGS</literal> is the arguments (whitespace separated) passed to this script.
 </para>
 
 <para>
@@ -408,6 +409,14 @@ you don't want &SCons; to change anything.
 </para>
 <para>
 &cv-MSVC_USE_SCRIPT; overrides &cv-link-MSVC_VERSION; and &cv-link-TARGET_ARCH;.
+</para>
+</summary>
+</cvar>
+
+<cvar name="MSVC_SCRIPT_ARGS">
+<summary>
+<para>
+This is the arguments (whitespace separated) passed to the script <literal>MSVC_USE_SCRIPT</literal>.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/msvc.xml
+++ b/SCons/Tool/msvc.xml
@@ -416,7 +416,7 @@ you don't want &SCons; to change anything.
 <cvar name="MSVC_USE_SCRIPT_ARGS">
 <summary>
 <para>
-Provides arguments passed to the script &cv-MSVC_USE_SCRIPT;.
+Provides arguments passed to the script &cv-link-MSVC_USE_SCRIPT;.
 </para>
 </summary>
 </cvar>

--- a/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/SConstruct
+++ b/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/SConstruct
@@ -1,0 +1,6 @@
+import os
+
+os.environ['SCONS_MSCOMMON_DEBUG']='MSDEBUG_OUTPUT.log'
+
+DefaultEnvironment(tools=[])
+env = Environment(tools=['msvc'], MSVC_USE_SCRIPT='fake_script.bat', MSVC_USE_SCRIPT_ARGS=['one','two'])

--- a/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/fake_script.bat
+++ b/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/fake_script.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Fake msvc batch script for use in testing MSVC_USE_SCRIPT_ARGS
+echo ARG1: %1  ARG2: %2

--- a/test/MSVC/MSVC_USE_SCRIPT_ARGS.py
+++ b/test/MSVC/MSVC_USE_SCRIPT_ARGS.py
@@ -1,0 +1,47 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test the $MSVC_USE_SCRIPT construction variable.
+"""
+
+import TestSCons
+
+_python_ = TestSCons._python_
+
+test = TestSCons.TestSCons()
+
+test.skip_if_not_msvc()
+test.dir_fixture('MSVC_USE_SCRIPT_ARGS-fixture')
+
+test.run(arguments = ".", status=0, stderr=None)
+
+test.must_contain('MSDEBUG_OUTPUT.log', "Calling 'fake_script.bat one two'")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
I installed multiple VS(VS2005, VS2015) and Windows SDK 6.0 on Win7. I want to use C++ compiler in VS2015, and Windows SDK 6.0, to build apps that target Windows 2003 server 32bit edition.

```
    env = Environment(MSVC_USE_SCRIPT=r'C:\Program Files\Microsoft SDKs\Windows\v6.0\Bin\SetEnv.cmd', MSVC_USE_SCRIPT_ARGS='/Release /x86 /2003')
```


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
