### PR TITLE
Documentation: minor fix in source xml files

### DIFF
--- a/SCons/Tool/msvc.xml
+++ b/SCons/Tool/msvc.xml
@@ -396,7 +396,7 @@ and extract the relevant variables from the result (typically
 <envar>%PATH%</envar>) for supplying to the build.
 This can be useful to force the use of a compiler version that
 &SCons; does not detect.
-&cv-MSVC_USE_SCRIPT_ARGS; privides arguments passed to this script.
+&cv-link-MSVC_USE_SCRIPT_ARGS; provides arguments passed to this script.
 </para>
 
 <para>

--- a/SCons/Tool/ninja/ninja.xml
+++ b/SCons/Tool/ninja/ninja.xml
@@ -202,7 +202,7 @@ python -m pip install ninja
                 The <parameter>msvc_deps_prefix</parameter> string.
                 Propagates directly into the generated &ninja; build file.
                 From Ninja's docs:
-                <quote>defines the string which should be stripped from msvc’s <option>/showIncludes</option> output</quote>
+                <quote>defines the string which should be stripped from msvc's <option>/showIncludes</option> output</quote>
             </para>
         </summary>
     </cvar>


### PR DESCRIPTION
Two minor changes were made to the documentation xml source files:
* ```Scons/Tool/msvc.xml``` - Fixed typo and changed variable reference to variable link reference.
* ```SCons/Tool/Ninja/ninja.xml``` - Changed right single apostrophe to apostrophe

Attempting to build the documentation on Windows yielded a possible problem with the ```ninja.xml``` file.  ***This could solely be the result of attempting to build the documentation on Windows***.

Running ```bin/docs-validate.py``` on the files in the master branch yields a validation error for msvc.xml based on the new ```MSVC_USE_SCRIPT_ARGS``` reference being present in the source xml file but not being present in the generated files.

Running ```bin/docs-update-generated.py``` yielded an lxml exception in the call ```doc.xinclude()``` indicating that the text was not UTF-8.  What is strange is that in my editor, the byte sequence in ```ninja.xml``` for the right single apostrophe appears to be a different sequence than the exception reported by lxml.  It seems as if the sequence reported by lxml is valid in cp1252 but not UTF-8.  The simplest workaround was to change the right singe apostrophe to a "regular" apostrophe.

***Again, this could be an issue with trying to build the html on documentation windows.***

The updated generated files were not included.

Tested on Windows 10 64-bit, with Python 3.6.8 64-bit.

Feel free to reprimand and close if not applicable.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
