### PR TITLE
Small cleanup in BoolVariable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       (';') - which is now documented with a hint to use a list instead
       to be portable. Splitting on space broke paths with embedded spaces.
       Fixes #4243.
+    - Cleanup: make sure BoolVariable usage in tests and examples uses Python
+      boolean values instead of 0/1.
 
   From Andrew Morrow
     - Avoid returning UniqueList for `children` and other `Executor` APIs. This type

--- a/SCons/Variables/BoolVariable.py
+++ b/SCons/Variables/BoolVariable.py
@@ -26,10 +26,10 @@
 Usage example::
 
     opts = Variables()
-    opts.Add(BoolVariable('embedded', 'build for an embedded system', 0))
+    opts.Add(BoolVariable('embedded', 'build for an embedded system', False))
     ...
-    if env['embedded'] == 1:
-    ...
+    if env['embedded']:
+        ...
 """
 
 from typing import Tuple, Callable
@@ -42,17 +42,17 @@ TRUE_STRINGS = ('y', 'yes', 'true', 't', '1', 'on' , 'all')
 FALSE_STRINGS = ('n', 'no', 'false', 'f', '0', 'off', 'none')
 
 
-def _text2bool(val) -> bool:
-    """Converts strings to True/False.
+def _text2bool(val: str) -> bool:
+    """Convert boolean-like string to boolean.
 
     If *val* looks like it expresses a bool-like value, based on
-    the :data:`TRUE_STRINGS` and :data:`FALSE_STRINGS` tuples,
+    the :const:`TRUE_STRINGS` and :const:`FALSE_STRINGS` tuples,
     return the appropriate value.
 
     This is usable as a converter function for SCons Variables.
 
     Raises:
-        ValueError: if the string cannot be converted.
+        ValueError: if *val* cannot be converted to boolean.
     """
 
     lval = val.lower()
@@ -64,13 +64,15 @@ def _text2bool(val) -> bool:
 
 
 def _validator(key, val, env) -> None:
-    """Validates the given value to be either true or false.
+    """Validate that the value of *key* in *env* is a boolean.
 
-    This is usable as a validator function for SCons Variables.
+    Parmaeter *val* is not used in the check.
+
+    Usable as a validator function for SCons Variables.
 
     Raises:
