### PR TITLE
[DOC] improve description of CPPDEFINES

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -79,6 +79,8 @@ DOCUMENTATION
   Added note on the possibly surprising feature that SCons always passes
   -sourcepath when calling javac, which affects how the class path is
   used when finding sources.
+- Added further details in the documentation of Append and related functions
+  on the special handling of CPPDEFINES.
 
 DEVELOPMENT
 -----------

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -156,7 +156,7 @@ env = Environment(CPPDEFINES={'B':2, 'A':None})
 
 <para>
 To ensure stable build order,
-&SCons; sorts the flags generated from any dictionary,
+&SCons; sorts the flags generated from any dictionary.
 Older &Python; interpreters did
 not guarantee to preserve dictionary keys in insert order.
 &Python; since version 3.7 does preserve order,
@@ -173,14 +173,22 @@ for example a list containing strings, tuples and/or dictionaries.
 <para>
 Note that &SCons; may call the compiler via a shell.
 If a macro definition contains characters such as spaces that
-have meaning to the shell, you may need to use the shell's
-quoting syntax to avoid interpretation before the preprocessor sees it.
-Function-like macros may be supported,
-depending on the compiler (see the respective documentation),
-in which case the <emphasis>name</emphasis>
-may also have quoting considerations,
-as parentheses frequently have meaning to shells.
+have meaning to the shell, or is intended to be a string value,
+you may need to use the shell's quoting syntax to avoid
+interpretation by the shell before the preprocessor sees it.
+Function-like macros are not supported via this mechanism
+(and some compilers do not even implement that functionality
+via the command lines).
+When quoting, note that
+one set of quote characters are used to define a &Python; string,
+then quotes embedded inside that would be consumed by the shell
+unless escaped.  These examples may help illustrate:
 </para>
+
+<example_commands>
+env = Environment(CPPDEFINES=['USE_ALT_HEADER=\\"foo_alt.h\\"'])
+env = Environment(CPPDEFINES=[('USE_ALT_HEADER', '\\"foo_alt.h\\"')])
+</example_commands>
 </summary>
 </cvar>
 

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -92,23 +92,24 @@ to each definition in &cv-link-CPPDEFINES;.
 <summary>
 <para>
 A platform independent specification of C preprocessor macro definitions.
-The definitions will be added to command lines
+The definitions are added to command lines
 through the automatically-generated
-&cv-link-_CPPDEFFLAGS; &consvar; (see above),
+&cv-link-_CPPDEFFLAGS; &consvar;,
 which is constructed according to
-the type of value of &cv-CPPDEFINES;:
+the contents of &cv-CPPDEFINES;:
 </para>
 
 <para>
 If &cv-CPPDEFINES; is a string,
 the values of the
 &cv-link-CPPDEFPREFIX; and &cv-link-CPPDEFSUFFIX; &consvars;
-will be respectively prepended and appended to 
-each definition in &cv-CPPDEFINES;.
+are respectively prepended and appended to 
+each definition in &cv-CPPDEFINES;,
+split on whitespace.
 </para>
 
 <example_commands>
-# Will add -Dxyz to POSIX compiler command lines,
+# Adds -Dxyz to POSIX compiler command lines,
 # and /Dxyz to Microsoft Visual C++ command lines.
 env = Environment(CPPDEFINES='xyz')
 </example_commands>
@@ -117,15 +118,19 @@ env = Environment(CPPDEFINES='xyz')
 If &cv-CPPDEFINES; is a list,
 the values of the
 &cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX; &consvars;
-will be respectively prepended and appended to 
+are respectively prepended and appended to 
 each element in the list.
 If any element is a list or tuple,
-then the first item is the name being
-defined and the second item is its value:
+then the first item is the macro name
+and the second item is the definition.
+If the definition is not omitted,
+these are combined into a
+<literal>name=definition</literal> item
+before the preending/appending.
 </para>
 
 <example_commands>
-# Will add -DB=2 -DA to POSIX compiler command lines,
+# Adds -DB=2 -DA to POSIX compiler command lines,
 # and /DB=2 /DA to Microsoft Visual C++ command lines.
 env = Environment(CPPDEFINES=[('B', 2), 'A'])
 </example_commands>
@@ -134,25 +139,24 @@ env = Environment(CPPDEFINES=[('B', 2), 'A'])
 If &cv-CPPDEFINES; is a dictionary,
 the values of the
 &cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX; &consvars;
-will be respectively prepended and appended to
-each item from the dictionary.
-The key of each dictionary item
-is a name being defined
-to the dictionary item's corresponding value;
-if the value is
-<literal>None</literal>,
-then the name is defined without an explicit value.
-Note that to ensure build order will be stable,
+are respectively prepended and appended to
+each key from the dictionary.
+If the value for a key is not <literal>None</literal>,
+then the key is the macro name and the value
+is the definition and these are combined into a
+<literal>name=definition</literal> item
+before the prepending/appending.
+Note that to ensure a stable build order,
 &SCons; sorts the flags generated from the dictionary,
 since a changed command line triggers a rebuild
 (older &Python; interpreters did
-not guarantee to preserve dictionary keys in insert order),
+not guarantee to preserve dictionary keys in insert order).
 This precaution may be removed in a future version.
 </para>
 
 <example_commands>
-# Will add -DA -DB=2 to POSIX compiler command lines,
-# and /DA /DB=2 to Microsoft Visual C++ command lines.
+# Adds -DA -DB=2 to POSIX compiler command lines,
+# or /DA /DB=2 to Microsoft Visual C++ command lines.
 env = Environment(CPPDEFINES={'B':2, 'A':None})
 </example_commands>
 
@@ -160,22 +164,18 @@ env = Environment(CPPDEFINES={'B':2, 'A':None})
 Depending on how contents are added to &cv-CPPDEFINES;,
 it may end up as a compound type,
 for example a list containing strings, tuples and/or dictionaries.
-&SCons; will still expand this correctly.
+&SCons; expands this correctly.
 </para>
 
 <para>
-Note that if a value contains spaces (or other syntax that
-will be meaningful to the shell that calls the compiler)
-it needs to be quoted:
+Note that &SCons; may call the compiler via a shell.
+If a macro definition contains characters such as spaces that
+have meaning to the shell, you may need to use the shell's
+quoting syntax to avoid interpretation before the 
+preprocessor sees it. In particular, function-like macros
+may be supported (see the documentation for the compiler in question),
+but parentheses frequently have meaning to shells.
 </para>
-
-<example_commands>
-# SPACED will just get the string 'spaced', arg will be a separate arg
-env = Environment(CPPDEFINES={'SPACED': 'spaced arg'})
-# SPACED will get the full value
-env = Environment(CPPDEFINES={'SPACED': '"spaced arg"'})
-</example_commands>
-
 </summary>
 </cvar>
 

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -120,8 +120,8 @@ the values of the
 &cv-CPPDEFPREFIX; and &cv-CPPDEFSUFFIX; &consvars;
 are respectively prepended and appended to 
 each element in the list.
-If any element is a list or tuple,
-then the first item is the macro name
+If any element is a tuple (or list)
+then the first item of the tuple is the macro name
 and the second item is the definition.
 If the definition is not omitted,
 these are combined into a
