### PR TITLE
Normalize use of test.sleep()

### DIFF
--- a/test/CacheDir/timestamp-match.py
+++ b/test/CacheDir/timestamp-match.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that CAcheDir() works when using 'timestamp-match' decisions.
@@ -41,21 +40,15 @@ Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
 
 test.write('file.in', "file.in\n")
 
-test.run(arguments = '--cache-show --debug=explain .')
-
+test.run(arguments='--cache-show --debug=explain .')
 test.must_match('file.out', "file.in\n")
+test.up_to_date(options='--cache-show --debug=explain', arguments='.')
 
-test.up_to_date(options = '--cache-show --debug=explain', arguments = '.')
-
-test.sleep()
-
+test.sleep()  # delay for timestamps
 test.touch('file.in')
-
-test.not_up_to_date(options = '--cache-show --debug=explain', arguments = '.')
-
-test.up_to_date(options = '--cache-show --debug=explain', arguments = '.')
-
-test.up_to_date(options = '--cache-show --debug=explain', arguments = '.')
+test.not_up_to_date(options='--cache-show --debug=explain', arguments='.')
+test.up_to_date(options='--cache-show --debug=explain', arguments='.')
+test.up_to_date(options='--cache-show --debug=explain', arguments='.')
 
 test.pass_test()
 

--- a/test/CacheDir/timestamp-newer.py
+++ b/test/CacheDir/timestamp-newer.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that CAcheDir() works when using 'timestamp-newer' decisions.
@@ -41,21 +40,16 @@ Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))
 
 test.write('file.in', "file.in\n")
 
-test.run(arguments = '--cache-show --debug=explain .')
-
+test.run(arguments='--cache-show --debug=explain .')
 test.must_match('file.out', "file.in\n")
+test.up_to_date(options='--cache-show --debug=explain', arguments='.')
 
-test.up_to_date(options = '--cache-show --debug=explain', arguments = '.')
-
-test.sleep()
-
+test.sleep()  # delay for timestamps
 test.touch('file.in')
 
-test.not_up_to_date(options = '--cache-show --debug=explain', arguments = '.')
-
-test.up_to_date(options = '--cache-show --debug=explain', arguments = '.')
-
-test.up_to_date(options = '--cache-show --debug=explain', arguments = '.')
+test.not_up_to_date(options='--cache-show --debug=explain', arguments='.')
+test.up_to_date(options='--cache-show --debug=explain', arguments='.')
+test.up_to_date(options='--cache-show --debug=explain', arguments='.')
 
 test.pass_test()
 

--- a/test/Copy-Action.py
+++ b/test/Copy-Action.py
@@ -166,7 +166,7 @@ def must_be_same(f1, f2):
     for value in ['ST_MODE', 'ST_MTIME']:
         v = getattr(stat, value)
         if s1[v] != s2[v]:
-            msg = f"{f1!r}[{value}] {s1[v1]} != {f2!r}[{value}] {s2[v]}\n"
+            msg = f"{f1!r}[{value}] {s1[v]} != {f2!r}[{value}] {s2[v]}\n"
             sys.stderr.write(msg)
             errors += 1
 

--- a/test/Copy-Action.py
+++ b/test/Copy-Action.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the Copy() Action works, and preserves file modification
@@ -37,29 +36,32 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 Execute(Copy('f1.out', 'f1.in'))
 Execute(Copy(File('d2.out'), 'd2.in'))
 Execute(Copy('d3.out', File('f3.in')))
+
 def cat(env, source, target):
     target = str(target[0])
     with open(target, "w") as f:
         for src in source:
             with open(str(src), "r") as ifp:
                 f.write(ifp.read())
+
 Cat = Action(cat)
 env = Environment()
-env.Command('bar.out', 'bar.in', [Cat,
-                                  Copy("f4.out", "f4.in"),
-                                  Copy("d5.out", "d5.in"),
-                                  Copy("d6.out", "f6.in")])
-env = Environment(OUTPUT = 'f7.out', INPUT = 'f7.in')
+env.Command(
+    'bar.out',
+    'bar.in',
+    [Cat, Copy("f4.out", "f4.in"), Copy("d5.out", "d5.in"), Copy("d6.out", "f6.in")],
+)
+env = Environment(OUTPUT='f7.out', INPUT='f7.in')
 env.Command('f8.out', 'f8.in', [Copy('$OUTPUT', '$INPUT'), Cat])
 env.Command('f9.out', 'f9.in', [Cat, Copy('${TARGET}-Copy', '$SOURCE')])
 
-env.CopyTo( 'd4', 'f10.in' )
-env.CopyAs( 'd4/f11.out', 'f11.in')
-env.CopyAs( 'd4/f12.out', 'd5/f12.in')
+env.CopyTo('d4', 'f10.in')
+env.CopyAs('d4/f11.out', 'f11.in')
+env.CopyAs('d4/f12.out', 'd5/f12.in')
 
 env.Command('f   13.out', 'f   13.in', Copy('$TARGET', '$SOURCE'))
 """)
@@ -87,19 +89,20 @@ test.write('f   13.in', "f   13.in\n")
 os.chmod('f1.in', 0o646)
 os.chmod('f4.in', 0o644)
 
-test.sleep()
+test.sleep()  # delay for timestamps
 
 d4_f10_in   = os.path.join('d4', 'f10.in')
 d4_f11_out  = os.path.join('d4', 'f11.out')
 d4_f12_out  = os.path.join('d4', 'f12.out')
 d5_f12_in   = os.path.join('d5', 'f12.in')
 
-expect = test.wrap_stdout(read_str = """\
+expect = test.wrap_stdout(
+    read_str="""\
 Copy("f1.out", "f1.in")
 Copy("d2.out", "d2.in")
 Copy("d3.out", "f3.in")
 """,
-                          build_str = """\
+    build_str="""\
 cat(["bar.out"], ["bar.in"])
 Copy("f4.out", "f4.in")
 Copy("d5.out", "d5.in")
@@ -112,9 +115,10 @@ Copy("f7.out", "f7.in")
 cat(["f8.out"], ["f8.in"])
 cat(["f9.out"], ["f9.in"])
 Copy("f9.out-Copy", "f9.in")
-""" % locals())
+""" % locals(),
+)
 
-test.run(options = '-n', arguments = '.', stdout = expect)
+test.run(options='-n', arguments='.', stdout=expect)
 
 test.must_not_exist('f1.out')
 test.must_not_exist('d2.out')
@@ -162,23 +166,21 @@ def must_be_same(f1, f2):
     for value in ['ST_MODE', 'ST_MTIME']:
         v = getattr(stat, value)
         if s1[v] != s2[v]:
-            msg = '%s[%s] %s != %s[%s] %s\n' % \
-                  (repr(f1), value, s1[v],
-                   repr(f2), value, s2[v],)
+            msg = f"{f1!r}[{value}] {s1[v1]} != {f2!r}[{value}] {s2[v]}\n"
             sys.stderr.write(msg)
-            errors = errors + 1
+            errors += 1
 
