### PR TITLE
Add support for multiple MSVC platform toolsets for a single Visual Studio installation

### DIFF
--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -533,12 +533,12 @@ _VCVER_TO_VSWHERE_VER = {
         ["-version", "[17.0, 18.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
     ],
     '14.2': [
-        ["-version", "[16.0, 17.0)"],  # default: Enterprise, Professional, Community  (order unpredictable?)
-        ["-version", "[16.0, 17.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
+        ["-version", "[16.0, 18.0)"],  # default: Enterprise, Professional, Community  (order unpredictable?)
+        ["-version", "[16.0, 18.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
     ],
     '14.1': [
-        ["-version", "[15.0, 16.0)"],  # default: Enterprise, Professional, Community (order unpredictable?)
-        ["-version", "[15.0, 16.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
+        ["-version", "[15.0, 18.0)"],  # default: Enterprise, Professional, Community (order unpredictable?)
+        ["-version", "[15.0, 18.0)", "-products", "Microsoft.VisualStudio.Product.BuildTools"],  # BuildTools
     ],
     '14.1Exp': [
         ["-version", "[15.0, 16.0)", "-products", "Microsoft.VisualStudio.Product.WDExpress"],  # Express
@@ -1095,6 +1095,10 @@ def msvc_find_valid_batch_script(env, version):
                 if env.get('MSVC_UWP_APP') == '1':
                     # Initialize environment variables with store/UWP paths
                     arg = (arg + ' store').lstrip()
+
+                # VS2015 can still be found separately, even when installed as a toolset
+                if maj > 14 or min >= 1:
+                    arg = (arg + ' -vcvars_ver={}.{}'.format(maj, min)).lstrip()
 
             try:
                 d = script_env(vc_script, args=arg)


### PR DESCRIPTION
Visual Studio versions starting from 2017 support multiple "platform toolsets" for a single Visual Studio installation. SCons seems to only support the matching toolset version for the currently installed Visual Studio version (for example vc143 when Visual Studio 2022 is installed). The vc140 toolset is a notable exception since it can be detected with the older method of reading registry entries (as used by SCons already). Basically, before this pull requests the following combinations would not work correctly (without adding `MSVC_USE_SCRIPT` and `MSVC_USE_SCRIPT_ARGS` to the environment):
- Visual Studio 2019: vc141 compiler
- Visual Studio 2022: vc141 and vc142 compilers

I have tested my (very small) changes on a clean Windows 11 installation (in a virtual machine) with all of the following configurations without any problems:
- Visual Studio 2015: vc140 compiler
- Visual Studio 2017: vc140 and vc141 compilers
- Visual Studio 2019: vc140, vc141 and vc142 compilers
- Visual Studio 2022: vc140, vc141, vc142 and vc143 compilers

A small note I have to make: the warning message differs a little bit when you don't have a Visual Studio version installed at all versus when only the specific toolset is not available, although I believe the messages make sense in a way. Two example situations with their corresponding warning that SCons throws:
- You want to compile with vc142 but you only have Visual Studio 2017 installed:
`scons: warning: VC version 14.2 not installed.  C/C++ compilers are most likely not set correctly.`
- You want to compile with vc142 and have Visual Studio 2022 installed, but not the platform toolset for vc142:
`scons: warning: Could not find MSVC compiler 'cl'. It may need to be installed separately with Visual Studio.`

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
