### PR TITLE
Migrate Taskmaster tracing to use python logging

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       not be called until all AddOption() calls are completed. Resolves Issue #4187
     - Refactored SCons/Taskmaster into a package. Moved SCons/Jobs.py into that package.
       NOTE: If you hook into SCons.Jobs, you'll have to change that to use SCons.Taskmaster.Jobs
+    - Changed the Taskmaster trace logic to use python's logging module. The output formatting
+      should remain (mostly) the same. Minor update to unittest for this to adjust for 1 less newline.
+
 
 
   From Dan Mezhiborsky:

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -37,8 +37,6 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
-- List fixes of outright bugs
-
 - Added missing newline to generated compilation database (compile_commands.json)
 - A list argument as the source to the Copy() action function is now handled.
   Both the implementation and the strfunction which prints the progress
@@ -47,14 +45,10 @@ FIXES
 IMPROVEMENTS
 ------------
 
-- List improvements that wouldn't be visible to the user in the
-  documentation:  performance improvements (describe the circumstances
-  under which they would be observed), or major code cleanups
+- Changed the Taskmaster trace logic to use python's logging module.
 
 PACKAGING
 ---------
-
-- List changes in the way SCons is packaged and/or released
 
 - SCons now has three requirements files: requirements.txt describes
   requirements to run scons; requirements-dev.txt requirements to
@@ -64,10 +58,6 @@ PACKAGING
 
 DOCUMENTATION
 -------------
-
-- List any significant changes to the documentation (not individual
-  typo fixes, even if they're mentioned in src/CHANGES.txt to give
-  the contributor credit)
 
 - Updated the --hash-format manpage entry.
 - EnsureSConsVersion, EnsurePythonVersion, Exit, GetLaunchDir and

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1291,22 +1291,11 @@ def _build_targets(fs, options, targets, target_top):
             """Leave the order of dependencies alone."""
             return dependencies
 
-    def tmtrace_cleanup(tfile):
-        tfile.close()
-
-    if options.taskmastertrace_file == '-':
-        tmtrace = sys.stdout
-    elif options.taskmastertrace_file:
-        tmtrace = open(options.taskmastertrace_file, 'w')
-        atexit.register(tmtrace_cleanup, tmtrace)
-    else:
-        tmtrace = None
-    taskmaster = SCons.Taskmaster.Taskmaster(nodes, task_class, order, tmtrace)
+    taskmaster = SCons.Taskmaster.Taskmaster(nodes, task_class, order, options.taskmastertrace_file)
 
     # Let the BuildTask objects get at the options to respond to the
     # various print_* settings, tree_printer list, etc.
     BuildTask.options = options
-
 
     is_pypy = platform.python_implementation() == 'PyPy'
     # As of 3.7, python removed support for threadless platforms.

--- a/SCons/Taskmaster/TaskmasterTests.py
+++ b/SCons/Taskmaster/TaskmasterTests.py
@@ -1245,7 +1245,7 @@ Taskmaster: No candidate anymore.
         v_split=value.split('\n')
         e_split=expect.split('\n')
         if len(v_split) != len(e_split):
-            print("different number of lines:%d %d"%(len(v_split), len(e_split)))
+            print("different number of lines:%d %d" % (len(v_split), len(e_split)))
 
         # breakpoint()
         for v, e in zip(v_split, e_split):
@@ -1253,7 +1253,7 @@ Taskmaster: No candidate anymore.
             if v != e:
                 print("\n[%s]\n[%s]" % (v, e))
 
-        assert value == expect, "Expected:\n%s\nGot:\n%s"%(expect, value)
+        assert value == expect, "Expected:\n%s\nGot:\n%s" % (expect, value)
 
 
 if __name__ == "__main__":

--- a/SCons/Taskmaster/TaskmasterTests.py
+++ b/SCons/Taskmaster/TaskmasterTests.py
@@ -1241,10 +1241,19 @@ Task.postprocess():  node <executing  0   'n3'>
 
 Taskmaster: Looking for a node to evaluate
 Taskmaster: No candidate anymore.
