### PR TITLE
Added default values for source and target arguments to _defines 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added project_url for mailing lists and Discord
     - Updated project url in steup.cfg to be https instead of http
     - Updated setup.cfg to remove Python 3.5 and add Python 3.10
+    - Added default values for source and target arguments to _defines() function. This
+      is used to expand CPPDEFINES (and others). Previous change added those arguments
+      with no defaults, so old usage where _defines() was called without source and target
+      arguments would yield an exception. This issue was found via qt4 and qt5 tools in
+      scons-contrib https://github.com/SCons/scons-contrib/issues/45
 
 
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -45,7 +45,11 @@ FIXES
   with python 3.9 (or higher)
 - Fixed crash in C scanner's dictify_CPPDEFINES() function which happens if
   AppendUnique is called on CPPPATH. (Issue #4108).
-
+- Added default values for source and target arguments to _defines() function. This
+  is used to expand CPPDEFINES (and others). Previous change added those arguments
+  with no defaults, so old usage where _defines() was called without source and target
+  arguments would yield an exception. This issue was found via qt4 and qt5 tools in
+  scons-contrib https://github.com/SCons/scons-contrib/issues/45
 
 IMPROVEMENTS
 ------------

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -509,7 +509,7 @@ def processDefines(defs):
     return l
 
 
-def _defines(prefix, defs, suffix, env, target, source, c=_concat_ixes):
+def _defines(prefix, defs, suffix, env, target=None, source=None, c=_concat_ixes):
     """A wrapper around _concat_ixes that turns a list or string
     into a list of C preprocessor command-line definitions.
     """

--- a/SCons/DefaultsTests.py
+++ b/SCons/DefaultsTests.py
@@ -23,22 +23,40 @@
 
 import os
 import unittest
+import collections
 
 import TestCmd
 
-from SCons.Defaults import mkdir_func
+from SCons.Defaults import mkdir_func, _defines
+
+
+class DummyEnvironment(collections.UserDict):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.data.update(kwargs)
+
+    def subst(self, str_subst, target=None, source=None, conv=None):
+        if str_subst[0] == '$':
+            return self.data[str_subst[1:]]
+        return str_subst
+
+    def subst_list(self, str_subst, target=None, source=None, conv=None):
+        if str_subst[0] == '$':
+            return [self.data[str_subst[1:]]]
+        return [[str_subst]]
+
 
 class DefaultsTestCase(unittest.TestCase):
     def test_mkdir_func0(self):
-        test = TestCmd.TestCmd(workdir = '')
+        test = TestCmd.TestCmd(workdir='')
         test.subdir('sub')
         subdir2 = test.workpath('sub', 'dir1', 'dir2')
         # Simple smoke test
         mkdir_func(subdir2)
-        mkdir_func(subdir2)     # 2nd time should be OK too
+        mkdir_func(subdir2)  # 2nd time should be OK too
 
     def test_mkdir_func1(self):
-        test = TestCmd.TestCmd(workdir = '')
+        test = TestCmd.TestCmd(workdir='')
         test.subdir('sub')
         subdir1 = test.workpath('sub', 'dir1')
         subdir2 = test.workpath('sub', 'dir1', 'dir2')
@@ -48,7 +66,7 @@ class DefaultsTestCase(unittest.TestCase):
         mkdir_func(subdir1)
 
     def test_mkdir_func2(self):
-        test = TestCmd.TestCmd(workdir = '')
+        test = TestCmd.TestCmd(workdir='')
         test.subdir('sub')
         subdir1 = test.workpath('sub', 'dir1')
         subdir2 = test.workpath('sub', 'dir1', 'dir2')
@@ -64,6 +82,26 @@ class DefaultsTestCase(unittest.TestCase):
             pass
         else:
             self.fail("expected OSError")
+
+    def test__defines_no_target_or_source_arg(self):
+        """
+        Verify that _defines() function can handle either or neither source or
+        target being specified
+        """
+        env = DummyEnvironment()
+
+        # Neither source or target specified
+        x = _defines('-D', ['A', 'B', 'C'], 'XYZ', env)
+        self.assertEqual(x, ['-DAXYZ', '-DBXYZ', '-DCXYZ'])
+
+        # only source specified
+        y = _defines('-D', ['AA', 'BA', 'CA'], 'XYZA', env, 'XYZ')
+        self.assertEqual(y, ['-DAAXYZA', '-DBAXYZA', '-DCAXYZA'])
+
+        # source and target specified
+        z = _defines('-D', ['AAB', 'BAB', 'CAB'], 'XYZAB', env, 'XYZ', 'abc')
+        self.assertEqual(z,['-DAABXYZAB', '-DBABXYZAB', '-DCABXYZAB'])
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added default values for source and target arguments to _defines (used for expanding among other things CPPDEFINES). source and target arguements were previously added to allow those values to be used by alternative definitions for _defines. This broke previous usage, including scons-contribs qt4 and qt5 tools. (See  https://github.com/SCons/scons-contrib/issues/45 )


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