@@ -162,19 +162,21 @@ env = Environment(CPPDEFINES={'B':2, 'A':None})
 
 <para>
 Depending on how contents are added to &cv-CPPDEFINES;,
-it may end up as a compound type,
+it may be transformed into a compound type,
 for example a list containing strings, tuples and/or dictionaries.
-&SCons; expands this correctly.
+&SCons; can correctly expand such a compount type.
 </para>
 
 <para>
 Note that &SCons; may call the compiler via a shell.
 If a macro definition contains characters such as spaces that
 have meaning to the shell, you may need to use the shell's
-quoting syntax to avoid interpretation before the 
-preprocessor sees it. In particular, function-like macros
-may be supported (see the documentation for the compiler in question),
-but parentheses frequently have meaning to shells.
+quoting syntax to avoid interpretation before the preprocessor sees it.
+Function-like macros may be supported,
+depending on the compiler (see the respective documentation),
+in which case the <emphasis>name</emphasis>
+may also have quoting considerations,
+as parentheses frequently have meaning to shells.
 </para>
 </summary>
 </cvar>

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -104,7 +104,7 @@ If &cv-CPPDEFINES; is a string,
 the values of the
 &cv-link-CPPDEFPREFIX; and &cv-link-CPPDEFSUFFIX; &consvars;
 will be respectively prepended and appended to 
-each definition in &cv-link-CPPDEFINES;.
+each definition in &cv-CPPDEFINES;.
 </para>
 
 <example_commands>
@@ -142,11 +142,12 @@ to the dictionary item's corresponding value;
 if the value is
 <literal>None</literal>,
 then the name is defined without an explicit value.
-Note that the resulting flags are sorted by keyword
-to ensure that the order of the options on the
-command line is consistent each time
-&scons;
-is run.
+Note that to ensure build order will be stable,
+&SCons; sorts the flags generated from the dictionary,
+since a changed command line triggers a rebuild
+(older &Python; interpreters did
+not guarantee to preserve dictionary keys in insert order),
+This precaution may be removed in a future version.
 </para>
 
 <example_commands>
@@ -154,6 +155,27 @@ is run.
 # and /DA /DB=2 to Microsoft Visual C++ command lines.
 env = Environment(CPPDEFINES={'B':2, 'A':None})
 </example_commands>
+
+<para>
+Depending on how contents are added to &cv-CPPDEFINES;,
+it may end up as a compound type,
+for example a list containing strings, tuples and/or dictionaries.
+&SCons; will still expand this correctly.
+</para>
+
+<para>
+Note that if a value contains spaces (or other syntax that
+will be meaningful to the shell that calls the compiler)
+it needs to be quoted:
+</para>
+
+<example_commands>
+# SPACED will just get the string 'spaced', arg will be a separate arg
+env = Environment(CPPDEFINES={'SPACED': 'spaced arg'})
+# SPACED will get the full value
+env = Environment(CPPDEFINES={'SPACED': '"spaced arg"'})
+</example_commands>
+
 </summary>
 </cvar>
 

--- a/SCons/Defaults.xml
+++ b/SCons/Defaults.xml
@@ -122,9 +122,9 @@ are respectively prepended and appended to
 each element in the list.
 If any element is a tuple (or list)
 then the first item of the tuple is the macro name
-and the second item is the definition.
+and the second is the definition.
 If the definition is not omitted,
-these are combined into a
+the name and definition are combined into a single
 <literal>name=definition</literal> item
 before the preending/appending.
 </para>
@@ -142,16 +142,10 @@ the values of the
 are respectively prepended and appended to
 each key from the dictionary.
 If the value for a key is not <literal>None</literal>,
-then the key is the macro name and the value
-is the definition and these are combined into a
+then the key (macro name) and the value
+(macros definition) are combined into a single
 <literal>name=definition</literal> item
 before the prepending/appending.
-Note that to ensure a stable build order,
-&SCons; sorts the flags generated from the dictionary,
-since a changed command line triggers a rebuild
-(older &Python; interpreters did
-not guarantee to preserve dictionary keys in insert order).
-This precaution may be removed in a future version.
 </para>
 
 <example_commands>
@@ -161,10 +155,19 @@ env = Environment(CPPDEFINES={'B':2, 'A':None})
 </example_commands>
 
 <para>
+To ensure stable build order,
+&SCons; sorts the flags generated from any dictionary,
+Older &Python; interpreters did
+not guarantee to preserve dictionary keys in insert order.
+&Python; since version 3.7 does preserve order,
+so this precaution may be removed in a future version.
+</para>
+
+<para>
 Depending on how contents are added to &cv-CPPDEFINES;,
 it may be transformed into a compound type,
 for example a list containing strings, tuples and/or dictionaries.
-&SCons; can correctly expand such a compount type.
+&SCons; can correctly expand such a compound type.
 </para>
 
 <para>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -577,14 +577,16 @@ scons: `.' is up to date.
 Because &cv-link-CPPDEFINES; is intended for command-line
 specification of C/C++ preprocessor macros,
 it accepts additional syntax.
-A preprocessor macro can predefine a name by itself
-(example: <computeroutput>-DFOO</computeroutput>),
+A command-line preprocessor macro can predefine a name by itself
+(<computeroutput>-DFOO</computeroutput>),
 which gives it an implicit value,
-or with a replacement value
-(example: <computeroutput>-DBAR=1</computeroutput>).
-&SCons; allows you to specify a macro with a value
+or be given with a macro definition
+(<computeroutput>-DBAR=1</computeroutput>).
+&SCons; allows you to specify a macro with a definition
 by using a <literal>name=value</literal> string,
-or a tuple <literal>(name, value)</literal>,
+or a tuple <literal>(name, value)</literal>
+(it is usually best to include the tuple as an element
+of a list even if there is only one tuple),
 or a dictionary <literal>{name: value}</literal>.
 </para>
 
@@ -593,7 +595,7 @@ env = Environment(CPPDEFINES="FOO")
 print("CPPDEFINES =", env['CPPDEFINES'])
 env.Append(CPPDEFINES="BAR=1")
 print("CPPDEFINES =", env['CPPDEFINES'])
-env.Append(CPPDEFINES=("OTHER", 2))
+env.Append(CPPDEFINES=[("OTHER", 2)])
 print("CPPDEFINES =", env['CPPDEFINES'])
 env.Append(CPPDEFINES={"EXTRA": "arg"})
 print("CPPDEFINES =", env['CPPDEFINES'])
@@ -614,8 +616,8 @@ scons: `.' is up to date.
 Multiple &cv-CPPDEFINES; macros can be supplied in a sequence of tuples,
 or using the dictionary form.
 If a given macro name should not have a definition,
-the value can be omitted from the given tuple;
-if using the dictionary form,
+the value can be omitted from that tuple,
+or if using the dictionary form,
 specify the value as <constant>None</constant>.
 </para>
 

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -499,59 +499,59 @@ Multiple targets can be passed in to a single call to
 </arguments>
 <summary>
 <para>
-Intelligently append values to &consvars; in the &consenv;
-named by <varname>env</varname>.
+Appends value(s) intelligently to &consvars; in
+<varname>env</varname>.
 The &consvars; and values to add to them are passed as
 <parameter>key=val</parameter> pairs (&Python; keyword arguments).
 &f-env-Append; is designed to allow adding values
