### PR TITLE
[framework] use subprocess timeouts

### DIFF
--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -2848,7 +2848,7 @@ sys.exit(0)
 
 class timeout_TestCase(TestCmdTestCase):
     def test_initialization(self):
-        """Test initialization timeout"""
+        """Test initializating a TestCmd with a timeout"""
         test = TestCmd.TestCmd(workdir='', timeout=2)
         test.write('sleep.py', timeout_script)
 
@@ -2882,40 +2882,39 @@ class timeout_TestCase(TestCmdTestCase):
         test = TestCmd.TestCmd(workdir='', timeout=8)
         test.write('sleep.py', timeout_script)
 
-        test.run([sys.executable, test.workpath('sleep.py'), '2'],
-                 timeout=4)
+        test.run([sys.executable, test.workpath('sleep.py'), '2'], timeout=4)
         assert test.stderr() == '', test.stderr()
         assert test.stdout() == 'sleeping 2\nslept 2\n', test.stdout()
 
-        test.run([sys.executable, test.workpath('sleep.py'), '6'],
-                 timeout=4)
+        test.run([sys.executable, test.workpath('sleep.py'), '6'], timeout=4)
         assert test.stderr() == '', test.stderr()
         assert test.stdout() == 'sleeping 6\n', test.stdout()
 
-    def test_set_timeout(self):
-        """Test set_timeout()"""
-        test = TestCmd.TestCmd(workdir='', timeout=2)
-        test.write('sleep.py', timeout_script)
-
-        test.run([sys.executable, test.workpath('sleep.py'), '4'])
-        assert test.stderr() == '', test.stderr()
-        assert test.stdout() == 'sleeping 4\n', test.stdout()
-
-        test.set_timeout(None)
-
-        test.run([sys.executable, test.workpath('sleep.py'), '4'])
-        assert test.stderr() == '', test.stderr()
-        assert test.stdout() == 'sleeping 4\nslept 4\n', test.stdout()
-
-        test.set_timeout(6)
-
-        test.run([sys.executable, test.workpath('sleep.py'), '4'])
-        assert test.stderr() == '', test.stderr()
-        assert test.stdout() == 'sleeping 4\nslept 4\n', test.stdout()
-
-        test.run([sys.executable, test.workpath('sleep.py'), '8'])
-        assert test.stderr() == '', test.stderr()
-        assert test.stdout() == 'sleeping 8\n', test.stdout()
+    # This method has been removed
+    #def test_set_timeout(self):
+    #    """Test set_timeout()"""
+    #    test = TestCmd.TestCmd(workdir='', timeout=2)
+    #    test.write('sleep.py', timeout_script)
+    #
+    #    test.run([sys.executable, test.workpath('sleep.py'), '4'])
+    #    assert test.stderr() == '', test.stderr()
+    #    assert test.stdout() == 'sleeping 4\n', test.stdout()
+    #
+    #    test.set_timeout(None)
+    #
+    #    test.run([sys.executable, test.workpath('sleep.py'), '4'])
+    #    assert test.stderr() == '', test.stderr()
+    #    assert test.stdout() == 'sleeping 4\nslept 4\n', test.stdout()
+    #
+    #    test.set_timeout(6)
+    #
+    #    test.run([sys.executable, test.workpath('sleep.py'), '4'])
+    #    assert test.stderr() == '', test.stderr()
+    #    assert test.stdout() == 'sleeping 4\nslept 4\n', test.stdout()
+    #
+    #    test.run([sys.executable, test.workpath('sleep.py'), '8'])
+    #    assert test.stderr() == '', test.stderr()
+    #    assert test.stdout() == 'sleeping 8\n', test.stdout()
 
 
 

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -676,7 +676,7 @@ class TestCommon(TestCmd):
         """
         arguments = self.options_arguments(options, arguments)
         try:
-            return TestCmd.start(self, program, interpreter, arguments,
+            return super().start(program, interpreter, arguments,
                                  universal_newlines, **kw)
         except KeyboardInterrupt:
             raise
@@ -713,7 +713,7 @@ class TestCommon(TestCmd):
                         command.  A value of None means don't
                         test exit status.
         """
-        TestCmd.finish(self, popen, **kw)
+        super().finish(popen, **kw)
         match = kw.get('match', self.match)
         self._complete(self.stdout(), stdout,
                        self.stderr(), stderr, status, match)
@@ -750,7 +750,7 @@ class TestCommon(TestCmd):
             del kw['match']
         except KeyError:
             match = self.match
-        TestCmd.run(self, **kw)
+        super().run(**kw)
         self._complete(self.stdout(), stdout,
                        self.stderr(), stderr, status, match)
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -461,7 +461,7 @@ class TestSCons(TestCommon):
         """
         sconsflags = initialize_sconsflags(self.ignore_python_version)
         try:
-            TestCommon.run(self, *args, **kw)
+            super().run(*args, **kw)
         finally:
             restore_sconsflags(sconsflags)
 
@@ -1636,7 +1636,7 @@ else:
             kw['stdin'] = True
         sconsflags = initialize_sconsflags(self.ignore_python_version)
         try:
-            p = TestCommon.start(self, *args, **kw)
+            p = super().start(*args, **kw)
         finally:
             restore_sconsflags(sconsflags)
         return p


### PR DESCRIPTION
Since Python 3.3, the subprocess module has its own timeout implementation, so remove the test framework's custom one.

Required a little rejigger since the subprocess timeout is done on the `communicate()` call, not set up before the test is started.  Noted that the framework intends to support two levels: one for the testing class instance, and one for an individual `start` call, which should override the one in the instance.

Signed-off-by: Mats Wichmann <mats@linux.com>

https://scons.org/guidelines.html

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
