### PR TITLE
Test Framework tests: Windows fixes

### DIFF
--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -243,7 +243,7 @@ import atexit
 import sys
 import TestCmd
 
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 
 @atexit.register
 def cleanup():
@@ -415,7 +415,7 @@ class diff_TestCase(TestCmdTestCase):
     def test_diff_custom_function(self):
         """Test diff() using a custom function"""
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 def my_diff(a, b):
     return [
@@ -440,7 +440,7 @@ STDOUT==========================================================================
 
     def test_diff_string(self):
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff = 'diff_re')
 test.diff("a\\nb1\\nc\\n", "a\\nb2\\nc\\n", 'STDOUT')
@@ -457,7 +457,7 @@ STDOUT==========================================================================
     def test_error(self):
         """Test handling a compilation error in TestCmd.diff_re()"""
         script_input = """import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 assert TestCmd.diff_re([r"a.*(e"], ["abcde"])
 sys.exit(0)
@@ -472,7 +472,7 @@ sys.exit(0)
     def test_simple_diff_static_method(self):
         """Test calling the TestCmd.TestCmd.simple_diff() static method"""
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.simple_diff(['a', 'b', 'c', 'e', 'f1'],
                                      ['a', 'c', 'd', 'e', 'f2'])
@@ -485,7 +485,7 @@ sys.exit(0)
     def test_context_diff_static_method(self):
         """Test calling the TestCmd.TestCmd.context_diff() static method"""
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.context_diff(['a\\n', 'b\\n', 'c\\n', 'e\\n', 'f1\\n'],
                                       ['a\\n', 'c\\n', 'd\\n', 'e\\n', 'f2\\n'])
@@ -514,7 +514,7 @@ sys.exit(0)
     def test_unified_diff_static_method(self):
         """Test calling the TestCmd.TestCmd.unified_diff() static method"""
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.unified_diff(['a\\n', 'b\\n', 'c\\n', 'e\\n', 'f1\\n'],
                                       ['a\\n', 'c\\n', 'd\\n', 'e\\n', 'f2\\n'])
@@ -538,7 +538,7 @@ sys.exit(0)
     def test_diff_re_static_method(self):
         """Test calling the TestCmd.TestCmd.diff_re() static method"""
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 result = TestCmd.TestCmd.diff_re(['a', 'b', 'c', '.', 'f1'],
                                  ['a', 'c', 'd', 'e', 'f2'])
@@ -567,7 +567,7 @@ class diff_stderr_TestCase(TestCmdTestCase):
     def test_diff_stderr_default(self):
         """Test diff_stderr() default behavior"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd()
 test.diff_stderr('a\nb1\nc\n', 'a\nb2\nc\n')