-must_be_same('f1.out',                  'f1.in')
-must_be_same(['d2.out', 'file'],        ['d2.in', 'file'])
-must_be_same(['d3.out', 'f3.in'],       'f3.in')
-must_be_same('f4.out',                  'f4.in')
-must_be_same(['d5.out', 'file'],        ['d5.in', 'file'])
-must_be_same(['d6.out', 'f6.in'],       'f6.in')
-must_be_same('f7.out',                  'f7.in')
-must_be_same(['d4', 'f10.in'],          'f10.in')
-must_be_same(['d4', 'f11.out'],         'f11.in')
-must_be_same(['d4', 'f12.out'],         ['d5', 'f12.in'])
-must_be_same('f   13.out',              'f   13.in')
+must_be_same('f1.out', 'f1.in')
+must_be_same(['d2.out', 'file'], ['d2.in', 'file'])
+must_be_same(['d3.out', 'f3.in'], 'f3.in')
+must_be_same('f4.out', 'f4.in')
+must_be_same(['d5.out', 'file'], ['d5.in', 'file'])
+must_be_same(['d6.out', 'f6.in'], 'f6.in')
+must_be_same('f7.out', 'f7.in')
+must_be_same(['d4', 'f10.in'], 'f10.in')
+must_be_same(['d4', 'f11.out'], 'f11.in')
+must_be_same(['d4', 'f12.out'], ['d5', 'f12.in'])
+must_be_same('f   13.out', 'f   13.in')
 
 if errors:
     test.fail_test()

--- a/test/Decider/MD5-timestamp-Repository.py
+++ b/test/Decider/MD5-timestamp-Repository.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify behavior of the MD5-timestamp Decider() setting when combined with Repository() usage
@@ -38,12 +37,10 @@ test = TestSCons.TestSCons()
 test.subdir('Repository', 'work')
 repository = test.workpath('Repository')
 
-
 test.write(['Repository','content1.in'], "content1.in 1\n")
 test.write(['Repository','content2.in'], "content2.in 1\n")
 test.write(['Repository','content3.in'], "content3.in 1\n")
 # test.writable('Repository', 0)
-
 
 test.write(['work','SConstruct'], """\
 Repository(r'%s')
@@ -53,18 +50,14 @@ m.Decider('MD5-timestamp')
 m.Command('content1.out', 'content1.in', Copy('$TARGET', '$SOURCE'))
 m.Command('content2.out', 'content2.in', Copy('$TARGET', '$SOURCE'))
 m.Command('content3.out', 'content3.in', Copy('$TARGET', '$SOURCE'))
-"""%repository)
+""" % repository)
 
 test.run(chdir='work',arguments='.')
-
 test.up_to_date(chdir='work',arguments='.')
 
-test.sleep()
-
+test.sleep()  # delay for timestamps
 test.write(['Repository','content1.in'], "content1.in 2\n")
-
 test.touch(['Repository','content2.in'])
-
 time_content = os.stat(os.path.join(repository,'content3.in'))[stat.ST_MTIME]
 test.write(['Repository','content3.in'], "content3.in 2\n")
 test.touch(['Repository','content3.in'], time_content)
@@ -76,10 +69,9 @@ test.touch(['Repository','content3.in'], time_content)
 
 expect = test.wrap_stdout("""\
 Copy("content1.out", "%s")
-"""%os.path.join(repository,'content1.in'))
+""" % os.path.join(repository, 'content1.in'))
 
 test.run(chdir='work', arguments='.', stdout=expect)
-
 test.up_to_date(chdir='work', arguments='.')
 
 test.pass_test()

--- a/test/Decider/MD5-timestamp.py
+++ b/test/Decider/MD5-timestamp.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify behavior of the MD5-timestamp Decider() setting.
@@ -49,15 +48,10 @@ test.write('content2.in', "content2.in 1\n")
 test.write('content3.in', "content3.in 1\n")
 
 test.run(arguments = '.')
-
 test.up_to_date(arguments = '.')
 
-
-
-test.sleep()
-
+test.sleep()  # delay for timestamps
 test.write('content1.in', "content1.in 2\n")
-
 test.touch('content2.in')
 
 time_content = os.stat('content3.in')[stat.ST_MTIME]
@@ -73,11 +67,8 @@ expect = test.wrap_stdout("""\
 Copy("content1.out", "content1.in")
 """)
 
-test.run(arguments = '.', stdout=expect)
-
-test.up_to_date(arguments = '.')
-
-
+test.run(arguments='.', stdout=expect)
+test.up_to_date(arguments='.')
 
 test.pass_test()
 

--- a/test/Decider/timestamp.py
+++ b/test/Decider/timestamp.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify various interactions of the timestamp-match and timestamp-newer
@@ -54,27 +53,21 @@ test.write('newer1.in', "newer1.in\n")
 test.write('newer2.in', "newer2.in\n")
 
 test.run(arguments = '.')
-
 test.up_to_date(arguments = '.')
 
 time_match = os.stat('match2.out')[stat.ST_MTIME]
 time_newer = os.stat('newer2.out')[stat.ST_MTIME]
 
-
-
 # Now make all the source files newer than (different timestamps from)
 # the last time the targets were built, and touch the target files
 # of match1.out and newer1.out to see the different effects.
-
-test.sleep()
-
+test.sleep()  # delay for timestamps
 test.touch('match1.in')
 test.touch('newer1.in')
 test.touch('match2.in')
 test.touch('newer2.in')
 
-test.sleep()
-
+test.sleep()  # delay for timestamps
 test.touch('match1.out')
 test.touch('newer1.out')
 
@@ -90,7 +83,7 @@ Copy("match2.out", "match2.in")
 Copy("newer2.out", "newer2.in")
 """)
 
-test.run(arguments = '.', stdout=expect)
+test.run(arguments='.', stdout=expect)
 
 # Now, for the somewhat pathological case, reset the match2.out and
 # newer2.out timestamps to the older timestamp when the targets were
@@ -107,9 +100,7 @@ expect = test.wrap_stdout("""\
 Copy("newer2.out", "newer2.in")
 """)
 
-test.run(arguments = '.', stdout=expect)
-
-
+test.run(arguments='.', stdout=expect)
 
 test.pass_test()
 

--- a/test/Dir/source.py
+++ b/test/Dir/source.py
@@ -42,15 +42,16 @@ test.subdir('tstamp', [ 'tstamp', 'subdir' ],
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
+
 def writeTarget(target, source, env):
-    f=open(str(target[0]), 'w')
+    f = open(str(target[0]), 'w')
     f.write("stuff\\n")
     f.close()
     return 0
 
-test_bld_dir = Builder(action=writeTarget,
-                       source_factory=Dir,
-                       source_scanner=DirScanner)
+test_bld_dir = Builder(
+    action=writeTarget, source_factory=Dir, source_scanner=DirScanner
+)
 test_bld_file = Builder(action=writeTarget)
 env = Environment(tools=[])
 env['BUILDERS']['TestDir'] = test_bld_dir
@@ -61,34 +62,36 @@ env_tstamp.Decider('timestamp-newer')
 env_tstamp.TestFile(source='junk.txt', target='tstamp/junk.out')
 env_tstamp.TestDir(source='tstamp', target='tstamp.out')
 env_tstamp.Command('cmd-tstamp-noscan.out', 'cmd-tstamp', writeTarget)
-env_tstamp.Command('cmd-tstamp.out', 'cmd-tstamp', writeTarget,
-                 source_scanner=DirScanner)
+env_tstamp.Command(
+    'cmd-tstamp.out', 'cmd-tstamp', writeTarget, source_scanner=DirScanner
+)
 
 env_content = env.Clone()
 env_content.Decider('content')
 env_content.TestFile(source='junk.txt', target='content/junk.out')
 env_content.TestDir(source='content', target='content.out')
 env_content.Command('cmd-content-noscan.out', 'cmd-content', writeTarget)
-env_content.Command('cmd-content.out', 'cmd-content', writeTarget,
-                 source_scanner=DirScanner)
+env_content.Command(
+    'cmd-content.out', 'cmd-content', writeTarget, source_scanner=DirScanner
+)
 """)
 
