### PR TITLE
Add some time in Dir/source.py test because of filesystem precision.

### DIFF
--- a/test/Dir/source.py
+++ b/test/Dir/source.py
@@ -22,6 +22,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+import time
 
 """
 This test tests directories as source files.  The correct behavior is that
@@ -105,6 +106,8 @@ test.up_to_date(arguments='cmd-tstamp.out')
 test.up_to_date(arguments='cmd-content.out')
 test.up_to_date(arguments='cmd-tstamp-noscan.out')
 test.up_to_date(arguments='cmd-content-noscan.out')
+
+time.sleep(2)
 
 test.write([ 'tstamp', 'foo.txt' ], 'foo.txt 2\n')
 test.not_up_to_date(arguments='tstamp.out')

--- a/test/Dir/source.py
+++ b/test/Dir/source.py
@@ -22,7 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-import time
 
 """
 This test tests directories as source files.  The correct behavior is that
@@ -107,7 +106,7 @@ test.up_to_date(arguments='cmd-content.out')
 test.up_to_date(arguments='cmd-tstamp-noscan.out')
 test.up_to_date(arguments='cmd-content-noscan.out')
 
-time.sleep(2)
+test.sleep()
 
 test.write([ 'tstamp', 'foo.txt' ], 'foo.txt 2\n')
 test.not_up_to_date(arguments='tstamp.out')


### PR DESCRIPTION
the underlying stat module returns an integer for the mtime, so in some cases we are updating a file 2 times with 1 seconds interval, which gets recorded as the same mtime.

Even if we use something other than the stat module for floating point mtimes, sometimes the underlying filesystem only has 1 second precision anyways so this test should still respect that.


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
