### PR TITLE
Speed up a few tests for CI

### DIFF
--- a/test/Actions/actions.py
+++ b/test/Actions/actions.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -40,6 +39,7 @@ sys.exit(0)
 
 test.write('SConstruct', """
 B = Builder(action = r'%(_python_)s build.py $TARGET 1 $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 """ % locals())
@@ -54,6 +54,7 @@ test.up_to_date(arguments = '.')
 
 test.write('SConstruct', """
 B = Builder(action = r'%(_python_)s build.py $TARGET 2 $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 """ % locals())
@@ -73,6 +74,7 @@ def func(env, target, source):
     cp = subprocess.run(cmd, shell=True)
     return cp.returncode
 B = Builder(action = func)
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 """ % locals())
@@ -98,6 +100,7 @@ class bld:
         return self.cmd %% (' '.join(map(str, target)),
                             ' '.join(map(str, source)))
 B = Builder(action = bld())
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 """ % locals())
@@ -112,6 +115,8 @@ test.up_to_date(arguments = '.')
 test.write('SConstruct', """\
 def func(env, target, source):
     pass
+
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(S = Action('foo'),
                   F = Action(func),
                   L = Action(['arg1', 'arg2']))

--- a/test/Alias/Alias.py
+++ b/test/Alias/Alias.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -44,6 +43,7 @@ sys.exit(0)
 
 test.write('SConstruct', """
 B = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env['BUILDERS']['B'] = B
 env.B(target = 'f1.out', source = 'f1.in')
@@ -136,6 +136,7 @@ test.up_to_date(arguments = 'f1.out')
 test.write('SConstruct', """
 Decider('content')
 B = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env['BUILDERS']['B'] = B
 env.B(target = 'f1.out', source = 'f1.in')

--- a/test/Alias/Depends.py
+++ b/test/Alias/Depends.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -44,6 +43,7 @@ sys.exit(0)
 
 test.write('SConstruct', """
 B = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env['BUILDERS']['B'] = B
 env.B(target = 'f1.out', source = 'f1.in')

--- a/test/Alias/action.py
+++ b/test/Alias/action.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
 """
 Test that Aliases with actions work.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -52,6 +51,7 @@ def bar(target, source, env):
     with open('bar', 'wb') as f:
         f.write(bytearray("bar(%s, %s)\\n" % (target, source),'utf-8'))
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = {'Cat':Builder(action=cat)})
 env.Alias(target = ['build-f1'], source = 'f1.out', action = foo)
 f1 = env.Cat('f1.out', 'f1.in')

--- a/test/CPPPATH/CPPPATH.py
+++ b/test/CPPPATH/CPPPATH.py
@@ -246,6 +246,7 @@ test.up_to_date(arguments = args)
 
 # Change CPPPATH and make sure we don't rebuild because of it.
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(CPPPATH = Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'))
 obj = env.Object(target='foobar/prog', source='subdir/prog.c')
 env.Program(target='prog', source=obj)

--- a/test/CPPPATH/CPPPATH.py
+++ b/test/CPPPATH/CPPPATH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 
@@ -45,6 +44,7 @@ test.subdir('foobar',
             'inc2')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(CPPPATH = ['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
                   FOO='include')
 obj = env.Object(target='foobar/prog', source='subdir/prog.c')

--- a/test/CacheDir/option--cs.py
+++ b/test/CacheDir/option--cs.py
@@ -54,7 +54,6 @@ with open(sys.argv[1], 'w') as f:
 cache = test.workpath('cache')
 
 test.write(['src1', 'SConstruct'], """
-DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     with open('cat.out', 'a') as f:
@@ -63,6 +62,8 @@ def cat(env, source, target):
         for src in source:
             with open(str(src), "r") as f2:
                 f.write(f2.read())
+
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools=[], 
                   BUILDERS={'Internal':Builder(action=cat),
                             'External':Builder(action=r'%(_python_)s build.py $TARGET $SOURCES')})
@@ -156,6 +157,7 @@ hello_obj = 'hello' + _obj
 src2_hello = test.workpath('src2', hello_exe)
 
 test.write(['src2', 'SConstruct'], """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env.Program('hello.c')
 CacheDir(r'%s')

--- a/test/Default.py
+++ b/test/Default.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify various combinations of arguments to Default() work properly.
@@ -50,6 +49,7 @@ with open(sys.argv[1], 'w') as f, open(sys.argv[2], 'r') as ifp:
 #
 test.write(['one', 'SConstruct'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 env.B(target = 'bar.out', source = 'bar.in')
@@ -58,6 +58,7 @@ Default('foo.out')
 
 test.write(['two', 'SConstruct'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 env.B(target = 'bar.out', source = 'bar.in')
@@ -66,6 +67,7 @@ Default('foo.out', 'bar.out')
 
 test.write(['three', 'SConstruct'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'foo.out', source = 'foo.in')
 env.B(target = 'bar.out', source = 'bar.in')
@@ -74,6 +76,7 @@ Default(Split('foo.out bar.out'))
 
 test.write(['four', 'SConstruct'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = ['foo bar'], source = 'foo.in')
 env.B(target = 'foo', source = 'foo.in')
@@ -83,6 +86,7 @@ Default(['foo bar'])
 
 test.write(['five', 'SConstruct'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 Default(env.B(target = 'foo.out', source = 'foo.in'))
 Default(env.B(target = 'bar.out', source = 'bar.in'))
@@ -112,6 +116,7 @@ test.must_match(test.workpath('five', 'bar.out'), "five/bar.in\n", mode='r')
 # Test how a None Default() argument works to disable/reset default targets.
 test.write(['six', 'SConstruct'], """\
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 foo = env.B(target = 'foo.out', source = 'foo.in')
 bar = env.B(target = 'bar.out', source = 'bar.in')
@@ -123,6 +128,7 @@ test.run(chdir='six', status=2,
 
 test.write(['seven', 'SConstruct'], """\
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 foo = env.B(target = 'foo.out', source = 'foo.in')
 bar = env.B(target = 'bar.out', source = 'bar.in')
@@ -134,6 +140,7 @@ test.run(chdir='seven', status=2,
 
 test.write(['eight', 'SConstruct'], """\
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 foo = env.B(target = 'foo.out', source = 'foo.in')
 bar = env.B(target = 'bar.out', source = 'bar.in')
@@ -150,6 +157,7 @@ test.subdir('nine', ['nine', 'sub1'])
 
 test.write(['nine', 'SConstruct'], """\
 B = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'xxx.out', source = 'xxx.in')
 SConscript('sub1/SConscript')
@@ -159,6 +167,7 @@ test.write(['nine', 'xxx.in'], "xxx.in\n")
 
 test.write(['nine', 'sub1', 'SConscript'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'xxx.out', source = 'xxx.in')
 Default('xxx.out')
@@ -177,6 +186,7 @@ test.subdir('ten', ['ten', 'sub2'])
 test.write(['ten', 'SConstruct'], """\
 Default('sub2')
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'xxx.out', source = 'xxx.in')
 SConscript('sub2/SConscript')
@@ -186,6 +196,7 @@ test.write(['ten', 'xxx.in'], "xxx.in\n")
 
 test.write(['ten', 'sub2', 'SConscript'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 env.B(target = 'xxx.out', source = 'xxx.in')
 """ % locals())
@@ -202,6 +213,7 @@ test.subdir('eleven')
 
 test.write(['eleven', 'SConstruct'], """
 B = Builder(action = r'%(_python_)s ../build.py $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B }, XXX = 'foo.out')
 env.B(target = 'foo.out', source = 'foo.in')
 env.B(target = 'bar.out', source = 'bar.in')

--- a/test/Fortran/F77PATH.py
+++ b/test/Fortran/F77PATH.py
@@ -46,6 +46,7 @@ if not test.detect_tool(fc):
 test.subdir('include', 'subdir', ['subdir', 'include'], 'foobar', 'inc2')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(
     F77='%s',
     F77PATH=['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
@@ -226,6 +227,7 @@ test.up_to_date(arguments = args)
 
 # Change F77PATH and make sure we don't rebuild because of it.
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(
     F77='%s',
     F77PATH=Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),
@@ -285,6 +287,7 @@ test.up_to_date(arguments = args)
 
 # Check that a null-string F77PATH doesn't blow up.
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools=['%s'], F77PATH='', F77FLAGS='-x f77')
 env.Object('foo', source='empty.f77')
 """ % fc)

--- a/test/Fortran/F90PATH.py
+++ b/test/Fortran/F90PATH.py
@@ -46,6 +46,7 @@ if not test.detect_tool(fc):
 test.subdir('include', 'subdir', ['subdir', 'include'], 'foobar', 'inc2')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(
     F90=r'%s',
     F90PATH=['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
@@ -228,6 +229,7 @@ test.up_to_date(arguments = args)
 
 # Change F90PATH and make sure we don't rebuild because of it.
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(
     F90=r'%s',
     F90PATH=Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),

--- a/test/Fortran/FORTRANPATH.py
+++ b/test/Fortran/FORTRANPATH.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -45,6 +46,7 @@ if not test.detect_tool(fc):
 test.subdir('include', 'subdir', ['subdir', 'include'], 'foobar', 'inc2')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(
     FORTRAN='%s',
     FORTRANPATH=['$FOO', '${TARGET.dir}', '${SOURCE.dir}'],
@@ -241,6 +243,7 @@ test.up_to_date(arguments = args)
 
 # Change FORTRANPATH and make sure we don't rebuild because of it.
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(
     FORTRAN='%s',
     FORTRANPATH=Split('inc2 include ${TARGET.dir} ${SOURCE.dir}'),
@@ -304,6 +307,7 @@ test.up_to_date(arguments = args)
 
 # Check that a null-string FORTRANPATH doesn't blow up.
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(FORTRANPATH = '')
 env.Object('foo', source = 'empty.f')
 """)

--- a/test/Libs/LIBPATH.py
+++ b/test/Libs/LIBPATH.py
@@ -23,7 +23,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
 import os.path
 import time
 
@@ -41,6 +40,7 @@ prog1 = test.workpath('prog') + _exe
 prog2 = test.workpath(dll_ + 'shlib') + _dll
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env1 = Environment(LIBS=['foo1'], LIBPATH=['$FOO'], FOO='./lib1')
 
 f1 = env1.SharedObject('f1', 'f1.c')
@@ -118,6 +118,7 @@ test.fail_test(oldtime2 == os.path.getmtime(prog2))
 #test.up_to_date(arguments = '.')
 # Change LIBPATH and make sure we don't rebuild because of it.
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env1 = Environment(LIBS=['foo1'], LIBPATH=['./lib1', './lib2'])
 
 f1 = env1.SharedObject('f1', 'f1.c')
@@ -153,6 +154,7 @@ test.write('empty.c', 'int a=0;\n')
 
 # Check that a null-string LIBPATH doesn't blow up.
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(LIBPATH='')
 env.Library('foo', source='empty.c')
 """)

--- a/test/Libs/LIBS.py
+++ b/test/Libs/LIBS.py
@@ -51,6 +51,7 @@ foo5_exe = test.workpath('foo5' + _exe)
 slprog_exe = test.workpath('slprog' + _exe)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(LIBS=['bar'], LIBPATH = '.')
 env.Program(target='foo1', source='foo1.c')
 env2 = Environment(LIBS=[File(r'%s')], LIBPATH = '.')
@@ -161,6 +162,7 @@ test.run(program=slprog_exe, stdout='sl.c\nslprog.c\n')
 
 #
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(LIBS=['baz'])
 env.Program(target='foo1', source='foo1.c', LIBS=['$LIBS', 'bar'], LIBPATH = '.')
 SConscript('sub1/SConscript', 'env')
@@ -173,6 +175,7 @@ test.run(program=foo1_exe, stdout='sub1/bar.c\nsub2/baz.c\n')
 
 #
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(LIBS=['bar', 'baz'], LIBPATH = '.')
 env.Program(target='foo1', source='foo1.c')
 SConscript('sub1/SConscript', 'env')
@@ -191,6 +194,7 @@ test.run(program=foo1_exe, stdout='sub1/bar.c\nsub1/baz.c\n')
 
 #
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env.Program(target='foo1', source='foo1.c', LIBS=['bar', 'baz'], LIBPATH = '.')
 SConscript('sub1/SConscript', 'env')

--- a/test/Libs/SharedLibraryIxes.py
+++ b/test/Libs/SharedLibraryIxes.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that we can build shared libraries and link against shared
@@ -50,6 +49,7 @@ if isWindows:
         isWindows = False
         isMingw = True
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 
 # Make sure that the shared library can be located at runtime.

--- a/test/NodeOps.py
+++ b/test/NodeOps.py
@@ -50,6 +50,7 @@ test = TestSCons.TestSCons()
 test.subdir('bld', 'src', ['src', 'subsrcdir'])
 
 sconstruct = r"""
+DefaultEnvironment(tools=[])  # test speedup
 foo = Environment(SHOBJPREFIX='', WINDOWS_INSERT_DEF=1)
 foo.Append(SHCXXFLAGS = '-DFOO')
 bar = Environment(SHOBJPREFIX='', WINDOWS_INSERT_DEF=1)

--- a/test/Parallel/multiple-parents.py
+++ b/test/Parallel/multiple-parents.py
@@ -58,6 +58,7 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 vars = Variables()
 vars.Add(BoolVariable('interrupt', 'Interrupt the build.', False))
+DefaultEnvironment(tools=[])  # test speedup
 varEnv = Environment(variables=vars)
 
 def fail_action(target=None, source=None, env=None):

--- a/test/Program.py
+++ b/test/Program.py
@@ -40,12 +40,13 @@ foo5 = test.workpath('foo5' + _exe)
 foo_args = 'foo1%s foo2%s foo3%s foo4%s foo5%s' % (_exe, _exe, _exe, _exe, _exe)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env.Program(target='foo1', source='f1.c')
 env.Program(target='foo2', source=Split('f2a.c f2b.c f2c.c'))
 f3a = File('f3a.c')
 f3b = File('f3b.c')
-Program(target='foo3', source=[f3a, [f3b, 'f3c.c']])
+env.Program(target='foo3', source=[f3a, [f3b, 'f3c.c']])
 env.Program('foo4', 'f4.c')
 env.Program('foo5.c')
 """)

--- a/test/Repository/Java.py
+++ b/test/Repository/Java.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test building Java applications when using Repositories.
@@ -58,6 +57,7 @@ opts = '-Y ' + test.workpath('rep1')
 
 #
 test.write(['rep1', 'SConstruct'], """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools = ['javac'],
                   JAVAC = r'"%s"')
 env.Java(target = 'classes', source = 'src')

--- a/test/Repository/JavaH.py
+++ b/test/Repository/JavaH.py
@@ -79,6 +79,7 @@ opts = '-Y ' + test.workpath('rep1')
 
 #
 test.write(['rep1', 'SConstruct'], """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools=['javac', 'javah'], JAVAC=r'"%s"', JAVAH=r'"%s"')
 classes = env.Java(target='classes', source='src')
 env.JavaH(target='outdir', source=classes)

--- a/test/Repository/Program.py
+++ b/test/Repository/Program.py
@@ -36,7 +36,7 @@ for implicit_deps in ['0', '1', '2', '\"all\"']:
     work1_foo_c = test.workpath('work1', 'foo.c')
 
     test.write(['work1', 'SConstruct'], r"""
-DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])  # test speedup
 Repository(r'%s')
 env = Environment(IMPLICIT_COMMAND_DEPENDENCIES=%s)
 env.Program(target= 'foo', source = Split('aaa.c bbb.c foo.c'))
@@ -179,7 +179,7 @@ repository/foo.c
     work2_foo = test.workpath('work2', 'foo' + _exe)
 
     test.write(['work2', 'SConstruct'], r"""
-DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])  # test speedup
 Repository(r'%s')
 Repository(r'%s')
 env = Environment()

--- a/test/Repository/RMIC.py
+++ b/test/Repository/RMIC.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test building Java applications when using Repositories.
@@ -92,6 +91,7 @@ opts = '-Y ' + test.workpath('rep1')
 
 #
 test.write(['rep1', 'SConstruct'], """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools = ['javac', 'rmic'],
                   JAVAC = r'"%s"',
                   RMIC = r'"%s"')
@@ -360,6 +360,7 @@ test.up_to_date(chdir = 'work2', options = opts, arguments = ".")
 
 #
 test.write(['work3', 'SConstruct'], """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools = ['javac', 'rmic'],
                   JAVAC = r'"%s"',
                   RMIC = r'"%s"')

--- a/test/Repository/StaticLibrary.py
+++ b/test/Repository/StaticLibrary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import TestSCons
@@ -54,6 +53,8 @@ for implicit_deps in ['0', '1', '2', '\"all\"']:
 
     #
     test.write(['repository', 'SConstruct'], """
+
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(LIBS = ['xxx'], LIBPATH = '.',
                   IMPLICIT_COMMAND_DEPENDENCIES=%s)
 env.Library(target = 'xxx', source = ['aaa.c', 'bbb.c'])

--- a/test/Repository/VariantDir.py
+++ b/test/Repository/VariantDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 
@@ -38,6 +37,7 @@ opts = "-Y " + test.workpath('repository')
 
 #
 test.write(['repository', 'SConstruct'], r"""
+DefaultEnvironment(tools=[])  # test speedup
 VariantDir('build0', 'src', duplicate=0)
 VariantDir('build1', 'src', duplicate=1)
 SConscript('build0/SConscript')

--- a/test/Repository/include.py
+++ b/test/Repository/include.py
@@ -37,6 +37,7 @@ work_foo_h = test.workpath('work', 'foo.h')
 
 test.write(['work', 'SConstruct'], """
 Repository(r'%s')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(CPPPATH = ['.'])
 env.Program(target = 'foo', source = 'foo.c')
 """ % repository)

--- a/test/Repository/variants.py
+++ b/test/Repository/variants.py
@@ -77,6 +77,7 @@ opts = "-Y " + test.workpath('repository')
 test.write(['repository', 'SConstruct'], r"""
 OS = ARGUMENTS.get('OS', '')
 build1_os = "#build1/" + OS
+DefaultEnvironment(tools=[])  # test speedup
 default = Environment()
 ccflags = {
     '': '',

--- a/test/TAR/TAR.py
+++ b/test/TAR/TAR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -58,6 +57,7 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools = ['tar'], TAR = r'%(_python_)s mytar.py')
 env.Tar(target = 'aaa.tar', source = ['file1', 'file2'])
 env.Tar(target = 'aaa.tar', source = 'file3')
@@ -89,6 +89,7 @@ if tar:
     test.file_fixture('wrapper.py')
 
     test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 foo = Environment()
 tar = foo.Dictionary('TAR')
 bar = Environment(TAR = r'%(_python_)s wrapper.py ' + tar)

--- a/test/TARGETS.py
+++ b/test/TARGETS.py
@@ -66,6 +66,7 @@ test.run(arguments = 'bbb ccc=xyz -n aaa', stdout = expect)
 
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 print(list(map(str, DEFAULT_TARGETS)))
 print(list(map(str, BUILD_TARGETS)))

--- a/test/Value.py
+++ b/test/Value.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import re
 
@@ -49,6 +49,7 @@ def create(target, source, env):
     with open(str(target[0]), 'wb') as f:
         f.write(source[0].get_contents())
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env['BUILDERS']['B'] = Builder(action = create)
 env['BUILDERS']['S'] = Builder(action = r'%(_python_)s put.py $SOURCES into $TARGET')

--- a/test/Variables/ListVariable.py
+++ b/test/Variables/ListVariable.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ListVariable canned Variable type.
@@ -62,6 +61,7 @@ opts.AddVariables(
     LV('listvariable', 'listvariable help', 'all', names=['l1', 'l2', 'l3'])
     )
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 opts.Save(optsfile, env)
 Help(opts.GenerateHelpText(env))
@@ -115,7 +115,7 @@ check(['gl,qt', '0', 'gl qt', 'gl qt', "['gl qt']"])
 expect_stderr = """
 scons: *** Error converting option: shared
 Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 19)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=foo', stderr=expect_stderr, status=2)
 
@@ -124,28 +124,28 @@ test.run(arguments='shared=foo', stderr=expect_stderr, status=2)
 expect_stderr = """
 scons: *** Error converting option: shared
 Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 19)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=foo,ical', stderr=expect_stderr, status=2)
 
 expect_stderr = """
 scons: *** Error converting option: shared
 Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 19)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=ical,foo', stderr=expect_stderr, status=2)
 
 expect_stderr = """
 scons: *** Error converting option: shared
 Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 19)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=ical,foo,x11', stderr=expect_stderr, status=2)
 
 expect_stderr = """
 scons: *** Error converting option: shared
 Invalid value(s) for option: foo,bar
-""" + test.python_file_line(SConstruct_path, 19)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=foo,x11,,,bar', stderr=expect_stderr, status=2)
 
@@ -162,6 +162,7 @@ opts.AddVariables(
                names = ['ENET', 'GPIB', 'LINUX_GPIB', 'NO_GPIB']),
     )
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 Help(opts.GenerateHelpText(env))
 

--- a/test/Variables/PathVariable.py
+++ b/test/Variables/PathVariable.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the PathVariable canned option type, with tests for its 
@@ -61,6 +60,7 @@ opts.AddVariables(
     PV('qt_libraries', 'where the Qt library is installed', r'%s'),
     )
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 Help(opts.GenerateHelpText(env))
 
@@ -92,7 +92,7 @@ test.run(arguments=['qtdir=%s' % qtpath, 'qt_libraries=%s' % libpath])
 check([qtpath, libpath, libpath])
 
 qtpath = os.path.join(workpath, 'non', 'existing', 'path')
-SConstruct_file_line = test.python_file_line(test.workpath('SConstruct'), 14)[:-1]
+SConstruct_file_line = test.python_file_line(test.workpath('SConstruct'), 15)[:-1]
 
 expect_stderr = """
 scons: *** Path for option qtdir does not exist: %(qtpath)s
@@ -130,6 +130,7 @@ opts.AddVariables(
     PathVariable('X', 'X variable', r'%s', validator=PathVariable.PathAccept),
     )
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 
 print(env['X'])
@@ -163,6 +164,7 @@ opts.AddVariables(
     PathVariable('X', 'X variable', r'%s', validator=PathVariable.PathIsFile),
     )
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 
 print(env['X'])
@@ -170,7 +172,7 @@ print(env['X'])
 Default(env.Alias('dummy', None))
 """ % default_file)
 
-SConstruct_file_line = test.python_file_line(test.workpath('SConstruct'), 6)[:-1]
+SConstruct_file_line = test.python_file_line(test.workpath('SConstruct'), 7)[:-1]
 
 expect_stderr = """
 scons: *** File path for option X does not exist: %(default_file)s
@@ -209,6 +211,7 @@ opts.AddVariables(
     PathVariable('X', 'X variable', r'%s', validator=PathVariable.PathIsDir),
     )
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 
 print(env['X'])
@@ -257,6 +260,7 @@ opts.AddVariables(
     PathVariable('X', 'X variable', r'%s', validator=PathVariable.PathIsDirCreate),
     )
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 
 print(env['X'])

--- a/test/Variables/Variables.py
+++ b/test/Variables/Variables.py
@@ -28,6 +28,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 print(env['CC'])
 print(" ".join(env['CCFLAGS']))
@@ -94,6 +95,7 @@ def test_tool(env):
         env.Append(CCFLAGS = '-g')
 
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts, tools=['default', test_tool])
 
 Help('Variables settable in custom.py or on the command line:\\n' + opts.GenerateHelpText(env))
@@ -217,6 +219,7 @@ opts.Add('DEBUG_BUILD',
 opts.Add('UNSPECIFIED',
          'An option with no value')
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables = opts)
 
 print(env['RELEASE_BUILD'])
@@ -275,6 +278,7 @@ opts.Add('LISTOPTION_TEST',
          'none',
          names = ['a','b','c',])
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables = opts)
 
 print(env['RELEASE_BUILD'])
@@ -319,6 +323,7 @@ opts.Add('CC',
 opts.Add('UNSPECIFIED',
          'An option with no value')
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts)
 
 def compare(a, b):
@@ -355,6 +360,7 @@ Use scons -H for help about command-line options.
 
 test.write('SConstruct', """
 import SCons.Variables
+DefaultEnvironment(tools=[])  # test speedup
 env1 = Environment(variables = Variables())
 env2 = Environment(variables = SCons.Variables.Variables())
 """)

--- a/test/VariantDir/VariantDir.py
+++ b/test/VariantDir/VariantDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -56,7 +56,6 @@ bar52 = test.workpath('build', 'var5', 'bar2' + _exe)
 test.subdir('work1', 'work2', 'work3')
 
 test.write(['work1', 'SConstruct'], """
-DefaultEnvironment(tools=[])
 src = Dir('src')
 var2 = Dir('build/var2')
 var3 = Dir('build/var3')
@@ -64,6 +63,7 @@ var4 = Dir('build/var4')
 var5 = Dir('../build/var5')
 var6 = Dir('../build/var6')
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILD = 'build', SRC = 'src')
 
 VariantDir('build/var1', src)
@@ -119,7 +119,7 @@ except:
 
 if fortran and env.Detect(fortran):
     if sys.platform =='win32':
-        env_prog=Environment(tools=['mingw'], 
+        env_prog = Environment(tools=['mingw'], 
         # BUILD = env['BUILD'], SRC = ENV['src'],
         CPPPATH=env['CPPPATH'], FORTRANPATH=env['FORTRANPATH'] )
     else:
@@ -333,6 +333,7 @@ scons: `%s' is up to date.
 
 #
 test.write(['work2', 'SConstruct'], """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env.Program('prog.c')
 """)
@@ -356,6 +357,7 @@ test.up_to_date(chdir='work2', arguments='.')
 
 #
 test.write(['work2', 'SConstruct'], """\
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 VariantDir('build', '.')
 Export('env')

--- a/test/builderrors.py
+++ b/test/builderrors.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -45,6 +45,7 @@ sys.exit(exitval)
 test.write(['one', 'SConstruct'], """
 B0 = Builder(action = r'%(_python_)s ../build.py 0 $TARGET $SOURCES')
 B1 = Builder(action = r'%(_python_)s ../build.py 1 $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B0' : B0, 'B1' : B1 })
 env.B1(target = 'f1.out', source = 'f1.in')
 env.B0(target = 'f2.out', source = 'f2.in')
@@ -65,6 +66,7 @@ test.fail_test(os.path.exists(test.workpath('f3.out')))
 test.write(['two', 'SConstruct'], """
 B0 = Builder(action = r'%(_python_)s ../build.py 0 $TARGET $SOURCES')
 B1 = Builder(action = r'%(_python_)s ../build.py 1 $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B0': B0, 'B1' : B1 })
 env.B0(target = 'f1.out', source = 'f1.in')
 env.B1(target = 'f2.out', source = 'f2.in')
@@ -85,6 +87,7 @@ test.fail_test(os.path.exists(test.workpath('f3.out')))
 test.write(['three', 'SConstruct'], """
 B0 = Builder(action = r'%(_python_)s ../build.py 0 $TARGET $SOURCES')
 B1 = Builder(action = r'%(_python_)s ../build.py 1 $TARGET $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B0' : B0, 'B1': B1 })
 env.B0(target = 'f1.out', source = 'f1.in')
 env.B0(target = 'f2.out', source = 'f2.in')
@@ -103,6 +106,7 @@ test.must_match(['three', 'f2.out'], "three/f2.in\n", mode='r')
 test.fail_test(os.path.exists(test.workpath('f3.out')))
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env=Environment()
 env['ENV']['PATH'] = ''
 env.Command(target='foo.out', source=[], action='not_a_program')
@@ -116,6 +120,7 @@ test.must_not_contain_any_line(test.stderr(), ['Exception', 'Traceback'])
 # but that shouldn't cause a scons traceback.
 long_cmd = 'xyz ' + "foobarxyz" * 100000
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env=Environment()
 env.Command(target='longcmd.out', source=[], action='echo %s')
 """%long_cmd)
@@ -137,6 +142,7 @@ test.must_not_contain_any_line(test.stderr(), ['Exception', 'Traceback'])
 # This will also give an exit status not in exitvalmap,
 # with error "Permission denied" or "No such file or directory".
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env=Environment()
 env['SHELL'] = 'one'
 env.Command(target='badshell.out', source=[], action='foo')
@@ -156,6 +162,7 @@ test.must_contain_any_line(test.stderr(), expect)
 # Should not give traceback.
 test.write('SConstruct', """
 import os
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(ENV = os.environ)
 env.Command('dummy.txt', None, ['python -c "import sys; sys.exit(-1)"'])
 """)
@@ -170,6 +177,7 @@ test.must_not_contain_any_line(test.stderr(), ['Exception', 'Traceback'])
 test.write('SConstruct', """
 import atexit
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env2 = env.Clone()
 
@@ -190,6 +198,7 @@ test.must_not_contain_any_line(test.stderr(), ['Exception', 'Traceback'])
 
 # Bug #1053: Alias is called "all", but default is the File "all"
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env.Default("all")
 env.Alias("all", env.Install("dir", "file.txt"))

--- a/test/option/option--Y.py
+++ b/test/option/option--Y.py
@@ -169,6 +169,7 @@ workpath_r_OLD = test.workpath('r.OLD')
 work2_foo = test.workpath('work2', 'foo' + _exe)
 
 SConstruct = """
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 env.Program(target = 'foo', source = 'foo.c')
 """

--- a/test/option/option-n.py
+++ b/test/option/option-n.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -58,8 +60,8 @@ with open(sys.argv[1], 'w') as ofp:
 """)
 
 test.write('SConstruct', """
-DefaultEnvironment(tools=[])
 MyBuild = Builder(action=r'%(_python_)s build.py $TARGETS')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS={'MyBuild': MyBuild}, tools=[])
 env.Tool('install')
 env.MyBuild(target='f1.out', source='f1.in')
@@ -172,7 +174,6 @@ test.subdir('configure')
 test.set_match_function(TestSCons.match_re_dotall)
 test.set_diff_function(TestSCons.diff_re)
 test.write('configure/SConstruct', """\
-DefaultEnvironment(tools=[])
 def CustomTest(context):
     def userAction(target,source,env):
         import shutil
@@ -185,6 +186,7 @@ def CustomTest(context):
     context.Result(ok)
     return ok
 
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools=[])
 conf = Configure(env,
                  custom_tests={'CustomTest':CustomTest},

--- a/test/option/stack-size.py
+++ b/test/option/stack-size.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
 #
+# Copyright The SCons Foundation
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -20,9 +21,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -47,8 +45,8 @@ with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as infp:
 
 
 test.write(['work1', 'SConstruct'], """
-DefaultEnvironment(tools=[])
 B = Builder(action = r'%(_python_)s ../build.py $TARGETS $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(tools=[], BUILDERS = { 'B' : B })
 f1 = env.B(target = 'f1.out', source = 'f1.in')
 f2 = env.B(target = 'f2.out', source = 'f2.in')
@@ -62,6 +60,7 @@ test.write(['work1', 'f2.in'], "f2.in\n")
 test.write(['work2', 'SConstruct'], """
 SetOption('stack_size', 128)
 B = Builder(action = r'%(_python_)s ../build.py $TARGETS $SOURCES')
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(BUILDERS = { 'B' : B })
 f1 = env.B(target = 'f1.out', source = 'f1.in')
 f2 = env.B(target = 'f2.out', source = 'f2.in')

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1159,6 +1159,7 @@ void my_qt_symbol(const char *arg) {
 
         self.write([dir, 'lib', 'SConstruct'], r"""
 import sys
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 if sys.platform == 'win32':
     env.StaticLibrary('myqt', 'my_qobject.cpp')
@@ -1185,6 +1186,7 @@ if ARGUMENTS.get('noqtdir', 0):
     QTDIR = None
 else:
     QTDIR = r'%s'
+DefaultEnvironment(tools=[])  # test speedup
 env = Environment(
     QTDIR=QTDIR, QT_LIB=r'%s', QT_MOC=r'%s', QT_UIC=r'%s', tools=['default', 'qt']
 )


### PR DESCRIPTION
A collection of tests known to be among the slower ones to run on Windows got the addition of `DefaultEnvironment(tools=[])` calls in an attempt to speed things up a bit.  The is no test strategy change.

Test-only change: no SCons engine code or docs affected.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
