### PR TITLE
Let test framework still run if no psutil

### DIFF
--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -399,7 +399,7 @@ def clean_up_ninja_daemon(self, result_type) -> None:
     Working directory and temp files are removed.
     Skipped if this platform doesn't have psutil (e.g. msys2 on Windows)
     """
-    if not self or not HAVE_PSUTIL:
+    if not self:
         return
 
     for path in Path(self.workdir).rglob('.ninja'):
@@ -416,7 +416,7 @@ def clean_up_ninja_daemon(self, result_type) -> None:
                     except OSError:
                         pass
 
-                    while True:
+                    while HAVE_PSUTIL:
                         if pid not in [proc.pid for proc in psutil.process_iter()]:
                             break
                         else:


### PR DESCRIPTION
Some odd environments - the one I'm running into it is inside an msys2 POSIX shell on Windows, using msys Python - don't have a psutil module to install.  Let the test framework continue to work even if this is the case.

fixes #4199

this is a test (framework) only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