-
 """
-        assert value == expect, value
+        v_split=value.split('\n')
+        e_split=expect.split('\n')
+        if len(v_split) != len(e_split):
+            print("different number of lines:%d %d"%(len(v_split), len(e_split)))
 
+        # breakpoint()
+        for v, e in zip(v_split, e_split):
+            # print("%s:%s"%(v,e))
+            if v != e:
+                print("\n[%s]\n[%s]" % (v, e))
+
+        assert value == expect, "Expected:\n%s\nGot:\n%s"%(expect, value)
 
 
 if __name__ == "__main__":

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -667,9 +667,9 @@ class Taskmaster:
 
         log_handler.setFormatter(DispatchingFormatter(
             formatters={
-            'Taskmaster': tm_formatter,
-            'Task': task_formatter,
-        },
+                'Taskmaster': tm_formatter,
+                'Task': task_formatter,
+            },
             default_formatter=logging.Formatter('%(message)s')
         ))
 

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -893,7 +893,7 @@ class Taskmaster:
                 self.ready_exc = sys.exc_info()
                 if S: S.problem = S.problem + 1
                 if T:
-                    elf.trace.debug('       exception %s while scanning children.' % e)
+                    self.trace.debug('       exception %s while scanning children.' % e)
                 return node
 
             children_not_visited = []

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -665,11 +665,12 @@ class Taskmaster:
         task_formatter = logging.Formatter('%(name)s.%(message)s')
         Task.LOGGER = tl
 
-        log_handler.setFormatter(DispatchingFormatter({
+        log_handler.setFormatter(DispatchingFormatter(
+            formatters={
             'Taskmaster': tm_formatter,
             'Task': task_formatter,
         },
-            logging.Formatter('%(message)s')
+            default_formatter=logging.Formatter('%(message)s')
         ))
 
     def find_next_candidate(self):

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -168,7 +168,8 @@ class Task(ABC):
         """
         global print_prepare
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         # Now that it's the appropriate time, give the TaskMaster a
         # chance to raise any exceptions it encountered while preparing
@@ -222,7 +223,8 @@ class Task(ABC):
         prepare(), executed() or failed().
         """
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         try:
             cached_targets = []
@@ -265,7 +267,8 @@ class Task(ABC):
         the Node's callback methods.
         """
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         for t in self.targets:
             if t.get_state() == NODE_EXECUTING:
@@ -288,7 +291,8 @@ class Task(ABC):
         """
         global print_prepare
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         for t in self.targets:
             if t.get_state() == NODE_EXECUTING:
@@ -329,7 +333,8 @@ class Task(ABC):
         nodes when using Configure().
         """
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         # Invoke will_not_build() to clean-up the pending children
         # list.
@@ -356,7 +361,8 @@ class Task(ABC):
         nodes when using Configure().
         """
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         self.tm.will_not_build(self.targets, lambda n: n.set_state(NODE_FAILED))
 
@@ -368,7 +374,8 @@ class Task(ABC):
         visited--the canonical example being the "scons -c" option.
         """
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         self.out_of_date = self.targets[:]
         for t in self.targets:
