### PR TITLE
[NINJA] Added new alias 'shutdown-ninja-scons-daemon' to allow ninja to shutdown the daemon

### DIFF
--- a/.github/workflows/experimental_tests.yml
+++ b/.github/workflows/experimental_tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install ninja
-          # if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
           # sudo apt-get update
       - name: Test experimental packages ${{ matrix.os }}
         run: |

--- a/.github/workflows/experimental_tests.yml
+++ b/.github/workflows/experimental_tests.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Install dependencies including ninja ${{ matrix.os }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install ninja
-          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          python -m pip install ninja psutil
           # sudo apt-get update
       - name: Test experimental packages ${{ matrix.os }}
         run: |

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Install dependencies including ninja ${{ matrix.os }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install ninja
-          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          python -m pip install ninja psutil
           # sudo apt-get update
       - name: runtest ${{ matrix.os }}
         run: |

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install ninja
-          # if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
           # sudo apt-get update
       - name: runtest ${{ matrix.os }}
         run: |

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -137,6 +137,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       to connect to the server during start up.
     - Ninja: Added new alias "shutdown-ninja-scons-daemon" to allow ninja to shutdown the daemon.
       Also added cleanup to test framework to kill ninja scons daemons and clean ip daemon logs.
+      NOTE: Test for this requires python psutil module. It will be skipped if not present.
     - Ninja: Added command line variable NINJA_CMD_ARGS that allows to pass through ninja command line args.
       This can also be set in your Environment().
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -116,6 +116,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Note that these are called for every build command run by SCons. It could have considerable
       performance impact if not used carefully.
       to connect to the server during start up.
+    -Ninja: Added new alias "shutdown-ninja-scons-daemon" to allow ninja to shutdown the daemon.
+      Also added cleanup to test framework to kill ninja scons daemons and clean ip daemon logs.
 
   From Mats Wichmann:
     - Tweak the way default site_scons paths on Windows are expressed to

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -116,7 +116,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Note that these are called for every build command run by SCons. It could have considerable
       performance impact if not used carefully.
       to connect to the server during start up.
-    -Ninja: Added new alias "shutdown-ninja-scons-daemon" to allow ninja to shutdown the daemon.
+    - Ninja: Added new alias "shutdown-ninja-scons-daemon" to allow ninja to shutdown the daemon.
       Also added cleanup to test framework to kill ninja scons daemons and clean ip daemon logs.
 
   From Mats Wichmann:

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -24,6 +24,8 @@ NEW FUNCTIONALITY
   performance impact if not used carefully.
 - Added MSVC_USE_SETTINGS variable to pass a dictionary to configure the msvc compiler
   system environment as an alternative to bypassing Visual Studio autodetection entirely.
+- Ninja: Added new alias "shutdown-ninja-scons-daemon" to allow ninja to shutdown the daemon.
+  Also added cleanup to test framework to kill ninja scons daemons and clean ip daemon logs.
 
 
 DEPRECATED FUNCTIONALITY

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -27,6 +27,7 @@ NEW FUNCTIONALITY
   system environment as an alternative to bypassing Visual Studio autodetection entirely.
 - Ninja: Added new alias "shutdown-ninja-scons-daemon" to allow ninja to shutdown the daemon.
   Also added cleanup to test framework to kill ninja scons daemons and clean ip daemon logs.
+  NOTE: Test for this requires python psutil module. It will be skipped if not present.
 - Ninja: Added command line variable NINJA_CMD_ARGS that allows to pass through ninja command line args.
   This can also be set in your Environment().
 - Added a global policy setting and an environment policy variable for specifying the action to

--- a/SCons/Tool/ninja/NinjaState.py
+++ b/SCons/Tool/ninja/NinjaState.py
@@ -214,6 +214,12 @@ class NinjaState:
                 "pool": "local_pool",
                 "restat": 1
             },
+            "EXIT_SCONS_DAEMON": {
+                "command": "$PYTHON_BIN $NINJA_TOOL_DIR/ninja_daemon_build.py $PORT $NINJA_DIR_PATH --exit",
+                "description": "Shutting down ninja scons daemon server",
+                "pool": "local_pool",
+                "restat": 1
+            },
             "SCONS": {
                 "command": "$SCONS_INVOCATION $out",
                 "description": "$SCONS_INVOCATION $out",
@@ -608,6 +614,11 @@ class NinjaState:
         ninja.build(
             ["run_ninja_scons_daemon_phony", scons_daemon_dirty],
             rule="SCONS_DAEMON",
+        )
+
+        ninja.build(
+            "shutdown_ninja_scons_daemon_phony",
+            rule="EXIT_SCONS_DAEMON",
         )
 
 

--- a/SCons/Tool/ninja/__init__.py
+++ b/SCons/Tool/ninja/__init__.py
@@ -495,3 +495,4 @@ def generate(env):
 
 
     env.Alias('run-ninja-scons-daemon', 'run_ninja_scons_daemon_phony')
+    env.Alias('shutdown-ninja-scons-daemon', 'shutdown_ninja_scons_daemon_phony')

--- a/SCons/Tool/ninja/__init__.py
+++ b/SCons/Tool/ninja/__init__.py
@@ -465,7 +465,6 @@ def generate(env):
     # date-ness.
     SCons.Script.Main.BuildTask.needs_execute = lambda x: True
 
-
     def ninja_Set_Default_Targets(env, tlist):
         """
             Record the default targets if they were ever set by the user. Ninja
@@ -500,7 +499,6 @@ def generate(env):
 
     env['TEMPFILEDIR'] = "$NINJA_DIR/.response_files"
     env["TEMPFILE"] = NinjaNoResponseFiles
-
 
     env.Alias('run-ninja-scons-daemon', 'run_ninja_scons_daemon_phony')
     env.Alias('shutdown-ninja-scons-daemon', 'shutdown_ninja_scons_daemon_phony')

--- a/SCons/Tool/ninja/ninja_daemon_build.py
+++ b/SCons/Tool/ninja/ninja_daemon_build.py
@@ -65,7 +65,7 @@ while True:
                 logging.debug(f"ERROR: Server pid not found {daemon_dir / 'pidfile'} for request {sys.argv[3]}")
                 exit(1)
             else:
-                logging.debug(f"WARNING: Unecessary request to shutfown server, its already shutdown.")
+                logging.debug("WARNING: Unnecessary request to shutfown server, its already shutdown.")
                 exit(0)
 
         logging.debug(f"Sending request: {sys.argv[3]}")

--- a/SCons/Tool/ninja/ninja_daemon_build.py
+++ b/SCons/Tool/ninja/ninja_daemon_build.py
@@ -60,11 +60,22 @@ def log_error(msg):
 
 while True:
     try:
+        if not os.path.exists(daemon_dir / "pidfile"):
+            if sys.argv[3] != '--exit':
+                logging.debug(f"ERROR: Server pid not found {daemon_dir / 'pidfile'} for request {sys.argv[3]}")
+                exit(1)
+            else:
+                logging.debug(f"WARNING: Unecessary request to shutfown server, its already shutdown.")
+                exit(0)
+
         logging.debug(f"Sending request: {sys.argv[3]}")
         conn = http.client.HTTPConnection(
             "127.0.0.1", port=int(sys.argv[1]), timeout=60
         )
-        conn.request("GET", "/?build=" + sys.argv[3])
+        if sys.argv[3] == '--exit':
+            conn.request("GET", "/?exit=1")
+        else:
+            conn.request("GET", "/?build=" + sys.argv[3])
         response = None
 
         while not response:
@@ -81,6 +92,7 @@ while True:
                 if status != 200:
                     log_error(msg.decode("utf-8"))
                     exit(1)
+                    
                 logging.debug(f"Request Done: {sys.argv[3]}")
                 exit(0)
 

--- a/SCons/Tool/ninja/ninja_daemon_build.py
+++ b/SCons/Tool/ninja/ninja_daemon_build.py
@@ -54,9 +54,11 @@ logging.basicConfig(
     level=logging.DEBUG,
 )
 
+
 def log_error(msg):
     logging.debug(msg)
     sys.stderr.write(msg)
+
 
 while True:
     try:
@@ -65,7 +67,7 @@ while True:
                 logging.debug(f"ERROR: Server pid not found {daemon_dir / 'pidfile'} for request {sys.argv[3]}")
                 exit(1)
             else:
-                logging.debug("WARNING: Unnecessary request to shutfown server, its already shutdown.")
+                logging.debug("WARNING: Unnecessary request to shutdown server, it's already shutdown.")
                 exit(0)
 
         logging.debug(f"Sending request: {sys.argv[3]}")

--- a/SCons/Tool/ninja/ninja_scons_daemon.py
+++ b/SCons/Tool/ninja/ninja_scons_daemon.py
@@ -225,7 +225,7 @@ def daemon_thread_func():
                     with building_cv:
                         shared_state.finished_building += [building_node]
                     daemon_ready = False
-                    daemon_needs_to_shutdown = True
+                    shared_state.daemon_needs_to_shutdown = True
                     break
 
                 else:

--- a/SCons/Tool/ninja/ninja_scons_daemon.py
+++ b/SCons/Tool/ninja/ninja_scons_daemon.py
@@ -168,6 +168,7 @@ def daemon_thread_func():
         te.start()
 
         daemon_ready = False
+        
         building_node = None
         startup_complete = False
 
@@ -218,12 +219,14 @@ def daemon_thread_func():
                 except queue.Empty:
                     break
                 if "exit" in building_node:
+                    daemon_log("input: " + "exit")
                     p.stdin.write("exit\n".encode("utf-8"))
                     p.stdin.flush()
                     with building_cv:
                         shared_state.finished_building += [building_node]
                     daemon_ready = False
-                    raise
+                    daemon_needs_to_shutdown = True
+                    break
 
                 else:
                     input_command = "build " + building_node + "\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ rst2pdf
 ninja
 
 # Needed for test/Parallel/failed-build/failed-build.py
+# Also for test/ninja/shutdown_scons_daemon.py
 psutil

--- a/test/ninja/shutdown_scons_daemon.py
+++ b/test/ninja/shutdown_scons_daemon.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import os
+import psutil
+from timeit import default_timer as timer
+
+import TestSCons
+from TestCmd import IS_WINDOWS
+
+test = TestSCons.TestSCons()
+
+try:
+    import ninja
+except ImportError:
+    test.skip_test("Could not find module in python")
+
+_python_ = TestSCons._python_
+_exe = TestSCons._exe
+
+ninja_bin = os.path.abspath(
+    os.path.join(ninja.__file__, os.pardir, "data", "bin", "ninja" + _exe)
+)
+
+test.dir_fixture("ninja-fixture")
+
+test.file_fixture(
+    "ninja_test_sconscripts/sconstruct_force_scons_callback", "SConstruct"
+)
+
+test.run(stdout=None)
+pid = None
+test.must_exist(test.workpath('.ninja/scons_daemon_dirty'))
+with open(test.workpath('.ninja/scons_daemon_dirty')) as f:
+    pid = int(f.read())
+    if pid not in [proc.pid for proc in psutil.process_iter()]:
+        test.fail_test(message="daemon not running!")
+
+program = test.workpath("run_ninja_env.bat") if IS_WINDOWS else ninja_bin
+test.run(program=program, arguments='shutdown-ninja-scons-daemon', stdout=None)
+
+wait_time = 10
+start_time = timer()
+while True:
+    if wait_time > (timer() - start_time):
+        if pid not in [proc.pid for proc in psutil.process_iter()]:
+            break
+    else:
+        test.fail_test(message=f"daemon still not shutdown after {wait_time} seconds.")
+
+test.must_not_exist(test.workpath('.ninja/scons_daemon_dirty'))
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/ninja/shutdown_scons_daemon.py
+++ b/test/ninja/shutdown_scons_daemon.py
@@ -28,6 +28,8 @@ from timeit import default_timer as timer
 import TestSCons
 from TestCmd import IS_WINDOWS
 
+test = TestSCons.TestSCons()
+
 try:
     import ninja
 except ImportError:
@@ -38,7 +40,6 @@ try:
 except ImportError:
     test.skip_test("Could not find psutil module in python")
 
-test = TestSCons.TestSCons()
 
 _python_ = TestSCons._python_
 _exe = TestSCons._exe

--- a/test/ninja/shutdown_scons_daemon.py
+++ b/test/ninja/shutdown_scons_daemon.py
@@ -23,18 +23,22 @@
 #
 
 import os
-import psutil
 from timeit import default_timer as timer
 
 import TestSCons
 from TestCmd import IS_WINDOWS
 
-test = TestSCons.TestSCons()
-
 try:
     import ninja
 except ImportError:
-    test.skip_test("Could not find module in python")
+    test.skip_test("Could not find ninja module in python")
+
+try:
+    import psutil
+except ImportError:
+    test.skip_test("Could not find psutil module in python")
+
+test = TestSCons.TestSCons()
 
 _python_ = TestSCons._python_
 _exe = TestSCons._exe

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -400,7 +400,7 @@ def clean_up_ninja_daemon(self, result_type):
             pidfiles = [daemon_dir / 'pidfile', path / 'scons_daemon_dirty']
             for pidfile in pidfiles:
                 if pidfile.exists():
-                    with open(daemon_dir / 'pidfile') as f:
+                    with open(pidfile) as f:
                         try:
                             pid = int(f.read())
                             os.kill(pid, signal.SIGINT)

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -399,7 +399,7 @@ def clean_up_ninja_daemon(self, result_type):
                         try:
                             pid = int(f.read())
                             os.kill(pid, signal.SIGINT)
-                        except  OSError:
+                        except OSError:
                             pass
                     
                         while True:

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -386,7 +386,12 @@ def _caller(tblist, skip):
         atfrom = "\tfrom"
     return string
 
+
 def clean_up_ninja_daemon(self, result_type):
+    """
+    Kill any running scons daemon started by ninja and clean up it's working dir and
+    temp files.
+    """
     if self:
         for path in Path(self.workdir).rglob('.ninja'):
             daemon_dir = Path(tempfile.gettempdir()) / (
@@ -411,6 +416,7 @@ def clean_up_ninja_daemon(self, result_type):
             if not self._preserve[result_type]:
                 if daemon_dir.exists():
                     shutil.rmtree(daemon_dir)
+
 
 def fail_test(self=None, condition=True, function=None, skip=0, message=None):
     """Causes a test to exit with a fail.


### PR DESCRIPTION
Added a new alias for users to be able to shutdown the daemon gracefully on command. Also added clean up abilities to test framework to shutdown all daemons and remove scons daemon log directories if preserve is not set.


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
