### PR TITLE
Add lex/yacc filegen consvars

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -211,7 +211,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improvements to lex and yacc tools: better documentation of
       extra-file options, add test for extra-file behavior.
       -  Two new construction variables are introduced for lex (LEX_HEADER_FILE
-      and LEX_TABLE_FILE) as the preferred way of specifying these extra-file
+      and LEX_TABLES_FILE) as the preferred way of specifying these extra-file
       options.
       -  Two new construction variables are introduced for yacc
       (YACC_HEADER_FILE and YACC_GRAPH_FILE) as the preferred way of

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -209,11 +209,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Tool module loading no longer special-cases Jython, which is a dead
       project as far as SCons (no timeline in sight for Python 3 support).
     - Improvements to lex and yacc tools: better documentation of
-      extra-file options, add test for extra-file behavior.  Two new
-      construction variables are introduced for lex (LEXHEADERFILE and
-      LEXTABLEFILE) as the preferred way of specifying these extra-file
-      options. Two new construction variables are introduced for yacc
-      (YACCHEADERFILE and YACCGRAPHFILE) as the preferred way of
+      extra-file options, add test for extra-file behavior.
+      -  Two new construction variables are introduced for lex (LEX_HEADER_FILE
+      and LEX_TABLE_FILE) as the preferred way of specifying these extra-file
+      options.
+      -  Two new construction variables are introduced for yacc
+      (YACC_HEADER_FILE and YACC_GRAPH_FILE) as the preferred way of
       specifying these extra-file options.
 
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -209,7 +209,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Tool module loading no longer special-cases Jython, which is a dead
       project as far as SCons (no timeline in sight for Python 3 support).
     - Improvements to lex and yacc tools: better documentation of
-      extra-file options, add test for extra-file behavior.
+      extra-file options, add test for extra-file behavior.  Two new
+      construction variables are introduced for lex (LEXHEADERFILE and
+      LEXTABLEFILE) as the preferred way of specifying these extra-file
+      options. Two new construction variables are introduced for yacc
+      (YACCHEADERFILE and YACCGRAPHFILE) as the preferred way of
+      specifying these extra-file options.
+
 
   From Zhichang Yu:
     - Added MSVC_USE_SCRIPT_ARGS variable to pass arguments to MSVC_USE_SCRIPT.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -45,11 +45,11 @@ NEW FUNCTIONALITY
   option may be added in a future enhancement.
 - Fortran: a new construction variable FORTRANCOMMONFLAGS is added which is
   applied to all Fortran dialects, to enable global (all-dialect) settings.
-- lex: two new construction variables are introduced (LEXHEADERFILE
-  and LEXTABLEFILE) as the preferred way of specifying extra files that
+- lex: two new construction variables are introduced (LEX_HEADER_ILE
+  and LEX_TABLE_FILE) as the preferred way of specifying extra files that
   the tool can generate.
-- yacc: two new construction variables are introduced (YACCHEADERFILE
-  and YACCGRAPHFILE) as the preferred way of specifying extra files that
+- yacc: two new construction variables are introduced (YACC_HEADER_FILE
+  and YACC_GRAPH_FILE) as the preferred way of specifying extra files that
   the tool can generate (applies only when using GNU flex and GNU bison).
 
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -45,6 +45,12 @@ NEW FUNCTIONALITY
   option may be added in a future enhancement.
 - Fortran: a new construction variable FORTRANCOMMONFLAGS is added which is
   applied to all Fortran dialects, to enable global (all-dialect) settings.
+- lex: two new construction variables are introduced (LEXHEADERFILE
+  and LEXTABLEFILE) as the preferred way of specifying extra files that
+  the tool can generate.
+- yacc: two new construction variables are introduced (YACCHEADERFILE
+  and YACCGRAPHFILE) as the preferred way of specifying extra files that
+  the tool can generate (applies only when using GNU flex and GNU bison).
 
 
 DEPRECATED FUNCTIONALITY

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -46,7 +46,7 @@ NEW FUNCTIONALITY
 - Fortran: a new construction variable FORTRANCOMMONFLAGS is added which is
   applied to all Fortran dialects, to enable global (all-dialect) settings.
 - lex: two new construction variables are introduced (LEX_HEADER_ILE
-  and LEX_TABLE_FILE) as the preferred way of specifying extra files that
+  and LEX_TABLES_FILE) as the preferred way of specifying extra files that
   the tool can generate.
 - yacc: two new construction variables are introduced (YACC_HEADER_FILE
   and YACC_GRAPH_FILE) as the preferred way of specifying extra files that

