### PR TITLE
Added SHELL_ENV_EXPANDER  to configure/alter/generate shell environment before commands are spawned.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,7 +80,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added user configurable setting of ninja depfile format via NINJA_DEPFILE_PARSE_FORMAT.
       Now setting NINJA_DEPFILE_PARSE_FORMAT to [msvc,gcc,clang] can force the ninja expected
       format. Compiler tools will also configure the variable automatically.
-    - Added SHELL_ENV_EXPANDER construction variables. This variable allows the user to Define
+    - Added SHELL_ENV_GENERATOR  construction variables. This variable allows the user to Define
       a function which will be called to obtain an environment which will be used in the shell
       command of some Action.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,8 +81,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Now setting NINJA_DEPFILE_PARSE_FORMAT to [msvc,gcc,clang] can force the ninja expected
       format. Compiler tools will also configure the variable automatically.
     - Added SHELL_ENV_GENERATOR construction variables. This variable allows the user to Define
-      a function which will be called to obtain an environment which will be used in the shell
-      command of some Action.
+      a function which will be called to generate or alter the execution environment which will
+      be used in the shell command of some Action.
     - Updated ninja scons daemon scripts to output errors to stderr as well as the daemon log.
     - Fix typo in ninja scons daemon startup which causes ConnectionRefusedError to not retry 
       to connect to the server during start up.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,7 +80,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added user configurable setting of ninja depfile format via NINJA_DEPFILE_PARSE_FORMAT.
       Now setting NINJA_DEPFILE_PARSE_FORMAT to [msvc,gcc,clang] can force the ninja expected
       format. Compiler tools will also configure the variable automatically.
-    - Added SHELL_ENV_GENERATOR  construction variables. This variable allows the user to Define
+    - Added SHELL_ENV_GENERATOR construction variables. This variable allows the user to Define
       a function which will be called to obtain an environment which will be used in the shell
       command of some Action.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,23 +63,26 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Ninja: Fix issue where Configure files weren't being properly processed when build run
       via ninja.
     - Added ninja mingw support and improved ninja CommandGeneratorAction support.
-    - Update ninja file generation to only create response files for build commands 
+    - Update ninja file generation to only create response files for build commands
       which exceed MAXLINELENGTH
     - Ninja: Added NINJA_GENERATED_SOURCE_ALIAS_NAME which allows user to specify an
       Alias() which the ninja tool can use to determine which files are generated sources.
       If this is not set by the user then the ninja tool will still dynamically determine
       which files are generated sources based on NINJA_GENERATED_SOURCE_SUFFIXES, and create
-      a phony target _ninja_generated_sources. Generated sources will be built first by 
+      a phony target _ninja_generated_sources. Generated sources will be built first by
       ninja. This is needed because ninja cannot determine which generated sources are
       required by other build targets. Code contributed by MongoDB
       The downstream commit is here:
       https://github.com/mongodb/mongo/commit/2fef432fa6e7cf3fd4f22ba3b193222c2887f14f
     - Added special case for ninja scons daemon to work in win32 python3.6 environments.
-      This particular environment does a bad job managing popen standard file handles, so 
+      This particular environment does a bad job managing popen standard file handles, so
       some special workarounds are needed.
     - Added user configurable setting of ninja depfile format via NINJA_DEPFILE_PARSE_FORMAT.
       Now setting NINJA_DEPFILE_PARSE_FORMAT to [msvc,gcc,clang] can force the ninja expected
       format. Compiler tools will also configure the variable automatically.
+    - Added SHELL_ENV_EXPANDER construction variables. This variable allows the user to Define
+      a function which will be called to obtain an environment which will be used in the shell
+      command of some Action.
 
   From Mats Wichmann:
     - Tweak the way default site_scons paths on Windows are expressed to

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -17,8 +17,8 @@ NEW FUNCTIONALITY
 - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.
 - Added Configure.CheckMember() checker to check if struct/class has the specified member.
 - Added SHELL_ENV_GENERATOR construction variables. This variable allows the user to Define
-  a function which will be called to obtain an environment which will be used in the shell
-  command of some Action.
+  a function which will be called to generate or alter the execution environment which will
+  be used in the shell command of some Action.
 
 
 DEPRECATED FUNCTIONALITY

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -16,7 +16,7 @@ NEW FUNCTIONALITY
 
 - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.
 - Added Configure.CheckMember() checker to check if struct/class has the specified member.
-- Added SHELL_ENV_GENERATOR  construction variables. This variable allows the user to Define
+- Added SHELL_ENV_GENERATOR construction variables. This variable allows the user to Define
   a function which will be called to obtain an environment which will be used in the shell
   command of some Action.
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -16,6 +16,9 @@ NEW FUNCTIONALITY
 
 - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.
 - Added Configure.CheckMember() checker to check if struct/class has the specified member.