-test.write([ 'tstamp', 'foo.txt' ], 'foo.txt 1\n')
-test.write([ 'tstamp', '#hash.txt' ], 'hash.txt 1\n')
-test.write([ 'tstamp', 'subdir', 'bar.txt'], 'bar.txt 1\n')
-test.write([ 'tstamp', 'subdir', '#hash.txt'], 'hash.txt 1\n')
-test.write([ 'content', 'foo.txt' ], 'foo.txt 1\n')
-test.write([ 'content', '#hash.txt' ], 'hash.txt 1\n')
-test.write([ 'content', 'subdir', 'bar.txt' ], 'bar.txt 1\n')
-test.write([ 'content', 'subdir', '#hash.txt' ], 'hash.txt 1\n')
-test.write([ 'cmd-tstamp', 'foo.txt' ], 'foo.txt 1\n')
-test.write([ 'cmd-tstamp', '#hash.txt' ], 'hash.txt 1\n')
-test.write([ 'cmd-tstamp', 'subdir', 'bar.txt' ], 'bar.txt 1\n')
-test.write([ 'cmd-tstamp', 'subdir', '#hash.txt' ], 'hash.txt 1\n')
-test.write([ 'cmd-content', 'foo.txt' ], 'foo.txt 1\n')
-test.write([ 'cmd-content', '#hash.txt' ], '#hash.txt 1\n')
-test.write([ 'cmd-content', 'subdir', 'bar.txt' ], 'bar.txt 1\n')
-test.write([ 'cmd-content', 'subdir', '#hash.txt' ], 'hash.txt 1\n')
+test.write(['tstamp', 'foo.txt'], 'foo.txt 1\n')
+test.write(['tstamp', '#hash.txt'], 'hash.txt 1\n')
+test.write(['tstamp', 'subdir', 'bar.txt'], 'bar.txt 1\n')
+test.write(['tstamp', 'subdir', '#hash.txt'], 'hash.txt 1\n')
+test.write(['content', 'foo.txt'], 'foo.txt 1\n')
+test.write(['content', '#hash.txt'], 'hash.txt 1\n')
+test.write(['content', 'subdir', 'bar.txt'], 'bar.txt 1\n')
+test.write(['content', 'subdir', '#hash.txt'], 'hash.txt 1\n')
+test.write(['cmd-tstamp', 'foo.txt'], 'foo.txt 1\n')
+test.write(['cmd-tstamp', '#hash.txt'], 'hash.txt 1\n')
+test.write(['cmd-tstamp', 'subdir', 'bar.txt'], 'bar.txt 1\n')
+test.write(['cmd-tstamp', 'subdir', '#hash.txt'], 'hash.txt 1\n')
+test.write(['cmd-content', 'foo.txt'], 'foo.txt 1\n')
+test.write(['cmd-content', '#hash.txt'], '#hash.txt 1\n')
+test.write(['cmd-content', 'subdir', 'bar.txt'], 'bar.txt 1\n')
+test.write(['cmd-content', 'subdir', '#hash.txt'], 'hash.txt 1\n')
 test.write('junk.txt', 'junk.txt\n')
 
 test.run(arguments=".", stderr=None)
@@ -106,61 +109,61 @@ test.up_to_date(arguments='cmd-content.out')
 test.up_to_date(arguments='cmd-tstamp-noscan.out')
 test.up_to_date(arguments='cmd-content-noscan.out')
 
-test.sleep()
+test.sleep()  # delay for timestamps
 
-test.write([ 'tstamp', 'foo.txt' ], 'foo.txt 2\n')
+test.write(['tstamp', 'foo.txt'], 'foo.txt 2\n')
 test.not_up_to_date(arguments='tstamp.out')
 