@@ -584,7 +584,7 @@ sys.exit(0)
         """Test diff_stderr() not affecting diff_stdout() behavior"""
         self.popen_python(r"""
 import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stderr='diff_re')
 print("diff_stderr:")
@@ -605,7 +605,7 @@ diff_stdout:
     def test_diff_stderr_custom_function(self):
         """Test diff_stderr() using a custom function"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 def my_diff(a, b):
     return ["a:"] + a + ["b:"] + b
@@ -623,7 +623,7 @@ def
     def test_diff_stderr_TestCmd_function(self):
         """Test diff_stderr() using a TestCmd function"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stderr = TestCmd.diff_re)
 test.diff_stderr('a\n.\n', 'b\nc\n')
@@ -639,7 +639,7 @@ sys.exit(0)
     def test_diff_stderr_static_method(self):
         """Test diff_stderr() using a static method"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stderr=TestCmd.TestCmd.diff_re)
 test.diff_stderr('a\n.\n', 'b\nc\n')
@@ -655,7 +655,7 @@ sys.exit(0)
     def test_diff_stderr_string(self):
         """Test diff_stderr() using a string to fetch the diff method"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stderr='diff_re')
 test.diff_stderr('a\n.\n', 'b\nc\n')
@@ -674,7 +674,7 @@ class diff_stdout_TestCase(TestCmdTestCase):
     def test_diff_stdout_default(self):
         """Test diff_stdout() default behavior"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd()
 test.diff_stdout('a\nb1\nc\n', 'a\nb2\nc\n')
@@ -691,7 +691,7 @@ sys.exit(0)
         """Test diff_stdout() not affecting diff_stderr() behavior"""
         self.popen_python(r"""
 import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stdout='diff_re')
 print("diff_stdout:")
@@ -712,7 +712,7 @@ diff_stderr:
     def test_diff_stdout_custom_function(self):
         """Test diff_stdout() using a custom function"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 def my_diff(a, b):
     return ["a:"] + a + ["b:"] + b
@@ -730,7 +730,7 @@ def
     def test_diff_stdout_TestCmd_function(self):
         """Test diff_stdout() using a TestCmd function"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stdout = TestCmd.diff_re)
 test.diff_stdout('a\n.\n', 'b\nc\n')
@@ -746,7 +746,7 @@ sys.exit(0)
     def test_diff_stdout_static_method(self):
         """Test diff_stdout() using a static method"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stdout=TestCmd.TestCmd.diff_re)
 test.diff_stdout('a\n.\n', 'b\nc\n')
@@ -762,7 +762,7 @@ sys.exit(0)
     def test_diff_stdout_string(self):
         """Test diff_stdout() using a string to fetch the diff method"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(diff_stdout='diff_re')
 test.diff_stdout('a\n.\n', 'b\nc\n')
@@ -788,7 +788,7 @@ class exit_TestCase(TestCmdTestCase):
                              'no_result': "NO RESULT for test at line 5 of <stdin>\n"}
             global ExitError
             input = """import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(workdir = '%s')
 test.%s()
@@ -863,13 +863,13 @@ sys.stderr.write("run:  STDERR\\n")
         # Everything before this prepared our "source directory."
         # Now do the real test.
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 TestCmd.fail_test(condition = 1)
 """ % self.orig_cwd, status = 1, stderr = "FAILED test at line 4 of <stdin>\n")
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = '')
 test.run()
@@ -877,7 +877,7 @@ test.fail_test(condition = (test.status == 0))
 """ % self.orig_cwd, status = 1, stderr = "FAILED test of %s\n\tat line 6 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', description = 'xyzzy', workdir = '')
 test.run()
@@ -885,7 +885,7 @@ test.fail_test(condition = (test.status == 0))
 """ % self.orig_cwd, status = 1, stderr = "FAILED test of %s [xyzzy]\n\tat line 6 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = '')
 test.run()
@@ -895,7 +895,7 @@ test.fail_test(condition = (test.status == 0), function = xxx)
 """ % self.orig_cwd, status = 1, stderr = "printed on failure\nFAILED test of %s\n\tat line 8 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 def test1(self):
     self.run()
@@ -906,7 +906,7 @@ test2(TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = ''))
 """ % self.orig_cwd, status = 1, stderr = "FAILED test of %s\n\tat line 6 of <stdin> (test1)\n\tfrom line 8 of <stdin> (test2)\n\tfrom line 9 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 def test1(self):
     self.run()
@@ -1063,7 +1063,7 @@ class match_re_dotall_TestCase(TestCmdTestCase):
         # Now do the real test.
         try:
             script_input = """import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 assert TestCmd.match_re_dotall("abcde", r"a.*(e")
 sys.exit(0)
@@ -1136,7 +1136,7 @@ class match_re_TestCase(TestCmdTestCase):
         # Now do the real test.
         try:
             script_input = """import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 assert TestCmd.match_re("abcde\\n", "a.*(e\\n")
 sys.exit(0)
@@ -1346,13 +1346,13 @@ sys.stderr.write("run:  STDERR\\n")
         # Everything before this prepared our "source directory."
         # Now do the real test.
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 TestCmd.no_result(condition = 1)
 """ % self.orig_cwd, status = 2, stderr = "NO RESULT for test at line 4 of <stdin>\n")
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = '')
 test.run()
@@ -1360,7 +1360,7 @@ test.no_result(condition = (test.status == 0))
 """ % self.orig_cwd, status = 2, stderr = "NO RESULT for test of %s\n\tat line 6 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', description = 'xyzzy', workdir = '')
 test.run()
@@ -1368,7 +1368,7 @@ test.no_result(condition = (test.status == 0))
 """ % self.orig_cwd, status = 2, stderr = "NO RESULT for test of %s [xyzzy]\n\tat line 6 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = '')
 test.run()
@@ -1378,7 +1378,7 @@ test.no_result(condition = (test.status == 0), function = xxx)
 """ % self.orig_cwd, status = 2, stderr = "printed on no result\nNO RESULT for test of %s\n\tat line 8 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 def test1(self):
     self.run()
@@ -1389,7 +1389,7 @@ test2(TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = ''))
 """ % self.orig_cwd, status = 2, stderr = "NO RESULT for test of %s\n\tat line 6 of <stdin> (test1)\n\tfrom line 8 of <stdin> (test2)\n\tfrom line 9 of <stdin>\n" % run_env.workpath('run'))
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 def test1(self):
     self.run()