--- a/SCons/Tool/lex.py
+++ b/SCons/Tool/lex.py
@@ -80,17 +80,17 @@ def lexEmitter(target, source, env) -> tuple:
                 file_name = option[l:].strip()
                 target.append(file_name)
 
-    lexheaderfile = env.subst("$LEXHEADERFILE", target=target, source=source)
+    lexheaderfile = env.subst("$LEX_HEADER_FILE", target=target, source=source)
     if lexheaderfile:
         target.append(lexheaderfile)
         # rewrite user-supplied file string with a node, we need later
-        env.Replace(LEXHEADERFILE=env.File(lexheaderfile))
+        env.Replace(LEX_HEADER_FILE=env.File(lexheaderfile))
 
-    lextablesfile = env.subst("$LEXTABLESFILE", target=target, source=source)
+    lextablesfile = env.subst("$LEX_TABLE_FILE", target=target, source=source)
     if lextablesfile:
         target.append(lextablesfile)
         # rewrite user-supplied file string with a node, we need later
-        env.Replace(LEXTABLESFILE=env.File(lextablesfile))
+        env.Replace(LEX_TABLE_FILE=env.File(lextablesfile))
 
     return target, source
 
@@ -148,18 +148,18 @@ def generate(env) -> None:
     env.SetDefault(
         LEX=env.Detect(BINS),
         LEXFLAGS=CLVar(""),
-        LEXHEADERFILE="",
-        LEXTABLESFILE="",
+        LEX_HEADER_FILE="",
+        LEX_TABLE_FILE="",
     )
 
     if sys.platform == 'win32':
         env.SetDefault(LEXUNISTD=CLVar(""))
-        env["LEXCOM"] = "$LEX $LEXUNISTD $LEXFLAGS $_LEXHEADER $_LEXTABLES -t $SOURCES > $TARGET"
+        env["LEXCOM"] = "$LEX $LEXUNISTD $LEXFLAGS $_LEX_HEADER $_LEX_TABLES -t $SOURCES > $TARGET"
     else:
-        env["LEXCOM"] = "$LEX $LEXFLAGS $_LEXHEADER $_LEXTABLES -t $SOURCES > $TARGET"
+        env["LEXCOM"] = "$LEX $LEXFLAGS $_LEX_HEADER $_LEX_TABLES -t $SOURCES > $TARGET"
 
-    env['_LEXHEADER'] = '${LEXHEADERFILE and "--header-file=" + str(LEXHEADERFILE)}'
-    env['_LEXTABLES'] = '${LEXTABLESFILE and "--tables-file=" + str(LEXTABLESFILE)}'
+    env['_LEX_HEADER'] = '${LEX_HEADER_FILE and "--header-file=" + str(LEX_HEADER_FILE)}'
+    env['_LEX_TABLES'] = '${LEX_TABLE_FILE and "--tables-file=" + str(LEX_TABLE_FILE)}'
 
 
 def exists(env) -> Optional[str]:

--- a/SCons/Tool/lex.py
+++ b/SCons/Tool/lex.py
@@ -86,11 +86,11 @@ def lexEmitter(target, source, env) -> tuple:
         # rewrite user-supplied file string with a node, we need later
         env.Replace(LEX_HEADER_FILE=env.File(lexheaderfile))
 
-    lextablesfile = env.subst("$LEX_TABLE_FILE", target=target, source=source)
+    lextablesfile = env.subst("$LEX_TABLES_FILE", target=target, source=source)
     if lextablesfile:
         target.append(lextablesfile)
         # rewrite user-supplied file string with a node, we need later
-        env.Replace(LEX_TABLE_FILE=env.File(lextablesfile))
+        env.Replace(LEX_TABLES_FILE=env.File(lextablesfile))
 
     return target, source
 
@@ -149,7 +149,7 @@ def generate(env) -> None:
         LEX=env.Detect(BINS),
         LEXFLAGS=CLVar(""),
         LEX_HEADER_FILE="",
-        LEX_TABLE_FILE="",
+        LEX_TABLES_FILE="",
     )
 
     if sys.platform == 'win32':