-        KeyError: if key is not set in env
-        UserError: if key does not validate.
+        KeyError: if *key* is not set in *env*
+        UserError: if the value of *key* is not ``True`` or ``False``.
     """
     if not env[key] in (True, False):
         raise SCons.Errors.UserError(

--- a/SCons/Variables/BoolVariableTests.py
+++ b/SCons/Variables/BoolVariableTests.py
@@ -30,7 +30,7 @@ class BoolVariableTestCase(unittest.TestCase):
     def test_BoolVariable(self):
         """Test BoolVariable creation"""
         opts = SCons.Variables.Variables()
-        opts.Add(SCons.Variables.BoolVariable('test', 'test option help', 0))
+        opts.Add(SCons.Variables.BoolVariable('test', 'test option help', False))
 
         o = opts.options[0]
         assert o.key == 'test', o.key
@@ -42,7 +42,7 @@ class BoolVariableTestCase(unittest.TestCase):
     def test_converter(self):
         """Test the BoolVariable converter"""
         opts = SCons.Variables.Variables()
-        opts.Add(SCons.Variables.BoolVariable('test', 'test option help', 0))
+        opts.Add(SCons.Variables.BoolVariable('test', 'test option help', False))
 
         o = opts.options[0]
 
@@ -73,17 +73,17 @@ class BoolVariableTestCase(unittest.TestCase):
             x = o.converter(f)
             assert not x, "converter returned true for '%s'" % f
 
-        caught = None
+        caught = False
         try:
             o.converter('x')
         except ValueError:
-            caught = 1
-        assert caught, "did not catch expected ValueError"
+            caught = True
+        assert caught, "did not catch expected ValueError for 'x'"
 
     def test_validator(self):
         """Test the BoolVariable validator"""
         opts = SCons.Variables.Variables()
-        opts.Add(SCons.Variables.BoolVariable('test', 'test option help', 0))
+        opts.Add(SCons.Variables.BoolVariable('test', 'test option help', False))
 
         o = opts.options[0]
 
@@ -93,23 +93,24 @@ class BoolVariableTestCase(unittest.TestCase):
             'N' : 'xyzzy',
         }
 
+        # positive checks
         o.validator('T', 0, env)
-
         o.validator('F', 0, env)
 
-        caught = None
+        # negative checks
+        caught = False
         try:
             o.validator('N', 0, env)
         except SCons.Errors.UserError:
-            caught = 1
-        assert caught, "did not catch expected UserError for N"
+            caught = True
+        assert caught, "did not catch expected UserError for value %s" % env['N']
 
-        caught = None
+        caught = False
         try:
             o.validator('NOSUCHKEY', 0, env)
         except KeyError:
-            caught = 1
-        assert caught, "did not catch expected KeyError for NOSUCHKEY"
+            caught = True
+        assert caught, "did not catch expected KeyError for 'NOSUCHKEY'"
 
 
 if __name__ == "__main__":

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -4737,7 +4737,7 @@ the &Add; or &AddVariables; method:</para>
   <varlistentry id="v-BoolVariable">
   <term><function>BoolVariable</function>(<parameter>key, help, default</parameter>)</term>
   <listitem>
-<para>Returns a tuple of arguments
+<para>Return a tuple of arguments
 to set up a Boolean option.
 The option will use
 the specified name
@@ -4746,7 +4746,7 @@ have a default value of
 <parameter>default</parameter>,
 and <parameter>help</parameter>
 will form the descriptive part of the help text.
-The option will interpret the values
+The option will interpret the command-line values
 <userinput>y</userinput>,
 <userinput>yes</userinput>,
 <userinput>t</userinput>,
@@ -4756,7 +4756,7 @@ The option will interpret the values
 and
 <userinput>all</userinput>
 as true,
-and the values
+and the command-line values
 <userinput>n</userinput>,
 <userinput>no</userinput>,
 <userinput>f</userinput>,
@@ -4990,7 +4990,7 @@ vars.AddVariables(
     BoolVariable(
         "warnings",
         help="compilation with -Wall and similar",
-        default=1,
+        default=True,
     ),
     EnumVariable(
         "debug",

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -1281,7 +1281,7 @@ vars = Variables('custom.py', ARGUMENTS)
         <scons_example name="commandline_BoolVariable">
           <file name="SConstruct" printme="1">
 vars = Variables('custom.py')
-vars.Add(BoolVariable('RELEASE', help='Set to build for release', default=0))
+vars.Add(BoolVariable('RELEASE', help='Set to build for release', default=False))
 env = Environment(variables=vars, CPPDEFINES={'RELEASE_BUILD': '${RELEASE}'})
 env.Program('foo.c')
           </file>
@@ -1964,7 +1964,7 @@ vars = Variables()
 vars.AddVariables(
     ('RELEASE', 'Set to 1 to build for release', 0),
     ('CONFIG', 'Configuration file', '/etc/my_config'),
-    BoolVariable('warnings', help='compilation with -Wall and similiar', default=1),
+    BoolVariable('warnings', help='compilation with -Wall and similiar', default=True),
     EnumVariable(
         'debug',
         help='debug output and symbols',

--- a/test/Configure/issue-3469/fixture/SConstruct
+++ b/test/Configure/issue-3469/fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 This tests if we add/remove a test in between other tests if a rerun will properly cache the results.
 Github issue #3469
@@ -6,7 +10,7 @@ Github issue #3469
 DefaultEnvironment(tools=[])
 
 vars = Variables()
-vars.Add(BoolVariable('SKIP', 'Skip Middle Conf test', 0))
+vars.Add(BoolVariable('SKIP', 'Skip Middle Conf test', False))
 env = Environment(variables=vars)
 
 conf = Configure(env)

--- a/test/Copy-Option.py
+++ b/test/Copy-Option.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that setting Variables in an Environment doesn't prevent the
@@ -37,20 +36,22 @@ test.write('SConstruct', """
 gpib_options = ['NI_GPIB', 'NI_ENET']
 gpib_include = '/'
 
