### PR TITLE
Mingw tool fix to use the same search paths the generate and exists methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,7 +12,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Joseph Brill:
     - Verify that a user specified msvc script (via MSVC_USE_SCRIPT) exists and raise an exception
       when the user specified msvc script does not exist.
-    - Fix the mingw tool so that the generate and exists methods use the same mingw search paths
+    - Fix issue where if you only had mingw installed on a Windows system and no MSVC compiler, and
+      did not explicitly request the mingw tool, mingw tool initialization would fail and set the 
+      default compiler to MSVC which wasn't installed, yielding broken build.
+      Updated mingw tool so that the generate and exists methods use the same mingw search paths
       (issue #4134).
 
   From William Deegan:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Joseph Brill:
     - Verify that a user specified msvc script (via MSVC_USE_SCRIPT) exists and raise an exception
       when the user specified msvc script does not exist.
+    - Fix the mingw tool so that the generate and exists methods use the same mingw search paths
+      (issue #4134).
 
   From William Deegan:
     - Fix check for unsupported Python version. It was broken. Also now the error message

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -58,6 +58,8 @@ FIXES
   with no defaults, so old usage where _defines() was called without source and target
   arguments would yield an exception. This issue was found via qt4 and qt5 tools in
   scons-contrib https://github.com/SCons/scons-contrib/issues/45
+- Fixed an inconsistency in the mingw tool search paths which could result in a mingw
+  installation not being detected (issue #4134).
 
 IMPROVEMENTS
 ------------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -58,8 +58,11 @@ FIXES
   with no defaults, so old usage where _defines() was called without source and target
   arguments would yield an exception. This issue was found via qt4 and qt5 tools in
   scons-contrib https://github.com/SCons/scons-contrib/issues/45
-- Fixed an inconsistency in the mingw tool search paths which could result in a mingw
-  installation not being detected (issue #4134).
+- Fix issue where if you only had mingw installed on a Windows system and no MSVC compiler, and
+  did not explicitly request the mingw tool, mingw tool initialization would fail and set the 
+  default compiler to MSVC which wasn't installed, yielding broken build.
+  Updated mingw tool so that the generate and exists methods use the same mingw search paths
+  (issue #4134).
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/mingw.py
+++ b/SCons/Tool/mingw.py
@@ -41,7 +41,7 @@ import SCons.Defaults
 import SCons.Tool
 import SCons.Util
 
-mingw_paths = [
+mingw_base_paths = [
     r'c:\MinGW\bin',
     r'C:\cygwin64\bin',
     r'C:\msys64',
@@ -127,17 +127,24 @@ def find_version_specific_mingw_paths():
     One example of default mingw install paths is:
     C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev2\mingw64\bin
 
-    Use glob'ing to find such and add to mingw_paths
+    Use glob'ing to find such and add to mingw_base_paths
     """
     new_paths = glob.glob(r"C:\mingw-w64\*\mingw64\bin")
 
     return new_paths
 
 
+_mingw_all_paths = None
+
+def get_mingw_paths():
+    global _mingw_all_paths
+    if _mingw_all_paths is None:
+        _mingw_all_paths = mingw_base_paths + find_version_specific_mingw_paths()
+    return _mingw_all_paths
+
 def generate(env):
-    global mingw_paths
     # Check for reasoanble mingw default paths
-    mingw_paths += find_version_specific_mingw_paths()
+    mingw_paths = get_mingw_paths()
 
     mingw = SCons.Tool.find_program_path(env, key_program, default_paths=mingw_paths)
     if mingw:
@@ -204,6 +211,7 @@ def generate(env):
 
 
 def exists(env):
+    mingw_paths = get_mingw_paths()
     mingw = SCons.Tool.find_program_path(env, key_program, default_paths=mingw_paths)
     if mingw:
         mingw_bin_dir = os.path.dirname(mingw)


### PR DESCRIPTION
Fix for #4134.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
