### PR TITLE
Uguide: fix a typo of environment

### DIFF
--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -1618,7 +1618,7 @@ env.PrependUnique(CCFLAGS=['-g'])
 
       <para>
 
-      Rather than creating a cloned environmant for specific tasks,
+      Rather than creating a cloned &consenv; for specific tasks,
       you can <firstterm>override</firstterm> or add construction variables
       when calling a builder method by passing them as keyword arguments.
       The values of these overridden or added variables will only be in


### PR DESCRIPTION
Spotted by @night-ripper on Discord.  Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