-test.write([ 'tstamp', 'new.txt' ], 'new.txt\n')
+test.write(['tstamp', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='tstamp.out')
 
-test.write([ 'content', 'foo.txt' ], 'foo.txt 2\n')
+test.write(['content', 'foo.txt'], 'foo.txt 2\n')
 test.not_up_to_date(arguments='content.out')
 
-test.write([ 'content', 'new.txt' ], 'new.txt\n')
+test.write(['content', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='content.out')
 
-test.write([ 'cmd-tstamp', 'foo.txt' ], 'foo.txt 2\n')
+test.write(['cmd-tstamp', 'foo.txt'], 'foo.txt 2\n')
 test.not_up_to_date(arguments='cmd-tstamp.out')
 test.up_to_date(arguments='cmd-tstamp-noscan.out')
 
-test.write([ 'cmd-tstamp', 'new.txt' ], 'new.txt\n')
+test.write(['cmd-tstamp', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='cmd-tstamp.out')
 test.up_to_date(arguments='cmd-tstamp-noscan.out')
 
-test.write([ 'cmd-content', 'foo.txt' ], 'foo.txt 2\n')
+test.write(['cmd-content', 'foo.txt'], 'foo.txt 2\n')
 test.not_up_to_date(arguments='cmd-content.out')
 test.up_to_date(arguments='cmd-content-noscan.out')
 
-test.write([ 'cmd-content', 'new.txt' ], 'new.txt\n')
+test.write(['cmd-content', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='cmd-content.out')
 test.up_to_date(arguments='cmd-content-noscan.out')
 
-test.write([ 'tstamp', 'subdir', 'bar.txt' ], 'bar.txt 2\n')
+test.write(['tstamp', 'subdir', 'bar.txt'], 'bar.txt 2\n')
 test.not_up_to_date(arguments='tstamp.out')
 
-test.write([ 'tstamp', 'subdir', 'new.txt' ], 'new.txt\n')
+test.write(['tstamp', 'subdir', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='tstamp.out')
 
-test.write([ 'content', 'subdir', 'bar.txt' ], 'bar.txt 2\n')
+test.write(['content', 'subdir', 'bar.txt'], 'bar.txt 2\n')
 test.not_up_to_date(arguments='content.out')
 
-test.write([ 'content', 'subdir', 'new.txt' ], 'new.txt\n')
+test.write(['content', 'subdir', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='content.out')
 
-test.write([ 'cmd-tstamp', 'subdir', 'bar.txt' ], 'bar.txt 2\n')
+test.write(['cmd-tstamp', 'subdir', 'bar.txt'], 'bar.txt 2\n')
 test.not_up_to_date(arguments='cmd-tstamp.out')
 test.up_to_date(arguments='cmd-tstamp-noscan.out')
 
-test.write([ 'cmd-tstamp', 'subdir', 'new.txt' ], 'new.txt\n')
+test.write(['cmd-tstamp', 'subdir', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='cmd-tstamp.out')
 test.up_to_date(arguments='cmd-tstamp-noscan.out')
 
-test.write([ 'cmd-content', 'subdir', 'bar.txt' ], 'bar.txt 2\n')
+test.write(['cmd-content', 'subdir', 'bar.txt'], 'bar.txt 2\n')
 test.not_up_to_date(arguments='cmd-content.out')
 test.up_to_date(arguments='cmd-content-noscan.out')
 
-test.write([ 'cmd-content', 'subdir', 'new.txt' ], 'new.txt\n')
+test.write(['cmd-content', 'subdir', 'new.txt'], 'new.txt\n')
 test.not_up_to_date(arguments='cmd-content.out')
 test.up_to_date(arguments='cmd-content-noscan.out')
 

--- a/test/Libs/LIBPATH.py
+++ b/test/Libs/LIBPATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import time
@@ -40,20 +40,17 @@ test.subdir('lib1', 'lib2')
 prog1 = test.workpath('prog') + _exe
 prog2 = test.workpath(dll_ + 'shlib') + _dll
 
-test.write('SConstruct', """
-env1 = Environment(LIBS = [ 'foo1' ],
-                   LIBPATH = [ '$FOO' ],
-                   FOO='./lib1')
+test.write('SConstruct', """\
+env1 = Environment(LIBS=['foo1'], LIBPATH=['$FOO'], FOO='./lib1')
 
 f1 = env1.SharedObject('f1', 'f1.c')
 
-env1.Program(target = 'prog', source = 'prog.c')
-env1.Library(target = './lib1/foo1', source = f1)
+env1.Program(target='prog', source='prog.c')
+env1.Library(target='./lib1/foo1', source=f1)
 
-env2 = Environment(LIBS = 'foo2',
-                   LIBPATH = '.')
-env2.SharedLibrary(target = 'shlib', source = 'shlib.c', no_import_lib = 1)
-env2.Library(target = 'foo2', source = f1)
+env2 = Environment(LIBS='foo2', LIBPATH='.')
+env2.SharedLibrary(target='shlib', source='shlib.c', no_import_lib=1)
+env2.Library(target='foo2', source=f1)
 """)
 
 test.write('f1.c', r"""
@@ -99,8 +96,8 @@ test.run(program = prog1,
 
 oldtime1 = os.path.getmtime(prog1)
 oldtime2 = os.path.getmtime(prog2)
-time.sleep(2)
-test.run(arguments = '.')
+test.sleep()  # delay for timestamps
+test.run(arguments='.')
 
 test.fail_test(oldtime1 != os.path.getmtime(prog1))
 test.fail_test(oldtime2 != os.path.getmtime(prog2))
@@ -115,30 +112,25 @@ f1(void)
 }
 """)
 
-test.run(arguments = '.',
-         stderr=TestSCons.noisy_ar,
-         match=TestSCons.match_re_dotall)
-test.run(program = prog1,
-         stdout = "f1.c 1\nprog.c\n")
+test.run(arguments='.', stderr=TestSCons.noisy_ar, match=TestSCons.match_re_dotall)
+test.run(program=prog1, stdout="f1.c 1\nprog.c\n")
 test.fail_test(oldtime2 == os.path.getmtime(prog2))
 #test.up_to_date(arguments = '.')
 # Change LIBPATH and make sure we don't rebuild because of it.
-test.write('SConstruct', """
-env1 = Environment(LIBS = [ 'foo1' ],
-                  LIBPATH = [ './lib1', './lib2' ])
+test.write('SConstruct', """\
+env1 = Environment(LIBS=['foo1'], LIBPATH=['./lib1', './lib2'])
 
 f1 = env1.SharedObject('f1', 'f1.c')
 
-env1.Program(target = 'prog', source = 'prog.c')
-env1.Library(target = './lib1/foo1', source = f1)
+env1.Program(target='prog', source='prog.c')
+env1.Library(target='./lib1/foo1', source=f1)
 
-env2 = Environment(LIBS = 'foo2',
-                   LIBPATH = Split('. ./lib2'))
-env2.SharedLibrary(target = 'shlib', source = 'shlib.c', no_import_lib = 1)
-env2.Library(target = 'foo2', source = f1)
+env2 = Environment(LIBS='foo2', LIBPATH=Split('. ./lib2'))
+env2.SharedLibrary(target='shlib', source='shlib.c', no_import_lib=1)
+env2.Library(target='foo2', source=f1)
 """)
 
-test.up_to_date(arguments = '.', stderr=None)
+test.up_to_date(arguments='.', stderr=None)
 
 test.write('f1.c', r"""
 #include <stdio.h>
@@ -150,27 +142,22 @@ f1(void)
 }
 """)
 
-test.run(arguments = '.',
-         stderr=TestSCons.noisy_ar,
-         match=TestSCons.match_re_dotall)
-test.run(program = prog1,
-         stdout = "f1.c 2\nprog.c\n")
+test.run(arguments='.', stderr=TestSCons.noisy_ar, match=TestSCons.match_re_dotall)
+test.run(program=prog1, stdout="f1.c 2\nprog.c\n")
 
-test.up_to_date(arguments = '.')
+test.up_to_date(arguments='.')
 
 # We need at least one file for some implementations of the Library
 # builder, notably the SGI one.
 test.write('empty.c', 'int a=0;\n')
 
 # Check that a null-string LIBPATH doesn't blow up.
-test.write('SConstruct', """
-env = Environment(LIBPATH = '')
-env.Library('foo', source = 'empty.c')
+test.write('SConstruct', """\
+env = Environment(LIBPATH='')
+env.Library('foo', source='empty.c')
 """)
 
-test.run(arguments = '.',
-         stderr=TestSCons.noisy_ar,
-         match=TestSCons.match_re_dotall)
+test.run(arguments='.', stderr=TestSCons.noisy_ar, match=TestSCons.match_re_dotall)
 
 test.pass_test()
 

--- a/test/PharLap.py
+++ b/test/PharLap.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import sys
@@ -284,10 +283,10 @@ test.write([ "baz", "bar.lnk"],"""
 @asm.emb
 """)
 
-test.write("SConstruct", """
-env=Environment(tools = [ 'linkloc', '386asm' ],
-                ASFLAGS='-twocase -cvsym',
-                LINKFLAGS='@foo.lnk')
+test.write("SConstruct", """\
+env = Environment(
+    tools=['linkloc', '386asm'], ASFLAGS='-twocase -cvsym', LINKFLAGS='@foo.lnk'
+)
 env.Program(target='minasm', source='minasm.asm')
 """)
 
@@ -304,8 +303,8 @@ test.write([ "baz", "bar.lnk"],"""
 """)
 
 oldtime = os.path.getmtime(test.workpath('minasm.exe'))
-time.sleep(2) # Give the time stamp time to change
-test.run(arguments = '.')
+test.sleep()  # delay for timestamps
+test.run(arguments='.')
 test.fail_test(oldtime == os.path.getmtime(test.workpath('minasm.exe')))
 
 test.pass_test()

--- a/test/Program.py
+++ b/test/Program.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import time
@@ -40,13 +39,13 @@ foo4 = test.workpath('foo4' + _exe)
 foo5 = test.workpath('foo5' + _exe)
 foo_args = 'foo1%s foo2%s foo3%s foo4%s foo5%s' % (_exe, _exe, _exe, _exe, _exe)
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 env = Environment()
-env.Program(target = 'foo1', source = 'f1.c')
-env.Program(target = 'foo2', source = Split('f2a.c f2b.c f2c.c'))
+env.Program(target='foo1', source='f1.c')
+env.Program(target='foo2', source=Split('f2a.c f2b.c f2c.c'))
 f3a = File('f3a.c')
 f3b = File('f3b.c')
-Program(target = 'foo3', source = [f3a, [f3b, 'f3c.c']])
+Program(target='foo3', source=[f3a, [f3b, 'f3c.c']])
 env.Program('foo4', 'f4.c')
 env.Program('foo5.c')
 """)
@@ -156,15 +155,14 @@ main(int argc, char *argv[])
 }
 """)
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
-test.run(program = foo1, stdout = "f1.c\n")
-test.run(program = foo2, stdout = "f2a.c\nf2b.c\nf2c.c\n")
-test.run(program = foo3, stdout = "f3a.c\nf3b.c\nf3c.c\n")
-test.run(program = foo4, stdout = "f4.c\n")
-test.run(program = foo5, stdout = "foo5.c\n")
-
-test.up_to_date(arguments = '.')
+test.run(program=foo1, stdout="f1.c\n")
+test.run(program=foo2, stdout="f2a.c\nf2b.c\nf2c.c\n")
+test.run(program=foo3, stdout="f3a.c\nf3b.c\nf3c.c\n")
+test.run(program=foo4, stdout="f4.c\n")
+test.run(program=foo5, stdout="foo5.c\n")
+test.up_to_date(arguments='.')
 
 test.write('f1.c', r"""
 #include <stdio.h>
@@ -211,15 +209,14 @@ main(int argc, char *argv[])
 }
 """)
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
-test.run(program = foo1, stdout = "f1.c X\n")
-test.run(program = foo2, stdout = "f2a.c\nf2b.c\nf2c.c\n")
-test.run(program = foo3, stdout = "f3a.c\nf3b.c X\nf3c.c\n")
-test.run(program = foo4, stdout = "f4.c X\n")
-test.run(program = foo5, stdout = "foo5.c X\n")
-
-test.up_to_date(arguments = '.')
+test.run(program=foo1, stdout="f1.c X\n")
+test.run(program=foo2, stdout="f2a.c\nf2b.c\nf2c.c\n")
+test.run(program=foo3, stdout="f3a.c\nf3b.c X\nf3c.c\n")
+test.run(program=foo4, stdout="f4.c X\n")
+test.run(program=foo5, stdout="foo5.c X\n")
+test.up_to_date(arguments='.')
 
 # make sure the programs didn't get rebuilt, because nothing changed:
 oldtime1 = os.path.getmtime(foo1)
@@ -228,10 +225,8 @@ oldtime3 = os.path.getmtime(foo3)
 oldtime4 = os.path.getmtime(foo4)
 oldtime5 = os.path.getmtime(foo5)
 
-time.sleep(2) # introduce a small delay, to make the test valid
-
-test.run(arguments = foo_args)
-
+test.sleep()  # delay for timestamps
+test.run(arguments=foo_args)
 test.fail_test(oldtime1 != os.path.getmtime(foo1))
 test.fail_test(oldtime2 != os.path.getmtime(foo2))
 test.fail_test(oldtime3 != os.path.getmtime(foo3))
@@ -284,15 +279,14 @@ main(int argc, char *argv[])
 }
 """)
 
-test.run(arguments = foo_args)
+test.run(arguments=foo_args)
 
-test.run(program = foo1, stdout = "f1.c Y\n")
-test.run(program = foo2, stdout = "f2a.c\nf2b.c\nf2c.c\n")
-test.run(program = foo3, stdout = "f3a.c\nf3b.c Y\nf3c.c\n")
-test.run(program = foo4, stdout = "f4.c Y\n")
-test.run(program = foo5, stdout = "foo5.c Y\n")
-
-test.up_to_date(arguments = foo_args)
+test.run(program=foo1, stdout="f1.c Y\n")
+test.run(program=foo2, stdout="f2a.c\nf2b.c\nf2c.c\n")
+test.run(program=foo3, stdout="f3a.c\nf3b.c Y\nf3c.c\n")
+test.run(program=foo4, stdout="f4.c Y\n")
+test.run(program=foo5, stdout="foo5.c Y\n")
+test.up_to_date(arguments=foo_args)
 
 test.write('f1.c', r"""
 #include <stdio.h>
@@ -340,15 +334,14 @@ main(int argc, char *argv[])
 }
 """)
 
-test.run(arguments = foo_args)
+test.run(arguments=foo_args)
 
-test.run(program = foo1, stdout = "f1.c Z\n")
-test.run(program = foo2, stdout = "f2a.c\nf2b.c\nf2c.c\n")
-test.run(program = foo3, stdout = "f3a.c\nf3b.c Z\nf3c.c\n")
-test.run(program = foo4, stdout = "f4.c Z\n")
-test.run(program = foo5, stdout = "foo5.c Z\n")
-
-test.up_to_date(arguments = foo_args)
+test.run(program=foo1, stdout="f1.c Z\n")
+test.run(program=foo2, stdout="f2a.c\nf2b.c\nf2c.c\n")
+test.run(program=foo3, stdout="f3a.c\nf3b.c Z\nf3c.c\n")
+test.run(program=foo4, stdout="f4.c Z\n")
+test.run(program=foo5, stdout="foo5.c Z\n")
+test.up_to_date(arguments=foo_args)
 
 # make sure the programs didn't get rebuilt, because nothing changed:
 oldtime1 = os.path.getmtime(foo1)
@@ -357,10 +350,8 @@ oldtime3 = os.path.getmtime(foo3)
 oldtime4 = os.path.getmtime(foo4)
 oldtime5 = os.path.getmtime(foo5)
 
-time.sleep(2) # introduce a small delay, to make the test valid
-
-test.run(arguments = foo_args)
-
+test.sleep()  # delay for timestamps
+test.run(arguments=foo_args)
 test.fail_test(not (oldtime1 == os.path.getmtime(foo1)))
 test.fail_test(not (oldtime2 == os.path.getmtime(foo2)))
 test.fail_test(not (oldtime3 == os.path.getmtime(foo3)))

--- a/test/Repository/no-SConsignFile.py
+++ b/test/Repository/no-SConsignFile.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that using Repository() works even when the Repository has no
@@ -63,13 +62,10 @@ test.write(['src', 'foo.h'], """\
 
 # Make sure it's past the max_drift time,
 # so the source file signatures get saved.
-test.sleep(2)
+test.sleep()  # delay for timestamps
 
 test.run(chdir='build', arguments='.')
-
-test.run(program=test.workpath('build', 'foo'),
-         stdout="src/foo.h\nsrc/foo.c\n")
-
+test.run(program=test.workpath('build', 'foo'), stdout="src/foo.h\nsrc/foo.c\n")
 test.up_to_date(chdir='build', arguments='.')
 
 test.pass_test()

--- a/test/Repository/variants.py
+++ b/test/Repository/variants.py
@@ -31,20 +31,22 @@ from TestSCons import TestSCons, _exe, _obj
 
 test = TestSCons()
 
-test.subdir('repository',
-            ['repository', 'src1'],
-            ['repository', 'src2'],
-            ['repository', 'src2', 'include'],
-            ['repository', 'src2', 'xxx'],
-            ['repository', 'build2'],
-            ['repository', 'build2', 'foo'],
-            ['repository', 'build2', 'bar'],
-            'work1',
-            ['work1', 'src1'],
-            'work2',
-            ['work2', 'src2'],
-            ['work2', 'src2', 'include'],
-            ['work2', 'src2', 'xxx'])
+test.subdir(
+    'repository',
+    ['repository', 'src1'],
+    ['repository', 'src2'],
+    ['repository', 'src2', 'include'],
+    ['repository', 'src2', 'xxx'],
+    ['repository', 'build2'],
+    ['repository', 'build2', 'foo'],
+    ['repository', 'build2', 'bar'],
+    'work1',
+    ['work1', 'src1'],
+    'work2',
+    ['work2', 'src2'],
+    ['work2', 'src2', 'include'],
+    ['work2', 'src2', 'xxx'],
+)
 
 aaa_obj = 'aaa' + _obj
 bbb_obj = 'bbb' + _obj
@@ -56,14 +58,18 @@ repository_build1_foo_xxx = test.workpath('repository', 'build1', 'foo', 'xxx')
 work1_build1_foo_xxx = test.workpath('work1', 'build1', 'foo', 'xxx')
 work1_build1_bar_xxx = test.workpath('work1', 'build1', 'bar', 'xxx')
 
-repository_build2_foo_src2_xxx_xxx = test.workpath('repository', 'build2',
-                                                   'foo', 'src2', 'xxx', 'xxx')
-repository_build2_bar_src2_xxx_xxx = test.workpath('repository', 'build2',
-                                                   'bar', 'src2', 'xxx', 'xxx')
-work2_build2_foo_src2_xxx_xxx = test.workpath('work2', 'build2',
-                                              'foo', 'src2', 'xxx', 'xxx')
-work2_build2_bar_src2_xxx_xxx = test.workpath('work2', 'build2',
-                                              'bar', 'src2', 'xxx', 'xxx')
+repository_build2_foo_src2_xxx_xxx = test.workpath(
+    'repository', 'build2', 'foo', 'src2', 'xxx', 'xxx'
+)
+repository_build2_bar_src2_xxx_xxx = test.workpath(
+    'repository', 'build2', 'bar', 'src2', 'xxx', 'xxx'
+)
+work2_build2_foo_src2_xxx_xxx = test.workpath(
+    'work2', 'build2', 'foo', 'src2', 'xxx', 'xxx'
+)
+work2_build2_bar_src2_xxx_xxx = test.workpath(
+    'work2', 'build2', 'bar', 'src2', 'xxx', 'xxx'
+)
 
 opts = "-Y " + test.workpath('repository')
 
@@ -73,12 +79,13 @@ OS = ARGUMENTS.get('OS', '')
 build1_os = "#build1/" + OS
 default = Environment()
 ccflags = {
-    ''    : '',
-    'foo' : '-DFOO',
-    'bar' : '-DBAR',
+    '': '',
+    'foo': '-DFOO',
+    'bar': '-DBAR',
 }
-env1 = Environment(CCFLAGS = default.subst('$CCFLAGS %s' % ccflags[OS]),
-                   CPPPATH = build1_os)
+env1 = Environment(
+    CCFLAGS=default.subst('$CCFLAGS %s' % ccflags[OS]), CPPPATH=build1_os
+)
 VariantDir(build1_os, 'src1')
 SConscript(build1_os + '/SConscript', "env1")
 
@@ -95,8 +102,9 @@ test.write(['repository', 'build2', 'foo', 'SConscript'], r"""
 VariantDir('src2', '#src2')
 
 default = Environment()
-env2 = Environment(CCFLAGS = default.subst('$CCFLAGS -DFOO'),
-                   CPPPATH = ['#src2/xxx', '#src2/include'])
+env2 = Environment(
+    CCFLAGS=default.subst('$CCFLAGS -DFOO'), CPPPATH=['#src2/xxx', '#src2/include']
+)
 
 SConscript('src2/xxx/SConscript', "env2")
 """)
@@ -105,8 +113,9 @@ test.write(['repository', 'build2', 'bar', 'SConscript'], r"""
 VariantDir('src2', '#src2')
 
 default = Environment()
-env2 = Environment(CCFLAGS = default.subst('$CCFLAGS -DBAR'),
-                   CPPPATH = ['#src2/xxx', '#src2/include'])
+env2 = Environment(
+    CCFLAGS=default.subst('$CCFLAGS -DBAR'), CPPPATH=['#src2/xxx', '#src2/include']
+)
 
 SConscript('src2/xxx/SConscript', "env2")
 """)
@@ -216,12 +225,9 @@ repository/src1/bbb.c:  REPOSITORY_FOO
 repository/src1/main.c:  REPOSITORY_FOO
 """)
 
-database_name=test.get_sconsignname()
-
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+database_name = test.get_sconsignname()
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
 
@@ -237,10 +243,8 @@ repository/src2/xxx/include.h:  BAR
 repository/src2/xxx/main.c:  BAR
 """)
 
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
 
@@ -251,15 +255,10 @@ test.writable('repository', 0)
 #
 test.up_to_date(chdir='work1', options=opts + " OS=foo", arguments='build1')
 
-test.fail_test(os.path.exists(
-    test.workpath('work1', 'build1', 'foo', aaa_obj)))
-test.fail_test(os.path.exists(
-    test.workpath('work1', 'build1', 'foo', bbb_obj)))
-test.fail_test(os.path.exists(test.workpath(
-    'work1', 'build1', 'foo', main_obj)))
-
-test.fail_test(os.path.exists(
-    test.workpath('work1', 'build1', 'foo', xxx_exe)))
+test.fail_test(os.path.exists(test.workpath('work1', 'build1', 'foo', aaa_obj)))
+test.fail_test(os.path.exists(test.workpath('work1', 'build1', 'foo', bbb_obj)))
+test.fail_test(os.path.exists(test.workpath('work1', 'build1', 'foo', main_obj)))
+test.fail_test(os.path.exists(test.workpath('work1', 'build1', 'foo', xxx_exe)))
 
 #
 test.run(chdir='work1', options=opts, arguments='OS=bar .')
@@ -271,18 +270,13 @@ repository/src1/bbb.c:  REPOSITORY_BAR
 repository/src1/main.c:  REPOSITORY_BAR
 """)
 
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
-
 test.up_to_date(chdir='work1', options=opts + " OS=bar", arguments='build1')
 
-# Ensure file time stamps will be newer.
-time.sleep(2)
-
+test.sleep()  # delay for timestamps
 test.write(['work1', 'src1', 'iii.h'], r"""
 #ifdef  FOO
 #define STRING  "WORK_FOO"
@@ -302,13 +296,10 @@ repository/src1/bbb.c:  WORK_BAR
 repository/src1/main.c:  WORK_BAR
 """)
 
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
-
 test.up_to_date(chdir='work1', options=opts + " OS=bar", arguments='build1')
 
 #
@@ -320,38 +311,39 @@ repository/src1/bbb.c:  WORK_FOO
 repository/src1/main.c:  WORK_FOO
 """)
 
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
-
 test.up_to_date(chdir='work1', options=opts + " OS=foo", arguments='build1')
-
-#
 test.up_to_date(chdir='work2', options=opts, arguments='build2')
 
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'foo', 'src2', 'xxx', aaa_obj)))
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'foo', 'src2', 'xxx', bbb_obj)))
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'foo', 'src2', 'xxx', main_obj)))
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'foo', 'src2', 'xxx', xxx_exe)))
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'bar', 'src2', 'xxx', aaa_obj)))
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'bar', 'src2', 'xxx', bbb_obj)))
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'bar', 'src2', 'xxx', main_obj)))
-test.fail_test(os.path.exists(test.workpath(
-    'work2', 'build2', 'bar', 'src2', 'xxx', xxx_exe)))
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'foo', 'src2', 'xxx', aaa_obj))
+)
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'foo', 'src2', 'xxx', bbb_obj))
+)
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'foo', 'src2', 'xxx', main_obj))
+)
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'foo', 'src2', 'xxx', xxx_exe))
+)
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'bar', 'src2', 'xxx', aaa_obj))
+)
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'bar', 'src2', 'xxx', bbb_obj))
+)
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'bar', 'src2', 'xxx', main_obj))
+)
+test.fail_test(
+    os.path.exists(test.workpath('work2', 'build2', 'bar', 'src2', 'xxx', xxx_exe))
+)
 
