### PR TITLE
Add newline to end of compile_commands.json

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
         - Whatever John Doe did.
 
+  From Dan Mezhiborsky:
+    - Add newline to end of compilation db (compile_commands.json).
+
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -34,6 +34,8 @@ FIXES
 
 - List fixes of outright bugs
 
+- Added missing newline to generated compilation database (compile_commands.json)
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -163,6 +163,7 @@ def write_compilation_db(target, source, env):
         json.dump(
             entries, output_file, sort_keys=True, indent=4, separators=(",", ": ")
         )
+        output_file.write("\n")
 
 
 def scan_compilation_db(node, env, path):

--- a/test/CompilationDatabase/basic.py
+++ b/test/CompilationDatabase/basic.py
@@ -63,7 +63,8 @@ example_rel_file = """[
         "file": "test_main.c",
         "output": "test_main.o"
     }
-]""" % (sys.executable, test.workdir)
+]
+""" % (sys.executable, test.workdir)
 
 if sys.platform == 'win32':
     example_rel_file = example_rel_file.replace('\\', '\\\\')
@@ -80,7 +81,8 @@ example_abs_file = """[
         "file": "%s",
         "output": "%s"
     }
-]""" % (sys.executable, test.workdir, os.path.join(test.workdir, 'test_main.c'), os.path.join(test.workdir, 'test_main.o'))
+]
+""" % (sys.executable, test.workdir, os.path.join(test.workdir, 'test_main.c'), os.path.join(test.workdir, 'test_main.o'))
 
 if sys.platform == 'win32':
     example_abs_file = example_abs_file.replace('\\', '\\\\')

--- a/test/CompilationDatabase/variant_dir.py
+++ b/test/CompilationDatabase/variant_dir.py
@@ -77,7 +77,8 @@ example_rel_file = """[
         "file": "%(src_file)s",
         "output": "%(output2_file)s"
     }
-]""" % {'exe': sys.executable,
+]
+""" % {'exe': sys.executable,
         'workdir': test.workdir,
         'src_file': os.path.join('src', 'test_main.c'),
         'output_file': os.path.join('build', 'test_main.o'),
@@ -106,7 +107,8 @@ example_abs_file = """[
         "file": "%(abs_src_file)s",
         "output": "%(abs_output2_file)s"
     }
-]""" % {'exe': sys.executable,
+]
+""" % {'exe': sys.executable,
         'workdir': test.workdir,
         'src_file': os.path.join('src', 'test_main.c'),
         'abs_src_file': os.path.join(test.workdir, 'src', 'test_main.c'),
@@ -130,7 +132,8 @@ example_filter_build_file = """[
         "file": "%(src_file)s",
         "output": "%(output_file)s"
     }
-]""" % {'exe': sys.executable,
+]
+""" % {'exe': sys.executable,
         'workdir': test.workdir,
         'src_file': os.path.join('src', 'test_main.c'),
         'output_file': os.path.join('build', 'test_main.o'),
@@ -151,7 +154,8 @@ example_filter_build2_file = """[
         "file": "%(src_file)s",
         "output": "%(output2_file)s"
     }
-]""" % {'exe': sys.executable,
+]
+""" % {'exe': sys.executable,
         'workdir': test.workdir,
         'src_file': os.path.join('src', 'test_main.c'),
         'output2_file': os.path.join('build2', 'test_main.o'),


### PR DESCRIPTION
This adds a newline to `compile_commands.json`, which currently has no newline at EOF.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
