### PR TITLE
Fix one test in TestCommonTests

### DIFF
--- a/testing/framework/TestCommonTests.py
+++ b/testing/framework/TestCommonTests.py
@@ -1933,6 +1933,7 @@ class run_TestCase(TestCommonTestCase):
         STDOUT =========================================================================
         None
         STDERR =========================================================================
+        None
         """)
 
         expect_stderr = lstrip("""\
@@ -1940,13 +1941,13 @@ class run_TestCase(TestCommonTestCase):
         Traceback \\(most recent call last\\):
           File "<stdin>", line \\d+, in (\\?|<module>)
           File "[^"]+TestCommon.py", line \\d+, in run
-            super().run\\(\\*\\*kw\\)
+            super\\(\\).run\\(\\*\\*kw\\)
           File "[^"]+TestCmd.py", line \\d+, in run
-            p = self.start(program=program,
+            p = self.start\\(program=program,
           File "[^"]+TestCommon.py", line \\d+, in start
             raise e
           File "[^"]+TestCommon.py", line \\d+, in start
-            return super().start\\(program, interpreter, arguments,
+            return super\\(\\).start\\(program, interpreter, arguments,
           File "<stdin>", line \\d+, in raise_exception
         TypeError: forced TypeError
         """ % re.escape(repr(sys.executable)))


### PR DESCRIPTION
The framework tests have been failing one test in the Common set, partly due to a missing None in the expected text for the exception test, and partly due to a change in SCons code that appears in a traceback that had been captured, but not properly escaped.

This is a test-only change. **Note**: the GitHub CI does not run the framework tests, so the normal test run is being skipped. To verify, should run the test manually: `./runtest.py testing/framework/`.  There are still two fails coming from `TestCmdTests.py`, not addressed by this change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
