### PR TITLE
find_program_path() can now add discovered path

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -184,6 +184,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       that link has been modified (issue #3880)
     - Modernize a few tests that use now-deprecated unittest.getTestCaseNames
       and unittest.makeSuite - Python itself suggests the replacements.
+    - SCons.Tool.find_program_path now takes an optional add_path argument
+      to add a path to the execution environment if it was discovered in
+      default_paths. Previously, the routine, called by many tool modules,
+      never altered the execution environment, leaving it to the tools.
 
   From Zhichang Yu:
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.

--- a/SCons/Tool/ToolTests.py
+++ b/SCons/Tool/ToolTests.py
@@ -1,5 +1,6 @@
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,9 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 import unittest
@@ -99,20 +97,23 @@ class ToolTestCase(unittest.TestCase):
 
 
     def test_pathfind(self):
-        """Test that find_program_path() does not alter PATH"""
+        """Test that find_program_path() alters PATH only if add_path is true"""
 
         env = DummyEnvironment()
         PHONY_PATHS = [
             r'C:\cygwin64\bin',
             r'C:\cygwin\bin',
             '/usr/local/dummy/bin',
-            env.PHONY_PATH,     # will be recognized by dummy WhereIs
+            env.PHONY_PATH,  # will be recognized by dummy WhereIs
         ]
         env['ENV'] = {}
         env['ENV']['PATH'] = '/usr/local/bin:/opt/bin:/bin:/usr/bin'
         pre_path = env['ENV']['PATH']
         _ = SCons.Tool.find_program_path(env, 'no_tool', default_paths=PHONY_PATHS)
         assert env['ENV']['PATH'] == pre_path, env['ENV']['PATH']
+
+        _ = SCons.Tool.find_program_path(env, 'no_tool', default_paths=PHONY_PATHS, add_path=True)
+        assert env.PHONY_PATH in env['ENV']['PATH'], env['ENV']['PATH']
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Many tools contain a stanza like this, usually for the Windows case, where installed programs are rarely added to the "standard" path in SCons' execution environment (i.e. `env['ENV']["PATH']`):
```python
    javac = SCons.Tool.find_program_path(env, 'javac', default_paths=paths)
    if javac:
        javac_bin_dir = os.path.dirname(javac)
        env.AppendENVPath('PATH', javac_bin_dir)
```

This change adds a keyword argument `add_path` to `find_program_path()` to instruct it to add the path a program was discovered in, if it was in the extra paths passed in. The default is False, retaining the existing behavior.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