-without normally having to know the data type of an existing &consvar;.
+without having to think about the data type of an existing &consvar;.
 Regular &Python; syntax can also be used to manipulate the &consvar;,
-but for that you must know the type of the &consvar;:
-for example, different &Python; syntax is needed to combine
-a list of values with a single string value, or vice versa.
+but for that you may need to know the types involved,
+for example pure Python lets you directly "add" two lists of strings,
+but adding a string to a list or a list to a string requires
+different syntax - things &f-Append; takes care of.
 Some pre-defined &consvars; do have type expectations
 based on how &SCons; will use them,
 for example &cv-link-CPPDEFINES; is normally a string or a list of strings,
-but can be a string,
-a list of strings,
-a list of tuples,
-or a dictionary, while &cv-link-LIBEMITTER;
-would expect a callable or list of callables,
-and &cv-link-BUILDERS; would expect a mapping type.
+but can also be a list of tuples or a dictionary;
+while &cv-link-LIBEMITTER;
+is expected to be a callable or list of callables,
+and &cv-link-BUILDERS; is expected to be a dictionary.
 Consult the documentation for the various &consvars; for more details.
 </para>
 
 <para>
-The following descriptions apply to both the append
-and prepend functions, the only difference being
-the insertion point of the added values.
-</para>
-<para>
-If <varname>env</varname>.  does not have a &consvar;
-indicated by <parameter>key</parameter>,
-<parameter>val</parameter>
-is added to the environment under that key as-is.
+The following descriptions apply to both the &f-Append;
+and &f-Prepend; methods, as well as their
+<emphasis role="bold">Unique</emphasis> variants,
+with the differences being the insertion point of the added values
+and whether duplication is allowed.
 </para>
 
 <para>
-<parameter>val</parameter> can be almost any type,
-and &SCons; will combine it with an existing value into an appropriate type,
-but there are a few special cases to be aware of.
-When two strings are combined,
-the result is normally a new string,
-with the caller responsible for supplying any needed separation.
-The exception to this is the &consvar; &cv-link-CPPDEFINES;,
-in which each item will be postprocessed by adding a prefix
-and/or suffix,
-so the contents are treated as a list of strings, that is,
-adding a string will result in a separate string entry,
+<parameter>val</parameter> can be almost any type.
+If <varname>env</varname> does not have a &consvar;
+named <parameter>key</parameter>,
+it is simply stored with a value of <parameter>val</parameter> as-is.
+Otherwise, <parameter>val</parameter> is
+combinined with the existing value into an appropriate type
+which can hold the expanded contents.
+There are a few special cases to be aware of.
+Normally, when two strings are combined,
+the result is a new string containg their concatenation,
+so you are responsible for supplying any needed separation.
+The main exception to this is &cv-link-CPPDEFINES;,
+where, before it is actually added to the command line,
+each word will be postprocessed by adding a prefix and/or suffix,
+thus the contents are forced to a collection type.
+As a result, appending a string will result in a separate string entry,
 not a combined string. For &cv-CPPDEFINES; as well as
 for &cv-link-LIBS;, and the various <literal>*PATH</literal>;
 variables, &SCons; will supply the compiler-specific
