### PR TITLE
[Test] drop old exception msgs

### DIFF
--- a/test/Errors/Exception.py
+++ b/test/Errors/Exception.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -53,7 +52,7 @@ test.write('exit.in', 'exit\n')
 # so make sure the proper variations are supported in the following
 # regexp.
 expect = r"""scons: \*\*\* \[exit.out\] Exception : exit
-Traceback \((most recent call|innermost) last\):
+Traceback \(most recent call last\):
 (  File ".+", line \d+, in \S+
     [^\n]+
 )*(  File ".+", line \d+, in \S+

--- a/test/Errors/InternalError.py
+++ b/test/Errors/InternalError.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the exit status and error output if an SConstruct file
@@ -41,7 +40,7 @@ raise InternalError('error inside')
 """)
 
 test.run(stdout = "scons: Reading SConscript files ...\ninternal error\n",
-         stderr = r"""Traceback \((most recent call|innermost) last\):
+         stderr = r"""Traceback \(most recent call last\):
   File ".+", line \d+, in .+
   File ".+", line \d+, in .+
   File ".+", line \d+, in .+

--- a/test/GetBuildFailures/serial.py
+++ b/test/GetBuildFailures/serial.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,15 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
 """
 Verify that the GetBuildFailures() function returns a list of
 BuildError exceptions.  Also verify printing the BuildError
 attributes we expect to be most commonly used.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 import re
@@ -196,7 +195,7 @@ scons: *** [f12] f12: My SConsEnvironmentError
 scons: *** [f13] f13: My SConsEnvironmentError
 scons: *** [f14] InternalError : My InternalError
 """) + \
-r"""Traceback \((most recent call|innermost) last\):
+r"""Traceback \(most recent call last\):
 (  File ".+", line \d+, in \S+
     [^\n]+
 )*(  File ".+", line \d+, in \S+

--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import re
 
@@ -37,15 +36,15 @@ SConstruct_path = test.workpath('SConstruct')
 test.write(SConstruct_path, """\
 def func(source = None, target = None, env = None):
     raise Exception("func exception")
-B = Builder(action = func)
-env = Environment(BUILDERS = { 'B' : B })
-env.B(target = 'foo.out', source = 'foo.in')
+B = Builder(action=func)
+env = Environment(BUILDERS={'B': B})
+env.B(target='foo.out', source='foo.in')
 """)
 
 test.write('foo.in', "foo.in\n")
 
 expected_stderr = r"""scons: \*\*\* \[foo.out\] Exception : func exception
-Traceback \((most recent call|innermost) last\):
+Traceback \(most recent call last\):
 (  File ".+", line \d+, in \S+
     [^\n]+
 )*(  File ".+", line \d+, in \S+
@@ -56,10 +55,8 @@ Traceback \((most recent call|innermost) last\):
 Exception: func exception
 """ % re.escape(SConstruct_path)
 
-test.run(arguments = "foo.out", stderr = expected_stderr, status = 2)
-
-test.run(arguments = "-j2 foo.out", stderr = expected_stderr, status = 2)
-
+test.run(arguments="foo.out", stderr=expected_stderr, status=2)
+test.run(arguments="-j2 foo.out", stderr=expected_stderr, status=2)
 
 # Verify that exceptions caused by exit values of builder actions are
 # correctly signalled, for both Serial and Parallel jobs.
@@ -70,29 +67,28 @@ sys.exit(1)
 """)
 
 test.write(SConstruct_path, """
-Fail = Builder(action = r'%(_python_)s myfail.py $TARGETS $SOURCE')
-env = Environment(BUILDERS = { 'Fail' : Fail })
-env.Fail(target = 'out.f1', source = 'in.f1')
+Fail = Builder(action=r'%(_python_)s myfail.py $TARGETS $SOURCE')
+env = Environment(BUILDERS={'Fail': Fail})
+env.Fail(target='out.f1', source='in.f1')
 """ % locals())
 
 test.write('in.f1', "in.f1\n")
 
 expected_stderr = "scons: \\*\\*\\* \\[out.f1\\] Error 1\n"
 
-test.run(arguments = '.', status = 2, stderr = expected_stderr)
-test.run(arguments = '-j2 .', status = 2, stderr = expected_stderr)
-
+test.run(arguments='.', status=2, stderr=expected_stderr)
+test.run(arguments='-j2 .', status=2, stderr=expected_stderr)
 
 # Verify that all exceptions from simultaneous tasks are reported,
 # even if the exception is raised during the Task.prepare()
 # [Node.prepare()]
 
 test.write(SConstruct_path, """
-Fail = Builder(action = r'%(_python_)s myfail.py $TARGETS $SOURCE')
-env = Environment(BUILDERS = { 'Fail' : Fail })
-env.Fail(target = 'out.f1', source = 'in.f1')
-env.Fail(target = 'out.f2', source = 'in.f2')
-env.Fail(target = 'out.f3', source = 'in.f3')
+Fail = Builder(action=r'%(_python_)s myfail.py $TARGETS $SOURCE')
+env = Environment(BUILDERS={'Fail': Fail})
+env.Fail(target='out.f1', source='in.f1')
+env.Fail(target='out.f2', source='in.f2')
+env.Fail(target='out.f3', source='in.f3')
 """ % locals())
 
 # in.f2 is not created to cause a Task.prepare exception
@@ -100,7 +96,7 @@ test.write('in.f1', 'in.f1\n')
 test.write('in.f3', 'in.f3\n')
 
 # In Serial task mode, get the first exception and stop
-test.run(arguments = '.', status = 2, stderr = expected_stderr)
+test.run(arguments='.', status=2, stderr=expected_stderr)
 
 # In Parallel task mode, we will get all three exceptions.
 
@@ -117,10 +113,8 @@ expected_stderr_list = [
 # walk of '.' and are already considered up-to-date when we kick off the
 # "simultaneous" builds of the output (target) files.
 
-test.run(arguments = '-j7 -k .', status = 2, stderr = None)
-
+test.run(arguments='-j7 -k .', status=2, stderr=None)
 test.must_contain_all_lines(test.stderr(), expected_stderr_list)
-
 
 test.pass_test()
 

--- a/test/option/debug-stacktrace.py
+++ b/test/option/debug-stacktrace.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the --debug=stacktrace option.
@@ -34,36 +33,26 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
+
 def kfile_scan(node, env, target):
     raise Exception("kfile_scan error")
 
-kscan = Scanner(name = 'kfile',
-                function = kfile_scan,
-                skeys = ['.k'])
-
+kscan = Scanner(name='kfile', function=kfile_scan, skeys=['.k'])
 env = Environment(tools=[])
 env.Append(SCANNERS = [kscan])
 
 env.Command('foo', 'foo.k', Copy('$TARGET', '$SOURCE'))
 """)
