### PR TITLE
Make Exit(), GetLaunchDir() and SConscriptChdir() static

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,8 +10,8 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Anatoli Babenia:
-    - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() and
-      EnsurePythonVersion().
+    - Do not initialize DefaultEnvironment when calling EnsureSConsVersion(),
+      EnsurePythonVersion(), Exit(), GetLaunchDir() and SConscriptChdir().
     - Remove unused private method SConsEnvironment._exceeds_version().
 
   From William Deegan:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Anatoli Babenia:
     - Do not initialize DefaultEnvironment when calling EnsureSConsVersion() and
       EnsurePythonVersion().
+    - Remove unused private method SConsEnvironment._exceeds_version().
 
   From William Deegan:
     - Added ValidateOptions() which will check that all command line options are in either

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -385,11 +385,6 @@ class SConsEnvironment(SCons.Environment.Base):
     #
     # Private methods of an SConsEnvironment.
     #
-    def _exceeds_version(self, major, minor, v_major, v_minor):
-        """Return 1 if 'major' and 'minor' are greater than the version
-        in 'v_major' and 'v_minor', and 0 otherwise."""
-        return (major > v_major or (major == v_major and minor > v_minor))
-
     @staticmethod
     def _get_major_minor_revision(version_string):
         """Split a version string into major, minor and (optionally)

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -510,7 +510,8 @@ class SConsEnvironment(SCons.Environment.Base):
             print("Python %d.%d or greater required, but you have Python %s" %(major,minor,v))
             sys.exit(2)
 
-    def Exit(self, value=0):
+    @staticmethod
+    def Exit(value=0):
         sys.exit(value)
 
     def Export(self, *vars, **kw):
@@ -518,7 +519,8 @@ class SConsEnvironment(SCons.Environment.Base):
             global_exports.update(compute_exports(self.Split(var)))
         global_exports.update(kw)
 
-    def GetLaunchDir(self):
+    @staticmethod
+    def GetLaunchDir():
         global launch_dir
         return launch_dir
 
@@ -595,7 +597,8 @@ class SConsEnvironment(SCons.Environment.Base):
         subst_kw['exports'] = exports
         return _SConscript(self.fs, *files, **subst_kw)
 
-    def SConscriptChdir(self, flag: bool) -> None:
+    @staticmethod
+    def SConscriptChdir(flag: bool) -> None:
         global sconscript_chdir
         sconscript_chdir = flag
 

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -289,22 +289,23 @@ def Variables(files=None, args=ARGUMENTS):
 
 # Adding global functions to the SConscript name space.
 #
-# Static functions that do not use state in DefaultEnvironment().
+# Static functions that do not trigger initialization of
+# DefaultEnvironment() and don't use its state.
 EnsureSConsVersion = _SConscript.SConsEnvironment.EnsureSConsVersion
 EnsurePythonVersion = _SConscript.SConsEnvironment.EnsurePythonVersion
+Exit = _SConscript.SConsEnvironment.Exit
+GetLaunchDir = _SConscript.SConsEnvironment.GetLaunchDir
+SConscriptChdir = _SConscript.SConsEnvironment.SConscriptChdir
 
 # Functions that end up calling methods or Builders in the
 # DefaultEnvironment().
 GlobalDefaultEnvironmentFunctions = [
     # Methods from the SConsEnvironment class, above.
     'Default',
-    'Exit',
     'Export',
-    'GetLaunchDir',
     'Help',
     'Import',
     #'SConscript', is handled separately, below.
-    'SConscriptChdir',
 
     # Methods from the Environment.Base class.
     'AddPostAction',
@@ -378,6 +379,8 @@ GlobalDefaultBuilders = [
     'Package',
 ]
 
+# DefaultEnvironmentCall() initializes DefaultEnvironment() if it is not
+# created yet.
 for name in GlobalDefaultEnvironmentFunctions + GlobalDefaultBuilders:
     exec ("%s = _SConscript.DefaultEnvironmentCall(%s)" % (name, repr(name)))
 del name


### PR DESCRIPTION
Continuation of #4224 which is a consequence of https://github.com/SCons/scons/discussions/4223

* Do not initialize DefaultEnvironment when calling EnsureSConsVersion(),
  EnsurePythonVersion(), Exit(), GetLaunchDir() and SConscriptChdir().
* Remove unused private method SConsEnvironment._exceeds_version().

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
