### PR TITLE
Strip shell's backslashes from the computed include

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -207,6 +207,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.
     - Added Configure.CheckMember() checker to check if struct/class has the specified member.
 
+  From Ivan Kravets, PlatformIO:
+    - Conditional C/C++ Preprocessor: Strip shell's backslashes from the computed include (-DFOO_H=\"foo.h\")
+
 RELEASE 4.3.0 - Tue, 16 Nov 2021 18:12:46 -0700
 
   From Jacob Cassagnol:

--- a/SCons/cpp.py
+++ b/SCons/cpp.py
@@ -591,6 +591,9 @@ class PreProcessor:
         while not s[0] in '<"':
             try:
                 s = self.cpp_namespace[s]
+                # strip backslashes from the computed include (-DFOO_H=\"foo.h\")
+                for c in '<">':
+                    s = s.replace(f"\\{c}", c)
             except KeyError:
                 m = function_name.search(s)
 

--- a/SCons/cppTests.py
+++ b/SCons/cppTests.py
@@ -55,6 +55,8 @@ substitution_input = """
 
 #include XXX_FILE5
 #include XXX_FILE6
+
+#include SHELL_ESCAPED_H
 """
 
 
@@ -441,7 +443,8 @@ if_no_space_input = """
 class cppTestCase(unittest.TestCase):
     def setUp(self):
         self.cpp = self.cpp_class(current = ".",
-                                  cpppath = ['/usr/include'])
+                                  cpppath = ['/usr/include'],
+                                  dict={"SHELL_ESCAPED_H": '\\"file-shell-computed-yes\\"'})
 
     def test_basic(self):
         """Test basic #include scanning"""
@@ -531,6 +534,7 @@ class cppAllTestCase(cppTestCase):
     def setUp(self):
         self.cpp = self.cpp_class(current = ".",
                                   cpppath = ['/usr/include'],
+                                  dict={"SHELL_ESCAPED_H": '\\"file-shell-computed-yes\\"'},
                                   all=1)
 
 class PreProcessorTestCase(cppAllTestCase):
@@ -546,6 +550,7 @@ class PreProcessorTestCase(cppAllTestCase):
         ('include', '<', 'file4-yes'),
         ('include', '"', 'file5-yes'),
         ('include', '<', 'file6-yes'),
+        ('include', '"', 'file-shell-computed-yes'),
     ]
 
     ifdef_expect = [
@@ -647,6 +652,7 @@ class DumbPreProcessorTestCase(cppAllTestCase):
         ('include', '<', 'file4-yes'),
         ('include', '"', 'file5-yes'),
         ('include', '<', 'file6-yes'),
+        ('include', '"', 'file-shell-computed-yes'),
     ]
 
     ifdef_expect = [


### PR DESCRIPTION
**Conditional C/C++ Preprocessor: Strip shell's backslashes from the computed include (-DFOO_H=\"foo.h\")**

Related discussion: https://community.platformio.org/t/ldf-not-following-environment-variables-in-6-1-0rc1/28616/5?u=ivankravets

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
