### PR TITLE
MSVC environment vars cache warning for incompatible format

### DIFF
--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -110,7 +110,15 @@ def read_script_env_cache():
                 # json to the cache dictionary. Reconstruct the cache key
                 # tuple from the key list written to json.
                 envcache_list = json.load(f)
-                envcache = {tuple(d['key']): d['data'] for d in envcache_list}
+                if isinstance(envcache_list, list):
+                    envcache = {tuple(d['key']): d['data'] for d in envcache_list}
+                else:
+                    raise TypeError(
+                        'SCONS_CACHE_MSVC_CONFIG cache file read error: expected type {}, found type {}.\n' \
+                        '  Remove cache file {} and try again'.format(
+                            repr('list'), repr(type(envcache_list).__name__), repr(CONFIG_CACHE)
+                        )
+                    )
         except FileNotFoundError:
             # don't fail if no cache file, just proceed without it
             pass

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -35,6 +35,10 @@ from contextlib import suppress
 from pathlib import Path
 
 import SCons.Util
+import SCons.Warnings
+
+class MSVCCacheInvalidWarning(SCons.Warnings.WarningOnByDefault):
+    pass
 
 # SCONS_MSCOMMON_DEBUG is internal-use so undocumented:
 # set to '-' to print to console, else set to filename to log to
@@ -113,12 +117,12 @@ def read_script_env_cache():
                 if isinstance(envcache_list, list):
                     envcache = {tuple(d['key']): d['data'] for d in envcache_list}
                 else:
-                    raise TypeError(
-                        'SCONS_CACHE_MSVC_CONFIG cache file read error: expected type {}, found type {}.\n' \
-                        '  Remove cache file {} and try again'.format(
-                            repr('list'), repr(type(envcache_list).__name__), repr(CONFIG_CACHE)
-                        )
+                    # don't fail if incompatible format, just proceed without it
+                    warn_msg = "Incompatible format for msvc cache file {}: file may be overwritten.".format(
+                        repr(CONFIG_CACHE)
                     )
+                    SCons.Warnings.warn(MSVCCacheInvalidWarning, warn_msg)
+                    debug(warn_msg)
         except FileNotFoundError:
             # don't fail if no cache file, just proceed without it
             pass


### PR DESCRIPTION
Add warning when incompatible msvc cache file format detected.  Existing cache file likely will be overwritten.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
