### PR TITLE
Solution for Issue #4275 (Compilation db uses TEMPFILE generated command line instead of the plain command line)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       This should scale much better for highly parallel builds. You can also enable this via SetOption().
     - Fixed command line argument --diskcheck: previously a value of 'none' was ignored.
       SetOption('diskcheck','none') is unaffected, as it did not have the problem.
+    - Added overrides argument to SCons.Subst.scons_subst(), subst_list(), subst(), and Action's process(),
+      strfunction(). This allows passing a dictionary of envvars to override when evaluating subst()'d strings/lists
+    - Fixed Issue #4275 - when outputting compilation db and TEMPFILE was in use, the compilation db would have
+      command lines using the generated tempfile for long command lines, instead of the full command line for
+      the compilation step for the source/target pair.
 
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -66,6 +66,10 @@ FIXES
   will create a string joining the list with os.pathsep
 - Fixed command line argument --diskcheck: previously a value of 'none' was ignored.
   SetOption('diskcheck','none') is unaffected, as it did not have the problem.
+- Fixed Issue #4275 - when outputting compilation db and TEMPFILE was in use, the compilation db would have
+  command lines using the generated tempfile for long command lines, instead of the full command line for
+  the compilation step for the source/target pair.
+
 
 IMPROVEMENTS
 ------------
@@ -123,6 +127,9 @@ DEVELOPMENT
   underscore) which moved to a submodule, that code will have to be adjusted,
   as those are not imported to the package level (new SCons.Util.hashes has
   some of these, which are used by existing unit tests).
+- Added overrides argument to SCons.Subst.scons_subst(), subst_list(), subst(), and Action's process(),
+  strfunction(). This allows passing a dictionary of envvars to override when evaluating subst()'d strings/lists
+
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -875,11 +875,11 @@ class CommandAction(_ActionAction):
             return ' '.join(map(str, self.cmd_list))
         return str(self.cmd_list)
 
-    def process(self, target, source, env, executor=None):
+    def process(self, target, source, env, executor=None, overrides=False):
         if executor:
-            result = env.subst_list(self.cmd_list, 0, executor=executor)
+            result = env.subst_list(self.cmd_list, 0, executor=executor, overrides=overrides)
         else:
-            result = env.subst_list(self.cmd_list, 0, target, source)
+            result = env.subst_list(self.cmd_list, 0, target, source, overrides=overrides)
         silent = None
         ignore = None
         while True:
@@ -896,18 +896,18 @@ class CommandAction(_ActionAction):
             pass
         return result, ignore, silent
 
-    def strfunction(self, target, source, env, executor=None):
+    def strfunction(self, target, source, env, executor=None, overrides=False):
         if self.cmdstr is None:
             return None
         if self.cmdstr is not _null:
             from SCons.Subst import SUBST_RAW
             if executor:
-                c = env.subst(self.cmdstr, SUBST_RAW, executor=executor)
+                c = env.subst(self.cmdstr, SUBST_RAW, executor=executor, overrides=overrides)
             else:
-                c = env.subst(self.cmdstr, SUBST_RAW, target, source)
+                c = env.subst(self.cmdstr, SUBST_RAW, target, source, overrides=overrides)
             if c:
                 return c
-        cmd_list, ignore, silent = self.process(target, source, env, executor)
+        cmd_list, ignore, silent = self.process(target, source, env, executor, overrides=overrides)
         if silent:
             return ''
         return _string_from_cmd_list(cmd_list[0])

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -142,15 +142,15 @@ class Environment:
             self.d[k] = v
 
     # Just use the underlying scons_subst*() utility methods.
-    def subst(self, strSubst, raw=0, target=[], source=[], conv=None):
+    def subst(self, strSubst, raw=0, target=[], source=[], conv=None, overrides=False):
         return SCons.Subst.scons_subst(strSubst, self, raw,
-                                       target, source, self.d, conv=conv)
+                                       target, source, self.d, conv=conv, overrides=overrides)
 
     subst_target_source = subst
 
-    def subst_list(self, strSubst, raw=0, target=[], source=[], conv=None):
+    def subst_list(self, strSubst, raw=0, target=[], source=[], conv=None, overrides=False):
         return SCons.Subst.scons_subst_list(strSubst, self, raw,
-                                            target, source, self.d, conv=conv)
+                                            target, source, self.d, conv=conv, overrides=overrides)
 
     def __getitem__(self, item):
         return self.d[item]

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -481,7 +481,7 @@ class SubstitutionEnvironment:
     def lvars(self):
         return {}
 
