### PR TITLE
Build a scons-local zipapp (per PEP 441)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -96,6 +96,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - The single-file Util module was split into a package with a few
       functional areas getting their own files - Util.py had grown to
       over 2100 lines.
+    - Add a zipapp package of scons-local: can use SCons from a local
+      file which does not need unpacking.
 
 
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -90,8 +90,9 @@ PACKAGING
   requirements_pkg.txt are the requirements to do a full build
   (including docs build) with an intent to create the packages.
 - Moved rpm and debian directories under packaging
-- Added logic to help packagers enable reproducible builds into packaging/etc/. Please
-  read packaging/etc/README.txt if you are interested.
+- Added logic to help packagers enable reproducible builds into packaging/etc/.
+  Please read packaging/etc/README.txt if you are interested.
+- A zipapp of scons-local is now also built.
 
 
 DOCUMENTATION

--- a/site_scons/scons_local_package.py
+++ b/site_scons/scons_local_package.py
@@ -28,9 +28,8 @@ from Utilities import is_windows
 
 
 def get_local_package_file_list():
-    """
-    Get list of all files which should be included in scons-local package
-    """
+    """Get list of all files which should be included in scons-local package"""
+
     s_files = glob("SCons/**", recursive=True)
 
     # import pdb; pdb.set_trace()
@@ -102,20 +101,20 @@ def create_local_packages(env):
         PSV='.',
     )
 
-
-    do_zipapp = False
+    do_zipapp = True  # Q: maybe an external way to specify whether to build?
     if do_zipapp:
         # We need to descend into the versioned directory for zipapp,
         # but we don't know the version. env.Glob lets us expand that.
-        # The action isn't going to use the sources here, but including
-        # them makes sure the deps work out right.
+        # The action isn't going to use the sources, but including
+        # them makes sure SCons has populated the dir we're going to zip.
         app_dir = env.Glob(f"{build_local_dir}/scons-local-*")[0]
         zipapp = env.Command(
             target='#build/dist/scons-local-${VERSION}.pyz',
             source=installed_files,
             action=zipappit,
             CD=app_dir,
-            PSV='SCons',
+            PSV='.',
+            entry='SCons.Script.Main:main',
         )
 
     if is_windows():

--- a/site_scons/zip_utils.py
+++ b/site_scons/zip_utils.py
@@ -32,11 +32,11 @@ import zipapp
 
 
 def zipit(env, target, source):
-    """
-    zip *source* into *target*, using some values from *env*
+    """Action function to zip *source* into *target*
 
-    *env* values: `CD` is the directory to work in,
-    `PSV` is the directory name to walk down to find the files
+    Values extracted from *env*:
+      *CD*: the directory to work in
+      *PSV*: the directory name to walk down to find the files
     """
     print(f"Zipping {target[0]}:")
 
@@ -59,6 +59,8 @@ def zipit(env, target, source):
 
 
 def unzipit(env, target, source):
+    """Action function to unzip *source*"""
+
     print(f"Unzipping {source[0]}:")
     zf = zipfile.ZipFile(str(source[0]), 'r')
     for name in zf.namelist():
@@ -76,18 +78,24 @@ def unzipit(env, target, source):
 
 
 def zipappit(env, target, source):
-    """
-    Create a zipapp *target* from specified directory.
+    """Action function to Create a zipapp *target* from specified directory.
 
-    *env* values: ``"CD"`` is the Dir node for the place we want to work.
-    ``"PSV"`` is the directory name to point :meth:`zipapp.create_archive` at
-    (note *source* is unused here in favor of PSV)
+    Values extracted from *env*:
+      *CD*: the Dir node for the place we want to work.
+      *PSV*: the directory name to point :meth:`zipapp.create_archive` at
+        (note *source* is unused here in favor of PSV)
+      *main*: the entry point for the zipapp
     """
     print(f"Creating zipapp {target[0]}:")
     dest = target[0].abspath
     olddir = os.getcwd()
     os.chdir(env['CD'].abspath)
     try:
-        zipapp.create_archive(env['PSV'], dest, "/usr/bin/env python")
+        zipapp.create_archive(
+            source=env['PSV'],
+            target=dest,
+            main=env['entry'],
+            interpreter="/usr/bin/env python",
+        )
     finally:
         os.chdir(olddir)

--- a/site_scons/zip_utils.py
+++ b/site_scons/zip_utils.py
@@ -64,10 +64,7 @@ def unzipit(env, target, source):
     for name in zf.namelist():
         dest = os.path.join(env['UNPACK_ZIP_DIR'], name)
         dir = os.path.dirname(dest)
-        try:
-            os.makedirs(dir)
-        except:
-            pass
+        os.makedirs(dir, exist_ok=True)
         print(dest, name)
         # if the file exists, then delete it before writing
         # to it so that we don't end up trying to write to a symlink:
@@ -89,7 +86,6 @@ def zipappit(env, target, source):
     print(f"Creating zipapp {target[0]}:")
     dest = target[0].abspath
     olddir = os.getcwd()
-    #os.chdir(env.Dir(env['CD']).abspath)
     os.chdir(env['CD'].abspath)
     try:
         zipapp.create_archive(env['PSV'], dest, "/usr/bin/env python")