@@ -435,7 +442,8 @@ class Task(ABC):
         that can be put back on the candidates list.
         """
         T = self.tm.trace
-        if T: self.trace_message(self.node)
+        if T:
+            self.trace_message(self.node)
 
         # We may have built multiple targets, some of which may have
         # common parents waiting for this build.  Count up how many
@@ -452,7 +460,8 @@ class Task(ABC):
             # A node can only be in the pending_children set if it has
             # some waiting_parents.
             if t.waiting_parents:
-                if T: self.trace_message(t, 'removing')
+                if T:
+                    self.trace_message(t, 'removing')
                 pending_children.discard(t)
             for p in t.waiting_parents:
                 parents[p] = parents.get(p, 0) + 1
@@ -479,7 +488,8 @@ class Task(ABC):
 
         for p, subtract in parents.items():
             p.ref_count = p.ref_count - subtract
-            if T: self.trace_message(p, 'adjusted parent ref count')
+            if T:
+                self.trace_message(p, 'adjusted parent ref count')
             if p.ref_count == 0:
                 self.tm.candidates.append(p)
 
@@ -789,9 +799,6 @@ class Taskmaster:
             for p in n.waiting_parents:
                 assert p.ref_count > 0, (str(n), str(p), p.ref_count)
 
-    def tm_trace_message(self, message):
-        return 'Taskmaster: %s' % message
-
     def tm_trace_node(self, node):
         return('<%-10s %-3s %s>' % (StateString[node.get_state()],
                                     node.ref_count,
@@ -829,7 +836,8 @@ class Taskmaster:
         while True:
             node = self.next_candidate()
             if node is None:
-                if T: self.trace.debug('No candidate anymore.')
+                if T:
+                    self.trace.debug('No candidate anymore.')
                 return None
 
             node = node.disambiguate()
@@ -852,7 +860,8 @@ class Taskmaster:
             else:
                 S = None
 
-            if T: self.trace.debug('    Considering node %s and its children:' % self.tm_trace_node(node))
+            if T:
+                self.trace.debug('    Considering node %s and its children:' % self.tm_trace_node(node))
 
             if state == NODE_NO_STATE:
                 # Mark this node as being on the execution stack:
@@ -860,7 +869,8 @@ class Taskmaster:
             elif state > NODE_PENDING:
                 # Skip this node if it has already been evaluated:
                 if S: S.already_handled = S.already_handled + 1
-                if T: self.trace.debug('       already handled (executed)')
+                if T:
+                    self.trace.debug('       already handled (executed)')
                 continue
 
             executor = node.get_executor()
@@ -871,7 +881,8 @@ class Taskmaster:
                 exc_value = sys.exc_info()[1]
                 e = SCons.Errors.ExplicitExit(node, exc_value.code)
                 self.ready_exc = (SCons.Errors.ExplicitExit, e)
-                if T: self.trace.debug('       SystemExit')
+                if T:
+                    self.trace.debug('       SystemExit')
                 return node
             except Exception as e:
                 # We had a problem just trying to figure out the
@@ -880,7 +891,8 @@ class Taskmaster:
                 # raise the exception when the Task is "executed."
                 self.ready_exc = sys.exc_info()
                 if S: S.problem = S.problem + 1
-                if T: self.trace.debug('       exception %s while scanning children.' % e)
+                if T:
+                    elf.trace.debug('       exception %s while scanning children.' % e)
                 return node
 
             children_not_visited = []
@@ -891,7 +903,8 @@ class Taskmaster:
             for child in chain(executor.get_all_prerequisites(), children):
                 childstate = child.get_state()
 
-                if T: self.trace.debug('       ' + self.tm_trace_node(child))
+                if T:
+                    self.trace.debug('       ' + self.tm_trace_node(child))
 
                 if childstate == NODE_NO_STATE:
                     children_not_visited.append(child)
@@ -938,7 +951,8 @@ class Taskmaster:
                     n.set_state(NODE_FAILED)
 
                 if S: S.child_failed = S.child_failed + 1
-                if T: self.trace.debug('****** %s' % self.tm_trace_node(node))
+                if T:
+                    self.trace.debug('****** %s' % self.tm_trace_node(node))
                 continue
 
             if children_not_ready:
@@ -952,7 +966,8 @@ class Taskmaster:
                     # count so we can be put back on the list for
                     # re-evaluation when they've all finished.
                     node.ref_count =  node.ref_count + child.add_to_waiting_parents(node)
-                    if T: self.trace.debug('     adjusted ref count: %s, child %s' %
+                    if T:
+                        self.trace.debug('     adjusted ref count: %s, child %s' %
                                                 (self.tm_trace_node(node), repr(str(child))))
 
                 if T:
@@ -978,7 +993,8 @@ class Taskmaster:
             # The default when we've gotten through all of the checks above:
             # this node is ready to be built.
             if S: S.build = S.build + 1
-            if T: self.trace.debug('Evaluating %s' % self.tm_trace_node(node))
+            if T:
+                self.trace.debug('Evaluating %s' % self.tm_trace_node(node))
 
             # For debugging only:
             #
@@ -1060,7 +1076,8 @@ class Taskmaster:
 
                 for p in parents:
                     p.ref_count = p.ref_count - 1
-                    if T: self.trace.debug('       removing parent %s from the pending children set\n' %
+                    if T:
+                        self.trace.debug('       removing parent %s from the pending children set\n' %
                                                 self.tm_trace_node(p))
         except KeyError:
             # The container to_visit has been emptied.

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -35,6 +35,7 @@ from collections.abc import MappingView
 from contextlib import suppress
 from types import MethodType, FunctionType
 from typing import Optional, Union
+from logging import Formatter
 
 # Note: Util module cannot import other bits of SCons globally without getting
 # into import loops. Both the below modules import SCons.Util early on.
@@ -2158,6 +2159,17 @@ def wait_for_process_to_die(pid):
                     break
                 else:
                     time.sleep(0.1)
+
+# From: https://stackoverflow.com/questions/1741972/how-to-use-different-formatters-with-the-same-logging-handler-in-python
+class DispatchingFormatter(Formatter):
+
+    def __init__(self, formatters, default_formatter):
+        self._formatters = formatters
+        self._default_formatter = default_formatter
+
+    def format(self, record):
+        formatter = self._formatters.get(record.name, self._default_formatter)
+        return formatter.format(record)
 
 # Local Variables:
 # tab-width:4


### PR DESCRIPTION
Existing tests should ensure that this change is just internal.
I did add some logic to the trace testing unit test to show which line(s) were failing.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