-syntax (e.g. adding a <literal>-D</literal> or <literal>/D</literal>
+syntax (e.g. prepending a <literal>-D</literal> or <literal>/D</literal>
 prefix for &cv-CPPDEFINES;), so this syntax should be omitted when
 adding values to these variables.
-Example (gcc syntax shown in the expansion of &CPPDEFINES;):
+Examples (gcc syntax shown in the expansion of &CPPDEFINES;):
 </para>
 
 <example_commands>
@@ -572,27 +572,30 @@ scons: `.' is up to date.
 </screen>
 
 <para>
-Because &cv-link-CPPDEFINES; is intended to
-describe C/C++ pre-processor macro definitions,
+Because &cv-link-CPPDEFINES; is intended for command-line
+specification of C/C++ preprocessor macros,
 it accepts additional syntax.
-Preprocessor macros can be valued, or un-valued, as in
-<computeroutput>-DBAR=1</computeroutput> or
-<computeroutput>-DFOO</computeroutput>.
-The macro can be be supplied as a complete string including the value,
-or as a tuple (or list) of macro, value, or as a dictionary.
-Example (again gcc syntax in the expanded defines):
+A preprocessor macro can predefine a name by itself as
+<computeroutput>-DFOO</computeroutput>
+(which gives it an implicit value)
+or with a replacement value, as
+<computeroutput>-DBAR=1</computeroutput>.
+&SCons; allows you to specify a macro with a value
+as a <literal>name=value</literal> string,
+or as a tuple <literal>(name, value)</literal>,
+or as a dictionary <literal>{name: value}</literal>.
 </para>
 
 <example_commands>
 env = Environment(CPPDEFINES="FOO")
-print("CPPDEFINES={}".format(env['CPPDEFINES']))
+print(f"CPPDEFINES={env['CPPDEFINES']}")
 env.Append(CPPDEFINES="BAR=1")
-print("CPPDEFINES={}".format(env['CPPDEFINES']))
+print(f"CPPDEFINES={env['CPPDEFINES']}")
 env.Append(CPPDEFINES=("OTHER", 2))
-print("CPPDEFINES={}".format(env['CPPDEFINES']))
+print(f"CPPDEFINES={env['CPPDEFINES']}")
 env.Append(CPPDEFINES={"EXTRA": "arg"})
-print("CPPDEFINES={}".format(env['CPPDEFINES']))
-print("CPPDEFINES will expand to {}".format(env.subst("$_CPPDEFFLAGS")))
+print(f"CPPDEFINES={env['CPPDEFINES']}")
+print(f"CPPDEFINES will expand to {env.subst('$_CPPDEFFLAGS')}")
 </example_commands>
 
 <screen>
@@ -606,12 +609,41 @@ scons: `.' is up to date.
 </screen>
 
 <para>
+Multiple &cv-CPPDEFINES; macros can be supplied in a sequence of tuples,
+or using the dictionary form.
+If a given macro should not have a value,
+the value can be omitted from the given tuple;
+for the dictionary form,
+specify the value as <constant>None</constant>.
+</para>
+
+<example_commands>
+env = Environment()
+env.Append(CPPDEFINES=[("ONE", 1), ("TWO", )])
+print(f"CPPDEFINES={env['CPPDEFINES']}")
+env.Append(CPPDEFINES={"THREE": 3, "FOUR": None})
+print(f"CPPDEFINES={env['CPPDEFINES']}")
+print(f"CPPDEFINES will expand to {env.subst('$_CPPDEFFLAGS')}")
+</example_commands>
+
+<screen>
+CPPDEFINES=[('ONE', 1), ('TWO',)]
+CPPDEFINES=[('ONE', 1), ('TWO',), {'THREE': 3, 'FOUR': None}]
+CPPDEFINES will expand to -DONE=1 -DTWO -DTHREE=3 -DFOUR
+scons: `.' is up to date.
+</screen>
+
+<para>
+See &cv-link-CPPDEFINES; for more details.
+</para>
+
+<para>
 Adding a string <parameter>val</parameter>
 to a dictonary &consvar; will enter
 <parameter>val</parameter> as the key in the dict,
 and <literal>None</literal> as its value.
 Using a tuple type to supply a key + value only works
-for the special case of &cv-link-CPPDEFINES;
+for the special case of &cv-CPPDEFINES;
 described above.
 </para>
 
@@ -626,7 +658,7 @@ When using &f-env-Append; to modify &consvars;
 which are path specifications (conventionally,
 the names of such end in <literal>PATH</literal>),
 it is recommended to add the values as a list of strings,
-even if there is only a single string to add.
+even if you are only adding a single string.
 The same goes for adding library names to &cv-LIBS;.
 </para>
 
@@ -696,17 +728,17 @@ See also &f-link-env-PrependENVPath;.
 
 <scons_function name="AppendUnique">
 <arguments signature="env">
-(key=val, [...], delete_existing=False)
+(key=val, [...], [delete_existing=False])
 </arguments>
 <summary>
 <para>
 Append values to &consvars; in the current &consenv;,
 maintaining uniqueness.
-Works like &f-link-env-Append; (see for details),
-except that values already present in the &consvar;
+Works like &f-link-env-Append;
+except that values that would be duplicates
 will not be added again.
 If <parameter>delete_existing</parameter>
-is <constant>True</constant>,
+is set to <constant>True</constant>)
 the existing matching value is first removed,
 and the requested value is added,
 having the effect of moving such values to the end.
@@ -2716,7 +2748,7 @@ See also &f-link-env-AppendENVPath;.
 
 <scons_function name="PrependUnique">
 <arguments signature="env">
-(key=val, delete_existing=False, [...])
+(key=val, [...], [delete_existing=False])
 </arguments>
 <summary>
 <para>
@@ -2725,12 +2757,12 @@ maintaining uniqueness.
 Works like &f-link-env-Append; (see for details),
 except that values are added to the front,
 rather than the end, of any existing value of the &consvar;,
-and values already present in the &consvar;
+and values that would be duplicates
 will not be added again.
 If <parameter>delete_existing</parameter>
-is <constant>True</constant>,
+is set to <constant>True</constant>,
 the existing matching value is first removed,
-and the requested value is inserted,
+then the requested value is inserted,
 having the effect of moving such values to the front.
 </para>
 

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -507,11 +507,11 @@ The &consvars; and values to add to them are passed as
 without having to think about the data type of an existing &consvar;.
 Regular &Python; syntax can also be used to manipulate the &consvar;,
 but for that you may need to know the types involved,
-for example pure Python lets you directly "add" two lists of strings,
+for example pure &Python; does let you directly "add" two lists of strings,
 but adding a string to a list or a list to a string requires
 different syntax - things &f-Append; takes care of.
 Some pre-defined &consvars; do have type expectations
-based on how &SCons; will use them,
+based on how &SCons; will use them:
 for example &cv-link-CPPDEFINES; is normally a string or a list of strings,
 but can also be a list of tuples or a dictionary;
 while &cv-link-LIBEMITTER;
@@ -532,9 +532,11 @@ and whether duplication is allowed.
 <parameter>val</parameter> can be almost any type.
 If <varname>env</varname> does not have a &consvar;
 named <parameter>key</parameter>,
-it is simply stored with a value of <parameter>val</parameter> as-is.
+then <parameter>key</parameter> is simply
+stored with a value of <parameter>val</parameter>.
 Otherwise, <parameter>val</parameter> is
-combinined with the existing value into an appropriate type
+combinined with the existing value
+possibly converting into an appropriate type
 which can hold the expanded contents.
 There are a few special cases to be aware of.
 Normally, when two strings are combined,
@@ -547,9 +549,9 @@ thus the contents are forced to a collection type.
 As a result, appending a string will result in a separate string entry,
 not a combined string. For &cv-CPPDEFINES; as well as
 for &cv-link-LIBS;, and the various <literal>*PATH</literal>;
-variables, &SCons; will supply the compiler-specific
+variables, &SCons; will amend the variable by supplying the compiler-specific
 syntax (e.g. prepending a <literal>-D</literal> or <literal>/D</literal>
-prefix for &cv-CPPDEFINES;), so this syntax should be omitted when
+prefix for &cv-CPPDEFINES;), so you should omit this syntax when
 adding values to these variables.
 Examples (gcc syntax shown in the expansion of &CPPDEFINES;):
 </para>
@@ -575,35 +577,35 @@ scons: `.' is up to date.
 Because &cv-link-CPPDEFINES; is intended for command-line
 specification of C/C++ preprocessor macros,
 it accepts additional syntax.
-A preprocessor macro can predefine a name by itself as
-<computeroutput>-DFOO</computeroutput>
-(which gives it an implicit value)
-or with a replacement value, as
-<computeroutput>-DBAR=1</computeroutput>.
+A preprocessor macro can predefine a name by itself
+(example: <computeroutput>-DFOO</computeroutput>),
+which gives it an implicit value,
+or with a replacement value
+(example: <computeroutput>-DBAR=1</computeroutput>).
 &SCons; allows you to specify a macro with a value
-as a <literal>name=value</literal> string,
-or as a tuple <literal>(name, value)</literal>,
-or as a dictionary <literal>{name: value}</literal>.
+by using a <literal>name=value</literal> string,
+or a tuple <literal>(name, value)</literal>,
+or a dictionary <literal>{name: value}</literal>.
 </para>
 
 <example_commands>
 env = Environment(CPPDEFINES="FOO")
-print(f"CPPDEFINES={env['CPPDEFINES']}")
+print("CPPDEFINES =", env['CPPDEFINES'])
 env.Append(CPPDEFINES="BAR=1")
-print(f"CPPDEFINES={env['CPPDEFINES']}")
+print("CPPDEFINES =", env['CPPDEFINES'])
 env.Append(CPPDEFINES=("OTHER", 2))
-print(f"CPPDEFINES={env['CPPDEFINES']}")
+print("CPPDEFINES =", env['CPPDEFINES'])
 env.Append(CPPDEFINES={"EXTRA": "arg"})
-print(f"CPPDEFINES={env['CPPDEFINES']}")
-print(f"CPPDEFINES will expand to {env.subst('$_CPPDEFFLAGS')}")
+print("CPPDEFINES =", env['CPPDEFINES'])
+print("CPPDEFINES will expand to ", env.subst('$_CPPDEFFLAGS'))
 </example_commands>
 
 <screen>
 $ scons -Q
-CPPDEFINES=FOO
-CPPDEFINES=['FOO', 'BAR=1']
-CPPDEFINES=['FOO', 'BAR=1', ('OTHER', 2)]
-CPPDEFINES=['FOO', 'BAR=1', ('OTHER', 2), {'EXTRA': 'arg'}]
+CPPDEFINES = FOO
+CPPDEFINES = ['FOO', 'BAR=1']
+CPPDEFINES = ['FOO', 'BAR=1', ('OTHER', 2)]
+CPPDEFINES = ['FOO', 'BAR=1', ('OTHER', 2), {'EXTRA': 'arg'}]
 CPPDEFINES will expand to -DFOO -DBAR=1 -DOTHER=2 -DEXTRA=arg
 scons: `.' is up to date.
 </screen>
@@ -617,21 +619,22 @@ for the dictionary form,
 specify the value as <constant>None</constant>.
 </para>
 
-<example_commands>
+<!--TODO: at last check, this newly created example blew up SConsDoc/lxml -->
+<!--example_commands>
 env = Environment()
-env.Append(CPPDEFINES=[("ONE", 1), ("TWO", )])
-print(f"CPPDEFINES={env['CPPDEFINES']}")
-env.Append(CPPDEFINES={"THREE": 3, "FOUR": None})
-print(f"CPPDEFINES={env['CPPDEFINES']}")
-print(f"CPPDEFINES will expand to {env.subst('$_CPPDEFFLAGS')}")
-</example_commands>
+env.Append(CPPDEFINES =[("ONE", 1), ("TWO", )])
+print("CPPDEFINES =", env['CPPDEFINES'])
+env.Append(CPPDEFINES ={"THREE": 3, "FOUR": None})
+print("CPPDEFINES =", env['CPPDEFINES'])
+print("CPPDEFINES will expand to ", env.subst('$_CPPDEFFLAGS'))
+</example_commands-->
 
-<screen>
-CPPDEFINES=[('ONE', 1), ('TWO',)]
-CPPDEFINES=[('ONE', 1), ('TWO',), {'THREE': 3, 'FOUR': None}]
-CPPDEFINES will expand to -DONE=1 -DTWO -DTHREE=3 -DFOUR
+<!--screen>
+CPPDEFINES = [('ONE', 1), ('TWO',)]
+CPPDEFINES = [('ONE', 1), ('TWO',), {'THREE': 3, 'FOUR': None}]
+CPPDEFINES will expand to  -DONE=1 -DTWO -DTHREE=3 -DFOUR
 scons: `.' is up to date.
-</screen>
+</screen-->
 
 <para>
 See &cv-link-CPPDEFINES; for more details.
@@ -734,14 +737,14 @@ See also &f-link-env-PrependENVPath;.
 <para>
 Append values to &consvars; in the current &consenv;,
 maintaining uniqueness.
-Works like &f-link-env-Append;
-except that values that would be duplicates
-will not be added again.
+Works like &f-link-env-Append;,
+except that values that would become duplicates
+are not added.
 If <parameter>delete_existing</parameter>
-is set to <constant>True</constant>)
-the existing matching value is first removed,
-and the requested value is added,
-having the effect of moving such values to the end.
+is set to a true value, then for any duplicate,
+the existing instance of <parameter>val</parameter> is first removed,
+then <parameter>val</parameter> is appended,
+having the effect of moving it to the end.
 </para>
 
 <para>