-# Ensure file time stamps will be newer.
-time.sleep(2)
-
+test.sleep()  # delay for timestamps
 test.write(['work2', 'src2', 'include', 'my_string.h'], r"""
 #ifdef  FOO
 #define INCLUDE_OS      "FOO"
@@ -362,7 +354,6 @@ test.write(['work2', 'src2', 'include', 'my_string.h'], r"""
 #define INCLUDE_STRING  "work2/src2/include/my_string.h:  %s\n"
 """)
 
-#
 test.run(chdir='work2', options=opts, arguments='build2')
 
 test.run(program=work2_build2_foo_src2_xxx_xxx, stdout="""\
@@ -377,16 +368,12 @@ repository/src2/xxx/include.h:  BAR
 repository/src2/xxx/main.c:  BAR
 """)
 
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
 
-# Ensure file time stamps will be newer.
-time.sleep(2)
-
+test.sleep()  # delay for timestamps
 test.write(['work2', 'src2', 'xxx', 'include.h'], r"""
 #include <my_string.h>
 #ifdef  FOO
@@ -412,38 +399,37 @@ work2/src2/xxx/include.h:  BAR
 repository/src2/xxx/main.c:  BAR
 """)
 
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
 
-#
 test.unlink(['work2', 'src2', 'include', 'my_string.h'])
-
 test.run(chdir='work2', options=opts, arguments='build2')
 
-test.run(program=work2_build2_foo_src2_xxx_xxx, stdout="""\
+test.run(
+    program=work2_build2_foo_src2_xxx_xxx,
+    stdout="""\
 repository/src2/include/my_string.h:  FOO
 work2/src2/xxx/include.h:  FOO
 repository/src2/xxx/main.c:  FOO
-""")
+""",
+)
 
-test.run(program=work2_build2_bar_src2_xxx_xxx, stdout="""\
+test.run(
+    program=work2_build2_bar_src2_xxx_xxx,
+    stdout="""\
 repository/src2/include/my_string.h:  BAR
 work2/src2/xxx/include.h:  BAR
 repository/src2/xxx/main.c:  BAR
-""")
+""",
+)
 
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src1', database_name)))
-test.fail_test(os.path.exists(
-    test.workpath('repository', 'src2', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src1', database_name)))
+test.fail_test(os.path.exists(test.workpath('repository', 'src2', database_name)))
 test.fail_test(os.path.exists(test.workpath('work1', 'src1', database_name)))
 test.fail_test(os.path.exists(test.workpath('work2', 'src2', database_name)))
 
-#
 test.pass_test()
 
 # Local Variables:

--- a/test/Touch.py
+++ b/test/Touch.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the Touch() Action works.
@@ -34,30 +33,29 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 Execute(Touch('f1'))
 Execute(Touch(File('f1-File')))
+
 def cat(env, source, target):
     target = str(target[0])
     with open(target, "wb") as f:
         for src in source:
             with open(str(src), "rb") as ifp:
                 f.write(ifp.read())
+
 Cat = Action(cat)
 env = Environment()
 env.Command('f2.out', 'f2.in', [Cat, Touch("f3")])
 env = Environment(FILE='f4')
 env.Command('f5.out', 'f5.in', [Touch("$FILE"), Cat])
-env.Command('f6.out', 'f6.in', [Cat,
-                                Touch("Touch-$SOURCE"),
-                                Touch("$TARGET-Touch")])
+env.Command('f6.out', 'f6.in', [Cat, Touch("Touch-$SOURCE"), Touch("$TARGET-Touch")])
 
 # Make sure Touch works with a list of arguments
 env = Environment()
-env.Command('f7.out', 'f7.in', [Cat,
-                                Touch(["Touch-$SOURCE",
-                                       "$TARGET-Touch",
-                                       File("f8")])])
+env.Command(
+    'f7.out', 'f7.in', [Cat, Touch(["Touch-$SOURCE", "$TARGET-Touch", File("f8")])]
+)
 """)
 
 test.write('f1', "f1\n")