+- Added SHELL_ENV_EXPANDER construction variables. This variable allows the user to Define
+  a function which will be called to obtain an environment which will be used in the shell
+  command of some Action.
 
 
 DEPRECATED FUNCTIONALITY
@@ -42,7 +45,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - The change to "content" and "content-timestamp" Decider names is reflected
   in the User Guide as well, since the hash function may be other than md5
   (tidying up from earlier change)
-- Update ninja file generation to only create response files for build commands 
+- Update ninja file generation to only create response files for build commands
   which exceed MAXLINELENGTH
 - Update the debug output written to stdout for MSVC initialization which is enabled
   by setting SCONS_MSCOMMON_DEBUG=- to use the logging module. Also changed the debug
@@ -73,11 +76,11 @@ FIXES
   Alias() which the ninja tool can use to determine which files are generated sources.
   If this is not set by the user then the ninja tool will still dynamically determine
   which files are generated sources based on NINJA_GENERATED_SOURCE_SUFFIXES, and create
-  a phony target _ninja_generated_sources. Generated sources will be built first by 
+  a phony target _ninja_generated_sources. Generated sources will be built first by
   ninja. This is needed because ninja cannot determine which generated sources are
   required by other build targets.  Code contributed by MongoDB.
 - Added special case for ninja scons daemon to work in win32 python3.6 environments.
-  This particular environment does a bad job managing popen standard file handles, so 
+  This particular environment does a bad job managing popen standard file handles, so
   some special workarounds are needed.
 - Added user configurable setting of ninja depfile format via NINJA_DEPFILE_PARSE_FORMAT.
   Now setting NINJA_DEPFILE_PARSE_FORMAT to [msvc,gcc,clang] can force the ninja expected

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -16,7 +16,7 @@ NEW FUNCTIONALITY
 
 - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.
 - Added Configure.CheckMember() checker to check if struct/class has the specified member.
-- Added SHELL_ENV_EXPANDER construction variables. This variable allows the user to Define
+- Added SHELL_ENV_GENERATOR  construction variables. This variable allows the user to Define
   a function which will be called to obtain an environment which will be used in the shell
   command of some Action.
 

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -799,25 +799,25 @@ def _subproc(scons_env, cmd, error='ignore', **kw):
         if error == 'raise': raise
         # return a dummy Popen instance that only returns error
         class dummyPopen:
-            def __init__(self, e): 
+            def __init__(self, e):
                 self.exception = e
             # Add the following two to enable using the return value as a context manager
-            # for example 
+            # for example
             #    with Action._subproc(...) as po:
             #       logic here which uses po
 
-            def __enter__(self): 
+            def __enter__(self):
                 return self
 
-            def __exit__(self, *args): 
+            def __exit__(self, *args):
                 pass
 
-            def communicate(self, input=None): 
+            def communicate(self, input=None):
                 return ('', '')
 
-            def wait(self): 
+            def wait(self):
                 return -self.exception.errno
-                
+
             stdin = None
             class f:
                 def read(self): return ''
@@ -924,7 +924,7 @@ class CommandAction(_ActionAction):
 
         escape = env.get('ESCAPE', lambda x: x)
 
-        ENV = get_default_ENV(env)
+        ENV = env.get('SHELL_ENV_EXPANDER', get_default_ENV)(env)
 
         # Ensure that the ENV values are all strings:
         for key, value in ENV.items():

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -924,9 +924,10 @@ class CommandAction(_ActionAction):
 
         escape = env.get('ESCAPE', lambda x: x)
 
-        ENV = env.get('SHELL_ENV_EXPANDER', get_default_ENV)(env, target, source)
+        ENV = env.get('SHELL_ENV_GENERATOR ', get_default_ENV)(env, target, source)
 
         # Ensure that the ENV values are all strings:
+
         for key, value in ENV.items():
             if not is_String(value):
                 if is_List(value):

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -924,7 +924,7 @@ class CommandAction(_ActionAction):
 
         escape = env.get('ESCAPE', lambda x: x)
 
-        ENV = env.get('SHELL_ENV_GENERATOR ', get_default_ENV)(env, target, source)
+        ENV = env.get('SHELL_ENV_GENERATOR', get_default_ENV)(env, target, source)
 
         # Ensure that the ENV values are all strings:
 

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -732,7 +732,7 @@ def _string_from_cmd_list(cmd_list):
 default_ENV = None
 
 