@@ -2754,16 +2757,16 @@ See also &f-link-env-AppendENVPath;.
 <para>
 Prepend values to &consvars; in the current &consenv;,
 maintaining uniqueness.
-Works like &f-link-env-Append; (see for details),
+Works like &f-link-env-Append;,
 except that values are added to the front,
-rather than the end, of any existing value of the &consvar;,
-and values that would be duplicates
-will not be added again.
+rather than the end, of the &consvar;,
+and values that would become duplicates
+are not added.
 If <parameter>delete_existing</parameter>
-is set to <constant>True</constant>,
-the existing matching value is first removed,
-then the requested value is inserted,
-having the effect of moving such values to the front.
+is set to a true value, then for any duplicate,
+the existing instance of <parameter>val</parameter> is first removed,
+then <parameter>val</parameter> is inserted,
+having the effect of moving it to the front.
 </para>
 
 <para>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -620,21 +620,22 @@ specify the value as <constant>None</constant>.
 </para>
 
 <!--TODO: at last check, this newly created example blew up SConsDoc/lxml -->
-<!--example_commands>
+<example_commands>
 env = Environment()
 env.Append(CPPDEFINES =[("ONE", 1), ("TWO", )])
 print("CPPDEFINES =", env['CPPDEFINES'])
 env.Append(CPPDEFINES ={"THREE": 3, "FOUR": None})
 print("CPPDEFINES =", env['CPPDEFINES'])
 print("CPPDEFINES will expand to ", env.subst('$_CPPDEFFLAGS'))
-</example_commands-->
+</example_commands>
 
-<!--screen>
+<screen>
+$ scons -Q
 CPPDEFINES = [('ONE', 1), ('TWO',)]
 CPPDEFINES = [('ONE', 1), ('TWO',), {'THREE': 3, 'FOUR': None}]
 CPPDEFINES will expand to  -DONE=1 -DTWO -DTHREE=3 -DFOUR
 scons: `.' is up to date.
-</screen-->
+</screen>
 
 <para>
 See &cv-link-CPPDEFINES; for more details.

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -613,13 +613,12 @@ scons: `.' is up to date.
 <para>
 Multiple &cv-CPPDEFINES; macros can be supplied in a sequence of tuples,
 or using the dictionary form.
-If a given macro should not have a value,
+If a given macro name should not have a definition,
 the value can be omitted from the given tuple;
-for the dictionary form,
+if using the dictionary form,
 specify the value as <constant>None</constant>.
 </para>
 
-<!--TODO: at last check, this newly created example blew up SConsDoc/lxml -->
 <example_commands>
 env = Environment()
 env.Append(CPPDEFINES =[("ONE", 1), ("TWO", )])
@@ -643,18 +642,18 @@ See &cv-link-CPPDEFINES; for more details.
 
 <para>
 Adding a string <parameter>val</parameter>
-to a dictonary &consvar; will enter
-<parameter>val</parameter> as the key in the dict,
+to a dictonary-typed &consvar; enters
+<parameter>val</parameter> as the key in the dictionary,
 and <literal>None</literal> as its value.
-Using a tuple type to supply a key + value only works
-for the special case of &cv-CPPDEFINES;
+Using a tuple type to supply a <literal>key, value</literal>
+only works for the special case of &cv-CPPDEFINES;
 described above.
 </para>
 
 <para>
 Although most combinations of types work without
 needing to know the details, some combinations
-do not make sense and a &Python; exception will be raised.
+do not make sense and &Python; raises an exception.
 </para>
 
 <para>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -538,7 +538,7 @@ combinined with the existing value into an appropriate type
 which can hold the expanded contents.
 There are a few special cases to be aware of.
 Normally, when two strings are combined,
-the result is a new string containg their concatenation,
+the result is a new string containing their concatenation,
 so you are responsible for supplying any needed separation.
 The main exception to this is &cv-link-CPPDEFINES;,
 where, before it is actually added to the command line,

--- a/SCons/Tool/docbook/__init__.py
+++ b/SCons/Tool/docbook/__init__.py
@@ -69,7 +69,7 @@ re_refname = re.compile(r"<refname>([^<]*)</refname>")
 # lxml etree XSLT global max traversal depth
 #
 
-lmxl_xslt_global_max_depth = 3100
+lmxl_xslt_global_max_depth = 3600
 
 if has_lxml and lmxl_xslt_global_max_depth:
     def __lxml_xslt_set_global_max_depth(max_depth):

--- a/test/CPPDEFINES/append.py
+++ b/test/CPPDEFINES/append.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify appending to CPPPDEFINES with various data types.
@@ -39,16 +38,16 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 env_1738_2 = Environment(CPPDEFPREFIX='-D')
 env_1738_2['CPPDEFINES'] = ['FOO']
-env_1738_2.Append(CPPDEFINES={'value' : '1'})
+env_1738_2.Append(CPPDEFINES={'value': '1'})
 print(env_1738_2.subst('$_CPPDEFFLAGS'))
