### PR TITLE
Use super call instead of direct class call

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -59,6 +59,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - As "code modernization" all of SCons now uses the current super()
       zero-argument syntax instead of direct calls to a parent class method
       or the super() two-argument syntax.
+    - Renamed ParseFlag's internal data structure to "mapping" instead of
+      "dict" (avoid redefining builtin)
 
   From Zhichang Yu:
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,6 +56,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       processors for testing threads.
     - Fixed crash in C scanner's dictify_CPPDEFINES() function which happens if
       AppendUnique is called on CPPPATH. (Issue #4108).
+    - As "code modernization" all of SCons now uses the current super()
+      zero-argument syntax instead of direct calls to a parent class method
+      or the super() two-argument syntax.
 
   From Zhichang Yu:
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -848,7 +848,7 @@ class CommandAction(_ActionAction):
         # variables.
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Action.CommandAction')
 
-        _ActionAction.__init__(self, **kw)
+        super().__init__(**kw)
         if is_List(cmd):
             if [c for c in cmd if is_List(c)]:
                 raise TypeError("CommandAction should be given only "
@@ -1231,7 +1231,7 @@ class FunctionAction(_ActionAction):
                 # This is weird, just do the best we can.
                 self.funccontents = _object_contents(execfunction)
 
-        _ActionAction.__init__(self, **kw)
+        super().__init__(**kw)
 
     def function_name(self):
         try:

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -130,8 +130,8 @@ class DictCmdGenerator(SCons.Util.Selector):
     to return the proper action based on the file suffix of
     the source file."""
 
-    def __init__(self, dict=None, source_ext_match=1):
-        SCons.Util.Selector.__init__(self, dict)
+    def __init__(self, mapping=None, source_ext_match=True):
+        super().__init__(mapping)
         self.source_ext_match = source_ext_match
 
     def src_suffixes(self):
@@ -222,10 +222,11 @@ class OverrideWarner(UserDict):
     can actually invoke multiple builders.  This class only emits the
     warnings once, no matter how many Builders are invoked.
     """
-    def __init__(self, dict):
-        UserDict.__init__(self, dict)
+    def __init__(self, mapping):
+        super().__init__(mapping)
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Builder.OverrideWarner')
         self.already_warned = None
+
     def warn(self):
         if self.already_warned:
             return
@@ -245,7 +246,7 @@ def Builder(**kw):
         kw['action'] = SCons.Action.CommandGeneratorAction(kw['generator'], {})
         del kw['generator']
     elif 'action' in kw:
-        source_ext_match = kw.get('source_ext_match', 1)
+        source_ext_match = kw.get('source_ext_match', True)
         if 'source_ext_match' in kw:
             del kw['source_ext_match']
         if SCons.Util.is_Dict(kw['action']):
@@ -876,7 +877,7 @@ class CompositeBuilder(SCons.Util.Proxy):
 
     def __init__(self, builder, cmdgen):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Builder.CompositeBuilder')
-        SCons.Util.Proxy.__init__(self, builder)
+        super().__init__(builder)
 
         # cmdgen should always be an instance of DictCmdGenerator.
         self.cmdgen = cmdgen

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2521,16 +2521,20 @@ def NoSubstitutionProxy(subject):
     class _NoSubstitutionProxy(Environment):
         def __init__(self, subject):
             self.__dict__['__subject'] = subject
+
         def __getattr__(self, name):
             return getattr(self.__dict__['__subject'], name)
+
         def __setattr__(self, name, value):
             return setattr(self.__dict__['__subject'], name, value)
+
         def executor_to_lvars(self, kwdict):
             if 'executor' in kwdict:
                 kwdict['lvars'] = kwdict['executor'].get_lvars()
                 del kwdict['executor']
             else:
                 kwdict['lvars'] = {}
+
         def raw_to_mode(self, mapping):
             try:
                 raw = mapping['raw']
@@ -2539,10 +2543,13 @@ def NoSubstitutionProxy(subject):
             else:
                 del mapping['raw']
                 mapping['mode'] = raw
+
         def subst(self, string, *args, **kwargs):
             return string
+
         def subst_kw(self, kw, *args, **kwargs):
             return kw
+
         def subst_list(self, string, *args, **kwargs):
             nargs = (string, self,) + args
             nkw = kwargs.copy()
@@ -2550,6 +2557,7 @@ def NoSubstitutionProxy(subject):
             self.executor_to_lvars(nkw)
             self.raw_to_mode(nkw)
             return SCons.Subst.scons_subst_list(*nargs, **nkw)
+
         def subst_target_source(self, string, *args, **kwargs):
             nargs = (string, self,) + args
             nkw = kwargs.copy()
@@ -2557,6 +2565,7 @@ def NoSubstitutionProxy(subject):
             self.executor_to_lvars(nkw)
             self.raw_to_mode(nkw)
             return SCons.Subst.scons_subst(*nargs, **nkw)
+
     return _NoSubstitutionProxy(subject)
 
 # Local Variables:

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -810,11 +810,13 @@ sys.exit(0)
             "-fmerge-all-constants "
             "-fopenmp "
             "-mno-cygwin -mwindows "
-            "-arch i386 -isysroot /tmp "
+            "-arch i386 "
+            "-isysroot /tmp "
             "-iquote /usr/include/foo1 "
             "-isystem /usr/include/foo2 "
             "-idirafter /usr/include/foo3 "
             "-imacros /usr/include/foo4 "
+            "-include /usr/include/foo5 "
             "--param l1-cache-size=32 --param l2-cache-size=6144 "
             "+DD64 "
             "-DFOO -DBAR=value -D BAZ "
@@ -832,6 +834,7 @@ sys.exit(0)
                                 ('-isystem', '/usr/include/foo2'),
                                 ('-idirafter', '/usr/include/foo3'),
                                 ('-imacros', env.fs.File('/usr/include/foo4')),
+                                ('-include', env.fs.File('/usr/include/foo5')),
                                 ('--param', 'l1-cache-size=32'), ('--param', 'l2-cache-size=6144'),
                                 '+DD64'], repr(d['CCFLAGS'])
         assert d['CXXFLAGS'] == ['-std=c++0x'], repr(d['CXXFLAGS'])

--- a/SCons/Errors.py
+++ b/SCons/Errors.py
@@ -99,8 +99,8 @@ class BuildError(Exception):
         self.action = action
         self.command = command
 
-        Exception.__init__(self, node, errstr, status, exitstatus, filename,
-                           executor, action, command, exc_info)
+        super().__init__(node, errstr, status, exitstatus, filename,
+                         executor, action, command, exc_info)
 
     def __str__(self):
         if self.filename:
@@ -128,7 +128,7 @@ class ExplicitExit(Exception):
         self.node = node
         self.status = status
         self.exitstatus = status
-        Exception.__init__(self, *args)
+        super().__init__(*args)
 
 def convert_to_BuildError(status, exc_info=None):
     """Convert a return code to a BuildError Exception.

--- a/SCons/Job.py
+++ b/SCons/Job.py
@@ -238,7 +238,7 @@ else:
         and a boolean indicating whether the task executed successfully. """
 
         def __init__(self, requestQueue, resultsQueue, interrupted):
-            threading.Thread.__init__(self)
+            super().__init__()
             self.daemon = True
             self.requestQueue = requestQueue
             self.resultsQueue = resultsQueue

--- a/SCons/JobTests.py
+++ b/SCons/JobTests.py
@@ -410,13 +410,13 @@ class DummyNodeInfo:
 
 class testnode (SCons.Node.Node):
     def __init__(self):
-        SCons.Node.Node.__init__(self)
+        super().__init__()
         self.expect_to_be = SCons.Node.executed
         self.ninfo = DummyNodeInfo()
 
 class goodnode (testnode):
     def __init__(self):
-        SCons.Node.Node.__init__(self)
+        super().__init__()
         self.expect_to_be = SCons.Node.up_to_date
         self.ninfo = DummyNodeInfo()
 
@@ -430,7 +430,7 @@ class slowgoodnode (goodnode):
 
 class badnode (goodnode):
     def __init__(self):
-        goodnode.__init__(self)
+        super().__init__()
         self.expect_to_be = SCons.Node.failed
     def build(self, **kw):
         raise Exception('badnode exception')

--- a/SCons/Memoize.py
+++ b/SCons/Memoize.py
@@ -159,7 +159,7 @@ class CountDict(Counter):
     def __init__(self, cls_name, method_name, keymaker):
         """
         """
-        Counter.__init__(self, cls_name, method_name)
+        super().__init__(cls_name, method_name)
         self.keymaker = keymaker
     def count(self, *args, **kw):
         """ Counts whether the computed key value is already present

--- a/SCons/Node/Alias.py
+++ b/SCons/Node/Alias.py
@@ -99,7 +99,7 @@ class Alias(SCons.Node.Node):
     BuildInfo = AliasBuildInfo
 
     def __init__(self, name):
-        SCons.Node.Node.__init__(self)
+        super().__init__()
         self.name = name
         self.changed_since_last_build = 1
         self.store_info = 0

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -82,7 +82,7 @@ class EntryProxyAttributeError(AttributeError):
     of the underlying Entry involved in an AttributeError exception.
     """
     def __init__(self, entry_proxy, attribute):
-        AttributeError.__init__(self)
+        super().__init__()
         self.entry_proxy = entry_proxy
         self.attribute = attribute
     def __str__(self):
@@ -579,7 +579,7 @@ class Base(SCons.Node.Node):
         signatures."""
 
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Node.FS.Base')
-        SCons.Node.Node.__init__(self)
+        super().__init__()
 
         # Filenames and paths are probably reused and are intern'ed to save some memory.
         # Filename with extension as it was specified when the object was
@@ -982,7 +982,7 @@ class Entry(Base):
                  'contentsig']
 
     def __init__(self, name, directory, fs):
-        Base.__init__(self, name, directory, fs)
+        super().__init__(name, directory, fs)
         self._func_exists = 3
         self._func_get_contents = 1
 
@@ -1574,7 +1574,7 @@ class Dir(Base):
 
     def __init__(self, name, directory, fs):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Node.FS.Dir')
-        Base.__init__(self, name, directory, fs)
+        super().__init__(name, directory, fs)
         self._morph()
 
     def _morph(self):
@@ -2563,7 +2563,7 @@ class FileBuildInfo(SCons.Node.BuildInfoBase):
         if key != 'dependency_map' and hasattr(self, 'dependency_map'):
             del self.dependency_map
 
-        return super(FileBuildInfo, self).__setattr__(key, value)
+        return super().__setattr__(key, value)
 
     def convert_to_sconsign(self):
         """
@@ -2674,7 +2674,7 @@ class File(Base):
 
     def __init__(self, name, directory, fs):
         if SCons.Debug.track_instances: logInstanceCreation(self, 'Node.FS.File')
-        Base.__init__(self, name, directory, fs)
+        super().__init__(name, directory, fs)
         self._morph()
 
     def Entry(self, name):

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -2568,7 +2568,7 @@ class FileTestCase(_tempdirTestCase):
 
         class ChangedNode(SCons.Node.FS.File):
             def __init__(self, name, directory=None, fs=None):
-                SCons.Node.FS.File.__init__(self, name, directory, fs)
+                super().__init__(name, directory, fs)
                 self.name = name
                 self.Tag('found_includes', [])
                 self.stored_info = None
@@ -2608,7 +2608,7 @@ class FileTestCase(_tempdirTestCase):
         class ChangedEnvironment(SCons.Environment.Base):
 
             def __init__(self):
-                SCons.Environment.Base.__init__(self)
+                super().__init__()
                 self.decide_source = self._changed_timestamp_then_content
 
         class FakeNodeInfo:

--- a/SCons/Node/NodeTests.py
+++ b/SCons/Node/NodeTests.py
@@ -160,7 +160,7 @@ class NoneBuilder(Builder):
 
 class ListBuilder(Builder):
     def __init__(self, *nodes):
-        Builder.__init__(self)
+        super().__init__()
         self.nodes = nodes
     def execute(self, target, source, env):
         if hasattr(self, 'status'):
@@ -200,7 +200,7 @@ class MyNode(SCons.Node.Node):
     simulate a real, functional Node subclass.
     """
     def __init__(self, name):
-        SCons.Node.Node.__init__(self)
+        super().__init__()
         self.name = name
         self.Tag('found_includes', [])
     def __str__(self):
@@ -1226,7 +1226,7 @@ class NodeTestCase(unittest.TestCase):
         """Test the get_string() method."""
         class TestNode(MyNode):
             def __init__(self, name, sig):
-                MyNode.__init__(self, name)
+                super().__init__(name)
                 self.sig = sig
 
             def for_signature(self):

--- a/SCons/Node/Python.py
+++ b/SCons/Node/Python.py
@@ -83,7 +83,7 @@ class Value(SCons.Node.Node):
     BuildInfo = ValueBuildInfo
 
     def __init__(self, value, built_value=None, name=None):
-        SCons.Node.Node.__init__(self)
+        super().__init__()
         self.value = value
         self.changed_since_last_build = 6
         self.store_info = 0

--- a/SCons/SConf.py
+++ b/SCons/SConf.py
@@ -142,7 +142,7 @@ SCons.Warnings.enableWarningClass(SConfWarning)
 # some error definitions
 class SConfError(SCons.Errors.UserError):
     def __init__(self,msg):
-        SCons.Errors.UserError.__init__(self,msg)
+        super().__init__(msg)
 
 class ConfigureDryRunError(SConfError):
     """Raised when a file or directory needs to be updated during a Configure
@@ -152,13 +152,13 @@ class ConfigureDryRunError(SConfError):
             msg = 'Cannot create configure directory "%s" within a dry-run.' % str(target)
         else:
             msg = 'Cannot update configure test "%s" within a dry-run.' % str(target)
-        SConfError.__init__(self,msg)
+        super().__init__(msg)
 
 class ConfigureCacheError(SConfError):
     """Raised when a use explicitely requested the cache feature, but the test
     is run the first time."""
     def __init__(self,target):
-        SConfError.__init__(self, '"%s" is not yet built and cache is forced.' % str(target))
+        super().__init__('"%s" is not yet built and cache is forced.' % str(target))
 
 
 # define actions for building text files

--- a/SCons/SConsign.py
+++ b/SCons/SConsign.py
@@ -248,7 +248,7 @@ class DB(Base):
     determined by the database module.
     """
     def __init__(self, dir):
-        Base.__init__(self)
+        super().__init__()
 
         self.dir = dir
 
@@ -319,7 +319,7 @@ class Dir(Base):
         """
         fp - file pointer to read entries from
         """
-        Base.__init__(self)
+        super().__init__()
 
         if not fp:
             return
@@ -352,7 +352,7 @@ class DirFile(Dir):
             fp = None
 
         try:
-            Dir.__init__(self, fp, dir)
+            super().__init__(fp, dir)
         except KeyboardInterrupt:
             raise
         except Exception:

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -132,7 +132,7 @@ class CmdStringHolder(collections.UserString):
     proper escape sequences inserted.
     """
     def __init__(self, cmd, literal=None):
-        collections.UserString.__init__(self, cmd)
+        super().__init__(cmd)
         self.literal = literal
 
     def is_literal(self):
@@ -490,7 +490,7 @@ class ListSubber(collections.UserList):
     internally.
     """
     def __init__(self, env, mode, conv, gvars):
-        collections.UserList.__init__(self, [])
+        super().__init__([])
         self.env = env
         self.mode = mode
         self.conv = conv

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -121,7 +121,7 @@ class SubstTestCase(unittest.TestCase):
     class MyNode(DummyNode):
         """Simple node work-alike with some extra stuff for testing."""
         def __init__(self, name):
-            DummyNode.__init__(self, name)
+            super().__init__(name)
             class Attribute:
                 pass
             self.attribute = Attribute()

--- a/SCons/Tool/GettextCommon.py
+++ b/SCons/Tool/GettextCommon.py
@@ -206,7 +206,7 @@ class _POFileBuilder(BuilderBase):
             del kw['target_alias']
         if 'target_factory' not in kw:
             kw['target_factory'] = _POTargetFactory(env, alias=alias).File
-        BuilderBase.__init__(self, **kw)
+        super().__init__(**kw)
 
     def _execute(self, env, target, source, *args, **kw):
         """ Execute builder's actions.

--- a/SCons/Tool/MSCommon/sdk.py
+++ b/SCons/Tool/MSCommon/sdk.py
@@ -131,7 +131,7 @@ class WindowsSDK(SDKDefinition):
     """
     HKEY_FMT = r'Software\Microsoft\Microsoft SDKs\Windows\v%s\InstallationFolder'
     def __init__(self, *args, **kw):
-        SDKDefinition.__init__(self, *args, **kw)
+        super().__init__(*args, **kw)
         self.hkey_data = self.version
 
 class PlatformSDK(SDKDefinition):
@@ -140,7 +140,7 @@ class PlatformSDK(SDKDefinition):
     """
     HKEY_FMT = r'Software\Microsoft\MicrosoftSDK\InstalledSDKS\%s\Install Dir'
     def __init__(self, *args, **kw):
-        SDKDefinition.__init__(self, *args, **kw)
+        super().__init__(*args, **kw)
         self.hkey_data = self.uuid
 
 #

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -320,7 +320,7 @@ class _GenerateV7User(_UserGenerator):
             self.usrhead = V9UserHeader
             self.usrconf = V9UserConfiguration
             self.usrdebg = V9DebugSettings
-        _UserGenerator.__init__(self, dspfile, source, env)
+        super().__init__(dspfile, source, env)
 
     def UserProject(self):
         confkeys = sorted(self.configs.keys())
@@ -395,7 +395,7 @@ class _GenerateV10User(_UserGenerator):
         self.usrhead = V10UserHeader
         self.usrconf = V10UserConfiguration
         self.usrdebg = V10DebugSettings
-        _UserGenerator.__init__(self, dspfile, source, env)
+        super().__init__(dspfile, source, env)
 
     def UserProject(self):
         confkeys = sorted(self.configs.keys())
@@ -1487,7 +1487,7 @@ class _DSWGenerator:
 class _GenerateV7DSW(_DSWGenerator):
     """Generates a Solution file for MSVS .NET"""
     def __init__(self, dswfile, source, env):
-        _DSWGenerator.__init__(self, dswfile, source, env)
+        super().__init__(dswfile, source, env)
 
         self.file = None
         self.version = self.env['MSVS_VERSION']

--- a/SCons/UtilTests.py
+++ b/SCons/UtilTests.py
@@ -899,7 +899,7 @@ class HashTestCase(unittest.TestCase):
 
 class FIPSHashTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(FIPSHashTestCase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         ###############################
         # algorithm mocks, can check if we called with usedforsecurity=False for python >= 3.9

--- a/SCons/cppTests.py
+++ b/SCons/cppTests.py
@@ -853,7 +853,7 @@ class fileTestCase(unittest.TestCase):
         """)
         class MyPreProcessor(cpp.DumbPreProcessor):
             def __init__(self, *args, **kw):
-                cpp.DumbPreProcessor.__init__(self, *args, **kw)
+                super().__init__(*args, **kw)
                 self.files = []
             def __call__(self, file):
                 self.files.append(file)

--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -499,7 +499,7 @@ class Function(Item):
 
 class Tool(Item):
     def __init__(self, name):
-        Item.__init__(self, name)
+        super().__init__(name)
         self.entity = self.name.replace('+', 'X')
 
 

--- a/src/test_setup.py
+++ b/src/test_setup.py
@@ -81,7 +81,7 @@ class MyTestSCons(TestSCons.TestSCons):
     ]
 
     def __init__(self):
-        TestSCons.TestSCons.__init__(self)
+        super().__init__()
         self.root = self.workpath('root')
         self.prefix = self.root + os.path.splitdrive(sys.prefix)[1]
 

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -261,7 +261,7 @@ class TestCommon(TestCmd):
         calling the base class initialization, and then changing directory
         to the workdir.
         """
-        TestCmd.__init__(self, **kw)
+        super().__init__(**kw)
         os.chdir(self.workdir)
 
     def options_arguments(self, options, arguments):

--- a/testing/framework/TestRuntest.py
+++ b/testing/framework/TestRuntest.py
@@ -146,7 +146,7 @@ class TestRuntest(TestCommon):
             del kw['things_to_copy']
 
         orig_cwd = os.getcwd()
-        TestCommon.__init__(self, **kw)
+        super().__init__(**kw)
 
         dirs = [os.environ.get('SCONS_RUNTEST_DIR', orig_cwd)]
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -321,7 +321,7 @@ class TestSCons(TestCommon):
         if kw.get('ignore_python_version', -1) != -1:
             del kw['ignore_python_version']
 
-        TestCommon.__init__(self, **kw)
+        super().__init__(**kw)
 
         if not self.external:
             import SCons.Node.FS
@@ -1755,7 +1755,7 @@ class TimeSCons(TestSCons):
         if 'verbose' not in kw and not self.calibrate:
             kw['verbose'] = True
 
-        TestSCons.__init__(self, *args, **kw)
+        super().__init__(*args, **kw)
 
         # TODO(sgk):    better way to get the script dir than sys.argv[0]
         self.test_dir = os.path.dirname(sys.argv[0])

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -199,7 +199,7 @@ class TestSCons_time(TestCommon):
         if 'workdir' not in kw:
             kw['workdir'] = ''
 
-        TestCommon.__init__(self, **kw)
+        super().__init__(**kw)
 
     def archive_split(self, path):
         if path[-7:] == '.tar.gz':

--- a/testing/framework/TestSConsign.py
+++ b/testing/framework/TestSConsign.py
@@ -64,7 +64,7 @@ class TestSConsign(TestSCons):
             os.chdir(script_dir)
         self.script_dir = os.getcwd()
 
-        TestSCons.__init__(self, *args, **kw)
+        super().__init__(*args, **kw)
 
         self.my_kw = {
             'interpreter' : python,     # imported from TestSCons

--- a/testing/framework/TestUnit/taprunner.py
+++ b/testing/framework/TestUnit/taprunner.py
@@ -43,29 +43,29 @@ class TAPTestResult(TextTestResult):
         self.stream.flush()
 
     def addSuccess(self, test):
-        super(TextTestResult, self).addSuccess(test)
+        super().addSuccess(test)
         self._process(test, "ok")
 
     def addFailure(self, test, err):
-        super(TextTestResult, self).addFailure(test, err)
+        super().addFailure(test, err)
         self._process(test, "not ok", "FAIL")
         # [ ] add structured data about assertion
 
     def addError(self, test, err):
-        super(TextTestResult, self).addError(test, err)
+        super().addError(test, err)
         self._process(test, "not ok", "ERROR")
         # [ ] add structured data about exception
 
     def addSkip(self, test, reason):
-        super(TextTestResult, self).addSkip(test, reason)
+        super().addSkip(test, reason)
         self._process(test, "ok", directive=("  # SKIP  %s" % reason))
 
     def addExpectedFailure(self, test, err):
-        super(TextTestResult, self).addExpectedFailure(test, err)
+        super().addExpectedFailure(test, err)
         self._process(test, "not ok", directive="  # TODO")
 
     def addUnexpectedSuccess(self, test):
-        super(TextTestResult, self).addUnexpectedSuccess(test)
+        super().addUnexpectedSuccess(test)
         self._process(test, "not ok", "FAIL (unexpected success)")
 
     """
@@ -90,7 +90,7 @@ class TAPTestRunner(TextTestRunner):
         for case in test:
             case.suite = test
 
-        return super(TAPTestRunner, self).run(test)
+        return super().run(test)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- super used where direct call to superclass existed
- convert a few older-style super() (two-argument) uses
- in a few places, where there was an intersection with a super change,  variables that override a builtin (e.g. "dict") were renamed.
- added a trivial unit test in `EnvironmentTests.py` after initial submission of this PR generated a code coverage complaint about an uncovered "change" (the change was the variable renaming, the code behavior was not changed but the coverage test triggers only on "lines changed", not content)

There are no functional changes, so no doc or test impacts (will wait for the CI run to prove the the latter).

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
