### PR TITLE
Fortran variants now include FORTRANCOMMONFLAGS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -194,6 +194,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       to add a path to the execution environment if it was discovered in
       default_paths. Previously, the routine, called by many tool modules,
       never altered the execution environment, leaving it to the tools.
+    - A new construction variable FORTRANCOMMONFLAGS is added which is
+      applied to all Fortran dialects, in case someone needs to set some
+      flags globally. FORTRANFLAGS looked like it was intended for that,
+      but was not applied to other dialects, and e2e tests explicitly checked
+      that FORTRANFLAGS did not propagate outside the FORTRAN dialect,
+      so the conclusion is that behavior is intentional (issue #2257)
 
   From Zhichang Yu:
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -43,6 +43,8 @@ NEW FUNCTIONALITY
   is taken and the constructed environment is likely incomplete.  As implemented, the default
   global policy is "warning".  The ability to set the global policy via an SCons command-line
   option may be added in a future enhancement.
+- Fortran: a new construction variable FORTRANCOMMONFLAGS is added which is
+  applied to all Fortran dialects, to enable global (all-dialect) settings.
 
 
 DEPRECATED FUNCTIONALITY

--- a/SCons/Tool/FortranCommon.py
+++ b/SCons/Tool/FortranCommon.py
@@ -171,15 +171,15 @@ def DialectAddToEnv(env, dialect, suffixes, ppsuffixes, support_mods=False) -> N
     env[f'_{dialect}INCFLAGS'] = f'${{_concat(INC{dialect}PREFIX, {dialect}PATH, INC{dialect}SUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}}'
 
     if support_mods:
-        env[f'{dialect}COM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXX{dialect}'
-        env[f'{dialect}PPCOM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXXPP{dialect}'
-        env[f'SH{dialect}COM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXX{dialect}'
-        env[f'SH{dialect}PPCOM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXXPP{dialect}'
+        env[f'{dialect}COM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES'
+        env[f'{dialect}PPCOM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES'
+        env[f'SH{dialect}COM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES'
+        env[f'SH{dialect}PPCOM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES'
     else:
-        env[f'{dialect}COM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $_{dialect}INCFLAGS $SOURCES #XXX{dialect}'
-        env[f'{dialect}PPCOM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $SOURCES #XXXPP{dialect}'
-        env[f'SH{dialect}COM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $_{dialect}INCFLAGS $SOURCES #XXX{dialect}'
-        env[f'SH{dialect}PPCOM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $SOURCES #XXXPP{dialect}'
+        env[f'{dialect}COM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $_{dialect}INCFLAGS $SOURCES'
+        env[f'{dialect}PPCOM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $SOURCES'
+        env[f'SH{dialect}COM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $_{dialect}INCFLAGS $SOURCES'
+        env[f'SH{dialect}PPCOM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $SOURCES'
 
 
 def add_fortran_to_env(env) -> None:

--- a/SCons/Tool/FortranCommon.py
+++ b/SCons/Tool/FortranCommon.py
@@ -21,43 +21,48 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""
-
-Stuff for processing Fortran, common to all fortran dialects.
-
-"""
+"""Routines for setting up Fortran, common to all dialects."""
 
 import re
 import os.path
+from typing import Tuple
 
-import SCons.Action
 import SCons.Scanner.Fortran
 import SCons.Tool
 import SCons.Util
+from SCons.Action import Action
 
 
-def isfortran(env, source):
-    """Return 1 if any of code in source has fortran files in it, 0
-    otherwise."""
+def isfortran(env, source) -> bool:
+    """Returns True if source has any fortran files in it.
+
+    Only checks based on filename suffixes, does not examine code.
+    """
     try:
         fsuffixes = env['FORTRANSUFFIXES']
     except KeyError:
         # If no FORTRANSUFFIXES, no fortran tool, so there is no need to look
         # for fortran sources.
-        return 0
+        return False
 
     if not source:
         # Source might be None for unusual cases like SConf.
-        return 0
+        return False
     for s in source:
         if s.sources:
             ext = os.path.splitext(str(s.sources[0]))[1]
             if ext in fsuffixes:
-                return 1
-    return 0
+                return True
+    return False
 
 
-def _fortranEmitter(target, source, env):
+def _fortranEmitter(target, source, env) -> Tuple:
+    """Common code for Fortran emitter.
+
+    Called by both the static and shared object emitters,
+    mainly to account for generated module files.
+    """
+
     node = source[0].rfile()
     if not node.exists() and not node.is_derived():
        print("Could not locate " + str(node.name))
@@ -78,21 +83,29 @@ def _fortranEmitter(target, source, env):
     return (target, source)
 
 
-def FortranEmitter(target, source, env):
+def FortranEmitter(target, source, env) -> Tuple:
     import SCons.Defaults
     target, source = _fortranEmitter(target, source, env)
     return SCons.Defaults.StaticObjectEmitter(target, source, env)
 
 
-def ShFortranEmitter(target, source, env):
+def ShFortranEmitter(target, source, env) -> Tuple:
     import SCons.Defaults
     target, source = _fortranEmitter(target, source, env)
     return SCons.Defaults.SharedObjectEmitter(target, source, env)
 
 
-def ComputeFortranSuffixes(suffixes, ppsuffixes):
-    """suffixes are fortran source files, and ppsuffixes the ones to be
-    pre-processed. Both should be sequences, not strings."""
+def ComputeFortranSuffixes(suffixes, ppsuffixes) -> None:
+    """Update the suffix lists to reflect the platform requirements.
+
+    If upper-cased suffixes can be distinguished from lower, those are
+    added to *ppsuffixes*. If not, they are added to *suffixes*.
+
+    Args:
+        suffixes (list): indicate regular Fortran source files
+        ppsuffixes (list): indicate Fortran source files that should be
+          be run through the pre-processor
+    """
     assert len(suffixes) > 0
     s = suffixes[0]
     sup = s.upper()
@@ -102,31 +115,34 @@ def ComputeFortranSuffixes(suffixes, ppsuffixes):
     else:
         suffixes.extend(upper_suffixes)
 
-
-def CreateDialectActions(dialect):
+def CreateDialectActions(dialect) -> Tuple[Action, Action, Action, Action]:
     """Create dialect specific actions."""
-    CompAction = SCons.Action.Action('$%sCOM ' % dialect, '$%sCOMSTR' % dialect)
-    CompPPAction = SCons.Action.Action('$%sPPCOM ' % dialect, '$%sPPCOMSTR' % dialect)
-    ShCompAction = SCons.Action.Action('$SH%sCOM ' % dialect, '$SH%sCOMSTR' % dialect)
-    ShCompPPAction = SCons.Action.Action('$SH%sPPCOM ' % dialect, '$SH%sPPCOMSTR' % dialect)
-
+    CompAction = Action(f'${dialect}COM ', cmdstr=f'${dialect}COMSTR')
+    CompPPAction = Action(f'${dialect}PPCOM ', cmdstr=f'${dialect}PPCOMSTR')
+    ShCompAction = Action(f'$SH{dialect}COM ', cmdstr=f'$SH{dialect}COMSTR')
+    ShCompPPAction = Action(f'$SH{dialect}PPCOM ', cmdstr=f'$SH{dialect}PPCOMSTR')
     return CompAction, CompPPAction, ShCompAction, ShCompPPAction
 
 
-def DialectAddToEnv(env, dialect, suffixes, ppsuffixes, support_module=False):
-    """Add dialect specific construction variables."""
+def DialectAddToEnv(env, dialect, suffixes, ppsuffixes, support_mods=False) -> None:
+    """Add dialect specific construction variables.
+
+    Args:
+        dialect (str): dialect name
+        suffixes (list): suffixes associated with this dialect
+        ppsuffixes (list): suffixes using cpp associated with this dialect
+        support_mods (bool): whether this dialect supports modules
+    """
     ComputeFortranSuffixes(suffixes, ppsuffixes)
 
-    fscan = SCons.Scanner.Fortran.FortranScan("%sPATH" % dialect)
-
+    fscan = SCons.Scanner.Fortran.FortranScan(f"{dialect}PATH")
     for suffix in suffixes + ppsuffixes:
         SCons.Tool.SourceFileScanner.add_scanner(suffix, fscan)
 
-    env.AppendUnique(FORTRANSUFFIXES = suffixes + ppsuffixes)
+    env.AppendUnique(FORTRANSUFFIXES=suffixes + ppsuffixes)
 
     compaction, compppaction, shcompaction, shcompppaction = \
             CreateDialectActions(dialect)
-
     static_obj, shared_obj = SCons.Tool.createObjBuilders(env)
 
     for suffix in suffixes:
@@ -141,64 +157,60 @@ def DialectAddToEnv(env, dialect, suffixes, ppsuffixes, support_module=False):
         static_obj.add_emitter(suffix, FortranEmitter)
         shared_obj.add_emitter(suffix, ShFortranEmitter)
 
-    if '%sFLAGS' % dialect not in env:
-        env['%sFLAGS' % dialect] = SCons.Util.CLVar('')
-
-    if 'SH%sFLAGS' % dialect not in env:
-        env['SH%sFLAGS' % dialect] = SCons.Util.CLVar('$%sFLAGS' % dialect)
+    if f'{dialect}FLAGS' not in env:
+        env[f'{dialect}FLAGS'] = SCons.Util.CLVar('')
+    if f'SH{dialect}FLAGS' not in env:
+        env[f'SH{dialect}FLAGS'] = SCons.Util.CLVar(f'${dialect}FLAGS')
 
     # If a tool does not define fortran prefix/suffix for include path, use C ones
-    if 'INC%sPREFIX' % dialect not in env:
-        env['INC%sPREFIX' % dialect] = '$INCPREFIX'
+    if f'INC{dialect}PREFIX' not in env:
+        env[f'INC{dialect}PREFIX'] = '$INCPREFIX'
+    if f'INC{dialect}SUFFIX' not in env:
+        env[f'INC{dialect}SUFFIX'] = '$INCSUFFIX'
 
-    if 'INC%sSUFFIX' % dialect not in env:
-        env['INC%sSUFFIX' % dialect] = '$INCSUFFIX'
+    env[f'_{dialect}INCFLAGS'] = f'${{_concat(INC{dialect}PREFIX, {dialect}PATH, INC{dialect}SUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}}'
 
-    env['_%sINCFLAGS' % dialect] = '${_concat(INC%sPREFIX, %sPATH, INC%sSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}' % (dialect, dialect, dialect)
-
-    if support_module:
-        env['%sCOM' % dialect]     = '$%s -o $TARGET -c $%sFLAGS $_%sINCFLAGS $_FORTRANMODFLAG $SOURCES' % (dialect, dialect, dialect)
-        env['%sPPCOM' % dialect]   = '$%s -o $TARGET -c $%sFLAGS $CPPFLAGS $_CPPDEFFLAGS $_%sINCFLAGS $_FORTRANMODFLAG $SOURCES' % (dialect, dialect, dialect)
-        env['SH%sCOM' % dialect]    = '$SH%s -o $TARGET -c $SH%sFLAGS $_%sINCFLAGS $_FORTRANMODFLAG $SOURCES' % (dialect, dialect, dialect)
-        env['SH%sPPCOM' % dialect]  = '$SH%s -o $TARGET -c $SH%sFLAGS $CPPFLAGS $_CPPDEFFLAGS $_%sINCFLAGS $_FORTRANMODFLAG $SOURCES' % (dialect, dialect, dialect)
+    if support_mods:
+        env[f'{dialect}COM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXX{dialect}'
+        env[f'{dialect}PPCOM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXXPP{dialect}'
+        env[f'SH{dialect}COM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXX{dialect}'
+        env[f'SH{dialect}PPCOM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $_FORTRANMODFLAG $SOURCES #XXXPP{dialect}'
     else:
-        env['%sCOM' % dialect]     = '$%s -o $TARGET -c $%sFLAGS $_%sINCFLAGS $SOURCES' % (dialect, dialect, dialect)
-        env['%sPPCOM' % dialect]   = '$%s -o $TARGET -c $%sFLAGS $CPPFLAGS $_CPPDEFFLAGS $_%sINCFLAGS $SOURCES' % (dialect, dialect, dialect)
-        env['SH%sCOM' % dialect]    = '$SH%s -o $TARGET -c $SH%sFLAGS $_%sINCFLAGS $SOURCES' % (dialect, dialect, dialect)
-        env['SH%sPPCOM' % dialect]  = '$SH%s -o $TARGET -c $SH%sFLAGS $CPPFLAGS $_CPPDEFFLAGS $_%sINCFLAGS $SOURCES' % (dialect, dialect, dialect)
+        env[f'{dialect}COM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $_{dialect}INCFLAGS $SOURCES #XXX{dialect}'
+        env[f'{dialect}PPCOM'] = f'${dialect} -o $TARGET -c $FORTRANCOMMONFLAGS ${dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $SOURCES #XXXPP{dialect}'
+        env[f'SH{dialect}COM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $_{dialect}INCFLAGS $SOURCES #XXX{dialect}'
+        env[f'SH{dialect}PPCOM'] = f'$SH{dialect} -o $TARGET -c $FORTRANCOMMONFLAGS $SH{dialect}FLAGS $CPPFLAGS $_CPPDEFFLAGS $_{dialect}INCFLAGS $SOURCES #XXXPP{dialect}'
 
-def add_fortran_to_env(env):
-    """Add Builders and construction variables for Fortran to an Environment."""
+
+def add_fortran_to_env(env) -> None:
+    """Add Builders and construction variables for Fortran/generic."""
     try:
         FortranSuffixes = env['FORTRANFILESUFFIXES']
     except KeyError:
         FortranSuffixes = ['.f', '.for', '.ftn']
 
-    #print("Adding %s to fortran suffixes" % FortranSuffixes)
     try:
         FortranPPSuffixes = env['FORTRANPPFILESUFFIXES']
     except KeyError:
         FortranPPSuffixes = ['.fpp', '.FPP']
 
-    DialectAddToEnv(env, "FORTRAN", FortranSuffixes,
-                    FortranPPSuffixes, support_module=True)
+    DialectAddToEnv(env, "FORTRAN", FortranSuffixes, FortranPPSuffixes, support_mods=True)
 
+    # Module support
     env['FORTRANMODPREFIX'] = ''     # like $LIBPREFIX
     env['FORTRANMODSUFFIX'] = '.mod' # like $LIBSUFFIX
-
     env['FORTRANMODDIR'] = ''          # where the compiler should place .mod files
     env['FORTRANMODDIRPREFIX'] = ''    # some prefix to $FORTRANMODDIR - similar to $INCPREFIX
     env['FORTRANMODDIRSUFFIX'] = ''    # some suffix to $FORTRANMODDIR - similar to $INCSUFFIX
     env['_FORTRANMODFLAG'] = '$( ${_concat(FORTRANMODDIRPREFIX, FORTRANMODDIR, FORTRANMODDIRSUFFIX, __env__, RDirs, TARGET, SOURCE)} $)'
 
-def add_f77_to_env(env):
-    """Add Builders and construction variables for f77 to an Environment."""
+def add_f77_to_env(env) -> None:
+    """Add Builders and construction variables for f77 dialect."""
     try:
         F77Suffixes = env['F77FILESUFFIXES']
     except KeyError:
         F77Suffixes = ['.f77']
 
-    #print("Adding %s to f77 suffixes" % F77Suffixes)
     try:
         F77PPSuffixes = env['F77PPFILESUFFIXES']
     except KeyError:
@@ -206,59 +218,50 @@ def add_f77_to_env(env):
 
     DialectAddToEnv(env, "F77", F77Suffixes, F77PPSuffixes)
 
-def add_f90_to_env(env):
-    """Add Builders and construction variables for f90 to an Environment."""
+def add_f90_to_env(env) -> None:
+    """Add Builders and construction variables for f90 dialect."""
     try:
         F90Suffixes = env['F90FILESUFFIXES']
     except KeyError:
         F90Suffixes = ['.f90']
 
-    #print("Adding %s to f90 suffixes" % F90Suffixes)
     try:
         F90PPSuffixes = env['F90PPFILESUFFIXES']
     except KeyError:
         F90PPSuffixes = []
 
-    DialectAddToEnv(env, "F90", F90Suffixes, F90PPSuffixes,
-                    support_module=True)
+    DialectAddToEnv(env, "F90", F90Suffixes, F90PPSuffixes, support_mods=True)
 
-
-def add_f95_to_env(env):
-    """Add Builders and construction variables for f95 to an Environment."""
+def add_f95_to_env(env) -> None:
+    """Add Builders and construction variables for f95 dialect."""
     try:
         F95Suffixes = env['F95FILESUFFIXES']
     except KeyError:
         F95Suffixes = ['.f95']
 
-    #print("Adding %s to f95 suffixes" % F95Suffixes)
     try:
         F95PPSuffixes = env['F95PPFILESUFFIXES']
     except KeyError:
         F95PPSuffixes = []
 
-    DialectAddToEnv(env, "F95", F95Suffixes, F95PPSuffixes,
-                    support_module=True)
+    DialectAddToEnv(env, "F95", F95Suffixes, F95PPSuffixes, support_mods=True)
 
-
-def add_f03_to_env(env):
-    """Add Builders and construction variables for f03 to an Environment."""
+def add_f03_to_env(env) -> None:
+    """Add Builders and construction variables for f03 dialect."""
     try:
         F03Suffixes = env['F03FILESUFFIXES']
     except KeyError:
         F03Suffixes = ['.f03']
 
-    #print("Adding %s to f95 suffixes" % F95Suffixes)
     try:
         F03PPSuffixes = env['F03PPFILESUFFIXES']
     except KeyError:
         F03PPSuffixes = []
 
-    DialectAddToEnv(env, "F03", F03Suffixes, F03PPSuffixes,
-                    support_module=True)
+    DialectAddToEnv(env, "F03", F03Suffixes, F03PPSuffixes, support_mods=True)
 
-
-def add_f08_to_env(env):
-    """Add Builders and construction variables for f08 to an Environment."""
+def add_f08_to_env(env) -> None:
+    """Add Builders and construction variables for f08 dialect."""
     try:
         F08Suffixes = env['F08FILESUFFIXES']
     except KeyError:
@@ -269,13 +272,10 @@ def add_f08_to_env(env):
     except KeyError:
         F08PPSuffixes = []
 
-    DialectAddToEnv(env, "F08", F08Suffixes, F08PPSuffixes,
-                    support_module=True)
+    DialectAddToEnv(env, "F08", F08Suffixes, F08PPSuffixes, support_mods=True)
 
-
-def add_all_to_env(env):
-    """Add builders and construction variables for all supported fortran
-    dialects."""
+def add_all_to_env(env) -> None:
+    """Add builders and construction variables for all supported dialects."""
     add_fortran_to_env(env)
     add_f77_to_env(env)
     add_f90_to_env(env)

--- a/SCons/Tool/f03.xml
+++ b/SCons/Tool/f03.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.
@@ -45,6 +45,7 @@ Set construction variables for generic POSIX Fortran 03 compilers.
 <item>F03PPCOMSTR</item>
 <item>SHF03COMSTR</item>
 <item>SHF03PPCOMSTR</item>
+<item>FORTRANCOMMONFLAGS</item>
 </uses>
 </tool>
 
@@ -271,7 +272,7 @@ Options that are passed to the Fortran 03 compiler
 to generated shared-library objects.
 You only need to set &cv-link-SHF03FLAGS; if you need to define specific
 user options for Fortran 03 files.
-You should normally set the &cv-link-SHFORTRANFLAGS; variable,
+You should normally set the &cv-link-FORTRANCOMMONFLAGS; variable,
 which specifies the user-specified options
 passed to the default Fortran compiler
 for all Fortran versions.

--- a/SCons/Tool/f08.xml
+++ b/SCons/Tool/f08.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.
@@ -45,6 +45,7 @@ Set construction variables for generic POSIX Fortran 08 compilers.
 <item>F08PPCOMSTR</item>
 <item>SHF08COMSTR</item>
 <item>SHF08PPCOMSTR</item>
+<item>FORTRANCOMMONFLAGS</item>
 </uses>
 </tool>
 
@@ -271,7 +272,7 @@ Options that are passed to the Fortran 08 compiler
 to generated shared-library objects.
 You only need to set &cv-link-SHF08FLAGS; if you need to define specific
 user options for Fortran 08 files.
-You should normally set the &cv-link-SHFORTRANFLAGS; variable,
+You should normally set the &cv-link-FORTRANCOMMONFLAGS; variable,
 which specifies the user-specified options
 passed to the default Fortran compiler
 for all Fortran versions.

--- a/SCons/Tool/f77.xml
+++ b/SCons/Tool/f77.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.
@@ -58,6 +58,9 @@ Set construction variables for generic POSIX Fortran 77 compilers.
 <item>SHF77PPCOMSTR</item>
 <item>SHFORTRANCOMSTR</item>
 <item>SHFORTRANPPCOMSTR</item>
+<item>FORTRANFLAGS</item>
+<item>FORTRANCOMMONFLAGS</item>
+<item>SHFORTRANFLAGS</item>
 </uses>
 </tool>
 
@@ -284,7 +287,7 @@ Options that are passed to the Fortran 77 compiler
 to generated shared-library objects.
 You only need to set &cv-link-SHF77FLAGS; if you need to define specific
 user options for Fortran 77 files.
-You should normally set the &cv-link-SHFORTRANFLAGS; variable,
+You should normally set the &cv-link-FORTRANCOMMONFLAGS; variable,
 which specifies the user-specified options
 passed to the default Fortran compiler
 for all Fortran versions.

--- a/SCons/Tool/f90.xml
+++ b/SCons/Tool/f90.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.
@@ -45,6 +45,7 @@ Set construction variables for generic POSIX Fortran 90 compilers.
 <item>F90PPCOMSTR</item>
 <item>SHF90COMSTR</item>
 <item>SHF90PPCOMSTR</item>
+<item>FORTRANCOMMONFLAGS</item>
 </uses>
 </tool>
 
@@ -270,7 +271,7 @@ Options that are passed to the Fortran 90 compiler
 to generated shared-library objects.
 You only need to set &cv-link-SHF90FLAGS; if you need to define specific
 user options for Fortran 90 files.
-You should normally set the &cv-link-SHFORTRANFLAGS; variable,
+You should normally set the &cv-link-FORTRANCOMMONFLAGS; variable,
 which specifies the user-specified options
 passed to the default Fortran compiler
 for all Fortran versions.

--- a/SCons/Tool/f95.xml
+++ b/SCons/Tool/f95.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.
@@ -45,6 +45,7 @@ Set construction variables for generic POSIX Fortran 95 compilers.
 <item>F95PPCOMSTR</item>
 <item>SHF95COMSTR</item>
 <item>SHF95PPCOMSTR</item>
+<item>FORTRANCOMMONFLAGS</item>
 </uses>
 </tool>
 
@@ -271,7 +272,7 @@ Options that are passed to the Fortran 95 compiler
 to generated shared-library objects.
 You only need to set &cv-link-SHF95FLAGS; if you need to define specific
 user options for Fortran 95 files.
-You should normally set the &cv-link-SHFORTRANFLAGS; variable,
+You should normally set the &cv-link-FORTRANCOMMONFLAGS; variable,
 which specifies the user-specified options
 passed to the default Fortran compiler
 for all Fortran versions.

--- a/SCons/Tool/fortran.xml
+++ b/SCons/Tool/fortran.xml
@@ -102,7 +102,8 @@ FORTRAN dialect will be used. By default, this is <literal>['.fpp', '.FPP']</lit
 <cvar name="FORTRANFLAGS">
 <summary>
 <para>
-General user-specified options that are passed to the Fortran compiler.
+General user-specified options for the FORTRAN dialect
+that are passed to the Fortran compiler.
 Note that this variable does
 <emphasis>not</emphasis>
 contain
@@ -113,6 +114,16 @@ See
 &cv-link-_FORTRANINCFLAGS; and &cv-link-_FORTRANMODFLAG;,
 below,
 for the variables that expand those options.
+</para>
+</summary>
+</cvar>
+
+<cvar name="FORTRANCOMMONFLAGS">
+<summary>
+<para>
+General user-specified options that are passed to the Fortran compiler.
+Similar to &cv-link-FORTRANFLAGS;,
+but this variable is applied to all dialects.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/g77.py
+++ b/SCons/Tool/g77.py
@@ -22,13 +22,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-
 Tool-specific initialization for g77.
 
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()
 selection method.
-
 """
 
 import SCons.Util

--- a/SCons/Tool/g77.xml
+++ b/SCons/Tool/g77.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.
@@ -27,8 +27,7 @@ See its __doc__ string for a discussion of the format.
 <summary>
 <para>
 Set construction variables for the &g77; Fortran compiler.
-Calls the &t-f77; Tool module
-to set variables.
+Calls the &t-link-f77; Tool module to set variables.
 </para>
 </summary>
 </tool>

--- a/SCons/Tool/g77.xml
+++ b/SCons/Tool/g77.xml
@@ -27,9 +27,31 @@ See its __doc__ string for a discussion of the format.
 <summary>
 <para>
 Set construction variables for the &g77; Fortran compiler.
-Calls the &t-link-f77; Tool module to set variables.
 </para>
 </summary>
+<sets>
+<item>F77</item>
+<item>F77COM</item>
+<item>F77PPCOM</item>
+<item>F77FILESUFFIXES</item>
+<item>F77PPFILESUFFIXES</item>
+<item>FORTRAN</item>
+<item>FORTRANCOM</item>
+<item>FORTRANPPCOM</item>
+<item>SHF77</item>
+<item>SHF77COM</item>
+<item>SHF77PPCOM</item>
+<item>SHF77FLAGS</item>
+<item>SHFORTRAN</item>
+<item>SHFORTRANCOM</item>
+<item>SHFORTRANPPCOM</item>
+<item>SHFORTRANFLAGS</item>
+</sets>
+<uses>
+<item>F77FLAGS</item>
+<item>FORTRANFLAGS</item>
+<item>FORTRANCOMMONFLAGS</item>
+</uses>
 </tool>
 
 </sconsdoc>

--- a/SCons/Tool/gfortran.py
+++ b/SCons/Tool/gfortran.py
@@ -22,16 +22,12 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-
-Tool-specific initialization for gfortran, the GNU Fortran 95/Fortran
-2003 compiler.
+Tool-specific initialization for gfortran, the GNU Fortran compiler.
 
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()
 selection method.
-
 """
-
 
 import SCons.Util
 
@@ -44,15 +40,15 @@ def generate(env):
     fortran.generate(env)
 
     for dialect in ['F77', 'F90', 'FORTRAN', 'F95', 'F03', 'F08']:
-        env['%s' % dialect] = 'gfortran'
-        env['SH%s' % dialect] = '$%s' % dialect
+        env[f'{dialect}'] = 'gfortran'
+        env[f'SH{dialect}'] = f'${dialect}'
         if env['PLATFORM'] in ['cygwin', 'win32']:
-            env['SH%sFLAGS' % dialect] = SCons.Util.CLVar('$%sFLAGS' % dialect)
+            env[f'SH{dialect}FLAGS'] = SCons.Util.CLVar(f'${dialect}FLAGS')
         else:
-            env['SH%sFLAGS' % dialect] = SCons.Util.CLVar('$%sFLAGS -fPIC' % dialect)
+            env[f'SH{dialect}FLAGS'] = SCons.Util.CLVar(f'${dialect}FLAGS -fPIC')
 
-        env['INC%sPREFIX' % dialect] = "-I"
-        env['INC%sSUFFIX' % dialect] = ""
+        env[f'INC{dialect}PREFIX'] = "-I"
+        env[f'INC{dialect}SUFFIX'] = ""
 
     env['FORTRANMODDIRPREFIX'] = "-J"
 

--- a/SCons/Tool/gfortran.xml
+++ b/SCons/Tool/gfortran.xml
@@ -30,6 +30,20 @@ Sets construction variables for the GNU Fortran compiler.
 Calls the &t-link-fortran; Tool module to set variables.
 </para>
 </summary>
+<sets>
+<item>FORTRAN</item>
+<item>F77</item>
+<item>F90</item>
+<item>F95</item>
+<item>SHFORTRAN</item>
+<item>SHF77</item>
+<item>SHF90</item>
+<item>SHF95</item>
+<item>SHFORTRANFLAGS</item>
+<item>SHF77FLAGS</item>
+<item>SHF90FLAGS</item>
+<item>SHF95FLAGS</item>
+</sets>
 </tool>
 
 </sconsdoc>

--- a/SCons/Tool/gfortran.xml
+++ b/SCons/Tool/gfortran.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-__COPYRIGHT__
+Copyright The SCons Foundation
 
 This file is processed by the bin/SConsDoc.py module.
 See its __doc__ string for a discussion of the format.
@@ -26,23 +26,10 @@ See its __doc__ string for a discussion of the format.
 <tool name="gfortran">
 <summary>
 <para>
-Sets construction variables for the GNU F95/F2003 GNU compiler.
+Sets construction variables for the GNU Fortran compiler.
+Calls the &t-link-fortran; Tool module to set variables.
 </para>
 </summary>
-<sets>
-<item>FORTRAN</item>
-<item>F77</item>
-<item>F90</item>
-<item>F95</item>
-<item>SHFORTRAN</item>
-<item>SHF77</item>
-<item>SHF90</item>
-<item>SHF95</item>
-<item>SHFORTRANFLAGS</item>
-<item>SHF77FLAGS</item>
-<item>SHF90FLAGS</item>
-<item>SHF95FLAGS</item>
-</sets>
 </tool>
 
 </sconsdoc>

--- a/SCons/Tool/ifl.py
+++ b/SCons/Tool/ifl.py
@@ -1,15 +1,6 @@
-"""SCons.Tool.ifl
-
-Tool-specific initialization for the Intel Fortran compiler.
-
-There normally shouldn't be any need to import this module directly.
-It will usually be imported through the generic SCons.Tool.Tool()
-selection method.
-
-"""
-
+# MIT License
 #
-# __COPYRIGHT__
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -29,9 +20,13 @@ selection method.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""Tool-specific initialization for the Intel Fortran compiler.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+"""
 
 import SCons.Defaults
 from SCons.Scanner.Fortran import FortranScan

--- a/SCons/Tool/ifort.py
+++ b/SCons/Tool/ifort.py
@@ -22,16 +22,13 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-
 Tool-specific initialization for newer versions of the Intel Fortran Compiler
 for Linux/Windows (and possibly Mac OS X).
 
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()
 selection method.
-
 """
-
 
 import SCons.Defaults
 from SCons.Scanner.Fortran import FortranScan
@@ -61,18 +58,18 @@ def generate(env):
     fc = 'ifort'
 
     for dialect in ['F77', 'F90', 'FORTRAN', 'F95']:
-        env['%s' % dialect] = fc
-        env['SH%s' % dialect] = '$%s' % dialect
+        env[f'{dialect}'] = fc
+        env[f'SH{dialect}'] = f'${dialect}'
         if env['PLATFORM'] == 'posix':
-            env['SH%sFLAGS' % dialect] = SCons.Util.CLVar('$%sFLAGS -fPIC' % dialect)
+            env[f'SH{dialect}FLAGS'] = SCons.Util.CLVar(f'${dialect}FLAGS -fPIC')
 
     if env['PLATFORM'] == 'win32':
         # On Windows, the ifort compiler specifies the object on the
         # command line with -object:, not -o.  Massage the necessary
         # command-line construction variables.
         for dialect in ['F77', 'F90', 'FORTRAN', 'F95']:
-            for var in ['%sCOM' % dialect, '%sPPCOM' % dialect,
-                        'SH%sCOM' % dialect, 'SH%sPPCOM' % dialect]:
+            for var in [f'{dialect}COM', f'{dialect}PPCOM',
+                        f'SH{dialect}COM', f'SH{dialect}PPCOM']:
                 env[var] = env[var].replace('-o $TARGET', '-object:$TARGET')
         env['FORTRANMODDIRPREFIX'] = "/module:"
     else:

--- a/test/Fortran/F77PATH.py
+++ b/test/Fortran/F77PATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -39,30 +38,27 @@ test = TestSCons.TestSCons()
 
 fc = 'f77'
 if not test.detect_tool(fc):
-    test.skip_test('Could not find a f77 tool; skipping test.\n')
-    
-test.subdir('include',
-            'subdir',
-            ['subdir', 'include'],
-            'foobar',
-            'inc2')
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a f77 tool; skipping test.\n')
 
+test.subdir('include', 'subdir', ['subdir', 'include'], 'foobar', 'inc2')
 
-
-test.write('SConstruct', """
-env = Environment(F77 = '%s',
-                  F77PATH = ['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
-                  FOO='include',
-                  F77FLAGS = '-x f77')
+test.write('SConstruct', """\
+env = Environment(
+    F77='%s',
+    F77PATH=['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
+    FOO='include',
+    F77FLAGS='-x f77',
+)
 obj = env.Object(target='foobar/prog', source='subdir/prog.f77')
 env.Program(target='prog', source=obj)
 SConscript('subdir/SConscript', "env")
 
 VariantDir('variant', 'subdir', 0)
 include = Dir('include')
-env = Environment(F77 = '%s',
-                  F77PATH=[include, '#foobar', '#subdir'],
-                  F77FLAGS = '-x f77')
+env = Environment(F77='%s', F77PATH=[include, '#foobar', '#subdir'], F77FLAGS='-x f77')
 SConscript('variant/SConscript', "env")
 """ % (fc, fc))
 
@@ -115,8 +111,6 @@ r"""
       PRINT *, 'subdir/ttt.f77'
 """)
 
-
-
 test.run(arguments = args)
 
 test.run(program = test.workpath(prog),
@@ -150,8 +144,6 @@ test.run(program = test.workpath(variant_prog),
 test.must_not_exist(test.workpath('variant', 'prog.f77'))
 
 test.up_to_date(arguments = args)
-
-
 
 test.write(['include', 'foo.f77'],
 r"""
@@ -193,9 +185,6 @@ test.must_not_exist(test.workpath('variant', 'prog.f77'))
 
 test.up_to_date(arguments = args)
 
-
-
-#
 test.write(['include', 'bar.f77'],
 r"""
       PRINT *, 'include/bar.f77 2'
@@ -235,22 +224,22 @@ test.must_not_exist(test.workpath('variant', 'prog.f77'))
 
 test.up_to_date(arguments = args)
 
-
-
 # Change F77PATH and make sure we don't rebuild because of it.
-test.write('SConstruct', """
-env = Environment(F77 = '%s',
-                  F77PATH = Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),
-                  F77FLAGS = '-x f77')
+test.write('SConstruct', """\
+env = Environment(
+    F77='%s',
+    F77PATH=Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),
+    F77FLAGS='-x f77',
+)
 obj = env.Object(target='foobar/prog', source='subdir/prog.f77')
 env.Program(target='prog', source=obj)
 SConscript('subdir/SConscript', "env")
 
 VariantDir('variant', 'subdir', 0)
 include = Dir('include')
-env = Environment(F77 = '%s',
-                  F77PATH=['inc2', include, '#foobar', '#subdir'],
-                  F77FLAGS = '-x f77')
+env = Environment(
+    F77='%s', F77PATH=['inc2', include, '#foobar', '#subdir'], F77FLAGS='-x f77'
+)
 SConscript('variant/SConscript', "env")
 """ % (fc, fc))
 
@@ -294,19 +283,14 @@ test.run(program = test.workpath(variant_prog),
 
 test.up_to_date(arguments = args)
 
-
-
 # Check that a null-string F77PATH doesn't blow up.
-test.write('SConstruct', """
-env = Environment(tools = ['f77'], F77PATH = '', F77FLAGS = '-x f77')
-env.Object('foo', source = 'empty.f77')
-""")
+test.write('SConstruct', """\
+env = Environment(tools=['%s'], F77PATH='', F77FLAGS='-x f77')
+env.Object('foo', source='empty.f77')
+""" % fc)
 
 test.write('empty.f77', '')
-
 test.run(arguments = '.')
-
-
 
 test.pass_test()
 

--- a/test/Fortran/F90PATH.py
+++ b/test/Fortran/F90PATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -39,32 +38,29 @@ test = TestSCons.TestSCons()
 
 fc = 'f90'
 if not test.detect_tool(fc):
-    test.skip_test('Could not find a f90 tool; skipping test.\n')
-    
-test.subdir('include',
-            'subdir',
-            ['subdir', 'include'],
-            'foobar',
-            'inc2')
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a f90 tool; skipping test.\n')
 
-
+test.subdir('include', 'subdir', ['subdir', 'include'], 'foobar', 'inc2')
 
 test.write('SConstruct', """
-env = Environment(F90 = r'%s',
-                  F90PATH = ['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
-                  LINK = '$F90',
-                  FOO='include')
+env = Environment(
+    F90=r'%s',
+    F90PATH=['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
+    LINK='$F90',
+    FOO='include',
+)
 obj = env.Object(target='foobar/prog', source='subdir/prog.f90')
 env.Program(target='prog', source=obj)
 SConscript('subdir/SConscript', "env")
 
 VariantDir('variant', 'subdir', 0)
 include = Dir('include')
-env = Environment(F90 = r'%s',
-                  F90PATH=[include, '#foobar', '#subdir'],
-                  LINK = '$F90')
+env = Environment(F90=r'%s', F90PATH=[include, '#foobar', '#subdir'], LINK='$F90')
 SConscript('variant/SConscript', "env")
-""" % (fc, fc, ))
+""" % (fc, fc))
 
 test.write(['subdir', 'SConscript'],
 """
@@ -115,8 +111,6 @@ r"""
       PRINT *, 'subdir/ttt.f90'
 """)
 
-
-
 test.run(arguments = args)
 
 test.run(program = test.workpath(prog),
@@ -150,8 +144,6 @@ test.run(program = test.workpath(variant_prog),
 test.must_not_exist(test.workpath('variant', 'prog.f90'))
 
 test.up_to_date(arguments = args)
-
-
 
 test.write(['include', 'foo.f90'],
 r"""
@@ -193,9 +185,6 @@ test.must_not_exist(test.workpath('variant', 'prog.f90'))
 
 test.up_to_date(arguments = args)
 
-
-
-#
 test.write(['include', 'bar.f90'],
 r"""
       PRINT *, 'include/bar.f90 2'
@@ -238,27 +227,28 @@ test.up_to_date(arguments = args)
 
 
 # Change F90PATH and make sure we don't rebuild because of it.
-test.write('SConstruct', """
-env = Environment(F90 = r'%s',
-                  F90PATH = Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),
-                  LINK = '$F90')
+test.write('SConstruct', """\
+env = Environment(
+    F90=r'%s',
+    F90PATH=Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),
+    LINK='$F90'
+)
 obj = env.Object(target='foobar/prog', source='subdir/prog.f90')
 env.Program(target='prog', source=obj)
 SConscript('subdir/SConscript', "env")
 
 VariantDir('variant', 'subdir', 0)
 include = Dir('include')
-env = Environment(F90 = r'%s',
-                  F90PATH=['inc2', include, '#foobar', '#subdir'],
-                  LINK = '$F90')
+env = Environment(
+    F90=r'%s',
+    F90PATH=['inc2', include, '#foobar', '#subdir'],
+    LINK='$F90',
+)
 SConscript('variant/SConscript', "env")
 """ % (fc, fc))
 
 test.up_to_date(arguments = args)
 
-
-
-#
 test.write(['inc2', 'foo.f90'],
 r"""
       PRINT *, 'inc2/foo.f90 1'
@@ -295,8 +285,6 @@ test.run(program = test.workpath(variant_prog),
 """)
 
 test.up_to_date(arguments = args)
-
-
 
 test.pass_test()
 

--- a/test/Fortran/FORTRANCOMMONFLAGS.py
+++ b/test/Fortran/FORTRANCOMMONFLAGS.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test that while FORTRANFLAGS is not passed to another dialect,
+FORTRANCOMMONFLAGS is passed to both.
+"""
+
+import TestSCons
+
+_python_ = TestSCons._python_
+
+test = TestSCons.TestSCons()
+_exe = TestSCons._exe
+
+test.file_fixture('mylink.py')
+test.file_fixture(['fixture', 'myfortran_flags.py'])
+
+test.write('SConstruct', """
+env = Environment(
+    LINK=r'%(_python_)s mylink.py',
+    LINKFLAGS=[],
+    F90=r'%(_python_)s myfortran_flags.py g90',
+    F90FLAGS='-x',
+    FORTRAN=r'%(_python_)s myfortran_flags.py fortran',
+    FORTRANFLAGS='-y',
+    FORTRANCOMMONFLAGS='-z',
+)
+env.Program(target='test01', source='test01.f')
+env.Program(target='test02', source='test02.F')
+env.Program(target='test03', source='test03.for')
+env.Program(target='test04', source='test04.FOR')
+env.Program(target='test05', source='test05.ftn')
+env.Program(target='test06', source='test06.FTN')
+env.Program(target='test07', source='test07.fpp')
+env.Program(target='test08', source='test08.FPP')
+env.Program(target='test11', source='test11.f90')
+env.Program(target='test12', source='test12.F90')
+""" % locals())
+
+test.write('test01.f',   "This is a .f file.\n#link\n#fortran\n")
+test.write('test02.F',   "This is a .F file.\n#link\n#fortran\n")
+test.write('test03.for', "This is a .for file.\n#link\n#fortran\n")
+test.write('test04.FOR', "This is a .FOR file.\n#link\n#fortran\n")
+test.write('test05.ftn', "This is a .ftn file.\n#link\n#fortran\n")
+test.write('test06.FTN', "This is a .FTN file.\n#link\n#fortran\n")
+test.write('test07.fpp', "This is a .fpp file.\n#link\n#fortran\n")
+test.write('test08.FPP', "This is a .FPP file.\n#link\n#fortran\n")
+test.write('test11.f90', "This is a .f90 file.\n#link\n#g90\n")
+test.write('test12.F90', "This is a .F90 file.\n#link\n#g90\n")
+
+test.run(arguments = '.', stderr = None)
+
+test.must_match('test01' + _exe, " -c -z -y\nThis is a .f file.\n")
+test.must_match('test02' + _exe, " -c -z -y\nThis is a .F file.\n")
+test.must_match('test03' + _exe, " -c -z -y\nThis is a .for file.\n")
+test.must_match('test04' + _exe, " -c -z -y\nThis is a .FOR file.\n")
+test.must_match('test05' + _exe, " -c -z -y\nThis is a .ftn file.\n")
+test.must_match('test06' + _exe, " -c -z -y\nThis is a .FTN file.\n")
+test.must_match('test07' + _exe, " -c -z -y\nThis is a .fpp file.\n")
+test.must_match('test08' + _exe, " -c -z -y\nThis is a .FPP file.\n")
+test.must_match('test11' + _exe, " -c -z -x\nThis is a .f90 file.\n")
+test.must_match('test12' + _exe, " -c -z -x\nThis is a .F90 file.\n")
+
+
+fc = 'f90'
+g90 = test.detect_tool(fc)
+if g90:
+    test.file_fixture('wrapper.py')
+
+    test.write('SConstruct', """
+foo = Environment(F90='%(fc)s')
+f90 = foo.Dictionary('F90')
+bar = foo.Clone(F90=r'%(_python_)s wrapper.py ' + f90)
+foo.Program(target='foo', source='foo.f90')
+bar.Program(target='bar', source='bar.f90')
+""" % locals())
+
+    test.write('foo.f90', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f90'
+      END
+""")
+
+    test.write('bar.f90', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f90'
+      END
+""")
+
+    test.run(arguments='foo' + _exe, stderr=None)
+    test.run(program=test.workpath('foo'), stdout=" foo.f90\n")
+    test.must_not_exist('wrapper.out')
+
+    import sys
+
+    if sys.platform[:5] == 'sunos':
+        test.run(arguments='bar' + _exe, stderr=None)
+    else:
+        test.run(arguments='bar' + _exe)
+    test.run(program=test.workpath('bar'), stdout=" bar.f90\n")
+    test.must_match('wrapper.out', "wrapper.py\n")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Fortran/FORTRANFILESUFFIXES2.py
+++ b/test/Fortran/FORTRANFILESUFFIXES2.py
@@ -34,7 +34,7 @@ test.file_fixture('mylink.py')
 test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non default file suffix: .f, .f90 and .f95 for FORTRAN
-test.write( 'SConstruct', """\
+test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 env = Environment(
     LINK=r'%(_python_)s mylink.py',

--- a/test/Fortran/FORTRANFILESUFFIXES2.py
+++ b/test/Fortran/FORTRANFILESUFFIXES2.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,14 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
 _python_ = TestSCons._python_
-_exe   = TestSCons._exe
+_exe = TestSCons._exe
 
 test = TestSCons.TestSCons()
 
@@ -35,28 +34,30 @@ test.file_fixture('mylink.py')
 test.file_fixture(['fixture', 'myfortran.py'])
 
 # Test non default file suffix: .f, .f90 and .f95 for FORTRAN
-test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
-                  LINKFLAGS = [],
-                  F77 = r'%(_python_)s myfortran.py g77',
-                  FORTRAN = r'%(_python_)s myfortran.py fortran',
-                  FORTRANFILESUFFIXES = ['.f', '.f95', '.f90', '.ffake'],
-                  tools = ['default', 'fortran'])
-#print(env.Dump())
-env.Program(target = 'test01', source = 'test01.f')
-env.Program(target = 'test02', source = 'test02.f90')
-env.Program(target = 'test03', source = 'test03.f95')
-env.Program(target = 'test04', source = 'test04.ffake')
-env.Program(target = 'test05', source = 'test05.f77')
+test.write( 'SConstruct', """\
+DefaultEnvironment(tools=[])
+env = Environment(
+    LINK=r'%(_python_)s mylink.py',
+    LINKFLAGS=[],
+    F77=r'%(_python_)s myfortran.py g77',
+    FORTRAN=r'%(_python_)s myfortran.py fortran',
+    FORTRANFILESUFFIXES=['.f', '.f95', '.f90', '.ffake'],
+    tools=['default', 'fortran'],
+)
+env.Program(target='test01', source='test01.f')
+env.Program(target='test02', source='test02.f90')
+env.Program(target='test03', source='test03.f95')
+env.Program(target='test04', source='test04.ffake')
+env.Program(target='test05', source='test05.f77')
 """ % locals())
 
-test.write('test01.f',   "This is a .f file.\n#link\n#fortran\n")
-test.write('test02.f90',   "This is a .f90 file.\n#link\n#fortran\n")
+test.write('test01.f', "This is a .f file.\n#link\n#fortran\n")
+test.write('test02.f90', "This is a .f90 file.\n#link\n#fortran\n")
 test.write('test03.f95', "This is a .f95 file.\n#link\n#fortran\n")
 test.write('test04.ffake', "This is a .ffake file.\n#link\n#fortran\n")
 test.write('test05.f77', "This is a .f77 file.\n#link\n#g77\n")
 
-test.run(arguments = '.', stderr = None)
+test.run(arguments='.', stderr=None)
 
 test.must_match('test01' + _exe, "This is a .f file.\n")
 test.must_match('test02' + _exe, "This is a .f90 file.\n")

--- a/test/Fortran/FORTRANPATH.py
+++ b/test/Fortran/FORTRANPATH.py
@@ -37,28 +37,26 @@ test = TestSCons.TestSCons()
 
 fc = 'f77'
 if not test.detect_tool(fc):
-    test.skip_test('Could not find a f77 tool; skipping test.\n')
-    
-test.subdir('include',
-            'subdir',
-            ['subdir', 'include'],
-            'foobar',
-            'inc2')
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a f77 tool; skipping test.\n')
 
+test.subdir('include', 'subdir', ['subdir', 'include'], 'foobar', 'inc2')
 
-
-test.write('SConstruct', """
-env = Environment(FORTRAN = '%s',
-                  FORTRANPATH = ['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
-                  FOO='include')
+test.write('SConstruct', """\
+env = Environment(
+    FORTRAN='%s',
+    FORTRANPATH=['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
+    FOO='include'
+)
 obj = env.Object(target='foobar/prog', source='subdir/prog.f')
 env.Program(target='prog', source=obj)
 SConscript('subdir/SConscript', "env")
 
 VariantDir('variant', 'subdir', 0)
 include = Dir('include')
-env = Environment(FORTRAN = '%s',
-                  FORTRANPATH=[include, '#foobar', '#subdir'])
+env = Environment(FORTRAN='%s', FORTRANPATH=[include, '#foobar', '#subdir'])
 SConscript('variant/SConscript', "env")
 """ % (fc, fc))
 
@@ -151,8 +149,6 @@ test.must_not_exist(test.workpath('variant', 'prog.f'))
 
 test.up_to_date(arguments = args)
 
-
-
 test.write(['include', 'foo.f'],
 r"""
       PRINT *, 'include/foo.f 2'
@@ -197,9 +193,6 @@ test.must_not_exist(test.workpath('variant', 'prog.f'))
 
 test.up_to_date(arguments = args)
 
-
-
-#
 test.write(['include', 'bar.f'],
 r"""
       PRINT *, 'include/bar.f 2'
@@ -247,25 +240,26 @@ test.up_to_date(arguments = args)
 
 
 # Change FORTRANPATH and make sure we don't rebuild because of it.
-test.write('SConstruct', """
-env = Environment(FORTRAN = '%s',
-                  FORTRANPATH = Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'))
+test.write('SConstruct', """\
+env = Environment(
+    FORTRAN='%s',
+    FORTRANPATH=Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),
+)
 obj = env.Object(target='foobar/prog', source='subdir/prog.f')
 env.Program(target='prog', source=obj)
 SConscript('subdir/SConscript', "env")
 
 VariantDir('variant', 'subdir', 0)
 include = Dir('include')
-env = Environment(FORTRAN = '%s',
-                  FORTRANPATH=['inc2', include, '#foobar', '#subdir'])
+env = Environment(
+    FORTRAN='%s',
+    FORTRANPATH=['inc2', include, '#foobar', '#subdir'],
+)
 SConscript('variant/SConscript', "env")
 """ % (fc, fc))
 
 test.up_to_date(arguments = args)
 
-
-
-#
 test.write(['inc2', 'foo.f'],
 r"""
       PRINT *, 'inc2/foo.f 1'
@@ -307,8 +301,6 @@ test.run(program = test.workpath(variant_prog),
 """)
 
 test.up_to_date(arguments = args)
-
-
 
 # Check that a null-string FORTRANPATH doesn't blow up.
 test.write('SConstruct', """

--- a/test/Fortran/fixture/myfortran.py
+++ b/test/Fortran/fixture/myfortran.py
@@ -1,14 +1,17 @@
 import getopt
 import sys
+
 print(sys.argv)
 comment = ('#' + sys.argv[1]).encode()
-length = len(comment)
+
 opts, args = getopt.getopt(sys.argv[2:], 'cf:o:K:')
 for opt, arg in opts:
-    if opt == '-o': out = arg
-infile = open(args[0], 'rb')
-outfile = open(out, 'wb')
-for l in infile.readlines():
-    if l[:length] != comment:
-        outfile.write(l)
+    if opt == '-o':
+        out = arg
+
+with open(args[0], 'rb') as infile, open(out, 'wb') as outfile:
+    for l in infile:
+        if not l.startswith(comment):
+            outfile.write(l)
+
 sys.exit(0)

--- a/test/Fortran/fixture/myfortran_flags.py
+++ b/test/Fortran/fixture/myfortran_flags.py
@@ -1,16 +1,19 @@
 import getopt
 import sys
+
 comment = ('#' + sys.argv[1]).encode()
-opts, args = getopt.getopt(sys.argv[2:], 'cf:o:xy')
+
+opts, args = getopt.getopt(sys.argv[2:], 'cf:o:xyz')
 optstring = ''
 length = len(comment)
 for opt, arg in opts:
     if opt == '-o': out = arg
     elif opt not in ('-f', '-K'): optstring = optstring + ' ' + opt
-infile = open(args[0], 'rb')
-outfile = open(out, 'wb')
-outfile.write((optstring + "\n").encode())
-for l in infile.readlines():
-    if l[:length] != comment:
-        outfile.write(l)
+
+with open(args[0], 'rb') as infile, open(out, 'wb') as outfile:
+    outfile.write((optstring + "\n").encode())
+    for l in infile:
+        if not l.startswith(comment):
+            outfile.write(l)
+
 sys.exit(0)


### PR DESCRIPTION
The documentation hinted that `$FORTRANFLAGS` was included in the build lines for all dialects, but it was not.  Turns out, the test suite quite explicitly checks that `FORTRANFLAGS` doesn't leak through to other variants, so instead define a new `FORTRANCOMMONFLAGS` to serve the purpose of a flag that applies to all variants.

Assorted cleanup. And f-strings.

Fixes #2257

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