@@ -70,11 +68,12 @@ test.write('f7.in', "f7.in\n")
 old_f1_time = os.path.getmtime(test.workpath('f1'))
 old_f1_File_time = os.path.getmtime(test.workpath('f1-File'))
 
-expect = test.wrap_stdout(read_str = """\
+expect = test.wrap_stdout(
+    read_str="""\
 Touch("f1")
 Touch("f1-File")
 """,
-                          build_str = """\
+    build_str="""\
 cat(["f2.out"], ["f2.in"])
 Touch("f3")
 Touch("f4")
@@ -84,11 +83,11 @@ Touch("Touch-f6.in")
 Touch("f6.out-Touch")
 cat(["f7.out"], ["f7.in"])
 Touch(["Touch-f7.in", "f7.out-Touch", "f8"])
-""")
-test.run(options = '-n', arguments = '.', stdout = expect)
+""",
+)
+test.run(options='-n', arguments='.', stdout=expect)
 
-test.sleep(2)
-
+test.sleep()  # delay for timestamps
 new_f1_time = os.path.getmtime(test.workpath('f1'))
 test.fail_test(old_f1_time != new_f1_time)
 new_f1_File_time = os.path.getmtime(test.workpath('f1-File'))

--- a/test/chained-build.py
+++ b/test/chained-build.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -58,23 +57,20 @@ test.write(['w1', 'SConstruct1'], SConstruct1_contents)
 test.write(['w1', 'SConstruct2'], SConstruct2_contents)
 test.write(['w1', 'foo.in'], "foo.in 1")
 
-test.run(chdir='w1',
-         arguments="--max-drift=0 -f SConstruct1 foo.mid",
-         stdout = test.wrap_stdout('build(["foo.mid"], ["foo.in"])\n'))
+test.run(
+    chdir='w1',
+    arguments="--max-drift=0 -f SConstruct1 foo.mid",
+    stdout=test.wrap_stdout('build(["foo.mid"], ["foo.in"])\n'),
+)
+test.run(
+    chdir='w1',
+    arguments="--max-drift=0 -f SConstruct2 foo.out",
+    stdout=test.wrap_stdout('build(["foo.out"], ["foo.mid"])\n'),
+)
+test.up_to_date(chdir='w1', options="--max-drift=0 -f SConstruct1", arguments="foo.mid")
+test.up_to_date(chdir='w1', options="--max-drift=0 -f SConstruct2", arguments="foo.out")
 
-test.run(chdir='w1',
-         arguments="--max-drift=0 -f SConstruct2 foo.out",
-         stdout = test.wrap_stdout('build(["foo.out"], ["foo.mid"])\n'))
-
-test.up_to_date(chdir='w1',
-                options="--max-drift=0 -f SConstruct1",
-                arguments="foo.mid")
-
-test.up_to_date(chdir='w1',
-                options="--max-drift=0 -f SConstruct2",
-                arguments="foo.out")
-
-test.sleep()  # make sure foo.in rewrite has new mod-time
+test.sleep()  # delay for timestamps
 test.write(['w1', 'foo.in'], "foo.in 2")
 
 # Because we're using --max-drift=0, we use the cached csig value
@@ -86,17 +82,19 @@ test.up_to_date(chdir='w1',
 # Now try with --max-drift disabled.  The build of foo.out should still
 # be considered up-to-date, but the build of foo.mid now detects the
 # change and rebuilds, too, which then causes a rebuild of foo.out.
-test.up_to_date(chdir='w1',
-                options="--max-drift=-1 -f SConstruct2",
-                arguments="foo.out")
-
-test.run(chdir='w1',
-         arguments="--max-drift=-1 -f SConstruct1 foo.mid",
-         stdout = test.wrap_stdout('build(["foo.mid"], ["foo.in"])\n'))
-
-test.run(chdir='w1',
-         arguments="--max-drift=-1 -f SConstruct2 foo.out",
-         stdout = test.wrap_stdout('build(["foo.out"], ["foo.mid"])\n'))
+test.up_to_date(
+    chdir='w1', options="--max-drift=-1 -f SConstruct2", arguments="foo.out"
+)
+test.run(
+    chdir='w1',
+    arguments="--max-drift=-1 -f SConstruct1 foo.mid",
+    stdout=test.wrap_stdout('build(["foo.mid"], ["foo.in"])\n'),
+)
+test.run(
+    chdir='w1',
+    arguments="--max-drift=-1 -f SConstruct2 foo.out",
+    stdout=test.wrap_stdout('build(["foo.out"], ["foo.mid"])\n'),
+)
 
 test.pass_test()
 

--- a/test/sconsign/script/Signatures.py
+++ b/test/sconsign/script/Signatures.py
@@ -44,8 +44,8 @@ if NEED_HELPER:
 # in the expected output because paths in the .sconsign files are
 # canonicalized to use / as the separator.
 
-sub1_hello_c    = 'sub1/hello.c'
-sub1_hello_obj  = 'sub1/hello.obj'
+sub1_hello_c = 'sub1/hello.c'
+sub1_hello_obj = 'sub1/hello.obj'
 
 test.subdir('sub1', 'sub2')
 
@@ -135,7 +135,7 @@ env2.Program('sub2/hello.c')
 """,
 )
 # TODO in the above, we would normally want to run a python program
