### PR TITLE
Tweak --hash-format manpage entry

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1218,18 +1218,18 @@ to use the specified algorithm.</para>
 <para>If this option is omitted,
 the first supported hash format found is selected.
 Typically this is MD5, however, on a FIPS-compliant system
-using a version of Python less than 3.9,
-SHA1 or SHA256 will be chosen as the default.
-Python 3.9 and onwards clients will always default to MD5, even in FIPS mode.
+using a version of Python older than 3.9,
+SHA1 or SHA256 is chosen as the default.
+Python 3.9 and onwards clients always default to MD5, even in FIPS mode.
 </para>
 
 <para>Specifying this option changes the name of the SConsign database.
-The default database is <filename>.sconsign.dblite</filename>;
-in the presence of this option,
-<replaceable>ALGORITHM</replaceable> will
+The default database is <filename>.sconsign.dblite</filename>.
+In the presence of this option,
+<replaceable>ALGORITHM</replaceable> is
 be included in the name to indicate the difference,
 even if the argument is <parameter>md5</parameter>.
-For example, <option>--hash-format=sha256</option> will create a SConsign
+For example, <option>--hash-format=sha256</option> uses a SConsign
 database named <filename>.sconsign_sha256.dblite</filename>.
 </para>
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1227,7 +1227,7 @@ Python 3.9 and onwards clients always default to MD5, even in FIPS mode.
 The default database is <filename>.sconsign.dblite</filename>.
 In the presence of this option,
 <replaceable>ALGORITHM</replaceable> is
-be included in the name to indicate the difference,
+included in the name to indicate the difference,
 even if the argument is <parameter>md5</parameter>.
 For example, <option>--hash-format=sha256</option> uses a SConsign
 database named <filename>.sconsign_sha256.dblite</filename>.

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1205,26 +1205,33 @@ be appropriate for most uses.</para>
 <para>Set the hashing algorithm used by SCons to
 <replaceable>ALGORITHM</replaceable>.
 This value determines the hashing algorithm used in generating
-&contentsigs; or &CacheDir; keys.</para>
+&contentsigs;, &buildsigs; and &CacheDir; keys.</para>
 
-<para>The supported list of values are: md5, sha1, and sha256.
+<para>The supported list of values are:
+<parameter>md5</parameter>,
+<parameter>sha1</parameter>
+and <parameter>sha256</parameter>.
 However, the Python interpreter used to run SCons must have the corresponding
 support available in the <systemitem>hashlib</systemitem> module
 to use the specified algorithm.</para>
 
-<para>Specifying this value changes the name of the SConsign database.
+<para>If this option is omitted,
+the first supported hash format found is selected.
+Typically this is MD5, however, on a FIPS-compliant system
+using a version of Python less than 3.9,
+SHA1 or SHA256 will be chosen as the default.
+Python 3.9 and onwards clients will always default to MD5, even in FIPS mode.
+</para>
+
+<para>Specifying this option changes the name of the SConsign database.
+The default database is <filename>.sconsign.dblite</filename>;
+in the presence of this option,
+<replaceable>ALGORITHM</replaceable> will
+be included in the name to indicate the difference,
+even if the argument is <parameter>md5</parameter>.
 For example, <option>--hash-format=sha256</option> will create a SConsign
-database with name <filename>.sconsign_sha256.dblite</filename>.</para>
-
-<para>If this option is not specified, a the first supported hash format found
-is selected. Typically this is MD5, however, if you are on a FIPS-compliant system
-and using a version of Python less than 3.9, SHA1 or SHA256 will be chosen as the default.
-Python 3.9 and onwards clients will always default to MD5, even in FIPS mode, unless
-otherwise specified with the <option>--hash-format</option> option.</para>
-
-<para>For MD5 databases (either explicitly specified with <option>--hash-format=md5</option> or
-defaulted), the SConsign database is<filename>.sconsign.dblite</filename>. The newer SHA1 and
-SHA256 selections meanwhile store their databases to <filename>.sconsign_algorithmname.dblite</filename></para>
+database named <filename>.sconsign_sha256.dblite</filename>.
+</para>
 
 <para><emphasis>Available since &scons; 4.2.</emphasis></para>
   </listitem>

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -453,6 +453,7 @@
 <!ENTITY contentsig "<phrase xmlns='http://www.scons.org/dbxsd/v1.0'>content signature</phrase>">
 <!ENTITY contentsigs "<phrase xmlns='http://www.scons.org/dbxsd/v1.0'>content signatures</phrase>">
 <!ENTITY buildsig "<phrase xmlns='http://www.scons.org/dbxsd/v1.0'>build signature</phrase>">
+<!ENTITY buildsigs "<phrase xmlns='http://www.scons.org/dbxsd/v1.0'>build signatures</phrase>">
 
 <!ENTITY true "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>true</literal>">
 <!ENTITY false "<literal xmlns='http://www.scons.org/dbxsd/v1.0'>false</literal>">


### PR DESCRIPTION
Previously, there are some wording problems and one paragraph was essentially a restatement of an earlier one.  Also corrected the claim that `--hash-format=md5` would create an unadorned `.sconsign.dblite` - tested to show it is actually `.sconsign_md5.dblite`

Doc-only change

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
