### PR TITLE
fix function call typo causing no retry mechanism in ninja daemon startup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Now setting NINJA_DEPFILE_PARSE_FORMAT to [msvc,gcc,clang] can force the ninja expected
       format. Compiler tools will also configure the variable automatically.
     - Updated ninja scons daemon scripts to output errors to stderr as well as the daemon log.
+    - Fix typo in ninja scons daemon startup which causes ConnectionRefusedError to not retry 
+      to connect to the server during start up.
 
   From Mats Wichmann:
     - Tweak the way default site_scons paths on Windows are expressed to

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -89,7 +89,8 @@ FIXES
 - Restore the ability of the content-timestamp decider to see that a
   a source which is a symlink has changed if the file-system target of
   that link has been modified (issue #3880)
-
+- Fix typo in ninja scons daemon startup which causes ConnectionRefusedError to not retry 
+  to connect to the server during start up.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/ninja/ninja_run_daemon.py
+++ b/SCons/Tool/ninja/ninja_run_daemon.py
@@ -125,7 +125,7 @@ if not os.path.exists(ninja_builddir / "scons_daemon_dirty"):
         except ConnectionRefusedError:
             logging.debug(f"Server not ready, server PID: {p.pid}")
             time.sleep(1)
-            if p.poll is not None:
+            if p.poll() is not None:
                 log_error(f"Server process died, aborting: {p.returncode}")
                 sys.exit(p.returncode)
         except ConnectionResetError:


### PR DESCRIPTION
Fixed a silly typo which I am pretty sure is responsible for intermittent issues seen in the CI.

The ninja scons daemon server startup script will launch the daemon process, then attempt to connect to the server to make sure the server is running before exiting 0 (letting ninja know the server has started successfully). On slower systems the server may not respond fast enough and a connection refused will be issued. The client attempting to connect should retry in this situation in hopes the server is ready to respond in subsequent attempts to connect. 

The startup script has this logic, and it will also not retry if the server process has been confirmed killed via subprocess.poll() = not None. The issue is that the code omitted the parenthesis's and anytime a retry was needed, it would immediately end prematurely in failure.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