-# using "our python" like this:
+# using "our Python" like this:
 #    CCCOM=[[r'{_python_}', r'{fake_cc_py}', 'sub2', '$TARGET', '$SOURCE']],
 #    LINKCOM=[[r'{_python_}', r'{fake_link_py}', '$TARGET', '$SOURCE']],
 # however we're looking at dependencies with sconsign, so that breaks things.
@@ -160,17 +160,16 @@ test.write(['sub2', 'inc2.h'], r"""\
 #define STRING2 "inc2.h"
 """)
 
-test.sleep()
-
+test.sleep()  # delay for timestamps
 test.run(arguments = '. --max-drift=1')
 
 sig_re = r'[0-9a-fA-F]{32,64}'
 date_re = r'\S+ \S+ [ \d]\d \d\d:\d\d:\d\d \d\d\d\d'
-
 database_name = test.get_sconsignname()
 
-test.run_sconsign(arguments = f"-e hello.exe -e hello.obj sub1/{database_name}",
-         stdout = r"""hello.exe: %(sig_re)s \d+ \d+
+test.run_sconsign(
+    arguments=f"-e hello.exe -e hello.obj sub1/{database_name}",
+    stdout=r"""hello.exe: %(sig_re)s \d+ \d+
         %(sub1_hello_obj)s: %(sig_re)s \d+ \d+
         fake_link\.py: None \d+ \d+
         %(sig_re)s \[.*\]
@@ -178,10 +177,12 @@ hello.obj: %(sig_re)s \d+ \d+
         %(sub1_hello_c)s: None \d+ \d+
         fake_cc\.py: None \d+ \d+
         %(sig_re)s \[.*\]
-""" % locals())
+""" % locals(),
+)
 
