### PR TITLE
Adjust Sphinx doc build for moved Taskmaster

### DIFF
--- a/doc/sphinx/SCons.Taskmaster.rst
+++ b/doc/sphinx/SCons.Taskmaster.rst
@@ -1,0 +1,21 @@
+SCons.Taskmaster package
+========================
+
+Submodules
+----------
+
+SCons.Taskmaster.Job module
+---------------------------
+
+.. automodule:: SCons.Taskmaster.Job
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: SCons.Taskmaster
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/sphinx/SCons.rst
+++ b/doc/sphinx/SCons.rst
@@ -18,6 +18,7 @@ Subpackages
     SCons.Platform
     SCons.Scanner
     SCons.Script
+    SCons.Taskmaster
     SCons.Tool
     SCons.Variables
     SCons.compat
@@ -135,14 +136,6 @@ SCons.Subst module
 ------------------
 
 .. automodule:: SCons.Subst
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-SCons.Taskmaster module
------------------------
-
-.. automodule:: SCons.Taskmaster
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -31,6 +31,7 @@ SCons API Documentation
    SCons.Platform
    SCons.Scanner
    SCons.Script
+   SCons.Taskmaster
    SCons.Tool
    SCons.Variables
 


### PR DESCRIPTION
Sphinx needs to know the module/package structure for generating the API docs. Adjust for the recent move of Taskmaster and Job to a new package.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