-    def subst(self, string, raw=0, target=None, source=None, conv=None, executor=None):
+    def subst(self, string, raw=0, target=None, source=None, conv=None, executor=None, overrides=False):
         """Recursively interpolates construction variables from the
         Environment into the specified string, returning the expanded
         result.  Construction variables are specified by a $ prefix
@@ -496,7 +496,7 @@ class SubstitutionEnvironment:
         lvars['__env__'] = self
         if executor:
             lvars.update(executor.get_lvars())
-        return SCons.Subst.scons_subst(string, self, raw, target, source, gvars, lvars, conv)
+        return SCons.Subst.scons_subst(string, self, raw, target, source, gvars, lvars, conv, overrides=overrides)
 
     def subst_kw(self, kw, raw=0, target=None, source=None):
         nkw = {}
@@ -507,7 +507,7 @@ class SubstitutionEnvironment:
             nkw[k] = v
         return nkw
 
-    def subst_list(self, string, raw=0, target=None, source=None, conv=None, executor=None):
+    def subst_list(self, string, raw=0, target=None, source=None, conv=None, executor=None, overrides=False):
         """Calls through to SCons.Subst.scons_subst_list().  See
         the documentation for that function."""
         gvars = self.gvars()
@@ -515,7 +515,7 @@ class SubstitutionEnvironment:
         lvars['__env__'] = self
         if executor:
             lvars.update(executor.get_lvars())
-        return SCons.Subst.scons_subst_list(string, self, raw, target, source, gvars, lvars, conv)
+        return SCons.Subst.scons_subst_list(string, self, raw, target, source, gvars, lvars, conv, overrides=overrides)
 
     def subst_path(self, path, target=None, source=None):
         """Substitute a path list, turning EntryProxies into Nodes

--- a/SCons/Subst.py
+++ b/SCons/Subst.py
@@ -804,7 +804,8 @@ _separate_args = re.compile(r'(%s|\s+|[^\s$]+|\$)' % _dollar_exps_str)
 # space characters in the string result from the scons_subst() function.
 _space_sep = re.compile(r'[\t ]+(?![^{]*})')
 
-def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={}, lvars={}, conv=None):
+
+def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={}, lvars={}, conv=None, overrides=False):
     """Expand a string or list containing construction variable
     substitutions.
 
@@ -833,6 +834,10 @@ def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={
         if d:
             lvars = lvars.copy()
             lvars.update(d)
+
+    # Allow last ditch chance to override lvars
+    if overrides:
+        lvars.update(overrides)
 
     # We're (most likely) going to eval() things.  If Python doesn't
     # find a __builtins__ value in the global dictionary used for eval(),
@@ -882,7 +887,7 @@ def scons_subst(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={
 
     return result
 
-def scons_subst_list(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={}, lvars={}, conv=None):
+def scons_subst_list(strSubst, env, mode=SUBST_RAW, target=None, source=None, gvars={}, lvars={}, conv=None,overrides=False):
     """Substitute construction variables in a string (or list or other
     object) and separate the arguments into a command list.
 