-#0.96 broke copying  ListVariables ???
+# 0.96 broke copying  ListVariables ???
 opts = Variables('config.py', ARGUMENTS)
 opts.AddVariables(
-    BoolVariable('gpib', 'enable gpib support', 1),
-    ListVariable('gpib_options',
+    BoolVariable('gpib', 'enable gpib support', True),
+    ListVariable(
+        'gpib_options',
         'whether and what kind of gpib support shall be enabled',
         'all',
-        gpib_options),
-    )
-env = Environment(options = opts, CPPPATH = ['#/'])
-new_env=env.Clone()
+        gpib_options,
+    ),
+)
+env = Environment(options=opts, CPPPATH=['#/'])
+new_env = env.Clone()
 """)
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
 test.pass_test()
 

--- a/test/Parallel/multiple-parents.py
+++ b/test/Parallel/multiple-parents.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
 """
 Verify that a failed build action with -j works as expected.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 
@@ -58,67 +57,76 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 vars = Variables()
-vars.Add( BoolVariable('interrupt', 'Interrupt the build.', 0 ) )
+vars.Add(BoolVariable('interrupt', 'Interrupt the build.', False))
 varEnv = Environment(variables=vars)
 
-def fail_action(target = None, source = None, env = None):
+def fail_action(target=None, source=None, env=None):
     return 2
 
-def simulate_keyboard_interrupt(target = None, source = None, env = None):
+def simulate_keyboard_interrupt(target=None, source=None, env=None):
     # Directly invoked the SIGINT handler to simulate a
     # KeyboardInterrupt. This hack is necessary because there is no
     # easy way to get access to the current Job/Taskmaster object.
     import signal
+
     handler = signal.getsignal(signal.SIGINT)
     handler(signal.SIGINT, None)
     return 0
 
-interrupt = Command(target='interrupt',  source='', action=simulate_keyboard_interrupt)
+interrupt = Command(target='interrupt', source='', action=simulate_keyboard_interrupt)
 
 touch0 = Touch('${TARGETS[0]}')
 touch1 = Touch('${TARGETS[1]}')
 touch2 = Touch('${TARGETS[2]}')
 
-failed0  = Command(target='failed00',  source='', action=fail_action)
-ok0      = Command(target=['ok00a', 'ok00b', 'ok00c'], 
-                   source='', 
-                   action=[touch0, touch1, touch2])
-prereq0  = Command(target='prereq00',  source='', action=touch0)
-ignore0  = Command(target='ignore00',  source='', action=touch0)
-igreq0   = Command(target='igreq00',   source='', action=touch0)
+failed0 = Command(target='failed00', source='', action=fail_action)
+ok0 = Command(
+    target=['ok00a', 'ok00b', 'ok00c'],
+    source='',
+    action=[touch0, touch1, touch2],
+)
+prereq0 = Command(target='prereq00', source='', action=touch0)
+ignore0 = Command(target='ignore00', source='', action=touch0)
+igreq0 = Command(target='igreq00', source='', action=touch0)
 missing0 = Command(target='missing00', source='MissingSrc', action=touch0)
-withSE0  = Command(target=['withSE00a', 'withSE00b', 'withSE00c'], 
-                   source='', 
-                   action=[touch0, touch1, touch2, Touch('side_effect')])
-SideEffect('side_effect', withSE0) 
+withSE0 = Command(
+    target=['withSE00a', 'withSE00b', 'withSE00c'],
+    source='',
+    action=[touch0, touch1, touch2, Touch('side_effect')],
+)
+SideEffect('side_effect', withSE0)
 
-prev_level  = failed0 + ok0 + ignore0 + missing0 + withSE0
+prev_level = failed0 + ok0 + ignore0 + missing0 + withSE0
 prev_prereq = prereq0
 prev_ignore = ignore0
