### PR TITLE
Ajust test for 3.11+ enhanced error messages

### DIFF
--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -47,6 +47,7 @@ expected_stderr = r"""scons: \*\*\* \[foo.out\] Exception : func exception
 Traceback \(most recent call last\):
 (  File ".+", line \d+, in \S+
     [^\n]+
+    [^\n]+
 )*(  File ".+", line \d+, in \S+
 )*(  File ".+", line \d+, in \S+
     [^\n]+


### PR DESCRIPTION
There were four tests failing because the regexes for expected stdout didn't match with the addition of pointers in exceptions showing where the error occurs.  However, with 3.11.0b4, this has been backed off a bit: there are no arrow lines if the whole line would have been highlighted, since that adds no useful new information.  As a result, only one test now failed, and the regex there is expanded to handle that case.

This relates to, but does not close, issue #4162.  Test-only change, no impact to SCons core or docs.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