@@ -1413,13 +1413,13 @@ sys.stderr.write("run:  STDERR\\n")
         # Everything before this prepared our "source directory."
         # Now do the real test.
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 TestCmd.pass_test(condition = 1)
 """ % self.orig_cwd, stderr = "PASSED\n")
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = '')
 test.run()
@@ -1427,7 +1427,7 @@ test.pass_test(condition = (test.status == 0))
 """ % self.orig_cwd, stderr = "PASSED\n")
 
         self.popen_python("""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd(program = 'run', interpreter = 'python', workdir = '')
 test.run()
@@ -2051,7 +2051,7 @@ class set_diff_function_TestCase(TestCmdTestCase):
     def test_set_diff_function(self):
         """Test set_diff_function()"""
         self.popen_python(r"""import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd()
 test.diff("a\n", "a\n")
@@ -2064,7 +2064,7 @@ sys.exit(0)
         """Test set_diff_function():  stdout"""
         self.popen_python("""\
 import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd()
 print("diff:")
@@ -2093,7 +2093,7 @@ diff_stdout:
         """Test set_diff_function():  stderr """
         self.popen_python("""\
 import sys
-sys.path = ['%s'] + sys.path
+sys.path = [r'%s'] + sys.path
 import TestCmd
 test = TestCmd.TestCmd()
 print("diff:")

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -1840,7 +1840,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_exact)
         tc.run(arguments = "arg1 arg2 arg3",
@@ -1868,7 +1868,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(fail_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run()
         """)
@@ -1897,7 +1897,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(stderr_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run()
         """)
@@ -1929,8 +1929,8 @@ class run_TestCase(TestCommonTestCase):
         def raise_exception(*args, **kw):
             raise TypeError("forced TypeError")
         TestCmd.TestCmd.start = raise_exception
-        tc = TestCommon(program='%(pass_script)s',
-                        interpreter='%(python)s',
+        tc = TestCommon(program=r'%(pass_script)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run()
         """)
@@ -1966,7 +1966,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(stderr_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run(stderr = None)
         """)
@@ -1980,7 +1980,7 @@ class run_TestCase(TestCommonTestCase):
         def my_match_exact(actual, expect): return actual == expect
         from TestCommon import TestCommon, match_re_dotall
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_re_dotall)
         tc.run(arguments = "arg1 arg2 arg3",
@@ -1997,7 +1997,7 @@ class run_TestCase(TestCommonTestCase):
         def my_match_exact(actual, expect): return actual == expect
         from TestCommon import TestCommon, match_re_dotall
         tc = TestCommon(program=r'%(stderr_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_re_dotall)
         tc.run(arguments = "arg1 arg2 arg3",
@@ -2013,7 +2013,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(fail_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run(status = 1)
         """)
@@ -2026,7 +2026,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_exact)
         tc.run(stdout = r"%(pass_script)s:  STDOUT:  []" + "\\n")
@@ -2040,7 +2040,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(stderr_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_exact)
         tc.run(stderr = r"%(stderr_script)s:  STDERR:  []" + "\\n")
@@ -2054,7 +2054,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run(status = 1)
         """)
@@ -2084,7 +2084,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(fail_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run(status = 2)
         """)
@@ -2114,7 +2114,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run(stdout = "Not found\\n")
         """)
@@ -2146,7 +2146,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(stderr_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run(stderr = "Not found\\n")
         """)
@@ -2180,7 +2180,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_exact)
         tc.run(options = "opt1 opt2 opt3",
@@ -2195,7 +2195,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_exact)
         tc.run(options = "opt1 opt2 opt3",
@@ -2217,7 +2217,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon
         tc = TestCommon(program=r'%(signal_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='')
         tc.run()
         """)
@@ -2249,7 +2249,7 @@ class run_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(stdin_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir='',
                         match=match_exact)
         expect_stdout = r"%(stdin_script)s:  STDOUT:  'input'" + "\\n"
@@ -2277,7 +2277,7 @@ class start_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_exact)
         p = tc.start(options = "opt1 opt2 opt3")
@@ -2293,7 +2293,7 @@ class start_TestCase(TestCommonTestCase):
         script = lstrip("""\
         from TestCommon import TestCommon, match_exact
         tc = TestCommon(program=r'%(pass_script)s',
-                        interpreter='%(python)s',
+                        interpreter=r'%(python)s',
                         workdir="",
                         match=match_exact)
         p = tc.start(options = "opt1 opt2 opt3",


### PR DESCRIPTION
Where string pasting is done using test or interpreter paths, make sure they're pasted as raw strings to avoid problems on the Windows platform, where the likely presence of `'\Users'` is likely to cause a unicode error.

Note the framework tests aren't normally run by the CI.


Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