-prev_igreq  = igreq0
+prev_igreq = igreq0
 
 if varEnv['interrupt']:
     prev_level = prev_level + interrupt
 
-for i in range(1,20):
-    
-    failed = Command(target='failed%02d' % i,  source='', action=fail_action)
-    ok     = Command(target=['ok%02da' % i, 'ok%02db' % i, 'ok%02dc' % i], 
-                     source='',
-                     action=[touch0, touch1, touch2])
-    prereq = Command(target='prereq%02d' % i,  source='', action=touch0)
-    ignore = Command(target='ignore%02d' % i,  source='', action=touch0)
-    igreq  = Command(target='igreq%02d' % i,   source='', action=touch0)
-    missing = Command(target='missing%02d' %i, source='MissingSrc', action=touch0)
-    withSE  = Command(target=['withSE%02da' % i, 'withSE%02db' % i, 'withSE%02dc' % i], 
-                       source='', 
-                       action=[touch0, touch1, touch2, Touch('side_effect')])
-    SideEffect('side_effect', withSE) 
+for i in range(1, 20):
+
+    failed = Command(target='failed%02d' % i, source='', action=fail_action)
+    ok = Command(
+        target=['ok%02da' % i, 'ok%02db' % i, 'ok%02dc' % i],
+        source='',
+        action=[touch0, touch1, touch2],
+    )
+    prereq = Command(target='prereq%02d' % i, source='', action=touch0)
+    ignore = Command(target='ignore%02d' % i, source='', action=touch0)
+    igreq = Command(target='igreq%02d' % i, source='', action=touch0)
+    missing = Command(target='missing%02d' % i, source='MissingSrc', action=touch0)
+    withSE = Command(
+        target=['withSE%02da' % i, 'withSE%02db' % i, 'withSE%02dc' % i],
+        source='',
+        action=[touch0, touch1, touch2, Touch('side_effect')],
+    )
+    SideEffect('side_effect', withSE)
 
     next_level = failed + ok + ignore + igreq + missing + withSE
 
-    for j in range(1,10):
-        a = Alias('a%02d%02d' % (i,j), prev_level)
+    for j in range(1, 10):
+        a = Alias('a%02d%02d' % (i, j), prev_level)
 
         Requires(a, prev_prereq)
         Ignore(a, prev_ignore)
@@ -128,18 +136,18 @@ for i in range(1,20):
 
         next_level = next_level + a
 
-    prev_level  = next_level
+    prev_level = next_level
     prev_prereq = prereq
     prev_ignore = ignore
-    prev_igreq  = igreq
+    prev_igreq = igreq
 
 all = Alias('all', prev_level)
 
 Requires(all, prev_prereq)
-Ignore(all,  prev_ignore)
+Ignore(all, prev_ignore)
 
 Requires(all, prev_igreq)
-Ignore(all,  prev_igreq)
+Ignore(all, prev_igreq)
 
 Default(all)
 """)

--- a/test/Variables/BoolVariable.py
+++ b/test/Variables/BoolVariable.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the BoolVariable canned Variable type.
@@ -40,18 +39,18 @@ def check(expect):
     assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
 
 
-
 test.write(SConstruct_path, """\
 from SCons.Variables.BoolVariable import BoolVariable
+
 BV = BoolVariable
 
 from SCons.Variables import BoolVariable
 
 opts = Variables(args=ARGUMENTS)
 opts.AddVariables(
-    BoolVariable('warnings', 'compilation with -Wall and similiar', 1),
-    BV('profile', 'create profiling informations', 0),
-    )
+    BoolVariable('warnings', 'compilation with -Wall and similiar', True),
+    BV('profile', 'create profiling informations', False),
+)
 
 env = Environment(variables=opts)
 Help(opts.GenerateHelpText(env))
@@ -62,8 +61,6 @@ print(env['profile'])
 Default(env.Alias('dummy', None))
 """)
 
-
-
 test.run()
 check([str(True), str(False)])
 
@@ -73,11 +70,9 @@ check([str(False), str(True)])
 expect_stderr = """
 scons: *** Error converting option: warnings
 Invalid value for boolean option: irgendwas