@@ -159,7 +159,7 @@ def generate(env) -> None:
         env["LEXCOM"] = "$LEX $LEXFLAGS $_LEX_HEADER $_LEX_TABLES -t $SOURCES > $TARGET"
 
     env['_LEX_HEADER'] = '${LEX_HEADER_FILE and "--header-file=" + str(LEX_HEADER_FILE)}'
-    env['_LEX_TABLES'] = '${LEX_TABLE_FILE and "--tables-file=" + str(LEX_TABLE_FILE)}'
+    env['_LEX_TABLES'] = '${LEX_TABLES_FILE and "--tables-file=" + str(LEX_TABLES_FILE)}'
 
 
 def exists(env) -> Optional[str]:

--- a/SCons/Tool/lex.xml
+++ b/SCons/Tool/lex.xml
@@ -61,7 +61,7 @@ Sets construction variables for the &lex; lexical analyser.
 <item>LEXCOMSTR</item>
 <item>LEXFLAGS</item>
 <item>LEX_HEADER_FILE</item>
-<item>LEX_TABLE_FILE</item>
+<item>LEX_TABLES_FILE</item>
 </uses>
 </tool>
 
@@ -113,7 +113,7 @@ the output file is named by the option argument.
 Note that files specified by <option>--header-file=</option> and
 <option>--tables-file=</option> may not be properly handled
 by &SCons; in all situations. Consider using
-&cv-link-LEX_HEADER_FILE; and &cv-link-LEX_TABLE_FILE; instead.
+&cv-link-LEX_HEADER_FILE; and &cv-link-LEX_TABLES_FILE; instead.
 </para>
 </summary>
 </cvar>
@@ -129,7 +129,7 @@ command-line option. Use this in preference to including
 </summary>
 </cvar>
 
-<cvar name="LEX_TABLE_FILE">
+<cvar name="LEX_TABLES_FILE">
 <summary>
 <para>
 If supplied, write the lex tables to a file with the name

--- a/SCons/Tool/lex.xml
+++ b/SCons/Tool/lex.xml
@@ -60,8 +60,8 @@ Sets construction variables for the &lex; lexical analyser.
 <uses>
 <item>LEXCOMSTR</item>
 <item>LEXFLAGS</item>
-<item>LEXHEADERFILE</item>
-<item>LEXTABLESFILE</item>
+<item>LEX_HEADER_FILE</item>
+<item>LEX_TABLE_FILE</item>
 </uses>
 </tool>
 
@@ -113,12 +113,12 @@ the output file is named by the option argument.
 Note that files specified by <option>--header-file=</option> and
 <option>--tables-file=</option> may not be properly handled
 by &SCons; in all situations. Consider using
-&cv-link-LEXHEADERFILE; and &cv-link-LEXTABLESFILE; instead.
+&cv-link-LEX_HEADER_FILE; and &cv-link-LEX_TABLE_FILE; instead.
 </para>
 </summary>
 </cvar>
 
-<cvar name="LEXHEADERFILE">
+<cvar name="LEX_HEADER_FILE">
 <summary>
 <para>
 If supplied, generate a C header file with the name taken from this variable.
@@ -129,7 +129,7 @@ command-line option. Use this in preference to including
 </summary>
 </cvar>
 
-<cvar name="LEXTABLESFILE">
+<cvar name="LEX_TABLE_FILE">
 <summary>
 <para>
 If supplied, write the lex tables to a file with the name

--- a/SCons/Tool/lex.xml
+++ b/SCons/Tool/lex.xml
@@ -60,6 +60,8 @@ Sets construction variables for the &lex; lexical analyser.
 <uses>
 <item>LEXCOMSTR</item>
 <item>LEXFLAGS</item>
+<item>LEXHEADERFILE</item>
+<item>LEXTABLESFILE</item>
 </uses>
 </tool>
 
@@ -106,6 +108,35 @@ Recognized for this purpose are GNU &flex; options
 <option>--header-file=</option> and
 <option>--tables-file=</option>;
 the output file is named by the option argument.
+</para>
+<para>
+Note that files specified by <option>--header-file=</option> and
+<option>--tables-file=</option> may not be properly handled
+by &SCons; in all situations. Consider using
+&cv-link-LEXHEADERFILE; and &cv-link-LEXTABLESFILE; instead.
+</para>
+</summary>
+</cvar>
+
+<cvar name="LEXHEADERFILE">
+<summary>
+<para>
+If supplied, generate a C header file with the name taken from this variable.
+Will be emitted as a <option>--header-file=</option>
+command-line option. Use this in preference to including
+<option>--header-file=</option> in &cv-link-LEXFLAGS; directly.
+</para>
+</summary>
+</cvar>
+
+<cvar name="LEXTABLESFILE">
+<summary>
+<para>
+If supplied, write the lex tables to a file with the name
+taken from this variable.
+Will be emitted as a <option>--tables-file=</option>
+command-line option. Use this in preference to including
+<option>--tables-file=</option> in &cv-link-LEXFLAGS; directly.
 </para>
 </summary>
 </cvar>

