### PR TITLE
Remove last reference to distutils

### DIFF
--- a/site_scons/Utilities.py
+++ b/site_scons/Utilities.py
@@ -1,10 +1,10 @@
 import os
 import stat
 import time
-import distutils.util
+import sysconfig
 
 
-platform = distutils.util.get_platform()
+platform = sysconfig.get_platform()
 
 def is_windows():
     """ Check if we're on a Windows platform"""


### PR DESCRIPTION
distutils is deprecated, is now giving warnings, and will be removed in Python 3.12.  SCons code no longer uses it, but there was one reference in SCons' own `site_scons` (used when packaging).

This has no impact on SCons' operation, docs, or tests, only used when scons operates on itself for packaging purposes.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
