### PR TITLE
Fix missing newline when calling skip_test()

### DIFF
--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -782,6 +782,8 @@ class TestCommon(TestCmd):
         """
         if message:
             sys.stdout.write(message)
+            if not message.endswith('\n'):
+                sys.stdout.write('\n')
             sys.stdout.flush()
         pass_skips = os.environ.get('TESTCOMMON_PASS_SKIPS')
         if pass_skips in [None, 0, '0']:


### PR DESCRIPTION
If no newline at end of message supplied to skip_test(), then we write one to stdout after the original message

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