--- a/SCons/Tool/yacc.py
+++ b/SCons/Tool/yacc.py
@@ -98,17 +98,17 @@ def _yaccEmitter(target, source, env, ysuf, hsuf) -> tuple:
                 fileName = option[l:].strip()
                 target.append(fileName)
 
-    yaccheaderfile = env.subst("$YACCHEADERFILE", target=target, source=source)
+    yaccheaderfile = env.subst("$YACC_HEADER_FILE", target=target, source=source)
     if yaccheaderfile:
         target.append(yaccheaderfile)
         # rewrite user-supplied file string with a node, we need later
-        env.Replace(YACCHEADERFILE=env.File(yaccheaderfile))
+        env.Replace(YACC_HEADER_FILE=env.File(yaccheaderfile))
 
-    yaccgraphfile = env.subst("$YACCGRAPHFILE", target=target, source=source)
+    yaccgraphfile = env.subst("$YACC_GRAPH_FILE", target=target, source=source)
     if yaccgraphfile:
         target.append(yaccgraphfile)
         # rewrite user-supplied file string with a node, we need later
-        env.Replace(YACCGRAPHFILE=env.File(yaccgraphfile))
+        env.Replace(YACC_GRAPH_FILE=env.File(yaccgraphfile))
 
     return target, source
 
@@ -178,16 +178,16 @@ def generate(env) -> None:
     env.SetDefault(
         YACC=env.Detect(BINS),
         YACCFLAGS=CLVar(""),
-        YACCHEADERFILE="",
-        YACCGRAPHSFILE="",
+        YACC_HEADER_FILE="",
+        YACC_GRAPH_FILE="",
     )
 
-    env['YACCCOM'] = '$YACC $YACCFLAGS $_YACCHEADER $_YACCGRAPH -o $TARGET $SOURCES'
+    env['YACCCOM'] = '$YACC $YACCFLAGS $_YACC_HEADER $_YACC_GRAPH -o $TARGET $SOURCES'
     env['YACCHFILESUFFIX'] = '.h'
     env['YACCHXXFILESUFFIX'] = '.hpp'
     env['YACCVCGFILESUFFIX'] = '.vcg'
-    env['_YACCHEADER'] = '${YACCHEADERFILE and "--header=" + str(YACCHEADERFILE)}'
-    env['_YACCGRAPH'] = '${YACCGRAPHFILE and "--graph=" + str(YACCGRAPHFILE)}'
+    env['_YACC_HEADER'] = '${YACC_HEADER_FILE and "--header=" + str(YACC_HEADER_FILE)}'
+    env['_YACC_GRAPH'] = '${YACC_GRAPH_FILE and "--graph=" + str(YACC_GRAPH_FILE)}'
 
 
 def exists(env) -> Optional[str]:

--- a/SCons/Tool/yacc.xml
+++ b/SCons/Tool/yacc.xml
@@ -62,8 +62,8 @@ Sets construction variables for the &yacc; parse generator.
 <uses>
 <item>YACCCOMSTR</item>
 <item>YACCFLAGS</item>
-<item>YACCHEADERFILE</item>
-<item>YACCGRAPHFILE</item>
+<item>YACC_HEADER_FILE</item>
+<item>YACC_GRAPH_FILE</item>
 </uses>
 </tool>
 
@@ -146,12 +146,12 @@ but the output filename is named by the option argument.
 Note that files specified by <option>--header=</option> and
 <option>--graph=</option> may not be properly handled
 by &SCons; in all situations. Consider using
-&cv-link-YACCHEADERFILE; and &cv-link-YACCGRAPHFILE; instead.
+&cv-link-YACC_HEADER_FILE; and &cv-link-YACC_GRAPH_FILE; instead.
 </para>
 </summary>
 </cvar>
 
-<cvar name="YACCHEADERFILE">
+<cvar name="YACC_HEADER_FILE">
 <summary>
 <para>
 If supplied, generate a header file with the name taken from this variable.
