### PR TITLE
Remove an extra check in one ninja test

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Stop telling people to run "python setup.py install" in the User Guide.
       Adds new content on using virtualenvs to be able to have multiple
       different SCons versions available on one system.
+    - Added the "DefaultEnvironment(tools=[])" stanza to a number of tests
+      that are known to be particularly slow.  It's still just a tiny
+      speedup, but the Windows CI had been occasionally timing out,
+      so maybe this helps a bit.
+    - Remove an extra existence check in one ninja test that caused it
+      to be skipped on some otherwise-valid Windows installations.
 
 
   From Andrew Morrow

--- a/test/ninja/build_libraries.py
+++ b/test/ninja/build_libraries.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 #
+# MIT License
+#
 # Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -33,10 +35,6 @@ try:
     import ninja
 except ImportError:
     test.skip_test("Could not find ninja module. Skipping test.\n")
-
-ninja_binary = test.where_is('ninja')
-if not ninja_binary:
-    test.skip_test("Could not find ninja executable. Skipping test.\n")
 
 ninja_bin = os.path.abspath(os.path.join(
     ninja.__file__,


### PR DESCRIPTION
Caused it to unnecessarily skip the test on Windows platforms where the Python SCripts directory was not in the search path.  Test-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