@@ -907,6 +912,10 @@ def scons_subst_list(strSubst, env, mode=SUBST_RAW, target=None, source=None, gv
         if d:
             lvars = lvars.copy()
             lvars.update(d)
+
+    # Allow caller to specify last ditch override of lvars
+    if overrides:
+        lvars.update(overrides)
 
     # We're (most likely) going to eval() things.  If Python doesn't
     # find a __builtins__ value in the global dictionary used for eval(),

--- a/SCons/SubstTests.py
+++ b/SCons/SubstTests.py
@@ -713,6 +713,14 @@ class CLVar_TestCase(unittest.TestCase):
         assert cmd_list[0][3] == "call", cmd_list[0][3]
         assert cmd_list[0][4] == "test", cmd_list[0][4]
 
+
+    def test_subst_overriding_lvars_overrides(self):
+        """Test that optional passed arg overrides overrides gvars, and existing lvars."""
+        env=DummyEnv({'XXX' : 'xxx'})
+        result = scons_subst('$XXX', env, gvars=env.Dictionary(), overrides={'XXX': 'yyz'})
+        assert result == 'yyz', result
+
+
 class scons_subst_list_TestCase(SubstTestCase):
 
     basic_cases = [
@@ -1101,6 +1109,13 @@ class scons_subst_list_TestCase(SubstTestCase):
         assert result == [['xxx']], result
         result = scons_subst_list('$XXX', env, gvars={'XXX' : 'yyy'})
         assert result == [['yyy']], result
+
+    def test_subst_list_overriding_lvars_overrides(self):
+        """Test that optional passed arg overrides overrides gvars, and existing lvars."""
+        env = DummyEnv({'XXX':'xxx'})
+        result = scons_subst_list('$XXX', env, gvars=env.Dictionary(), overrides={'XXX': 'yyy'})
+        assert result == [['yyy']], result
+
 
 class scons_subst_once_TestCase(unittest.TestCase):
 

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -34,6 +34,8 @@ import itertools
 import fnmatch
 import SCons
 
+from SCons.Platform import TempFileMunge
+
 from .cxx import CXXSuffixes
 from .cc import CSuffixes
 from .asm import ASSuffixes, ASPPSuffixes
@@ -52,6 +54,7 @@ class __CompilationDbNode(SCons.Node.Python.Value):
     def __init__(self, value):
         SCons.Node.Python.Value.__init__(self, value)
         self.Decider(changed_since_last_build_node)
+
 
 def changed_since_last_build_node(child, target, prev_ni, node):
     """ Dummy decider to force always building"""
@@ -103,6 +106,11 @@ def make_emit_compilation_DB_entry(comstr):
     return emit_compilation_db_entry
 
 
+class CompDBTEMPFILE(TempFileMunge):
+    def __call__(self, target, source, env, for_signature):
+        return self.cmd
+
+
 def compilation_db_entry_action(target, source, env, **kw):
     """
     Create a dictionary with evaluated command line, target, source
@@ -119,6 +127,7 @@ def compilation_db_entry_action(target, source, env, **kw):
         target=env["__COMPILATIONDB_UOUTPUT"],
         source=env["__COMPILATIONDB_USOURCE"],
         env=env["__COMPILATIONDB_ENV"],
+        overrides={'TEMPFILE': CompDBTEMPFILE}
     )
 
     entry = {

--- a/test/CompilationDatabase/TEMPFILE.py
+++ b/test/CompilationDatabase/TEMPFILE.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,10 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
 """
-Test CompilationDatabase and several variations of ways to call it
-and values of COMPILATIONDB_USE_ABSPATH
+Test that CompilationDatabase works when TEMPFILE is being used to handle long
+commandlines for compilers/linkers/etc
 """
 
 import sys
@@ -33,27 +35,14 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.file_fixture('mylink.py')
 test.file_fixture('mygcc.py')
-
-test.verbose_set(1)
-test.file_fixture('fixture/SConstruct_tempfile', 'SConstruct')
 test.file_fixture('test_main.c')
+test.file_fixture('fixture/SConstruct_tempfile', 'SConstruct')
+
 test.run()
 
 rel_files = [
     'compile_commands_only_arg.json',
-    'compile_commands_target.json',
-    'compile_commands.json',
-    'compile_commands_over_rel.json',
-    'compile_commands_over_abs_0.json'
-]
-
-abs_files = [
-    'compile_commands_clone_abs.json',
-    'compile_commands_over_abs.json',
-    'compile_commands_target_over_abs.json',
-    'compile_commands_over_abs_1.json',
 ]
 
 example_rel_file = """[
@@ -73,24 +62,5 @@ for f in rel_files:
     # print("Checking:%s" % f)
     test.must_exist(f)
     test.must_match(f, example_rel_file, mode='r')
-
-example_abs_file = """[
-    {
-        "command": "%s mygcc.py cc -o test_main.o -c test_main.c",
-        "directory": "%s",
-        "file": "%s",
-        "output": "%s"
-    }
-]
-""" % (sys.executable, test.workdir, os.path.join(test.workdir, 'test_main.c'), os.path.join(test.workdir, 'test_main.o'))
-
-if sys.platform == 'win32':
-    example_abs_file = example_abs_file.replace('\\', '\\\\')
-
-
-for f in abs_files:
-    test.must_exist(f)
-    test.must_match(f, example_abs_file, mode='r')
-
 
 test.pass_test()

--- a/test/CompilationDatabase/basic.py
+++ b/test/CompilationDatabase/basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,7 +22,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
 """
 Test CompilationDatabase and several variations of ways to call it
 and values of COMPILATIONDB_USE_ABSPATH
@@ -46,7 +48,7 @@ rel_files = [
     'compile_commands_target.json',
     'compile_commands.json',
     'compile_commands_over_rel.json',
-    'compile_commands_over_abs_0.json'
+    'compile_commands_over_abs_0.json',
 ]
 
 abs_files = [

--- a/test/CompilationDatabase/fixture/SConstruct
+++ b/test/CompilationDatabase/fixture/SConstruct
@@ -7,7 +7,7 @@ env = Environment(
     LINKFLAGS=[],
     CC='$PYTHON mygcc.py cc',
     CXX='$PYTHON mygcc.py c++',
-    tools=['gcc','g++','gnulink'],
+    tools=['gcc', 'g++', 'gnulink'],
 )
 env.Tool('compilation_db')
 

--- a/test/CompilationDatabase/fixture/SConstruct_tempfile
+++ b/test/CompilationDatabase/fixture/SConstruct_tempfile
@@ -1,0 +1,45 @@
+import sys
+
+DefaultEnvironment(tools=[])
+env = Environment(
+    PYTHON=sys.executable,
+    LINK='$PYTHON mylink.py',
+    LINKFLAGS=[],
+    CC='$PYTHON mygcc.py cc',
+    CXX='$PYTHON mygcc.py c++',
+    tools=['gcc','g++','gnulink'],
+    MAXLINELENGTH=10,
+)
+# make sure TempFileMunge is used
+if 'TEMPFILE' not in env['CCCOM']:
+    env['CCCOM'] = '${TEMPFILE("%s")}'%(env['CCCOM'])
+
+env.Tool('compilation_db')
+
+outputs = []
+env_abs = env.Clone(COMPILATIONDB_USE_ABSPATH=True)
+outputs+= env_abs.CompilationDatabase('compile_commands_clone_abs.json')
+
+# Should be relative paths
+outputs+= env.CompilationDatabase('compile_commands_only_arg.json')
+outputs+= env.CompilationDatabase(target='compile_commands_target.json')
+
+# Should default name compile_commands.json
+outputs+= env.CompilationDatabase()
+
+# Should be absolute paths
+outputs+= env.CompilationDatabase('compile_commands_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
+outputs+= env.CompilationDatabase(target='compile_commands_target_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
+
+# Should be relative paths
+outputs+= env.CompilationDatabase('compile_commands_over_rel.json', COMPILATIONDB_USE_ABSPATH=False)
+
+# Try 1/0 for COMPILATIONDB_USE_ABSPATH
+outputs+= env.CompilationDatabase('compile_commands_over_abs_1.json', COMPILATIONDB_USE_ABSPATH=1)
+outputs+= env.CompilationDatabase('compile_commands_over_abs_0.json', COMPILATIONDB_USE_ABSPATH=0)
+
+env.Program('main', 'test_main.c')
+
+# Prevent actual call of $PYTHON @tempfile since "mygcc.py cc ..." is not a proper python statement
+# Interesting outputs are json databases
+env.Default(outputs)

--- a/test/CompilationDatabase/fixture/SConstruct_tempfile
+++ b/test/CompilationDatabase/fixture/SConstruct_tempfile
@@ -6,39 +6,22 @@ env = Environment(
     LINK='$PYTHON mylink.py',
     LINKFLAGS=[],
     CC='$PYTHON mygcc.py cc',
-    CXX='$PYTHON mygcc.py c++',
-    tools=['gcc','g++','gnulink'],
+    tools=['gcc'],
     MAXLINELENGTH=10,
 )
+
 # make sure TempFileMunge is used
 if 'TEMPFILE' not in env['CCCOM']:
-    env['CCCOM'] = '${TEMPFILE("%s")}'%(env['CCCOM'])
+    env['CCCOM'] = '${TEMPFILE("%s")}' % (env['CCCOM'])
 
 env.Tool('compilation_db')
 
 outputs = []
-env_abs = env.Clone(COMPILATIONDB_USE_ABSPATH=True)
-outputs+= env_abs.CompilationDatabase('compile_commands_clone_abs.json')
 
 # Should be relative paths
-outputs+= env.CompilationDatabase('compile_commands_only_arg.json')
-outputs+= env.CompilationDatabase(target='compile_commands_target.json')
+outputs += env.CompilationDatabase('compile_commands_only_arg.json')
 
-# Should default name compile_commands.json
-outputs+= env.CompilationDatabase()
-
-# Should be absolute paths
-outputs+= env.CompilationDatabase('compile_commands_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
-outputs+= env.CompilationDatabase(target='compile_commands_target_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
-
-# Should be relative paths
-outputs+= env.CompilationDatabase('compile_commands_over_rel.json', COMPILATIONDB_USE_ABSPATH=False)
-
-# Try 1/0 for COMPILATIONDB_USE_ABSPATH
-outputs+= env.CompilationDatabase('compile_commands_over_abs_1.json', COMPILATIONDB_USE_ABSPATH=1)
-outputs+= env.CompilationDatabase('compile_commands_over_abs_0.json', COMPILATIONDB_USE_ABSPATH=0)
-
-env.Program('main', 'test_main.c')
+env.Object('test_main.c')
 
 # Prevent actual call of $PYTHON @tempfile since "mygcc.py cc ..." is not a proper python statement
 # Interesting outputs are json databases

--- a/test/CompilationDatabase/fixture/SConstruct_tempfile
+++ b/test/CompilationDatabase/fixture/SConstruct_tempfile
@@ -8,6 +8,7 @@ env = Environment(
     CC='$PYTHON mygcc.py cc',
     tools=['gcc'],
     MAXLINELENGTH=10,
+    OBJSUFFIX='.o',
 )
 
 # make sure TempFileMunge is used

--- a/test/CompilationDatabase/tmpfile.py
+++ b/test/CompilationDatabase/tmpfile.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Test CompilationDatabase and several variations of ways to call it
+and values of COMPILATIONDB_USE_ABSPATH
+"""
+
+import sys
+import os
+import os.path
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.file_fixture('mylink.py')
+test.file_fixture('mygcc.py')
+
+test.verbose_set(1)
+test.file_fixture('fixture/SConstruct_tempfile', 'SConstruct')
+test.file_fixture('test_main.c')
+test.run()
+
+rel_files = [
+    'compile_commands_only_arg.json',
+    'compile_commands_target.json',
+    'compile_commands.json',
+    'compile_commands_over_rel.json',
+    'compile_commands_over_abs_0.json'
+]
+
+abs_files = [
+    'compile_commands_clone_abs.json',
+    'compile_commands_over_abs.json',
+    'compile_commands_target_over_abs.json',
+    'compile_commands_over_abs_1.json',
+]
+
+example_rel_file = """[
+    {
+        "command": "%s mygcc.py cc -o test_main.o -c test_main.c",
+        "directory": "%s",
+        "file": "test_main.c",
+        "output": "test_main.o"
+    }
+]
+""" % (sys.executable, test.workdir)
+
+if sys.platform == 'win32':
+    example_rel_file = example_rel_file.replace('\\', '\\\\')
+
+for f in rel_files:
+    # print("Checking:%s" % f)
+    test.must_exist(f)
+    test.must_match(f, example_rel_file, mode='r')
+
+example_abs_file = """[
+    {
+        "command": "%s mygcc.py cc -o test_main.o -c test_main.c",
+        "directory": "%s",
+        "file": "%s",
+        "output": "%s"
+    }
+]
+""" % (sys.executable, test.workdir, os.path.join(test.workdir, 'test_main.c'), os.path.join(test.workdir, 'test_main.o'))
+
+if sys.platform == 'win32':
+    example_abs_file = example_abs_file.replace('\\', '\\\\')
+
+
+for f in abs_files:
+    test.must_exist(f)
+    test.must_match(f, example_abs_file, mode='r')
+
+
+test.pass_test()

--- a/test/CompilationDatabase/variant_dir.py
+++ b/test/CompilationDatabase/variant_dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,7 +22,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
 """
 Test CompilationDatabase and several variations of ways to call it
 and values of COMPILATIONDB_USE_ABSPATH


### PR DESCRIPTION
Solution for Issue #4275  (Compilation db get's tmp file command line),  also extending serveral APIs to allow specifying an overrides dictionary which would override (at the last minute) any envvar or potentially env TARGET/SOURCE when subst is being called a subst() or subst_list().  Tests created. Docs still need to be updated.



## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