-def get_default_ENV(env):
+def get_default_ENV(env, target=None, source=None):
     """
     A fiddlin' little function that has an 'import SCons.Environment' which
     can't be moved to the top level without creating an import loop.  Since
@@ -924,7 +924,7 @@ class CommandAction(_ActionAction):
 
         escape = env.get('ESCAPE', lambda x: x)
 
-        ENV = env.get('SHELL_ENV_EXPANDER', get_default_ENV)(env)
+        ENV = env.get('SHELL_ENV_EXPANDER', get_default_ENV)(env, target, source)
 
         # Ensure that the ENV values are all strings:
         for key, value in ENV.items():

--- a/SCons/Action.xml
+++ b/SCons/Action.xml
@@ -203,7 +203,7 @@ in which the command should be executed.
 <cvar name="SHELL_ENV_GENERATOR">
   <summary>
     <para>
-A function to obtain the environment dictionary which will be used
+A function to generate or alter the environment dictionary which will be used
 when executing the &cv-link-SPAWN; function. This primarily give the
 user a chance to customize the execution environment for particular Actions.
 It must return a dictionary containing the environment variables as

--- a/SCons/Action.xml
+++ b/SCons/Action.xml
@@ -200,7 +200,7 @@ in which the command should be executed.
 </summary>
 </cvar>
 
-<cvar name="SHELL_ENV_EXPANDER">
+<cvar name="SHELL_ENV_GENERATOR ">
   <summary>
     <para>
 A function to obtain the environment dictionary which will be used

--- a/SCons/Action.xml
+++ b/SCons/Action.xml
@@ -200,4 +200,26 @@ in which the command should be executed.
 </summary>
 </cvar>
 
+<cvar name="SHELL_ENV_EXPANDER">
+  <summary>
+    <para>
+A function to obtain the environment dictionary which will be used
+when executing the &cv-link-SPAWN; function. This primarily give the
+user a chance to customize the shell environment for particular Actions.
+It must return a dictionary containing the environment variables as
+keys and the values as values.
+    </para>
+
+    <example_commands>
+def custom_shell_env(env):
+    </example_commands>
+
+    <para>
+      <varname>env</varname>
+The SCons construction environment from which the functionality
+shell environment can be derived from.
+    </para>
+  </summary>
+</cvar>
+
 </sconsdoc>

--- a/SCons/Action.xml
+++ b/SCons/Action.xml
@@ -200,7 +200,7 @@ in which the command should be executed.
 </summary>
 </cvar>
 
-<cvar name="SHELL_ENV_GENERATOR ">
+<cvar name="SHELL_ENV_GENERATOR">
   <summary>
     <para>
 A function to obtain the environment dictionary which will be used

--- a/SCons/Action.xml
+++ b/SCons/Action.xml
@@ -205,19 +205,27 @@ in which the command should be executed.
     <para>
 A function to obtain the environment dictionary which will be used
 when executing the &cv-link-SPAWN; function. This primarily give the
-user a chance to customize the shell environment for particular Actions.
+user a chance to customize the execution environment for particular Actions.
 It must return a dictionary containing the environment variables as
 keys and the values as values.
     </para>
 
     <example_commands>
-def custom_shell_env(env):
+def custom_shell_env(env, target, source):
     </example_commands>
 
     <para>
       <varname>env</varname>
-The SCons construction environment from which the functionality
-shell environment can be derived from.
+The SCons construction environment from which the
+execution environment can be derived from.
+    </para>
+    <para>
+    <varname>target</varname>
+The list of targets associated with this action.
+    </para>
+        <para>
+    <varname>source</varname>
+The list of sources associated with this action.
     </para>
   </summary>
 </cvar>

--- a/test/Actions/subst_shell_env-fixture/SConstruct
+++ b/test/Actions/subst_shell_env-fixture/SConstruct
@@ -10,7 +10,7 @@ def expand_this_generator(env, target, source, for_signature):
 
 env = Environment(tools=['textfile'])
 
-env['SHELL_ENV_EXPANDER'] = custom_environment_expansion
+env['SHELL_ENV_GENERATOR '] = custom_environment_expansion
 
 env['EXPAND_THIS'] = expand_this_generator
 env['ENV']['EXPANDED_SHELL_VAR'] = "$EXPAND_THIS"

--- a/test/Actions/subst_shell_env-fixture/SConstruct
+++ b/test/Actions/subst_shell_env-fixture/SConstruct
@@ -10,7 +10,7 @@ def expand_this_generator(env, target, source, for_signature):
 
 env = Environment(tools=['textfile'])
 
-env['SHELL_ENV_GENERATOR '] = custom_environment_expansion
+env['SHELL_ENV_GENERATOR'] = custom_environment_expansion
 
 env['EXPAND_THIS'] = expand_this_generator
 env['ENV']['EXPANDED_SHELL_VAR'] = "$EXPAND_THIS"

--- a/test/Actions/subst_shell_env-fixture/SConstruct
+++ b/test/Actions/subst_shell_env-fixture/SConstruct
@@ -21,4 +21,4 @@ env.Textfile('expand_script.py', [
     'print(os.environ["EXPANDED_SHELL_VAR"])',
     'print(os.environ["NON_EXPANDED_SHELL_VAR"])',
 ])
-env.Command('out.txt', 'expand_script.py', f'{sys.executable} $SOURCE > $TARGET')
+env.Command('out.txt', 'expand_script.py', fr'{sys.executable} $SOURCE > $TARGET')

--- a/test/Actions/subst_shell_env-fixture/SConstruct
+++ b/test/Actions/subst_shell_env-fixture/SConstruct
@@ -1,7 +1,7 @@
 import sys
 
 def custom_environment_expansion(env, target, source):
-    ENV = env['ENV']
+    ENV = env['ENV'].copy()
     ENV['EXPANDED_SHELL_VAR'] = env.subst(env['ENV']['EXPANDED_SHELL_VAR'], target=target, source=source)
     return ENV
 
@@ -22,3 +22,5 @@ env.Textfile('expand_script.py', [
     'print(os.environ["NON_EXPANDED_SHELL_VAR"])',
 ])
 env.Command('out.txt', 'expand_script.py', fr'{sys.executable} $SOURCE > $TARGET')
+
+env.Depends('out.txt', env.Command('out2.txt', 'expand_script.py', fr'{sys.executable} $SOURCE > $TARGET'))

--- a/test/Actions/subst_shell_env-fixture/SConstruct
+++ b/test/Actions/subst_shell_env-fixture/SConstruct
@@ -1,0 +1,24 @@
+import sys
+
+def custom_environment_expansion(env, target, source):
+    ENV = env['ENV']
+    ENV['EXPANDED_SHELL_VAR'] = env.subst(env['ENV']['EXPANDED_SHELL_VAR'], target=target, source=source)
+    return ENV
+
+def expand_this_generator(env, target, source, for_signature):
+    return "I_got_expanded_to_" + str(target[0])
+
+env = Environment(tools=['textfile'])
+
+env['SHELL_ENV_EXPANDER'] = custom_environment_expansion
+
+env['EXPAND_THIS'] = expand_this_generator
+env['ENV']['EXPANDED_SHELL_VAR'] = "$EXPAND_THIS"
+env['ENV']['NON_EXPANDED_SHELL_VAR'] = "$EXPAND_THIS"
+
+env.Textfile('expand_script.py', [
+    'import os',
+    'print(os.environ["EXPANDED_SHELL_VAR"])',
+    'print(os.environ["NON_EXPANDED_SHELL_VAR"])',
+])
+env.Command('out.txt', 'expand_script.py', f'{sys.executable} $SOURCE > $TARGET')

--- a/test/Actions/subst_shell_env.py
+++ b/test/Actions/subst_shell_env.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+"""
+Verify that an Action list with a string command containing a Unicode file
+name, and a Python function action, works corectly.  This verifies that
+the signatures of the two actions can be concatenated without encoding
+Unicode problems.
+"""
+import os
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.dir_fixture('subst_shell_env-fixture')
+
+test.run(arguments = ['-Q'])
+test.must_match('out.txt', f"I_got_expanded_to_out.txt{os.linesep}$EXPAND_THIS{os.linesep}")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Actions/subst_shell_env.py
+++ b/test/Actions/subst_shell_env.py
@@ -37,6 +37,7 @@ test.dir_fixture('subst_shell_env-fixture')
 
 test.run(arguments = ['-Q'])
 test.must_match('out.txt', f"I_got_expanded_to_out.txt{os.linesep}$EXPAND_THIS{os.linesep}")
+test.must_match('out2.txt', f"I_got_expanded_to_out2.txt{os.linesep}$EXPAND_THIS{os.linesep}")
 
 test.pass_test()
 

--- a/test/Actions/subst_shell_env.py
+++ b/test/Actions/subst_shell_env.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -22,7 +22,6 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that shell environment variables can be expanded per target/source

--- a/test/Actions/subst_shell_env.py
+++ b/test/Actions/subst_shell_env.py
@@ -25,10 +25,8 @@
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
-Verify that an Action list with a string command containing a Unicode file
-name, and a Python function action, works corectly.  This verifies that
-the signatures of the two actions can be concatenated without encoding
-Unicode problems.
+Verify that shell environment variables can be expanded per target/source
+when exectuting actions on the command line.
 """
 import os
 


### PR DESCRIPTION
From Discord: https://discord.com/channels/571796279483564041/973241313778630727/973342497331900426

Added SHELL_ENV_EXPANDER construction variables. This variable allows the user to Define a function which will be called to obtain an environment which will be used in the shell command of some Action.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