-#env_1738_2.Object('test_1738_2', 'main.c')
+# env_1738_2.Object('test_1738_2', 'main.c')
 
 # https://github.com/SCons/scons/issues/2300
-env_2300_1 = Environment(CPPDEFINES = 'foo', CPPDEFPREFIX='-D')
+env_2300_1 = Environment(CPPDEFINES='foo', CPPDEFPREFIX='-D')
 env_2300_1.Append(CPPDEFINES='bar')
 print(env_2300_1.subst('$_CPPDEFFLAGS'))
 
-env_2300_2 = Environment(CPPDEFINES = ['foo'], CPPDEFPREFIX='-D') # note the list
+env_2300_2 = Environment(CPPDEFINES=['foo'], CPPDEFPREFIX='-D')  # note the list
 env_2300_2.Append(CPPDEFINES='bar')
 print(env_2300_2.subst('$_CPPDEFFLAGS'))
 
@@ -57,9 +56,10 @@ print(env_2300_2.subst('$_CPPDEFFLAGS'))
 # Python3 dicts dont preserve order. Hence we supply subclass of OrderedDict
 # whose __str__ and __repr__ act like a normal dict.
 from collections import OrderedDict
+
 class OrderedPrintingDict(OrderedDict):
     def __repr__(self):
-        return '{' + ', '.join(['%r: %r'%(k, v) for (k, v) in self.items()]) + '}'
+        return '{' + ', '.join(['%r: %r' % (k, v) for (k, v) in self.items()]) + '}'
 
     __str__ = __repr__
 
@@ -68,23 +68,24 @@ class OrderedPrintingDict(OrderedDict):
     def __semi_deepcopy__(self):
         return self.copy()
 
-cases=[('string', 'FOO'),
-       ('list', ['NAME1', 'NAME2']),
-       ('list-of-2lists', [('NAME1','VAL1'), ['NAME2','VAL2']]),
-       ('dict', OrderedPrintingDict([('NAME2', 'VAL2'), ('NAME3', None), ('NAME1', 'VAL1')]))
-       ]
+cases = [
+    ('string', 'FOO'),
+    ('list', ['NAME1', 'NAME2']),
+    ('list-of-2lists', [('NAME1', 'VAL1'), ['NAME2', 'VAL2']]),
+    ('dict', OrderedPrintingDict([('NAME2', 'VAL2'), ('NAME3', None), ('NAME1', 'VAL1')])),
+]
 
 for (t1, c1) in cases:
     for (t2, c2) in cases:
         print("==== Testing CPPDEFINES, appending a %s to a %s"%(t2, t1))
         print("   orig = %s, append = %s"%(c1, c2))
-        env=Environment(CPPDEFINES = c1, CPPDEFPREFIX='-D')
-        env.Append(CPPDEFINES = c2)
+        env=Environment(CPPDEFINES=c1, CPPDEFPREFIX='-D')
+        env.Append(CPPDEFINES=c2)
         final=env.subst('$_CPPDEFFLAGS',source="src", target="tgt")
         print('Append:\\n\\tresult=%s\\n\\tfinal=%s'%\\
               (env['CPPDEFINES'], final))
-        env=Environment(CPPDEFINES = c1, CPPDEFPREFIX='-D')
-        env.AppendUnique(CPPDEFINES = c2)
+        env=Environment(CPPDEFINES=c1, CPPDEFPREFIX='-D')
+        env.AppendUnique(CPPDEFINES=c2)
         final=env.subst('$_CPPDEFFLAGS',source="src", target="tgt")
         print('AppendUnique:\\n\\tresult=%s\\n\\tfinal=%s'%\\
               (env['CPPDEFINES'], final))
@@ -225,11 +226,10 @@ AppendUnique:
 	final=-DNAME1=VAL1 -DNAME2=VAL2 -DNAME3
 """
 
-build_output="scons: `.' is up to date.\n"
+build_output = "scons: `.' is up to date.\n"
 
-expect = test.wrap_stdout(build_str=build_output,
-                          read_str = expect_print_output)
-test.run(arguments = '.', stdout=expect)
+expect = test.wrap_stdout(build_str=build_output, read_str=expect_print_output)
+test.run(arguments='.', stdout=expect)
 test.pass_test()
 
 # Local Variables:

--- a/test/CPPDEFINES/basic.py
+++ b/test/CPPDEFINES/basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify basic use of CPPPDEFINES with various data types.
@@ -37,7 +36,7 @@ test_list = [
     'xyz',
     ['x', 'y', 'z'],
     ['x', ['y', 123], 'z', ('int', '$INTEGER')],
-    { 'c' : 3, 'b': None, 'a' : 1 },
+    {'c': 3, 'b': None, 'a': 1},
     "${TESTDEFS}",
     "${GEN}",
 ]
@@ -48,19 +47,33 @@ def generator(target, source, env, for_signature):
     return 'TARGET_AND_SOURCE_ARE_MISSING'
 
 for i in test_list:
-    env = Environment(CPPDEFPREFIX='-D', CPPDEFSUFFIX='', INTEGER=0, TESTDEFS=["FOO", "BAR=1"], GEN=generator)
+    env = Environment(
+        CPPDEFPREFIX='-D',
+        CPPDEFSUFFIX='',
+        INTEGER=0,
+        TESTDEFS=["FOO", "BAR=1"],
+        GEN=generator,
+    )
     ttt = env.Entry('#ttt')
     sss = env.Entry('#sss')
     print(env.Clone(CPPDEFINES=i).subst('$_CPPDEFFLAGS', target=[ttt], source=[sss]))
+
 for i in test_list:
-    env = Environment(CPPDEFPREFIX='|', CPPDEFSUFFIX='|', INTEGER=1, TESTDEFS=["FOO", "BAR=1"], GEN=generator)
+    env = Environment(
+        CPPDEFPREFIX='|',
+        CPPDEFSUFFIX='|',
+        INTEGER=1,
+        TESTDEFS=["FOO", "BAR=1"],
+        GEN=generator,
+    )
     ttt = env.Entry('#ttt')
     sss = env.Entry('#sss')
     print(env.Clone(CPPDEFINES=i).subst('$_CPPDEFFLAGS', target=[ttt], source=[sss]))
 """)
 