-
 test.write('foo.k', "foo.k\n")
 
 test.run(status = 2, stderr = "scons: *** [foo] Exception : kfile_scan error\n")
-
-test.run(arguments = "--debug=stacktrace",
-         status = 2,
-         stderr = None)
-
+test.run(arguments="--debug=stacktrace", status=2, stderr=None)
 lines = [
     "scons: *** [foo] Exception : kfile_scan error",
     "scons: internal stack trace:",
     'raise Exception("kfile_scan error")',
 ]
-
 test.must_contain_all_lines(test.stderr(), lines)
-
-
 
 # Test that --debug=stacktrace works for UserError exceptions,
 # which are handled by different code than other exceptions.
@@ -73,25 +62,14 @@ import SCons.Errors
 raise SCons.Errors.UserError("explicit UserError!")
 """)
 
-test.run(arguments = '--debug=stacktrace',
-         status = 2,
-         stderr = None)
-
+test.run(arguments='--debug=stacktrace', status=2, stderr=None)
 user_error_lines = [
     'UserError: explicit UserError!',
     'scons: *** explicit UserError!',
 ]
-
-# The "(most recent call last)" message is used by more recent Python
-# versions than the "(innermost last)" message, so that's the one
-# we report if neither matches.
-traceback_lines = [
-    "Traceback (most recent call last)",
-    "Traceback (innermost last)",
-]
-
+traceback_lines = ["Traceback (most recent call last)",]
 test.must_contain_all_lines(test.stderr(), user_error_lines)
-test.must_contain_any_line(test.stderr(), traceback_lines)
+test.must_contain_all_lines(test.stderr(), traceback_lines)
 
 # Test that full path names to SConscript files show up in stack traces.
 
@@ -99,17 +77,9 @@ test.write('SConstruct', """\
 1/0
 """)
 
-test.run(arguments = '--debug=stacktrace',
-         status = 2,
-         stderr = None)
-
-lines = [
-    '  File "%s", line 1:' % test.workpath('SConstruct'),
-]
-
+test.run(arguments='--debug=stacktrace', status=2, stderr=None)
+lines = ['  File "%s", line 1:' % test.workpath('SConstruct'),]
 test.must_contain_all_lines(test.stderr(), lines)
-
-
 
 test.pass_test()
 

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -1943,7 +1943,7 @@ class run_TestCase(TestCommonTestCase):
 
         expect_stderr = lstrip("""\
         Exception trying to execute: \\[%s, '[^']*pass'\\]
-        Traceback \\((innermost|most recent call) last\\):
+        Traceback \\(most recent call last\\):
           File "<stdin>", line \\d+, in (\\?|<module>)
           File "[^"]+TestCommon.py", line \\d+, in run
             TestCmd.run\\(self, \\*\\*kw\\)


### PR DESCRIPTION
Minor maintenance to drop a regex group in a few tests (including in a test framework test) which allowed for two different exception messages: one belongs to very old Pythons which are no longer supported by SCons.

This is a test-only change, and has no functional effect.

Signed-off-by: Mats Wichmann <mats@linux.com>

# Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
