### PR TITLE
Use the logging framework for internal MSCommon debug output written to stdout

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       default compiler to MSVC which wasn't installed, yielding broken build.
       Updated mingw tool so that the generate and exists methods use the same mingw search paths
       (issue #4134).
+    - Update the internal mscommon debug handling for stdout to use the logging framework.  Update
+      the debug record format so that the output logged to stdout contains the output that is logged
+      to a file.
 
   From William Deegan:
     - Fix check for unsupported Python version. It was broken. Also now the error message

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,9 +17,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       default compiler to MSVC which wasn't installed, yielding broken build.
       Updated mingw tool so that the generate and exists methods use the same mingw search paths
       (issue #4134).
-    - Update the internal mscommon debug handling for stdout to use the logging framework.  Update
-      the debug record format so that the output logged to stdout contains the output that is logged
-      to a file.
+    - Update the debug output written to stdout for MSVC initialization which is enabled by setting
+      SCONS_MSCOMMON_DEBUG=- to use the logging module. Also changed the debug output format
+      written to stdout to include more information about the source for each message of MSVC
+      initialization debugging output.  A single space was added before the message for all
+      debugging output records written to stdout and to files.
 
   From William Deegan:
     - Fix check for unsupported Python version. It was broken. Also now the error message

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -42,6 +42,11 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - The change to "content" and "content-timestamp" Decider names is reflected
   in the User Guide as well, since the hash function may be other than md5
   (tidying up from earlier change)
+- Update the debug output written to stdout for MSVC initialization which is enabled
+  by setting SCONS_MSCOMMON_DEBUG=- to use the logging module. Also changed the debug
+  output format written to stdout to include more information about the source for each
+  message of MSVC initialization debugging output.  A single space was added before the
+  message for all debugging output records written to stdout and to files.
 
 
 FIXES

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -37,14 +37,7 @@ import SCons.Util
 # SCONS_MSCOMMON_DEBUG is internal-use so undocumented:
 # set to '-' to print to console, else set to filename to log to
 LOGFILE = os.environ.get('SCONS_MSCOMMON_DEBUG')
-if LOGFILE == '-':
-    def debug(message, *args):
-        if args:
-            print(message % args)
-        else:
-            print(message)
-
-elif LOGFILE:
+if LOGFILE:
     import logging
     modulelist = (
         # root module and parent/root module
@@ -71,17 +64,24 @@ elif LOGFILE:
             relfilename = relfilename.replace('\\', '/')
             record.relfilename = relfilename
             return True
+    # Log format looks like:
+    #   00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3'       [file]
+    #   debug:00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3' [stdout]
+    log_format=(
+        '%(relativeCreated)05dms'
+        ':%(relfilename)s'
+        ':%(funcName)s'
+        '#%(lineno)s'
+        ': %(message)s'
+    )
+    if LOGFILE == '-':
+        log_format = 'debug:' + log_format
+        log_handler = logging.StreamHandler(sys.stdout)
+    else:
+        log_handler = logging.FileHandler(filename=LOGFILE)
     logging.basicConfig(
-        # This looks like:
-        #   00109ms:MSCommon/vc.py:find_vc_pdir#447:VC found '14.3'
-        format=(
-            '%(relativeCreated)05dms'
-            ':%(relfilename)s'
-            ':%(funcName)s'
-            '#%(lineno)s'
-            ':%(message)s'
-        ),
-        filename=LOGFILE,
+        format=log_format,
+        handlers=[log_handler],
         level=logging.DEBUG)
     logger = logging.getLogger(name=__name__)
     logger.addFilter(_Debug_Filter())

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -65,8 +65,8 @@ if LOGFILE:
             record.relfilename = relfilename
             return True
     # Log format looks like:
-    #   00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3'       [file]
-    #   debug:00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3' [stdout]
+    #   00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3'        [file]
+    #   debug: 00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3' [stdout]
     log_format=(
         '%(relativeCreated)05dms'
         ':%(relfilename)s'

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -75,7 +75,7 @@ if LOGFILE:
         ': %(message)s'
     )
     if LOGFILE == '-':
-        log_format = 'debug:' + log_format
+        log_format = 'debug: ' + log_format
         log_handler = logging.StreamHandler(sys.stdout)
     else:
         log_handler = logging.FileHandler(filename=LOGFILE)


### PR DESCRIPTION
This PR updates the internal mscommon debug handling when writing to ```stdout``` to use the logging framework rather than simple print statements and to use the same debug record format/content as when writing the debug content directly to a file.  

This PR unifies the two methods of mscommon debug output based on nearly identical debug record format.  A prefix of ```debug: ``` is added to the debug record format when logging to stdout as compared to logging to a file.  This makes the stdout output easier to read due to the format change.   See below for examples.

A single space was added before the message content for readability and consistency with other scons output statements in the debug output written to ```stdout``` and written to a file.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