@@ -162,7 +162,7 @@ command-line option. Use this in preference to including
 </summary>
 </cvar>
 
-<cvar name="YACCGRAPHFILE">
+<cvar name="YACC_GRAPH_FILE">
 <summary>
 <para>
 If supplied, write a graph of the automaton to a file with the name

--- a/SCons/Tool/yacc.xml
+++ b/SCons/Tool/yacc.xml
@@ -62,6 +62,8 @@ Sets construction variables for the &yacc; parse generator.
 <uses>
 <item>YACCCOMSTR</item>
 <item>YACCFLAGS</item>
+<item>YACCHEADERFILE</item>
+<item>YACCGRAPHFILE</item>
 </uses>
 </tool>
 
@@ -138,6 +140,36 @@ and <option>--graph=</option>,
 which is similar to
 <option>-g</option>
 but the output filename is named by the option argument.
+</para>
+
+<para>
+Note that files specified by <option>--header=</option> and
+<option>--graph=</option> may not be properly handled
+by &SCons; in all situations. Consider using
+&cv-link-YACCHEADERFILE; and &cv-link-YACCGRAPHFILE; instead.
+</para>
+</summary>
+</cvar>
+
+<cvar name="YACCHEADERFILE">
+<summary>
+<para>
+If supplied, generate a header file with the name taken from this variable.
+Will be emitted as a <option>--header=</option>
+command-line option. Use this in preference to including
+<option>--header=</option> in &cv-link-YACCFLAGS; directly.
+</para>
+</summary>
+</cvar>
+
+<cvar name="YACCGRAPHFILE">
+<summary>
+<para>
+If supplied, write a graph of the automaton to a file with the name
+taken from this variable.
+Will be emitted as a <option>--graph=</option>
+command-line option. Use this in preference to including
+<option>--graph=</option> in &cv-link-YACCFLAGS; directly.
 </para>
 </summary>
 </cvar>

--- a/test/LEX/FLEXFLAGS.py
+++ b/test/LEX/FLEXFLAGS.py
@@ -78,8 +78,8 @@ env = Environment(
 env.CFile(
     target='aaa',
     source='aaa.l',
-    LEXHEADERFILE='header.h',
-    LEXTABLESFILE='tables.t',
+    LEX_HEADER_FILE='header.h',
+    LEX_TABLE_FILE='tables.t',
 )
 """)
 test.write(['sub2', 'aaa.l'], "aaa.l\nLEXFLAGS\n")

--- a/test/LEX/FLEXFLAGS.py
+++ b/test/LEX/FLEXFLAGS.py
@@ -79,7 +79,7 @@ env.CFile(
     target='aaa',
     source='aaa.l',
     LEX_HEADER_FILE='header.h',
-    LEX_TABLE_FILE='tables.t',
+    LEX_TABLES_FILE='tables.t',
 )
 """)
 test.write(['sub2', 'aaa.l'], "aaa.l\nLEXFLAGS\n")

--- a/test/YACC/BISONFLAGS.py
+++ b/test/YACC/BISONFLAGS.py
@@ -25,7 +25,10 @@
 
 """
 Test that detection of file-writing options in YACCFLAGS works.
+Also test that the construction vars for the same purpose work.
 """
+
+from pathlib import Path
 
 import TestSCons
 from TestCmd import IS_WINDOWS
@@ -42,16 +45,18 @@ else:
 
 test = TestSCons.TestSCons()
 
-test.subdir('sub')
+test.subdir('sub1')
+test.subdir('sub2')
 
 test.dir_fixture('YACCFLAGS-fixture')
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-SConscript("sub/SConscript")
+SConscript(dirs=['sub1', 'sub2'])
 """)
 
-test.write(['sub', 'SConscript'], """\
+# this SConscript is for the options-in-flags version
+test.write(['sub1', 'SConscript'], """\
 import sys
 
 env = Environment(
@@ -65,21 +70,56 @@ t = [str(target) for target in targs]
 if not all((len(t) == 3, "header.h" in t, "graph.g" in t)):
     sys.exit(1)
 """ % locals())