-expect = test.wrap_stdout(build_str="scons: `.' is up to date.\n",
-                          read_str = """\
+expect = test.wrap_stdout(
+    build_str="scons: `.' is up to date.\n",
+    read_str="""\
 -Dxyz
 -Dx -Dy -Dz
 -Dx -Dy=123 -Dz -Dint=0
@@ -73,7 +86,8 @@ expect = test.wrap_stdout(build_str="scons: `.' is up to date.\n",
 |a=1| |b| |c=3|
 |FOO| |BAR=1|
 |ttt_GENERATED_sss|
-""")
+""",
+)
 
 test.run(arguments = '.', stdout=expect)
 

--- a/test/CPPDEFINES/live.py
+++ b/test/CPPDEFINES/live.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify basic use of CPPDEFINES with live compilation.
@@ -33,14 +32,14 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-foo = Environment(CPPDEFINES = ['FOO', ('VAL', '$VALUE')], VALUE=7)
-bar = Environment(CPPDEFINES = {'BAR':None, 'VAL':8})
-baz = Environment(CPPDEFINES = ['BAZ', ('VAL', 9)])
-f = foo.Object(target = 'foo', source = 'prog.c')
-b = bar.Object(target = 'bar', source = 'prog.c')
-foo.Program(target = 'foo', source = f)
-bar.Program(target = 'bar', source = b)
-baz.Program(target = 'baz', source = 'baz.cpp')
+foo = Environment(CPPDEFINES=['FOO', ('VAL', '$VALUE')], VALUE=7)
+bar = Environment(CPPDEFINES={'BAR': None, 'VAL': 8})
+baz = Environment(CPPDEFINES=['BAZ', ('VAL', 9)])
+f = foo.Object(target='foo', source='prog.c')
+b = bar.Object(target='bar', source='prog.c')
+foo.Program(target='foo', source=f)
+bar.Program(target='bar', source=b)
+baz.Program(target='baz', source='baz.cpp')
 """)
 
 test.write('prog.c', r"""
@@ -75,11 +74,11 @@ main(int argc, char *argv[])
 """)
 
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
-test.run(program = test.workpath('foo'), stdout = "prog.c:  FOO 7\n")
-test.run(program = test.workpath('bar'), stdout = "prog.c:  BAR 8\n")
-test.run(program = test.workpath('baz'), stdout = "baz.cpp:  BAZ 9\n")
+test.run(program=test.workpath('foo'), stdout="prog.c:  FOO 7\n")
+test.run(program=test.workpath('bar'), stdout="prog.c:  BAR 8\n")
+test.run(program=test.workpath('baz'), stdout="baz.cpp:  BAZ 9\n")
 
 test.pass_test()
 

--- a/test/CPPDEFINES/pkg-config.py
+++ b/test/CPPDEFINES/pkg-config.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify merging with MergeFlags to CPPPDEFINES with various data types.
@@ -35,7 +34,7 @@ test = TestSCons.TestSCons()
 
 pkg_config_path = test.where_is('pkg-config')
 if not pkg_config_path:
-    test.skip_test("Could not find 'pkg-config' in system PATH, skipping test.\n")
+    test.skip_test("Could not find 'pkg-config', skipping test.\n")
 pkg_config_path = pkg_config_path.replace("\\", "/")
 
 test.write('bug.pc', """\
@@ -69,12 +68,14 @@ else:
 test.write('SConstruct', """\
 import os
 import sys
+
 # Python3 dicts dont preserve order. Hence we supply subclass of OrderedDict
 # whose __str__ and __repr__ act like a normal dict.
 from collections import OrderedDict
+
 class OrderedPrintingDict(OrderedDict):
     def __repr__(self):
-        return '{' + ', '.join(['%r: %r'%(k, v) for (k, v) in self.items()]) + '}'
+        return '{' + ', '.join(['%r: %r' % (k, v) for (k, v) in self.items()]) + '}'
 
     __str__ = __repr__
 
@@ -85,31 +86,43 @@ class OrderedPrintingDict(OrderedDict):
 """ + """
 # https://github.com/SCons/scons/issues/2671
 # Passing test cases
-env_1 = Environment(CPPDEFINES=[('DEBUG','1'), 'TEST'], tools = ['%(pkg_config_tools)s'])
+env_1 = Environment(CPPDEFINES=[('DEBUG', '1'), 'TEST'], tools=['%(pkg_config_tools)s'])
 if sys.platform == 'win32':
-    os.environ['PKG_CONFIG_PATH'] = env_1.Dir('.').abspath.replace("\\\\" , "/")
-env_1.ParseConfig('%(pkg_config_cl_path)s "%(pkg_config_path)s" --cflags %(pkg_config_file)s')
+    os.environ['PKG_CONFIG_PATH'] = env_1.Dir('.').abspath.replace("\\\\", "/")
+env_1.ParseConfig(
+    '%(pkg_config_cl_path)s "%(pkg_config_path)s" --cflags %(pkg_config_file)s'
+)
 print(env_1.subst('$_CPPDEFFLAGS'))
 
-env_2 = Environment(CPPDEFINES=[('DEBUG','1'), 'TEST'], tools = ['%(pkg_config_tools)s'])
+env_2 = Environment(CPPDEFINES=[('DEBUG', '1'), 'TEST'], tools=['%(pkg_config_tools)s'])
 env_2.MergeFlags('-DSOMETHING -DVARIABLE=2')
 print(env_2.subst('$_CPPDEFFLAGS'))
 
 # Failing test cases
-env_3 = Environment(CPPDEFINES=OrderedPrintingDict([('DEBUG', 1), ('TEST', None)]), tools = ['%(pkg_config_tools)s'])
-env_3.ParseConfig('%(pkg_config_cl_path)s "%(pkg_config_path)s" --cflags %(pkg_config_file)s')
+env_3 = Environment(
+    CPPDEFINES=OrderedPrintingDict([('DEBUG', 1), ('TEST', None)]),
+    tools=['%(pkg_config_tools)s'],
+)
+env_3.ParseConfig(
+    '%(pkg_config_cl_path)s "%(pkg_config_path)s" --cflags %(pkg_config_file)s'
+)
 print(env_3.subst('$_CPPDEFFLAGS'))
 
-env_4 = Environment(CPPDEFINES=OrderedPrintingDict([('DEBUG', 1), ('TEST', None)]), tools = ['%(pkg_config_tools)s'])
+env_4 = Environment(
+    CPPDEFINES=OrderedPrintingDict([('DEBUG', 1), ('TEST', None)]),
+    tools=['%(pkg_config_tools)s'],
+)
 env_4.MergeFlags('-DSOMETHING -DVARIABLE=2')
 print(env_4.subst('$_CPPDEFFLAGS'))
 
 # https://github.com/SCons/scons/issues/1738
-env_1738_1 = Environment(tools = ['%(pkg_config_tools)s'])
-env_1738_1.ParseConfig('%(pkg_config_cl_path)s "%(pkg_config_path)s" --cflags --libs %(pkg_config_file)s')
-env_1738_1.Append(CPPDEFINES={'value' : '1'})
+env_1738_1 = Environment(tools=['%(pkg_config_tools)s'])
+env_1738_1.ParseConfig(
+    '%(pkg_config_cl_path)s "%(pkg_config_path)s" --cflags --libs %(pkg_config_file)s'
+)
+env_1738_1.Append(CPPDEFINES={'value': '1'})
 print(env_1738_1.subst('$_CPPDEFFLAGS'))
-"""%locals() )
+""" % locals())
 
 expect_print_output="""\
 -DDEBUG=1 -DTEST -DSOMETHING -DVARIABLE=2
@@ -119,11 +132,10 @@ expect_print_output="""\
 -DSOMETHING -DVARIABLE=2 -Dvalue=1
 """
 
-build_output="scons: `.' is up to date.\n"
+build_output = "scons: `.' is up to date.\n"
 
-expect = test.wrap_stdout(build_str=build_output,
-                          read_str = expect_print_output)
-test.run(arguments = '.', stdout=expect)
+expect = test.wrap_stdout(build_str=build_output, read_str=expect_print_output)
+test.run(arguments='.', stdout=expect)
 test.pass_test()
 
 # Local Variables:

--- a/test/CPPDEFINES/scan.py
+++ b/test/CPPDEFINES/scan.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that use of the Scanner that evaluates CPP lines works as expected.
@@ -41,12 +40,12 @@ f3_exe = 'f3' + TestSCons._exe
 f4_exe = 'f4' + TestSCons._exe
 
 test.write('SConstruct', """\
-env = Environment(CPPPATH = ['.'])
+env = Environment(CPPPATH=['.'])
 
-f1 = env.Object('f1', 'fff.c', CPPDEFINES = ['F1'])
-f2 = env.Object('f2', 'fff.c', CPPDEFINES = [('F2', 1)])
-f3 = env.Object('f3', 'fff.c', CPPDEFINES = {'F3':None})
-f4 = env.Object('f4', 'fff.c', CPPDEFINES = {'F4':1})
+f1 = env.Object('f1', 'fff.c', CPPDEFINES=['F1'])
+f2 = env.Object('f2', 'fff.c', CPPDEFINES=[('F2', 1)])
+f3 = env.Object('f3', 'fff.c', CPPDEFINES={'F3': None})
+f4 = env.Object('f4', 'fff.c', CPPDEFINES={'F4': 1})
 
 env.Program('f1', ['prog.c', f1])
 env.Program('f2', ['prog.c', f2])
@@ -107,76 +106,64 @@ main(int argc, char *argv[])
 }
 """)
 
+test.run(arguments='.')
 
-
-test.run(arguments = '.')
-
-test.run(program = test.workpath('f1'), stdout = "prog.c:  F1\n")
-test.run(program = test.workpath('f2'), stdout = "prog.c:  F2\n")
-test.run(program = test.workpath('f3'), stdout = "prog.c:  F3\n")
-test.run(program = test.workpath('f4'), stdout = "prog.c:  F4\n")
-
-
+test.run(program=test.workpath('f1'), stdout="prog.c:  F1\n")
+test.run(program=test.workpath('f2'), stdout="prog.c:  F2\n")
+test.run(program=test.workpath('f3'), stdout="prog.c:  F3\n")
+test.run(program=test.workpath('f4'), stdout="prog.c:  F4\n")
 
 test.write('f1.h', """
 #define STRING  "F1 again"
 """)
 
-test.up_to_date(arguments = '%(f2_exe)s %(f3_exe)s %(f4_exe)s' % locals())
+test.up_to_date(arguments='%(f2_exe)s %(f3_exe)s %(f4_exe)s' % locals())
 
-test.not_up_to_date(arguments = '.')
+test.not_up_to_date(arguments='.')
 
-test.run(program = test.workpath('f1'), stdout = "prog.c:  F1 again\n")
-test.run(program = test.workpath('f2'), stdout = "prog.c:  F2\n")
-test.run(program = test.workpath('f3'), stdout = "prog.c:  F3\n")
-test.run(program = test.workpath('f4'), stdout = "prog.c:  F4\n")
-
-
+test.run(program=test.workpath('f1'), stdout="prog.c:  F1 again\n")
+test.run(program=test.workpath('f2'), stdout="prog.c:  F2\n")
+test.run(program=test.workpath('f3'), stdout="prog.c:  F3\n")
+test.run(program=test.workpath('f4'), stdout="prog.c:  F4\n")
 
 test.write('f2.h', """
 #define STRING  "F2 again"
 """)
 
-test.up_to_date(arguments = '%(f1_exe)s %(f3_exe)s %(f4_exe)s' % locals())
+test.up_to_date(arguments='%(f1_exe)s %(f3_exe)s %(f4_exe)s' % locals())
 
-test.not_up_to_date(arguments = '.')
+test.not_up_to_date(arguments='.')
 
-test.run(program = test.workpath('f1'), stdout = "prog.c:  F1 again\n")
-test.run(program = test.workpath('f2'), stdout = "prog.c:  F2 again\n")
-test.run(program = test.workpath('f3'), stdout = "prog.c:  F3\n")
-test.run(program = test.workpath('f4'), stdout = "prog.c:  F4\n")
-
-
+test.run(program=test.workpath('f1'), stdout="prog.c:  F1 again\n")
+test.run(program=test.workpath('f2'), stdout="prog.c:  F2 again\n")
+test.run(program=test.workpath('f3'), stdout="prog.c:  F3\n")
+test.run(program=test.workpath('f4'), stdout="prog.c:  F4\n")
 
 test.write('f3.h', """
 #define STRING  "F3 again"
 """)
 
-test.up_to_date(arguments = '%(f1_exe)s %(f2_exe)s %(f4_exe)s' % locals())
+test.up_to_date(arguments='%(f1_exe)s %(f2_exe)s %(f4_exe)s' % locals())
 
-test.not_up_to_date(arguments = '.')
+test.not_up_to_date(arguments='.')
 
-test.run(program = test.workpath('f1'), stdout = "prog.c:  F1 again\n")
-test.run(program = test.workpath('f2'), stdout = "prog.c:  F2 again\n")
-test.run(program = test.workpath('f3'), stdout = "prog.c:  F3 again\n")
-test.run(program = test.workpath('f4'), stdout = "prog.c:  F4\n")
-
-
+test.run(program=test.workpath('f1'), stdout="prog.c:  F1 again\n")
+test.run(program=test.workpath('f2'), stdout="prog.c:  F2 again\n")
+test.run(program=test.workpath('f3'), stdout="prog.c:  F3 again\n")
+test.run(program=test.workpath('f4'), stdout="prog.c:  F4\n")
 
 test.write('f4.h', """
 #define STRING  "F4 again"
 """)
 
-test.up_to_date(arguments = '%(f1_exe)s %(f2_exe)s %(f3_exe)s' % locals())
+test.up_to_date(arguments='%(f1_exe)s %(f2_exe)s %(f3_exe)s' % locals())
 
-test.not_up_to_date(arguments = '.')
+test.not_up_to_date(arguments='.')
 
-test.run(program = test.workpath('f1'), stdout = "prog.c:  F1 again\n")
-test.run(program = test.workpath('f2'), stdout = "prog.c:  F2 again\n")
-test.run(program = test.workpath('f3'), stdout = "prog.c:  F3 again\n")
-test.run(program = test.workpath('f4'), stdout = "prog.c:  F4 again\n")
-
-
+test.run(program=test.workpath('f1'), stdout="prog.c:  F1 again\n")
+test.run(program=test.workpath('f2'), stdout="prog.c:  F2 again\n")
+test.run(program=test.workpath('f3'), stdout="prog.c:  F3 again\n")
+test.run(program=test.workpath('f4'), stdout="prog.c:  F4 again\n")
 
 test.pass_test()
 

--- a/test/CPPDEFINES/undefined.py
+++ b/test/CPPDEFINES/undefined.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that $_CPPDEFFLAGS doesn't barf when CPPDEFINES isn't defined.
@@ -37,10 +36,9 @@ env = Environment()
 print(env.subst('$_CPPDEFFLAGS'))
 """)
 
-expect = test.wrap_stdout(build_str="scons: `.' is up to date.\n",
-                          read_str = "\n")
+expect = test.wrap_stdout(build_str="scons: `.' is up to date.\n", read_str="\n")
 
-test.run(arguments = '.', stdout=expect)
+test.run(arguments='.', stdout=expect)
 
 test.pass_test()
 


### PR DESCRIPTION
The `CPPDEFINES` entry and the `Append` method entry has some additional clarification added, about ways cpp macros can be specified. Added a couple more examples to illustrate.

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
