### PR TITLE
test framework: fix exception on timeout

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Renamed ParseFlag's internal data structure to "mapping" instead of
       "dict" (avoid redefining builtin)
     - Fix an old use-before-set bug in tex tool (issue #2888)
+    - Fix a test harness exception returning stderr if a wait_for timed out.
 
   From Zhichang Yu:
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -311,6 +311,7 @@ import time
 import traceback
 from collections import UserList, UserString
 from subprocess import PIPE, STDOUT
+from typing import Optional
 
 IS_WINDOWS = sys.platform == 'win32'
 IS_MACOS = sys.platform == 'darwin'
@@ -1641,7 +1642,7 @@ class TestCmd:
         """
         time.sleep(seconds)
 
-    def stderr(self, run=None):
+    def stderr(self, run=None) -> Optional[str]:
         """Returns the error output from the specified run number.
 
         If there is no specified run number, then returns the error
@@ -1653,10 +1654,13 @@ class TestCmd:
             run = len(self._stderr)
         elif run < 0:
             run = len(self._stderr) + run
-        run = run - 1
-        return self._stderr[run]
+        run -= 1
+        try:
+            return self._stderr[run]
+        except IndexError:
+            return None
 
-    def stdout(self, run=None):
+    def stdout(self, run=None) -> Optional[str]:
         """Returns the stored standard output from a given run.
 
         Args:
@@ -1673,7 +1677,7 @@ class TestCmd:
             run = len(self._stdout)
         elif run < 0:
             run = len(self._stdout) + run
-        run = run - 1
+        run -= 1
         try:
             return self._stdout[run]
         except IndexError:


### PR DESCRIPTION
If the framework wait_for() method actually times out, it tries to return stdout and stderr by calling the framework methods of those names.  The stdout() method was protected against the message not having been captured (as is the case on timeout).  Updated the stderr() method to use the same technique.

No doc impacts - testing only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
