### PR TITLE
Bump versions on CI runners

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,45 +26,43 @@ install:
 environment:
   matrix:
 
-    - WINPYTHON: "Python310"
+    - WINPYTHON: "Python311"
       COVERAGE: 0
 
-    - WINPYTHON: "Python37"
-      COVERAGE: 0
+    - WINPYTHON: "Python310"
+      COVERAGE: 1
 
     - WINPYTHON: "Python38"
       COVERAGE: 0
           
     - WINPYTHON: "Python36"
-      COVERAGE: 1
+      COVERAGE: 0
 
-
-
-
+    # skipping 3.7 and 3.9 at this time
 
 # remove sets of build jobs based on criteria below
 # to fine tune the number and platforms tested
 matrix:
   exclude:
-    # test python 3.8 on Visual Studio 2017 image
+    # test python 3.6 on Visual Studio 2017 image
+    - image: Visual Studio 2017
+      WINPYTHON: "Python311"
     - image: Visual Studio 2017
       WINPYTHON: "Python310"
-    - image: Visual Studio 2017
-      WINPYTHON: "Python37"
     - image: Visual Studio 2017
       WINPYTHON: "Python38"
 
-    # test python 3.7 on Visual Studio 2019 image
+    # test python 3.8 on Visual Studio 2019 image
+    - image: Visual Studio 2019
+      WINPYTHON: "Python311"
     - image: Visual Studio 2019
       WINPYTHON: "Python310"
     - image: Visual Studio 2019
       WINPYTHON: "Python36"
 
-    # test python 3.10 on Visual Studio 2022 image
+    # test python 3.10 and 3.11 on Visual Studio 2022 image
     - image: Visual Studio 2022
       WINPYTHON: "Python36"
-    - image: Visual Studio 2022
-      WINPYTHON: "Python37"
     - image: Visual Studio 2022
       WINPYTHON: "Python38"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,8 @@ install:
 # build matrix will be number of images multiplied by each '-' below,
 # less any exclusions.
 # split builds into sets of four jobs due to appveyor per-job time limit
+# Leaving the Coverage build on VS2017 for build-time reasons (1hr time limit)
+# Maybe move this one somewhere else in future to restore some flexibility.
 environment:
   matrix:
 
@@ -30,13 +32,13 @@ environment:
       COVERAGE: 0
 
     - WINPYTHON: "Python310"
-      COVERAGE: 1
+      COVERAGE: 0
 
     - WINPYTHON: "Python38"
       COVERAGE: 0
           
     - WINPYTHON: "Python36"
-      COVERAGE: 0
+      COVERAGE: 1
 
     # skipping 3.7 and 3.9 at this time
 

--- a/.github/workflows/experimental_tests.yml
+++ b/.github/workflows/experimental_tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -36,15 +36,17 @@ jobs:
         with:
           platform: x64
 
-      - name: Set up Python 3.8 ${{ matrix.os }}
+      - name: Set up Python 3.11 ${{ matrix.os }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.11'
+
       - name: Install dependencies including ninja ${{ matrix.os }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install ninja psutil
           # sudo apt-get update
+
       - name: Test experimental packages ${{ matrix.os }}
         run: |
           python runtest.py test/import.py test/ninja

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -30,18 +30,21 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      #- name: Set up Python 3.10 ${{ matrix.os }}
-      #  uses: actions/setup-python@v2
-      #  with:
-      #    python-version: 3.10
+      - name: Set up Python 3.10 ${{ matrix.os }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
       - name: Install dependencies including ninja ${{ matrix.os }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip -r requirements-dev.txt
           # sudo apt-get update
+
       - name: runtest ${{ matrix.os }}
         run: |
           python runtest.py --all --time --jobs=2
+
       - name: Archive Failed tests ${{ matrix.os }}
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies including ninja ${{ matrix.os }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
           # sudo apt-get update
 
       - name: runtest ${{ matrix.os }}

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-22.04']
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -30,10 +30,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.8 ${{ matrix.os }}
+      - name: Set up Python 3.10 ${{ matrix.os }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies including ninja ${{ matrix.os }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
@@ -41,10 +41,10 @@ jobs:
           # sudo apt-get update
       - name: runtest ${{ matrix.os }}
         run: |
-          python runtest.py -a -j 2
-      - name: Archive Failed tests
+          python runtest.py --all --time --jobs=2
+      - name: Archive Failed tests ${{ matrix.os }}
         uses: actions/upload-artifact@v2
         with:
-          name: linux-failed-tests
+          name: ${{ matrix.os }}-failed-tests
           path: |
             failed_tests.log

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -30,14 +30,14 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.10 ${{ matrix.os }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.10
+      #- name: Set up Python 3.10 ${{ matrix.os }}
+      #  uses: actions/setup-python@v2
+      #  with:
+      #    python-version: 3.10
       - name: Install dependencies including ninja ${{ matrix.os }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install ninja psutil
+          python -m pip -r requirements-dev.txt
           # sudo apt-get update
       - name: runtest ${{ matrix.os }}
         run: |

--- a/.github/workflows/scons-package.yml
+++ b/.github/workflows/scons-package.yml
@@ -15,10 +15,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.10'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -28,6 +30,7 @@ jobs:
         sudo apt-get -y install docbook-xml docbook-xsl xsltproc fop docbook-xsl-doc-pdf
         # try to keep the texlive install as small as we can to save some time/space
         sudo apt-get -y --no-install-recommends install texlive biber texmaker ghostscript texlive-latex-base texlive-latex-extra texlive-bibtex-extra texlive-font-utils latexmk
+
     # This is disabled until the run can be configured to only
     # check the code that matters, else we fail on non-essentials
     # like the bench/ stuff.
@@ -37,14 +40,17 @@ jobs:
     #    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     #    # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Update Doc sources (some parts are generated)
       run: |
         python bin/docs-update-generated.py
         python bin/docs-validate.py
         python bin/docs-create-example-outputs.py
+
     - name: Build SCons packages
       run: |
         python scripts/scons.py
+
     - name: Verify package
       run: |
         ls -l build/dist


### PR DESCRIPTION
Chages appveyor test matrix: 3.6, 3.8, 3.10+cov, 3.11

Linux build now uses ubuntu-22.04 (although ubuntu-latest is about to become 22.04 anyway, be explicit for now); use 3.10.

Want to see the result of one full build, then maybe we can amend to add a MacOS builder. Maybe a coverage build on Linux?

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
