### PR TITLE
Fix content-timestamp decider for symlinks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -112,6 +112,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix a test harness exception returning stderr if a wait_for timed out.
     - ParseConfig now correctly passes the *unique* flag to a user-supplied
       flag-merging function.
+    - Restore the ability of the content-timestamp decider to see that a
+      a source which is a symlink has changed if the file-system target of
+      that link has been modified (issue #3880)
 
   From Zhichang Yu:
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -86,6 +86,10 @@ FIXES
   in initial msvc detection and msvc batch file determination when configuring the build
   environment.  This could lead to build failures when only an MSVC Express instance is installed
   and the MSVC version is not explicitly specified (issue #2668 and issue #2697).
+- Restore the ability of the content-timestamp decider to see that a
+  a source which is a symlink has changed if the file-system target of
+  that link has been modified (issue #3880)
+
 
 IMPROVEMENTS
 ------------

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -1933,7 +1933,7 @@ class Dir(Base):
             return self.srcdir
         return Base.srcnode(self)
 
-    def get_timestamp(self):
+    def get_timestamp(self) -> int:
         """Return the latest timestamp from among our children"""
         stamp = 0
         for kid in self.children():
@@ -1941,11 +1941,11 @@ class Dir(Base):
                 stamp = kid.get_timestamp()
         return stamp
 
-    def get_abspath(self):
+    def get_abspath(self) -> str:
         """Get the absolute path of the file."""
         return self._abspath
 
-    def get_labspath(self):
+    def get_labspath(self) -> str:
         """Get the absolute path of the file."""
         return self._labspath
 
@@ -2787,7 +2787,7 @@ class File(Base):
         return size
 
     @SCons.Memoize.CountMethodCall
-    def get_timestamp(self) -> float:
+    def get_timestamp(self) -> int:
         try:
             return self._memo['get_timestamp']
         except KeyError:

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -736,7 +736,7 @@ class Base(SCons.Node.Node):
         st = self.stat()
 
         if st:
-            return st.st_mtime
+            return st[stat.ST_MTIME]
         else:
             return None
 

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -255,7 +255,7 @@ else:
 def _copy_func(fs, src, dest):
     shutil.copy2(src, dest)
     st = fs.stat(src)
-    fs.chmod(dest, stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
+    fs.chmod(dest, stat.S_IMODE(st.st_mode) | stat.S_IWRITE)
 
 
 Valid_Duplicates = ['hard-soft-copy', 'soft-hard-copy',
@@ -733,39 +733,33 @@ class Base(SCons.Node.Node):
         return SCons.Node._rexists_map[self._func_rexists](self)
 
     def getmtime(self):
-        if self.islink():
-            st = self.lstat()
-        else:
-            st = self.stat()
+        st = self.stat()
 
         if st:
-            return st[stat.ST_MTIME]
+            return st.st_mtime
         else:
             return None
 
     def getsize(self):
-        if self.islink():
-            st = self.lstat()
-        else:
-            st = self.stat()
+        st = self.stat()
 
         if st:
-            return st[stat.ST_SIZE]
+            return st.st_size
         else:
             return None
 
     def isdir(self):
         st = self.stat()
-        return st is not None and stat.S_ISDIR(st[stat.ST_MODE])
+        return st is not None and stat.S_ISDIR(st.st_mode)
 
     def isfile(self):
         st = self.stat()
-        return st is not None and stat.S_ISREG(st[stat.ST_MODE])
+        return st is not None and stat.S_ISREG(st.st_mode)
 
     if hasattr(os, 'symlink'):
         def islink(self):
             st = self.lstat()
-            return st is not None and stat.S_ISLNK(st[stat.ST_MODE])
+            return st is not None and stat.S_ISLNK(st.st_mode)
     else:
         def islink(self):
             return False                    # no symlinks
@@ -2793,7 +2787,7 @@ class File(Base):
         return size
 
     @SCons.Memoize.CountMethodCall
-    def get_timestamp(self) -> int:
+    def get_timestamp(self) -> float:
         try:
             return self._memo['get_timestamp']
         except KeyError:

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -408,8 +408,8 @@ class VariantDirTestCase(unittest.TestCase):
                            None)
         os.chmod(test.workpath('src/foo'), stat.S_IRUSR | stat.S_IWRITE)
         st = os.stat(test.workpath('build/foo'))
-        assert (stat.S_IMODE(st[stat.ST_MODE]) & stat.S_IWRITE), \
-            stat.S_IMODE(st[stat.ST_MODE])
+        assert (stat.S_IMODE(st.st_mode) & stat.S_IWRITE), \
+            stat.S_IMODE(st.st_mode)
 
         # This used to generate a UserError when we forbid the source
         # directory from being outside the top-level SConstruct dir.
@@ -769,9 +769,9 @@ class FileNodeInfoTestCase(_tempdirTestCase):
 
         ni.update(fff)
 
-        mtime = st[stat.ST_MTIME]
+        mtime = st.st_mtime
         assert ni.timestamp == mtime, (ni.timestamp, mtime)
-        size = st[stat.ST_SIZE]
+        size = st.st_size
         assert ni.size == size, (ni.size, size)
 
         import time
@@ -781,9 +781,9 @@ class FileNodeInfoTestCase(_tempdirTestCase):
 
         st = os.stat('fff')
 
-        mtime = st[stat.ST_MTIME]
+        mtime = st.st_mtime
         assert ni.timestamp != mtime, (ni.timestamp, mtime)
-        size = st[stat.ST_SIZE]
+        size = st.st_size
         assert ni.size != size, (ni.size, size)
 
 

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -769,7 +769,7 @@ class FileNodeInfoTestCase(_tempdirTestCase):
 
         ni.update(fff)
 
-        mtime = st.st_mtime
+        mtime = st[stat.ST_MTIME]
         assert ni.timestamp == mtime, (ni.timestamp, mtime)
         size = st.st_size
         assert ni.size == size, (ni.size, size)
@@ -781,7 +781,7 @@ class FileNodeInfoTestCase(_tempdirTestCase):
 
         st = os.stat('fff')
 
-        mtime = st.st_mtime
+        mtime = st[stat.ST_MTIME]
         assert ni.timestamp != mtime, (ni.timestamp, mtime)
         size = st.st_size
         assert ni.size != size, (ni.size, size)

--- a/test/Decider/content-timestamp-symlink.py
+++ b/test/Decider/content-timestamp-symlink.py
@@ -32,6 +32,9 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
+if not test.platform_has_symlink():
+    test.skip_test('Symbolic links not reliably available on this platform, skipping test.\n')
+
 # a dummy "compiler" for the builder
 test.write('build.py', r"""
 import sys

--- a/test/Decider/content-timestamp-symlink.py
+++ b/test/Decider/content-timestamp-symlink.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test the content-timestamp decider (formerly known as md5-timestamp)
+correctly detects modification of a source file which is a symlink.
+"""
+
+import os
+
+import TestSCons
+
+_python_ = TestSCons._python_
+
+test = TestSCons.TestSCons()
+
+# a dummy "compiler" for the builder
+test.write('build.py', r"""
+import sys
+
+with open(sys.argv[1], 'wb') as ofp:
+    for infile in sys.argv[2:]:
+        with open (infile, 'rb') as ifp:
+            ofp.write(ifp.read())
+sys.exit(0)
+""")
+
+test.write('SConstruct', """
+DefaultEnvironment(tools=[])
+Build = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
+env = Environment(tools=[], BUILDERS={'Build': Build})
+env.Decider('content-timestamp')
+env.Build(target='match1.out', source='match1.in')
+env.Build(target='match2.out', source='match2.in')
+""" % locals()
+)
+
+test.write('match1.in', 'match1.in\n')
+test.symlink('match1.in', 'match2.in')
+
+test.run(arguments='.')
+test.must_match('match1.out', 'match1.in\n')
+test.must_match('match2.out', 'match1.in\n')
+
+# first make sure some time has elapsed, so a low-granularity timestamp
+# doesn't fail to trigger
+test.sleep()
+# Now update the source file contents, both targets should rebuild
+test.write('match1.in', 'match2.in\n')
+
+test.run(arguments='.')
+test.must_match('match1.out', 'match2.in\n', message="match1.out not rebuilt\n")
+test.must_match('match2.out', 'match2.in\n', message="match2.out not rebuilt\n")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Decider/content-timestamp-symlink.py
+++ b/test/Decider/content-timestamp-symlink.py
@@ -26,8 +26,6 @@ Test the content-timestamp decider (formerly known as md5-timestamp)
 correctly detects modification of a source file which is a symlink.
 """
 
-import os
-
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -47,13 +45,12 @@ sys.exit(0)
 
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
-Build = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
+Build = Builder(action=r'%(_python_)s build.py $TARGET $SOURCES')
 env = Environment(tools=[], BUILDERS={'Build': Build})
 env.Decider('content-timestamp')
 env.Build(target='match1.out', source='match1.in')
 env.Build(target='match2.out', source='match2.in')
-""" % locals()
-)
+""" % locals())
 
 test.write('match1.in', 'match1.in\n')
 test.symlink('match1.in', 'match2.in')

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1665,7 +1665,12 @@ else:
             alt_cpp_suffix = '.C'
         return alt_cpp_suffix
 
-    def platform_has_symlink(self):
+    def platform_has_symlink(self) -> bool:
+        """Retun an indication of whether symlink tests should be run.
+
+        Despite the name, we really mean "are they reliably usable"
+        rather than "do they exist" - basically the Windows case.
+        """
         if not hasattr(os, 'symlink') or sys.platform == 'win32':
             return False
         else:


### PR DESCRIPTION
The base filesystem node class has `getmtime()` and `getsize()` functions.  Those were changed in an earlier commit to use the `lstat()` method if the node represented a symbolic link. However, we actually want the information of the file the symlink points to, or we can't detect changes to the mtime or size of the underlying file, and miss rebuilds if content-timestamp is used.

Added a testcase which shows the failure to rebuild from the symlinked source.

No doc impacts.

Fixes #3880

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
