### PR TITLE
Static script functions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-  From Anatoli Babenia
+  From Anatoli Babenia:
     - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() and
       EnsurePythonVersion().
 
@@ -21,10 +21,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).
 
-  From Flaviu Tamas
+  From Flaviu Tamas:
     - Added -fsanitize support to ParseFlags().  This will propagate to CCFLAGS and LINKFLAGS.
 
-  From Ryan Saunders
+  From Ryan Saunders:
     - Fixed runtest.py failure on Windows caused by excessive escaping of the path to python.exe.
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,10 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Anatoli Babenia
+    - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() and
+      EnsurePythonVersion().
+
   From William Deegan:
     - Added ValidateOptions() which will check that all command line options are in either
       those specified by SCons itself, or by AddOption() in SConstruct/SConscript.  It should
@@ -22,10 +26,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Ryan Saunders
     - Fixed runtest.py failure on Windows caused by excessive escaping of the path to python.exe.
-
-  From Anatoli Babenia
-    - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() and
-      EnsurePythonVersion().
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Ryan Saunders
     - Fixed runtest.py failure on Windows caused by excessive escaping of the path to python.exe.
 
+  From Anatoli Babenia
+    - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() 
+
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700
 
   From Joseph Brill:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,7 +24,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fixed runtest.py failure on Windows caused by excessive escaping of the path to python.exe.
 
   From Anatoli Babenia
-    - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() 
+    - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() and
+      EnsurePythonVersion().
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 
 - Added -fsanitize support to ParseFlags().  This will propagate to CCFLAGS and LINKFLAGS.
+- Calling EnsureSConsVersion() and EnsurePythonVersion() won't initialize
+  DefaultEnvironment anymore.
 
 FIXES
 -----

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -507,7 +507,8 @@ class SConsEnvironment(SCons.Environment.Base):
                   (scons_ver_string, SCons.__version__))
             sys.exit(2)
 
-    def EnsurePythonVersion(self, major, minor):
+    @staticmethod
+    def EnsurePythonVersion(major, minor):
         """Exit abnormally if the Python version is not late enough."""
         if sys.version_info < (major, minor):
             v = sys.version.split()[0]

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -390,7 +390,8 @@ class SConsEnvironment(SCons.Environment.Base):
         in 'v_major' and 'v_minor', and 0 otherwise."""
         return (major > v_major or (major == v_major and minor > v_minor))
 
-    def _get_major_minor_revision(self, version_string):
+    @staticmethod
+    def _get_major_minor_revision(version_string):
         """Split a version string into major, minor and (optionally)
         revision parts.
 
@@ -488,14 +489,15 @@ class SConsEnvironment(SCons.Environment.Base):
     def Default(self, *targets):
         SCons.Script._Set_Default_Targets(self, targets)
 
-    def EnsureSConsVersion(self, major, minor, revision=0):
+    @staticmethod
+    def EnsureSConsVersion(major, minor, revision=0):
         """Exit abnormally if the SCons version is not late enough."""
         # split string to avoid replacement during build process
         if SCons.__version__ == '__' + 'VERSION__':
             SCons.Warnings.warn(SCons.Warnings.DevelopmentVersionWarning,
                 "EnsureSConsVersion is ignored for development version")
             return
-        scons_ver = self._get_major_minor_revision(SCons.__version__)
+        scons_ver = SConsEnvironment._get_major_minor_revision(SCons.__version__)
         if scons_ver < (major, minor, revision):
             if revision:
                 scons_ver_string = '%d.%d.%d' % (major, minor, revision)

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -126,8 +126,7 @@ GetBuildFailures        = Main.GetBuildFailures
 #profiling               = Main.profiling
 #repositories            = Main.repositories
 
-from . import SConscript
-_SConscript = SConscript
+from . import SConscript as _SConscript
 
 call_stack              = _SConscript.call_stack
 

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -287,14 +287,17 @@ def Variables(files=None, args=ARGUMENTS):
     return SCons.Variables.Variables(files, args)
 
 
-# The list of global functions to add to the SConscript name space
-# that end up calling corresponding methods or Builders in the
+# Adding global functions to the SConscript name space.
+#
+# Static functions that do not use state in DefaultEnvironment().
+EnsureSConsVersion = _SConscript.SConsEnvironment.EnsureSConsVersion
+
+# Functions that end up calling methods or Builders in the
 # DefaultEnvironment().
 GlobalDefaultEnvironmentFunctions = [
     # Methods from the SConsEnvironment class, above.
     'Default',
     'EnsurePythonVersion',
-    'EnsureSConsVersion',
     'Exit',
     'Export',
     'GetLaunchDir',

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -291,13 +291,13 @@ def Variables(files=None, args=ARGUMENTS):
 #
 # Static functions that do not use state in DefaultEnvironment().
 EnsureSConsVersion = _SConscript.SConsEnvironment.EnsureSConsVersion
+EnsurePythonVersion = _SConscript.SConsEnvironment.EnsurePythonVersion
 
 # Functions that end up calling methods or Builders in the
 # DefaultEnvironment().
 GlobalDefaultEnvironmentFunctions = [
     # Methods from the SConsEnvironment class, above.
     'Default',
-    'EnsurePythonVersion',
     'Exit',
     'Export',
     'GetLaunchDir',


### PR DESCRIPTION
Makes `EnsureSConsVersion` and `EnsurePythonVersion` functions static, so that they don't trigger initialization of default environment. This should speed up things a bit.

If there are more stateless functions like this, I would probably move them into a separate file like `Script/Functions.py` to try to simplify things even more.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
