### PR TITLE
Fix -fsanitize flag handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,15 +9,11 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
-
-        - Whatever John Doe did.
-
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).
 
   From Flaviu Tamas
-    - Fixed -fsanitize argument not being passed to the linker
+    - Added -fsanitize support to ParseFlags().  This will propagate to CCFLAGS and LINKFLAGS.
 
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).
 
+  From Flaviu Tamas
+    - Fixed -fsanitize argument not being passed to the linker
+
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -26,8 +26,7 @@ DEPRECATED FUNCTIONALITY
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 
-- List modifications to existing features, where the previous behavior
-  wouldn't actually be considered a bug
+- Added -fsanitize support to ParseFlags().  This will propagate to CCFLAGS and LINKFLAGS.
 
 FIXES
 -----

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -802,7 +802,7 @@ class SubstitutionEnvironment:
                     '-openmp',
                     '-fmerge-all-constants',
                     '-fopenmp',
-                ):
+                ) or arg.startswith('-fsanitize'):
                     mapping['CCFLAGS'].append(arg)
                     mapping['LINKFLAGS'].append(arg)
                 elif arg == '-mwindows':

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -2512,6 +2512,7 @@ and added to the following construction variables:
 -frameworkdir=          FRAMEWORKPATH
 -fmerge-all-constants   CCFLAGS, LINKFLAGS
 -fopenmp                CCFLAGS, LINKFLAGS
+-fsanitize              CCFLAGS, LINKFLAGS
 -include                CCFLAGS
 -imacros                CCFLAGS
 -isysroot               CCFLAGS, LINKFLAGS

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -2493,15 +2493,15 @@ This can be used to call a <filename>*-config</filename>
 command typical of the POSIX programming environment
 (for example,
 <command>pkg-config</command>).
-Note that such a comamnd is executed using the
+Note that such a command is executed using the
 SCons execution environment;
 if the command needs additional information,
-that information needs to be explcitly provided.
+that information needs to be explicitly provided.
 See &f-link-ParseConfig; for more details.
 </para>
 
 <para>
-Flag values are translated accordig to the prefix found,
+Flag values are translated according to the prefix found,
 and added to the following construction variables:
 </para>
 

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -820,6 +820,8 @@ sys.exit(0)
             "--param l1-cache-size=32 --param l2-cache-size=6144 "
             "+DD64 "
             "-DFOO -DBAR=value -D BAZ "
+            "-fsanitize=memory "
+            "-fsanitize-address-use-after-return "
         )
 
         d = env.ParseFlags(s)
@@ -836,7 +838,9 @@ sys.exit(0)
                                 ('-imacros', env.fs.File('/usr/include/foo4')),
                                 ('-include', env.fs.File('/usr/include/foo5')),
                                 ('--param', 'l1-cache-size=32'), ('--param', 'l2-cache-size=6144'),
-                                '+DD64'], repr(d['CCFLAGS'])
+                                '+DD64',
+                                '-fsanitize=memory',
+                                '-fsanitize-address-use-after-return'], repr(d['CCFLAGS'])
         assert d['CXXFLAGS'] == ['-std=c++0x'], repr(d['CXXFLAGS'])
         assert d['CPPDEFINES'] == ['FOO', ['BAR', 'value'], 'BAZ'], d['CPPDEFINES']
         assert d['CPPFLAGS'] == ['-Wp,-cpp'], d['CPPFLAGS']
@@ -856,7 +860,9 @@ sys.exit(0)
                                   '-mno-cygwin', '-mwindows',
                                   ('-arch', 'i386'),
                                   ('-isysroot', '/tmp'),
-                                  '+DD64'], repr(d['LINKFLAGS'])
+                                  '+DD64',
+                                  '-fsanitize=memory',
+                                  '-fsanitize-address-use-after-return'], repr(d['LINKFLAGS'])
         assert d['RPATH'] == ['rpath1', 'rpath2', 'rpath3'], d['RPATH']
 
 

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -2925,15 +2925,15 @@ This can be used to call a <filename>*-config</filename>
 command typical of the POSIX programming environment
 (for example,
 <command>pkg-config</command>).
-Note that such a comamnd is executed using the
+Note that such a command is executed using the
 SCons execution environment;
 if the command needs additional information,
-that information needs to be explcitly provided.
+that information needs to be explicitly provided.
 See &f-link-ParseConfig; for more details.
 </para>
 
 <para>
-Flag values are translated accordig to the prefix found,
+Flag values are translated according to the prefix found,
 and added to the following construction variables:
 </para>
 

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -2944,6 +2944,7 @@ and added to the following construction variables:
 -frameworkdir=          FRAMEWORKPATH
 -fmerge-all-constants   CCFLAGS, LINKFLAGS
 -fopenmp                CCFLAGS, LINKFLAGS
+-fsanitize              CCFLAGS, LINKFLAGS
 -include                CCFLAGS
 -imacros                CCFLAGS
 -isysroot               CCFLAGS, LINKFLAGS


### PR DESCRIPTION
These parameters need to be passed to both the compiler and the linker,
otherwise lots of "undefined reference to `__asan_stack_malloc_0'"
errors get emitted at link time, since the appropriate library is not
linked in.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
