### PR TITLE
Update setup/installation chapter in User Guide

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -52,6 +52,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Fixes #4243.
     - Cleanup: make sure BoolVariable usage in tests and examples uses Python
       boolean values instead of 0/1.
+    - Stop telling people to run "python setup.py install" in the User Guide.
+      Adds new content on using virtualenvs to be able to have multiple
+      different SCons versions available on one system.
+
 
   From Andrew Morrow
     - Avoid returning UniqueList for `children` and other `Executor` APIs. This type

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -79,6 +79,9 @@ DOCUMENTATION
   Added note on the possibly surprising feature that SCons always passes
   -sourcepath when calling javac, which affects how the class path is
   used when finding sources.
+- Updated the User Guide chapter on installation: modernized the notes
+  on Python installs, SCons installs, and having multiple SCons versions
+  present on a single system.
 
 DEVELOPMENT
 -----------

--- a/doc/user/build-install.xml
+++ b/doc/user/build-install.xml
@@ -1,4 +1,10 @@
 <?xml version='1.0'?>
+<!--
+SPDX-License-Identifier: MIT
+
+Copyright The SCons Foundation
+-->
+
 <!DOCTYPE sconsdoc [
 
     <!ENTITY % version SYSTEM "../version.xml">
@@ -22,46 +28,19 @@
          xmlns="http://www.scons.org/dbxsd/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
 <title>Building and Installing &SCons;</title>
-
-<!--
-
-  __COPYRIGHT__
-
-  Permission is hereby granted, free of charge, to any person obtaining
-  a copy of this software and associated documentation files (the
-  "Software"), to deal in the Software without restriction, including
-  without limitation the rights to use, copy, modify, merge, publish,
-  distribute, sublicense, and/or sell copies of the Software, and to
-  permit persons to whom the Software is furnished to do so, subject to
-  the following conditions:
-
-  The above copyright notice and this permission notice shall be included
-  in all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
--->
 
   <para>
 
   This chapter will take you through the basic steps
-  of installing &SCons; on your system,
-  and building &SCons; if you don't have a
-  pre-built package available
-  (or simply prefer the flexibility of building it yourself).
+  of installing &SCons; so you can use it for your your projects.
   Before that, however, this chapter will also describe the basic steps
-  involved in installing Python on your system,
+  involved in installing &Python; on your system,
   in case that is necessary.
-  Fortunately, both &SCons; and Python
-  are very easy to install on almost any system,
-  and Python already comes installed on many systems.
+  Fortunately, both &SCons; and &Python;
+  are easy to install on almost any system,
+  and &Python; already comes installed on many systems.
 
   </para>
 
@@ -70,31 +49,31 @@
   <para>
 
   Lastly, this chapter also contains a section that
-  provides a brief overview of the Python programming language,
+  provides a brief overview of the &Python; programming language,
   which is the language used to implement &SCons;,
   and which forms the basis of the &SCons; configuration files.
-  Becoming familiar with some Python concepts will make it easier
+  Becoming familiar with some &Python; concepts will make it easier
   to understand many of the examples in this User's Guide.
   Nevertheless, it <emphasis>is</emphasis> possible
-  to configure simple &SCons; builds without knowing Python,
+  to configure simple &SCons; builds without knowing &Python;,
   so you can skip this section if you
   want to dive in and pick up things
   by example- -or, of course, if you are
-  already familiar with Python.
+  already familiar with &Python;.
 
   </para>
 
   -->
 
-  <section>
+  <section id="sect-install-python">
   <title>Installing Python</title>
 
     <para>
-    Because &SCons; is written in Python,
-    you need to have Python installed on your system
+    Because &SCons; is written in the &Python; programming language,
+    you need to have a &Python; interpreter available on your system
     to use &SCons;.
-    Before you try to install Python,
-    you should check to see if Python is already
+    Before you try to install &Python;,
+    check to see if &Python; is already
     available on your system  by typing
     <userinput>python -V</userinput>
     (capital 'V')
@@ -106,28 +85,34 @@
 
     <screen>
 $ <userinput>python -V</userinput>
-Python 3.7.1
+Python 3.9.15
     </screen>
 
     <para>
-    Note to Windows users: there are a number of different ways Python
+    If you get a version like 2.7.x, you may need to try using the
+    name <command>python3</command> - current &SCons; no longer
+    works with &Python; 2.
+    </para>
+
+    <para>
+    Note to Windows users: there are a number of different ways &Python;
     can be installed or invoked on Windows, it is beyond the scope
-    of this guide to unravel all of them. Many will have an additional
+    of this guide to unravel all of them. Some have an additional
     program called the <firstterm>Python launcher</firstterm> (described,
     somewhat technically, in
     <ulink url="https://www.python.org/dev/peps/pep-0397/">PEP 397</ulink>):
     try using the command name <command>py</command> instead of
     <command>python</command>, if that is not available drop
-    back to trying <command>python</command>.
+    back to trying <command>python</command>
     </para>
 
     <screen>
 C:\><userinput>py -V</userinput>
-Python 3.7.1
+Python 3.9.15
     </screen>
 
     <para>
-    If Python is not installed on your system,
+    If &Python; is not installed on your system,
     or is not findable in the current search path,
     you will see an error message
     stating something like <computeroutput>"command not found"</computeroutput>
@@ -135,14 +120,14 @@ Python 3.7.1
     or <computeroutput>"'python' is not recognized as an internal
     or external command, operable progam or batch file"</computeroutput>
     (on Windows <command>cmd</command>).
-    In that case, you need to either install Python
+    In that case, you need to either install &Python;
     or fix the search path
     before you can install &SCons;.
     </para>
 
     <para>
-    The canonical location for downloading Python 
-    from Python's own website is:
+    The link for downloading &Python; installers (Windows and Mac)
+    from the project's own website is:
     <ulink url="https://www.python.org/download">https://www.python.org/download</ulink>.
     There are useful system-specific entries on setup and
     usage to be found at:
@@ -150,34 +135,56 @@ Python 3.7.1
     </para>
 
     <para>
-    For Linux systems, Python is
-    almost certainly available as a supported package, possibly
+    For Linux systems, &Python; is
+    almost certainly available as a supported package, probably
     installed by default; this is often preferred over installing
-    by other means, and is easier than installing from source code.
+    by other means as the system package will be built with
+    carefully chosen optimizations, and will be kept up to date
+    with bug fixes and security patches. In fact, the &Python;
+    project itself does not build installers for Linux for this reason.
     Many such systems have separate packages for
-    Python 2 and Python 3 - make sure the Python 3 package is
+    &Python; 2 and &Python; 3 - make sure the &Python; 3 package is
     installed, as the latest &SCons; requires it.
     Building from source may still be a
-    useful option if you need a version that is not offered by
+    useful option if you need a specific version that is not offered by
     the distribution you are using.
     </para>
 
     <para>
-    &SCons; will work with Python 3.5 or later.
-    If you need to install Python and have a choice,
-    we recommend using the most recent Python version available.
-    Newer Pythons have significant improvements
+    Recent versions of the Mac no longer come with &Python;
+    pre-installed; older versions came with a rather out of date
+    version (based on &Python; 2.7) which is insufficient to run
+    current &SCons;.
+    The python.org installer can be used on the Mac, but there are
+    also other sources such as MacPorts and Homebrew.
+    The Anaconda installation also comes with a bundled &Python;.
+    </para>
+
+    <para>
+    Windows has even more choices.  The Python.org installer is
+    a traditional <filename>.exe</filename> style;
+    the same software is also released as a Windows application through
+    the Microsoft Store.  Several alternative builds also exist
+    such as Chocolatey and ActiveState, and, again,
+    a version of Python comes with Anaconda.
+    </para>
+
+    <para>
+    &SCons; will work with &Python; 3.6 or later.
+    If you need to install &Python; and have a choice,
+    we recommend using the most recent &Python; version available.
+    Newer &Python; versions have significant improvements
     that help speed up the performance of &SCons;.
     </para>
 
   </section>
 
-  <section>
+  <section id="sect-install-scons">
   <title>Installing &SCons;</title>
 
     <para>
-    The canonical way to install &SCons; is from the Python Package
-    Index (PyPi):
+    The recommended way to install &SCons; is from the &Python; Package
+    Index (<ulink url="https://pypi.org/project/SCons/">PyPI</ulink>):
     </para>
 
     <screen>
@@ -185,9 +192,9 @@ Python 3.7.1
     </screen>
 
     <para>
-    If you prefer not to install to the Python system location,
-    or do not have privileges to do so, you can add a flag to
-    install to a location specific to your own account:
+    If you prefer not to install to the &Python; system location,
+    or do not have privileges to do so, you can add a flag to install
+    to a location specific to your own account and &Python; version:
     </para>
 
     <screen>
@@ -197,7 +204,7 @@ Python 3.7.1
     <para>
     For those users using Anaconda or Miniconda, use the
     <command>conda</command> installer instead, so the &scons;
-    install location will match the version of Python that
+    install location will match the version of &Python; that
     system will be using. For example:
     </para>
 
@@ -206,43 +213,61 @@ Python 3.7.1
     </screen>
 
     <para>
-    &SCons; comes pre-packaged for installation on many Linux systems.
-    Check your package installation system
-    to see if there is an &SCons; package available.
-    Many people prefer to install distribution-native packages if available,
-    as they provide a central point for management and updating.
-    During the still-ongoing Python 2 to 3 transition,
-    some distributions may still have two &SCons; packages available,
-    one which uses Python 2 and one which uses Python 3.  Since
-    the latest &scons; only runs on Python 3, to get the current version
-    you should choose the Python 3 package.
+    If you need a specific
+    version of &SCons; that is different from the current version,
+    <systemitem>pip</systemitem> has a version option
+    (e.g. <userinput>python -m pip install scons==3.1.2</userinput>),
+    or you can follow the instructions in the following sections.
     </para>
 
     <para>
-    If you need a specific
-    version of &SCons; that is different from the package available,
-    <systemitem>pip</systemitem> has a version option or you can follow
-    the instructions in the next section.
+    &SCons; does comes pre-packaged for installation on many Linux systems.
+    Check your package installation system
+    to see if there is an up-to-date &SCons; package available.
+    Many people prefer to install distribution-native packages if available,
+    as they provide a central point for management and updating;
+    however not all distributions update in a timely fashion.
+    During the still-ongoing &Python; 2 to 3 transition,
+    some distributions may still have two &SCons; packages available,
+    one which uses &Python; 2 and one which uses &Python; 3.  Since
+    the latest &scons; only runs on &Python; 3, to get the current version
+    you should choose the &Python; 3 package.
     </para>
 
   </section>
 
-  <section>
-  <title>Building and Installing &SCons; on Any System</title>
+  <section id="sect-scons-no-install">
+  <title>Using &SCons; Without Installing</title>
 
     <para>
-    If a pre-built &SCons; package is not available for your system,
-    and installing using <systemitem>pip</systemitem> is not suitable,
-    then you can still easily build and install &SCons; using the native
-    Python <systemitem>setuptools</systemitem> package.
+    You don't actually need to "install" &SCons; to use it.
+    Nor do you need to "build" it, unless you are interested in
+    producing the &SCons; documentation, which does use several
+    tools to produce HTML, PDF and other output formats from
+    files in the source tree.
+    All you need to do is
+    call the <filename>scons.py</filename> driver script in a
+    location that contains an &SCons; tree, and it will figure out
+    the rest. You can test that like this:
     </para>
 
+    <screen>
+$ <userinput>python <replaceable>/path/to/unpacked</replaceable>/scripts/scons.py --version</userinput>
+    </screen>
+
     <para>
-    The first step is to download either the
+    To make use of an uninstalled &SCons;,
+    the first step is to download either the
     <filename>scons-&buildversion;.tar.gz</filename>
     or <filename>scons-&buildversion;.zip</filename>,
     which are available from the SCons download page at
     <ulink url="https://scons.org/pages/download.html">https://scons.org/pages/download.html</ulink>.
+    There is also a <literal>scons-local</literal> bundle you can make
+    use of.  It is arranged a little bit differently, with the idea
+    that you can include it with your own project if you want people
+    to be able to do builds without having to download or install &SCons;.
+    Finally, you can also use a checkout of the git tree from GitHub
+    at a location to point to.
     </para>
 
     <para>
@@ -252,194 +277,87 @@ Python 3.7.1
     or <application>WinZip</application> on Windows.
     This will create a directory called
     <filename>scons-&buildversion;</filename>,
-    usually in your local directory.
-    Then change your working directory to that directory
-    and install &SCons; by executing the following commands:
+    usually in your local directory.  The driver script
+    will be in a subdirectory named <filename>scripts</filename>,
+    unless you are using <literal>scons-local</literal>,
+    in which case it will be in the top directory.
+    Now you only need to call <filename>scons.py</filename> by
+    giving a full or relative path to it in order to use that
+    &SCons; version.
     </para>
-
-    <screen>
-# <userinput>cd scons-&buildversion;</userinput>
-# <userinput>python setup.py install</userinput>
-    </screen>
 
     <para>
-
-    This will build &SCons;,
-    install the &scons; script
-    in the python which is used to run the setup.py's scripts directory
-    (<filename>/usr/local/bin</filename> or
-    <filename>C:\Python37\Scripts</filename>),
-    and will install the &SCons; build engine
-    in the corresponding library directory for the python used
-    (<filename>/usr/local/lib/scons</filename> or
-    <filename>C:\Python37\scons</filename>).
-    Because these are system directories,
-    you may need root (on Linux or UNIX) or Administrator (on Windows)
-    privileges to install &SCons; like this.
-
+    Note that instructions for older versions may have suggested
+    running <userinput>python setup.py install</userinput> to
+    "build and install" &SCons;. This is no longer recommended
+    (in fact, it is not recommended by the wider &Python; packaging
+    community for <emphasis>any</emphasis> end-user installations
+    of &Python; software). There is a <filename>setup.py</filename> file,
+    but it is only tested and used for the automated procedure which
+    prepares  an &SCons; bundle for making a release on PyPI,
+    and even that is not guaranteed to work in future.
     </para>
 
-    <!--
+  </section>
 
-    <section>
-    <title>Building and Installing &SCons; in the Standard Python Library Directories</title>
-
-      <para>
-
-      XXX
-
-      </para>
-
-    </section>
-
-    -->
-
-    <section>
-    <title>Building and Installing Multiple Versions of &SCons; Side-by-Side</title>
+  <section id="sect-install-scons-multi">
+  <title>Running Multiple Versions of &SCons; Side-by-Side</title>
 
       <para>
-
-      The &SCons; <filename>setup.py</filename> script
-      has some extensions that support
-      easy installation of multiple versions of &SCons;
-      in side-by-side locations.
-      This makes it easier to download and
-      experiment with different versions of &SCons;
-      before moving your official build process to a new version,
-      for example.
-
+      In some cases you may need several versions of &SCons;
+      present on a system at the same time - perhaps you have
+      an older project to build that has not yet been "ported"
+      to a newer &SCons; version, or maybe you want to test a
+      new &SCons; release side-by-side with a previous one
+      before switching over.
+      The use of an "uninstalled" package as described in the
+      previous section can be of use for this purpose.
       </para>
 
       <para>
-
-      To install &SCons; in a version-specific location,
-      add the <option>--version-lib</option> option
-      when you call <filename>setup.py</filename>:
-
-      </para>
-
-      <screen>
-# <userinput>python setup.py install --version-lib</userinput>
-      </screen>
-
-      <para>
-
-      This will install the &SCons; build engine
-      in the
-      <filename>/usr/lib/scons-&buildversion;</filename>
-      or
-      <filename>C:\Python27\scons-&buildversion;</filename>
-      directory, for example.
-
+      Another approach to multiple versions is to create
+      &Python; virtualenvs, and install different &SCons; versions in each.
+      A Python <firstterm>virtual environment</firstterm>
+      is a directory with an isolated set of Python packages,
+      where packages you install/upgrade/remove inside the
+      environment do not affect anything outside it,
+      and those you install/upgrade/remove outside of it
+      do not affect anything inside it.
+      In other words, anything you do with <command>pip</command>
+      in the environment stays in that environment.
+      The &Python; standard library provides a module called
+      <systemitem>venv</systemitem> for creating these
+      (<ulink url="https://docs.python.org/e/library/venv.html"/>),
+      although there are also other tools which provide more precise
+      control of the setup.
       </para>
 
       <para>
-
-      If you use the <option>--version-lib</option> option
-      the first time you install &SCons;,
-      you do not need to specify it each time you install
-      a new version.
-      The &SCons; <filename>setup.py</filename> script
-      will detect the version-specific directory name(s)
-      and assume you want to install all versions
-      in version-specific directories.
-      You can override that assumption in the future
-      by explicitly specifying the <option>--standalone-lib</option> option.
-
+      Using a virtualenv can be useful even for a single version of
+      &SCons;, to gain the advantages of having an isolated environment.
+      It also gets around the problem of not having administrative
+      privileges on a particular system to install a distribution
+      package or use <command>pip</command> to install to a
+      system location, as the virtualenv is completely under your control.
       </para>
 
-    </section>
-
-    <section>
-    <title>Installing &SCons; in Other Locations</title>
-
       <para>
-
-      You can install &SCons; in locations other than
-      the default by specifying the <option>--prefix=</option> option:
-
+      The following outline shows how this could be set up
+      on a Linux/POSIX system (the syntax will be a bit different
+      on Windows):
       </para>
 
       <screen>
-# <userinput>python setup.py install --prefix=/opt/scons</userinput>
+$ <emphasis>create virtualenv named scons3</emphasis>
+$ <emphasis>create virtualenv named scons4</emphasis>
+$ <userinput>source scons3/bin/activate</userinput>
+$ <userinput>pip install scons==3.1.2</userinput>
+$ <userinput>deactivate</userinput>
+$ <userinput>source scons4/bin/activate</userinput>
+$ <userinput>pip install scons</userinput>
+$ <userinput>deactivate</userinput>
+$ <emphasis>activate a virtualenv and run 'scons' to use that version</emphasis>
       </screen>
-
-      <para>
-
-      This would
-      install the <application>scons</application> script in
-      <filename>/opt/scons/bin</filename>
-      and the build engine in
-      <filename>/opt/scons/lib/scons</filename>,
-
-      </para>
-
-      <para>
-
-      Note that you can specify both the <option>--prefix=</option>
-      and the <option>--version-lib</option> options
-      at the same type,
-      in which case <filename>setup.py</filename>
-      will install the build engine
-      in a version-specific directory
-      relative to the specified prefix.
-      Adding <option>--version-lib</option> to the
-      above example would install the build engine in
-      <filename>/opt/scons/lib/scons-&buildversion;</filename>.
-
-      </para>
-
-    </section>
-
-    <section>
-    <title>Building and Installing &SCons; Without Administrative Privileges</title>
-
-      <para>
-
-      If you don't have the right privileges to install &SCons;
-      in a system location,
-      simply use the <literal>--prefix=</literal> option
-      to install it in a location of your choosing.
-      For example,
-      to install &SCons; in appropriate locations
-      relative to the user's <literal>$HOME</literal> directory,
-      the &scons; script in
-      <filename>$HOME/bin</filename>
-      and the build engine in
-      <filename>$HOME/lib/scons</filename>,
-      simply type:
-
-      </para>
-
-      <screen>
-$ <userinput>python setup.py install --prefix=$HOME</userinput>
-      </screen>
-
-      <para>
-
-      You may, of course, specify any other location you prefer,
-      and may use the <option>--version-lib</option> option
-      if you would like to install version-specific directories
-      relative to the specified prefix.
-
-      </para>
-
-      <para>
-
-      This can also be used to experiment with a newer
-      version of &SCons; than the one installed
-      in your system locations.
-      Of course, the location in which you install the
-      newer version of the &scons; script
-      (<filename>$HOME/bin</filename> in the above example)
-      must be configured in your &PATH; variable
-      before the directory containing
-      the system-installed version
-      of the &scons; script.
-
-      </para>
-
-    </section>
 
   </section>
 


### PR DESCRIPTION
No longer tell people to install via `python setup.py install` (possibly with additional arguments on library directories and paths which no longer worked). Simplify, and mention use of virtualenvs as the current way to have multiple SCons versions installed.

Fixes #4259

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