-test.write(['sub', 'aaa.y'], "aaa.y\nYACCFLAGS\n")
+test.write(['sub1', 'aaa.y'], "aaa.y\nYACCFLAGS\n")
+
+# this SConscript is for the construction var version
+test.write(['sub2', 'SConscript'], """\
+import sys
+
+env = Environment(
+    YACC=r'%(_python_)s myyacc.py',
+    YACCFLAGS='-x',
+    tools=['yacc', '%(linker)s', '%(compiler)s'],
+)
+env.CFile(
+    target='aaa',
+    source='aaa.y',
+    YACCHEADERFILE='header.h',
+    YACCGRAPHFILE='graph.g',
+)
+""" % locals())
+test.write(['sub2', 'aaa.y'], "aaa.y\nYACCFLAGS\n")
+
 test.run('.', stderr=None)
-test.must_match(['sub', 'aaa.c'], "aaa.y\n -x --header=header.h --graph=graph.g\n")
+test.must_match(['sub1', 'aaa.c'], "aaa.y\n -x --header=header.h --graph=graph.g\n")
 
 # NOTE: this behavior is "wrong" but we're keeping it for compat:
-# the generated files should go into 'sub'.
+# the generated files should go into 'sub1', not the topdir.
 test.must_match(['header.h'], 'yacc header\n')
 test.must_match(['graph.g'], 'yacc graph\n')
 
 # To confirm the files from the file-output options were tracked,
+# we should do a clean and make sure they got removed.
+# As noted, they currently don't go into the tracked location,
+# so using the check in the SConscript instead.
+#test.run(arguments='-c .')
+#test.must_not_exist(test.workpath(['sub1', 'header.h']))
+#test.must_not_exist(test.workpath(['sub1', 'graph.g']))
+
+sub2 = Path('sub2')
+headerfile = sub2 / 'header.h'
+graphfile = sub2 / 'graph.g'
+yaccflags = f"aaa.y\n -x --header={headerfile} --graph={graphfile}\n"
+test.must_match(['sub2', 'aaa.c'], yaccflags)
+test.must_match(['sub2', 'header.h'], 'yacc header\n')
+test.must_match(['sub2', 'graph.g'], 'yacc graph\n')
+
+# To confirm the files from the file-output options were tracked,
 # do a clean and make sure they got removed. As noted, they currently
 # don't go into the tracked location, so using the the SConscript check instead.
-#test.run(arguments='-c .')
-#test.must_not_exist(test.workpath(['sub', 'header.h']))
-#test.must_not_exist(test.workpath(['sub', 'graph.g']))
+test.run(arguments='-c .')
+test.must_not_exist(test.workpath('sub2', 'header.h'))
+test.must_not_exist(test.workpath('sub2', 'graph.g'))
 
 test.pass_test()
 

--- a/test/YACC/BISONFLAGS.py
+++ b/test/YACC/BISONFLAGS.py
@@ -84,8 +84,8 @@ env = Environment(
 env.CFile(
     target='aaa',
     source='aaa.y',
-    YACCHEADERFILE='header.h',
-    YACCGRAPHFILE='graph.g',
+    YACC_HEADER_FILE='header.h',
+    YACC_GRAPH_FILE='graph.g',
 )
 """ % locals())
 test.write(['sub2', 'aaa.y'], "aaa.y\nYACCFLAGS\n")

--- a/test/YACC/YACCFLAGS-fixture/myyacc.py
+++ b/test/YACC/YACCFLAGS-fixture/myyacc.py
@@ -6,7 +6,7 @@ from pathlib import Path
 def make_side_effect(path, text):
     p = Path(path)
     if str(p.parent) != '.':
-        p.mkdir(parents=True, exist_ok=True)
+        p.parent.mkdir(parents=True, exist_ok=True)
     with p.open(mode="wb") as f:
         f.write(text)
 

--- a/test/fixture/mylex.py
+++ b/test/fixture/mylex.py
@@ -15,7 +15,7 @@ from pathlib import Path
 def make_side_effect(path, text):
     p = Path(path)
     if str(p.parent) != '.':
-        p.mkdir(parents=True, exist_ok=True)
+        p.parent.mkdir(parents=True, exist_ok=True)
     with p.open(mode="wb") as f:
         f.write(text)
 


### PR DESCRIPTION
lex and yacc tools both got two new construction variables for specifying side effect creation of additional files, this method avoids the user embedding the options in `LEXFLAGS` and `YACCFLAGS` - the latter lets the commands generate the files, but the paths would not be properly relocated by SCons, so if the build was initiated in a subdirectory (including any time a variant dir is used), the generated files would go into the top directory instead.

Fixes #4154

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