-test.run_sconsign(arguments = f"-e hello.exe -e hello.obj -r sub1/{database_name}",
-         stdout = r"""hello.exe: %(sig_re)s '%(date_re)s' \d+
+test.run_sconsign(
+    arguments=f"-e hello.exe -e hello.obj -r sub1/{database_name}",
+    stdout=r"""hello.exe: %(sig_re)s '%(date_re)s' \d+
         %(sub1_hello_obj)s: %(sig_re)s '%(date_re)s' \d+
         fake_link\.py: None '%(date_re)s' \d+
         %(sig_re)s \[.*\]
@@ -189,7 +190,8 @@ hello.obj: %(sig_re)s '%(date_re)s' \d+
         %(sub1_hello_c)s: None '%(date_re)s' \d+
         fake_cc\.py: None '%(date_re)s' \d+
         %(sig_re)s \[.*\]
-""" % locals())
+""" % locals(),
+)
 
 test.pass_test()
 

--- a/test/sconsign/script/dblite.py
+++ b/test/sconsign/script/dblite.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that various ways of getting at a an sconsign file written with
@@ -97,17 +96,11 @@ main(int argc, char *argv[])
 }
 """)
 
-test.write(['sub2', 'inc1.h'], r"""\
-#define STRING1 "inc1.h"
-""")
+test.write(['sub2', 'inc1.h'], r'#define STRING1 "inc1.h"')
+test.write(['sub2', 'inc2.h'], r'#define STRING2 "inc2.h"')
 
-test.write(['sub2', 'inc2.h'], r"""\
-#define STRING2 "inc2.h"
-""")
-
-test.sleep()
-
-test.run(arguments = '. --max-drift=1')
+test.sleep()  # delay for timestamps
+test.run(arguments='. --max-drift=1')
 
 sig_re = r'[0-9a-fA-F]{32,64}'
 date_re = r'\S+ \S+ [ \d]\d \d\d:\d\d:\d\d \d\d\d\d'
@@ -146,23 +139,23 @@ hello%(_obj)s: %(sig_re)s '%(date_re)s' \d+
 
 common_flags = '-e hello%(_exe)s -e hello%(_obj)s -d sub1' % locals()
 
-test.run_sconsign(arguments = "%s my_sconsign" % common_flags,
-                  stdout = expect)
+test.run_sconsign(arguments="%s my_sconsign" % common_flags, stdout=expect)
 
-test.run_sconsign(arguments = "%s my_sconsign.dblite" % common_flags,
-                  stdout = expect)
+test.run_sconsign(arguments="%s my_sconsign.dblite" % common_flags, stdout=expect)
 
-test.run_sconsign(arguments = "%s -f dblite my_sconsign" % common_flags,
-                  stdout = expect)
+test.run_sconsign(arguments="%s -f dblite my_sconsign" % common_flags, stdout=expect)
 
-test.run_sconsign(arguments = "%s -f dblite my_sconsign.dblite" % common_flags,
-                  stdout = expect)
+test.run_sconsign(
+    arguments="%s -f dblite my_sconsign.dblite" % common_flags, stdout=expect
+)
 
-test.run_sconsign(arguments = "%s -r -f dblite my_sconsign" % common_flags,
-                  stdout = expect_r)
+test.run_sconsign(
+    arguments="%s -r -f dblite my_sconsign" % common_flags, stdout=expect_r
+)
 
-test.run_sconsign(arguments = "%s -r -f dblite my_sconsign.dblite" % common_flags,
-                  stdout = expect_r)
+test.run_sconsign(
+    arguments="%s -r -f dblite my_sconsign.dblite" % common_flags, stdout=expect_r
+)
 
 test.pass_test()
 


### PR DESCRIPTION
An earlier change relating to testing delays for timestamp consistency exposed that some tests used `time.sleep` while others used the harness's `test.sleep`. This change adjusts the ones that are done for file timestamp delay management to consistently all use `test.sleep` - with an annotation, so it's easier to spot.  There are still tests that use `time.sleep` with other intervals that were left alone.

Affected tests were reformatted, in the spirit of gradually improving tests that you otherwise touch...

This is a test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