-""" + test.python_file_line(SConstruct_path, 12)
+""" + test.python_file_line(SConstruct_path, 13)
 
 test.run(arguments='warnings=irgendwas', stderr = expect_stderr, status=2)
-
-
 
 test.pass_test()
 

--- a/test/Variables/help.py
+++ b/test/Variables/help.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the Variables help messages.
@@ -46,37 +45,52 @@ test.subdir(qtpath)
 test.subdir(libpath)
          
 test.write('SConstruct', """
-from SCons.Variables import BoolVariable, EnumVariable, ListVariable, \
-   PackageVariable, PathVariable
+from SCons.Variables import (
+    BoolVariable,
+    EnumVariable,
+    ListVariable,
+    PackageVariable,
+    PathVariable,
+)
 
 list_of_libs = Split('x11 gl qt ical')
 qtdir = r'%(qtpath)s'
 
 opts = Variables(args=ARGUMENTS)
 opts.AddVariables(
-    BoolVariable('warnings', 'compilation with -Wall and similiar', 1),
-    BoolVariable('profile', 'create profiling informations', 0),
-    EnumVariable('debug', 'debug output and symbols', 'no',
-               allowed_values=('yes', 'no', 'full'),
-               map={}, ignorecase=0),  # case sensitive
-    EnumVariable('guilib', 'gui lib to use', 'gtk',
-               allowed_values=('motif', 'gtk', 'kde'),
-               map={}, ignorecase=1), # case insensitive
-    EnumVariable('some', 'some option', 'xaver',
-               allowed_values=('xaver', 'eins'),
-               map={}, ignorecase=2), # make lowercase
-    ListVariable('shared',
-               'libraries to build as shared libraries',
-               'all',
-               names = list_of_libs),
-    PackageVariable('x11',
-                  'use X11 installed here (yes = search some places)',
-                  'yes'),
+    BoolVariable('warnings', 'compilation with -Wall and similiar', True),
+    BoolVariable('profile', 'create profiling informations', False),
+    EnumVariable(
+        'debug',
+        'debug output and symbols',
+        'no',
+        allowed_values=('yes', 'no', 'full'),
+        map={},
+        ignorecase=0,
+    ),  # case sensitive
+    EnumVariable(
+        'guilib',
+        'gui lib to use',
+        'gtk',
+        allowed_values=('motif', 'gtk', 'kde'),
+        map={},
+        ignorecase=1,
+    ),  # case insensitive
+    EnumVariable(
+        'some',
+        'some option',
+        'xaver',
+        allowed_values=('xaver', 'eins'),
+        map={},
+        ignorecase=2,
+    ),  # make lowercase
+    ListVariable(
+        'shared', 'libraries to build as shared libraries', 'all', names=list_of_libs
+    ),
+    PackageVariable('x11', 'use X11 installed here (yes = search some places)', 'yes'),
     PathVariable('qtdir', 'where the root of Qt is installed', qtdir),
-    PathVariable('qt_libraries',
-               'where the Qt library is installed',
-               r'%(libdirvar)s'),
-    )
+    PathVariable('qt_libraries', 'where the Qt library is installed', r'%(libdirvar)s'),
+)
 
 env = Environment(variables=opts)
 Help(opts.GenerateHelpText(env))
@@ -96,11 +110,11 @@ scons: Reading SConscript files ...
 scons: done reading SConscript files.
 
 warnings: compilation with -Wall and similiar (yes|no)
-    default: 1
+    default: True
     actual: %(str_True)s
 
 profile: create profiling informations (yes|no)
-    default: 0
+    default: False
     actual: %(str_False)s
 
 debug: debug output and symbols (yes|no|full)

--- a/test/no-global-dependencies.py
+++ b/test/no-global-dependencies.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that files are correctly located in the variant directory even when


### PR DESCRIPTION
For consistency, have `BoolVariable` usage use `True` and `False` instead of 0 and 1 - mainly this is tests and doc examples.

Reformatted a few embedded test files.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
