### PR TITLE
Maintenance: fix some fiddly checker errors

### DIFF
--- a/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
+++ b/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
@@ -157,7 +157,7 @@ def convertLength(length):
     global pixelsPerInch
     global unitHash
 
-    m = re.search('([+-]?[\d.]+)(\S+)', length)
+    m = re.search(r'([+-]?[\d.]+)(\S+)', length)
     if m is not None and m.lastindex > 1:
         unit = pixelsPerInch
         if m.group(2) in unitHash:
@@ -204,11 +204,11 @@ def lookupVariable(tctxt, varName, default):
         return default
 
     # If it's a list, get the first element
-    if type(varString) == type([]):
+    if isinstance(varString, list):
         varString = varString[0]
 
     # If it's not a string, it must be a node, get its content
-    if type(varString) != type(""):
+    if not isinstance(varString, str):
         varString = varString.content
 
     return varString

--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -1880,7 +1880,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*fail
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -1940,13 +1940,13 @@ class run_TestCase(TestCommonTestCase):
         Traceback \\(most recent call last\\):
           File "<stdin>", line \\d+, in (\\?|<module>)
           File "[^"]+TestCommon.py", line \\d+, in run
-            TestCmd.run\\(self, \\*\\*kw\\)
+            super().run\\(\\*\\*kw\\)
           File "[^"]+TestCmd.py", line \\d+, in run
-            .*
+            p = self.start(program=program,
           File "[^"]+TestCommon.py", line \\d+, in start
             raise e
           File "[^"]+TestCommon.py", line \\d+, in start
-            return TestCmd.start\\(self, program, interpreter, arguments,
+            return super().start\\(program, interpreter, arguments,
           File "<stdin>", line \\d+, in raise_exception
         TypeError: forced TypeError
         """ % re.escape(repr(sys.executable)))
@@ -2066,7 +2066,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*pass
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2096,7 +2096,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*fail
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2128,7 +2128,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*pass
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 
@@ -2162,7 +2162,7 @@ class run_TestCase(TestCommonTestCase):
         FAILED test of .*stderr
         \\tat line \\d+ of .*TestCommon\\.py \\(_complete\\)
         \\tfrom line \\d+ of .*TestCommon\\.py \\(run\\)
-        \\tfrom line \\d+ of <stdin>( \(<module>\))?
+        \\tfrom line \\d+ of <stdin>( \\(<module>\\))?
         """)
         expect_stderr = re.compile(expect_stderr, re.M)
 


### PR DESCRIPTION
- A rawstring to avoid an invalid escape warning.
- A couple of instances where code is comparing `type()` calls,   advice is to is `isinstance()` instead.
- Missing backslashes on escapes in framewok test (rarely run) Updating expected traceback msg in framework test after the   code which forces the exception changed in a previous revision.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