--- a/site_scons/zip_utils.py
+++ b/site_scons/zip_utils.py
@@ -1,54 +1,97 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Actions to zip and unzip, for working with SCons release bundles
+Action for creating a zipapp
+"""
+
 import os.path
+import zipfile
+import zipapp
 
 
-zcat = 'gzip -d -c'
+def zipit(env, target, source):
+    """
+    zip *source* into *target*, using some values from *env*
 
-#
-# Figure out if we can handle .zip files.
-#
-zipit = None
-unzipit = None
-try:
-    import zipfile
+    *env* values: `CD` is the directory to work in,
+    `PSV` is the directory name to walk down to find the files
+    """
+    print(f"Zipping {target[0]}:")
 
-    def zipit(env, target, source):
-        print("Zipping %s:" % str(target[0]))
-        def visit(arg, dirname, filenames):
-            for filename in filenames:
-                path = os.path.join(dirname, filename)
-                if os.path.isfile(path):
-                    arg.write(path)
-        # default ZipFile compression is ZIP_STORED
-        zf = zipfile.ZipFile(str(target[0]), 'w', compression=zipfile.ZIP_DEFLATED)
-        olddir = os.getcwd()
-        os.chdir(env.Dir(env['CD']).abspath)
+    def visit(arg, dirname, filenames):
+        for filename in filenames:
+            path = os.path.join(dirname, filename)
+            if os.path.isfile(path):
+                arg.write(path)
+
+    # default ZipFile compression is ZIP_STORED
+    zf = zipfile.ZipFile(str(target[0]), 'w', compression=zipfile.ZIP_DEFLATED)
+    olddir = os.getcwd()
+    os.chdir(env.Dir(env['CD']).abspath)
+    try:
+        for dirname, dirnames, filenames in os.walk(env['PSV']):
+            visit(zf, dirname, filenames)
+    finally:
+        os.chdir(olddir)
+    zf.close()
+
+
+def unzipit(env, target, source):
+    print(f"Unzipping {source[0]}:")
+    zf = zipfile.ZipFile(str(source[0]), 'r')
+    for name in zf.namelist():
+        dest = os.path.join(env['UNPACK_ZIP_DIR'], name)
+        dir = os.path.dirname(dest)
         try:
-            for dirname, dirnames, filenames in os.walk(env['PSV']):
-                visit(zf, dirname, filenames)
-        finally:
-            os.chdir(olddir)
-        zf.close()
+            os.makedirs(dir)
+        except:
+            pass
+        print(dest, name)
+        # if the file exists, then delete it before writing
+        # to it so that we don't end up trying to write to a symlink:
+        if os.path.isfile(dest) or os.path.islink(dest):
+            os.unlink(dest)
+        if not os.path.isdir(dest):
+            with open(dest, 'wb') as fp:
+                fp.write(zf.read(name))
 
-    def unzipit(env, target, source):
-        print("Unzipping %s:" % str(source[0]))
-        zf = zipfile.ZipFile(str(source[0]), 'r')
-        for name in zf.namelist():
-            dest = os.path.join(env['UNPACK_ZIP_DIR'], name)
-            dir = os.path.dirname(dest)
-            try:
-                os.makedirs(dir)
-            except:
-                pass
-            print(dest,name)
-            # if the file exists, then delete it before writing
-            # to it so that we don't end up trying to write to a symlink:
-            if os.path.isfile(dest) or os.path.islink(dest):
-                os.unlink(dest)
-            if not os.path.isdir(dest):
-                with open(dest, 'wb') as fp:
-                    fp.write(zf.read(name))
 
-except ImportError:
-    if unzip and zip:
-        zipit = "cd $CD && $ZIP $ZIPFLAGS $( ${TARGET.abspath} $) $PSV"
-        unzipit = "$UNZIP $UNZIPFLAGS $SOURCES"
+def zipappit(env, target, source):
+    """
+    Create a zipapp *target* from specified directory.
+
+    *env* values: ``"CD"`` is the Dir node for the place we want to work.
+    ``"PSV"`` is the directory name to point :meth:`zipapp.create_archive` at
+    (note *source* is unused here in favor of PSV)
+    """
+    print(f"Creating zipapp {target[0]}:")
+    dest = target[0].abspath
+    olddir = os.getcwd()
+    #os.chdir(env.Dir(env['CD']).abspath)
+    os.chdir(env['CD'].abspath)
+    try:
+        zipapp.create_archive(env['PSV'], dest, "/usr/bin/env python")
+    finally:
+        os.chdir(olddir)


### PR DESCRIPTION
To use, set `do_zipapp` to `True` in `site_scons/scons_local_package.py` (notice as submitted, building is disabled)

Will produce a `build/dist/scons-local-${VERSION}.pyz` which can be directly executed - copy to a work dir, and run as
```console
python scons-local-4.3.1.pyz
```
or even
```console
./scons-local-4.3.1.pyz
```

Windows should have a file association for `.pyz` files, otherwise it works there too by calling it as an argument of the interpreter.

`site_scons/zip_utils.py` doesn't need a fallback for the zip module, it's guaranteed to be in supported Python versions (as is zipapp), so was able to simplify the existing code a bit.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
