### PR TITLE
Propagate shell environment variable SOURCE_DATE_EPOCH

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       EnsurePythonVersion(), Exit(), GetLaunchDir() and SConscriptChdir().
     - Remove unused private method SConsEnvironment._exceeds_version().
 
+  From Bernhard M. Wiedemann:
+    - Preserve SOURCE_DATE_EPOCH for reproducible builds
+
   From William Deegan:
     - Added ValidateOptions() which will check that all command line options are in either
       those specified by SCons itself, or by AddOption() in SConstruct/SConscript.  It should

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1034,6 +1034,8 @@ class Base(SubstitutionEnvironment):
         # should override any values set by the tools.
         for key, val in save.items():
             self._dict[key] = val
+        if 'SOURCE_DATE_EPOCH' in os.environ:
+            self._dict['ENV']['SOURCE_DATE_EPOCH'] = os.environ['SOURCE_DATE_EPOCH']
 
         # Finally, apply any flags to be merged in
         if parse_flags:


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation


This is a PoC patch to
Preserve `SOURCE_DATE_EPOCH` for reproducible builds.

https://reproducible-builds.org/specs/source-date-epoch/ says
>  Build processes MUST NOT unset this variable for child processes if it is already present.

Without this patch, openSUSE's `games/globulation2` builds varied from a .cpp file with `__TIME__` that should be normalized by `g++` as we set `SOURCE_DATE_EPOCH`.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann at suse.de>

I am not familiar with the scons codebase, thus would appreciate help to get this improved.