### PR TITLE
Fix dictify_CPPDEFINES exeception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -50,8 +50,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Pass window size to formatter so it formats for wider displays too.
     - runtest.py now accepts -j 0 to auto-detect number of usable
       processors for testing threads.
-    - Fixed Scanner/C:dictify_CPPDEFINES() crash if given single-item
-      tuples, as can happen if AppendUnique has been called (issue 4108).
+    - Fixed crash in C scanner's dictify_CPPDEFINES() function which happens if
+      AppendUnique is called on CPPPATH. (Issue #4108).
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -50,6 +50,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Pass window size to formatter so it formats for wider displays too.
     - runtest.py now accepts -j 0 to auto-detect number of usable
       processors for testing threads.
+    - Fixed Scanner/C:dictify_CPPDEFINES() crash if given single-item
+      tuples, as can happen if AppendUnique has been called (issue 4108).
 
 
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -42,6 +42,9 @@ FIXES
 
 - Fix a number of Python ResourceWarnings which are issued when running SCons and/or it's tests
   with python 3.9 (or higher)
+- Fixed crash in C scanner's dictify_CPPDEFINES() function which happens if
+  AppendUnique is called on CPPPATH. (Issue #4108).
+
 
 IMPROVEMENTS
 ------------

--- a/SCons/Scanner/C.py
+++ b/SCons/Scanner/C.py
@@ -61,7 +61,8 @@ class SConsCPPScanner(SCons.cpp.PreProcessor):
             self.missing.append((file, self.current_file))
             return ''
 
-def dictify_CPPDEFINES(env):
+def dictify_CPPDEFINES(env) -> dict:
+    """Returns CPPDEFINES converted to a dict."""
     cppdefines = env.get('CPPDEFINES', {})
     if cppdefines is None:
         return {}
@@ -69,7 +70,11 @@ def dictify_CPPDEFINES(env):
         result = {}
         for c in cppdefines:
             if SCons.Util.is_Sequence(c):
-                result[c[0]] = c[1]
+                try:
+                    result[c[0]] = c[1]
+                except IndexError:
+                    # it could be a one-item sequence
+                    result[c[0]] = None
             else:
                 result[c] = None
         return result

--- a/SCons/Scanner/CTests.py
+++ b/SCons/Scanner/CTests.py
@@ -490,6 +490,17 @@ class CConditionalScannerTestCase3(unittest.TestCase):
         headers = ['d1/f1.h']
         deps_match(self, deps, headers)
 
+class dictify_CPPDEFINESTestCase(unittest.TestCase):
+    def runTest(self):
+        """Make sure single-item tuples convert correctly.
+
+        This is a regression test: AppendUnique turns sequences into
+        lists of tuples, and dictify could gack on these.
+        """
+        env = DummyEnvironment(CPPDEFINES=(("VALUED_DEFINE", 1), ("UNVALUED_DEFINE", )))
+        d = SCons.Scanner.C.dictify_CPPDEFINES(env)
+        expect = {'VALUED_DEFINE': 1, 'UNVALUED_DEFINE': None}
+        assert d == expect
 
 def suite():
     suite = unittest.TestSuite()
@@ -510,6 +521,7 @@ def suite():
     suite.addTest(CConditionalScannerTestCase1())
     suite.addTest(CConditionalScannerTestCase2())
     suite.addTest(CConditionalScannerTestCase3())
+    suite.addTest(dictify_CPPDEFINESTestCase())
     return suite
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the C scanner converted `CPPDEFINES` to a dict, if an element is a single-item sequence `c`, it would take an IndexError trying to access `c[1]`. This could happen if AppendUnique has been called as it converts to tuples.

Fixes #4108

No doc impacts, this fixes up existing behavior.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
