### PR TITLE
make ninja scons daemon scripts output to stderr as well as logfile.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,6 +80,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added user configurable setting of ninja depfile format via NINJA_DEPFILE_PARSE_FORMAT.
       Now setting NINJA_DEPFILE_PARSE_FORMAT to [msvc,gcc,clang] can force the ninja expected
       format. Compiler tools will also configure the variable automatically.
+    - Updated ninja scons daemon scripts to output errors to stderr as well as the daemon log.
 
   From Mats Wichmann:
     - Tweak the way default site_scons paths on Windows are expressed to

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -104,6 +104,7 @@ IMPROVEMENTS
   and msvc batch file determination when configuring the build environment.  Simplify the msvc
   code by eliminating special case handling primarily due to the differences between the full
   versions and express versions of visual studio.
+- Updated ninja scons daemon scripts to output errors to stderr as well as the daemon log.
 
 PACKAGING
 ---------

--- a/SCons/Tool/ninja/ninja_daemon_build.py
+++ b/SCons/Tool/ninja/ninja_daemon_build.py
@@ -53,6 +53,10 @@ logging.basicConfig(
     level=logging.DEBUG,
 )
 
+def log_error(msg):
+    logging.debug(msg)
+    sys.stderr.write(msg)
+
 while True:
     try:
         logging.debug(f"Sending request: {sys.argv[3]}")
@@ -68,19 +72,19 @@ while True:
             except (http.client.RemoteDisconnected, http.client.ResponseNotReady):
                 time.sleep(0.01)
             except http.client.HTTPException:
-                logging.debug(f"Error: {traceback.format_exc()}")
+                log_error(f"Error: {traceback.format_exc()}")
                 exit(1)
             else:
                 msg = response.read()
                 status = response.status
                 if status != 200:
-                    print(msg.decode("utf-8"))
+                    log_error(msg.decode("utf-8"))
                     exit(1)
                 logging.debug(f"Request Done: {sys.argv[3]}")
                 exit(0)
 
     except Exception:
-        logging.debug(f"Failed to send command: {traceback.format_exc()}")
+        log_error(f"Failed to send command: {traceback.format_exc()}")
         exit(1)
 
 

--- a/SCons/Tool/ninja/ninja_run_daemon.py
+++ b/SCons/Tool/ninja/ninja_run_daemon.py
@@ -60,6 +60,10 @@ logging.basicConfig(
     level=logging.DEBUG,
 )
 
+def log_error(msg):
+    logging.debug(msg)
+    sys.stderr.write(msg)
+
 if not os.path.exists(ninja_builddir / "scons_daemon_dirty"):
     cmd = [
         sys.executable,
@@ -107,14 +111,13 @@ if not os.path.exists(ninja_builddir / "scons_daemon_dirty"):
             except (http.client.RemoteDisconnected, http.client.ResponseNotReady):
                 time.sleep(0.01)
             except http.client.HTTPException:
-                logging.debug(f"Error: {traceback.format_exc()}")
-                sys.stderr.write(error_msg)
+                log_error(f"Error: {traceback.format_exc()}")
                 exit(1)
             else:
                 msg = response.read()
                 status = response.status
                 if status != 200:
-                    print(msg.decode("utf-8"))
+                    log_error(msg.decode("utf-8"))
                     exit(1)
                 logging.debug("Server Responded it was ready!")
                 break
@@ -123,15 +126,13 @@ if not os.path.exists(ninja_builddir / "scons_daemon_dirty"):
             logging.debug(f"Server not ready, server PID: {p.pid}")
             time.sleep(1)
             if p.poll is not None:
-                logging.debug(f"Server process died, aborting: {p.returncode}")
+                log_error(f"Server process died, aborting: {p.returncode}")
                 sys.exit(p.returncode)
         except ConnectionResetError:
-            logging.debug("Server ConnectionResetError")
-            sys.stderr.write(error_msg)
+            log_error("Server ConnectionResetError")
             exit(1)
         except Exception:
-            logging.debug(f"Error: {traceback.format_exc()}")
-            sys.stderr.write(error_msg)
+            log_error(f"Error: {traceback.format_exc()}")
             exit(1)
 
 # Local Variables:


### PR DESCRIPTION
I noticed in appveyor run in https://github.com/SCons/scons/pull/4144, intermittentally the ninja tests will fail. Unfortunately the ninja daemon prints most of its info to a logfile and not stderr, so when looking at the logs in the CI its hard to see what went wrong.

This PR puts the error message to stderr as well as the logs.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
