### PR TITLE
uguide: variant dir tweaking

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -105,6 +105,9 @@ DOCUMENTATION
 - Updated the User Guide chapter on installation: modernized the notes
   on Python installs, SCons installs, and having multiple SCons versions
   present on a single system.
+- Updated the User Guide chapter on variant directories with more
+  explanation, and the introduction of terms like "out of tree" that
+  may help in forming a mental model.
 
 DEVELOPMENT
 -----------

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -145,19 +145,26 @@ to support additional input file types.
 </para>
 
 <para>Information about files involved in the build,
-including a cryptographic hash of the contents,
+including a cryptographic hash of the contents of source files,
 is cached for later reuse.
 By default this hash (the <firstterm>&contentsig;</firstterm>)
 is used to determine if a file has changed since the last build,
-but this can be controlled by selecting an appropriate
+although this can be controlled by selecting an appropriate
 <firstterm>&f-link-Decider;</firstterm> function.
 Implicit dependency files are also part of out-of-date computation.
 The scanned implicit dependency information can optionally be
 cached and used to speed up future builds.
-A hash of each executed build action (the <firstterm>&buildsig;</firstterm>
+A hash of each executed build action (the <firstterm>&buildsig;</firstterm>)
 is cached, so that changes to build instructions (changing flags, etc.)
 or to the build tools themselves (new version)
 can also trigger a rebuild.
+</para>
+
+<para>
+&SCons; supports the concept of separated source and build
+directories through the definition of
+<firstterm>variant directories</firstterm>
+(see the &f-link-VariantDir; function).
 </para>
 
 <para>
@@ -167,11 +174,15 @@ looks for a file named
 in the current directory and reads the
 build configuration from that file
 (other names are allowed,
-see <xref linkend="sconscript_files"/> for more information).
-The &SConstruct;
+see <xref linkend="sconscript_files"/> 
+and the <link linkend="opt-f"><option>-f</option></link> option
+for more information).
+The build may be structured in a hierarchical manner:
+the &SConstruct;
 file may specify subsidiary
 configuration files by calling the
-&f-link-SConscript; function.
+&f-link-SConscript; function, 
+and these may, in turn, do the same.
 By convention,
 these subsidiary files are named
 &SConscript;,
@@ -182,7 +193,14 @@ is used to refer
 generically to the complete set of
 configuration files for a project
 (including the &SConstruct; file),
-regardless of the actual file names or number of such files.</para>
+regardless of the actual file names or number of such files.
+A hierarchical build is not recursive - all of
+the SConscript files are processed in a single pass,
+although each is processed in a separate context so
+as not to interfere with one another. &SCons; provides
+mechanisms for information to be shared between
+SConscript files when needed.
+</para>
 
 <para>Before reading the &SConscript; files,
 &scons;
@@ -870,9 +888,10 @@ files).</para>
   <varlistentry>
   <term><emphasis role="bold">duplicate</emphasis></term>
   <listitem>
-<para>Print a line for each unlink/relink (or copy) of a variant file from
-its source file.  Includes debugging info for unlinking stale variant
-files, as well as unlinking old targets before building them.</para>
+<para>Print a line for each unlink/relink (or copy) of a file in
+a variant directory from its source file.
+Includes debugging info for unlinking stale variant directory files,
+as well as unlinking old targets before building them.</para>
   </listitem>
   </varlistentry>
 
@@ -3686,9 +3705,9 @@ The default value is
 specifies a file which collects the output from commands
 that are executed to check for the existence of header files, libraries, etc.
 The default is <quote><filename>#/config.log</filename></quote>.
-If you are using the
-&VariantDir; function,
-you may want to specify a subdirectory under your variant directory.</para>
+If you are using variant directories,
+you may want to place the log file for a given build
+under that build's variant directory.</para>
 <para>
 <parameter>config_h</parameter>
 specifies a C header file where the results of tests
@@ -6720,7 +6739,7 @@ For example, the command line string:</para>
 echo Last build occurred $TODAY. &gt; $TARGET
 </screen>
 
-<para>but the build signature added to any target files would be computed from:</para>
+<para>but the &buildsig; added to any target files would be computed from:</para>
 
 <screen>
 echo Last build occurred  . &gt; $TARGET
@@ -6741,8 +6760,8 @@ The callable must accept four arguments:
 <parameter>env</parameter> is the &consenv; to use for context,
 and <parameter>for_signature</parameter> is
 a boolean value that tells the callable
-if it is being called for the purpose of generating a build signature.
-Since the build signature is used for rebuild determination,
+if it is being called for the purpose of generating a &buildsig;.
+Since the &buildsig; is used for rebuild determination,
 variable elements that do not affect whether
 a rebuild should be triggered
 should be omitted from the returned string

--- a/doc/user/hierarchy.xml
+++ b/doc/user/hierarchy.xml
@@ -1,4 +1,10 @@
 <?xml version='1.0'?>
+<!--
+SPDX-License-Identifier: MIT
+
+Copyright The SCons Foundation
+-->
+
 <!DOCTYPE sconsdoc [
     <!ENTITY % scons SYSTEM "../scons.mod">
     %scons;
@@ -18,32 +24,8 @@
          xmlns="http://www.scons.org/dbxsd/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
 <title>Hierarchical Builds</title>
-
-<!--
-
-  __COPYRIGHT__
-
-  Permission is hereby granted, free of charge, to any person obtaining
-  a copy of this software and associated documentation files (the
-  "Software"), to deal in the Software without restriction, including
-  without limitation the rights to use, copy, modify, merge, publish,
-  distribute, sublicense, and/or sell copies of the Software, and to
-  permit persons to whom the Software is furnished to do so, subject to
-  the following conditions:
-
-  The above copyright notice and this permission notice shall be included
-  in all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
--->
 
 <!--
 
@@ -193,11 +175,11 @@ make no difference to the build.
   hierarchy of directories.
   Organizing a large software build using &SCons;
   involves creating a hierarchy of build scripts
-  using the &SConscript; function.
+  which are connected together using the &f-link-SConscript; function.
 
   </para>
 
-  <section>
+  <section id="sect-sconscript-files">
   <title>&SConscript; Files</title>
 
     <para>
@@ -219,10 +201,14 @@ make no difference to the build.
     </para>
 
     <sconstruct>
-SConscript(['drivers/display/SConscript',
-            'drivers/mouse/SConscript',
-            'parser/SConscript',
-            'utilities/SConscript'])
+SConscript(
+    [
+        'drivers/display/SConscript',
+        'drivers/mouse/SConscript',
+        'parser/SConscript',
+        'utilities/SConscript',
+    ]
+)
     </sconstruct>
 
     <para>
@@ -241,9 +227,7 @@ SConscript(['drivers/display/SConscript',
     </para>
 
     <sconstruct>
-SConscript(['drivers/SConscript',
-            'parser/SConscript',
-            'utilities/SConscript'])
+SConscript(['drivers/SConscript', 'parser/SConscript', 'utilities/SConscript'])
     </sconstruct>
 
     <para>
@@ -255,8 +239,7 @@ SConscript(['drivers/SConscript',
     </para>
 
     <sconstruct>
-SConscript(['display/SConscript',
-            'mouse/SConscript'])
+SConscript(['display/SConscript', 'mouse/SConscript'])
     </sconstruct>
 
     <para>
@@ -272,7 +255,7 @@ SConscript(['display/SConscript',
 
   </section>
 
-  <section>
+  <section id="sect-sconscript-relative-paths">
   <title>Path Names Are Relative to the &SConscript; Directory</title>
 
     <para>
@@ -280,7 +263,7 @@ SConscript(['display/SConscript',
     Subsidiary &SConscript; files make it easy to create a build
     hierarchy because all of the file and directory names
     in a subsidiary &SConscript; files are interpreted
-    relative to the directory in which the &SConscript; file lives.
+    relative to the directory in which that &SConscript; file lives.
     Typically, this allows the &SConscript; file containing the
     instructions to build a target file
     to live in the same directory as the source files
@@ -288,6 +271,8 @@ SConscript(['display/SConscript',
     making it easy to update how the software is built
     whenever files are added or deleted
     (or other changes are made).
+    It also tends to keep scripts more readable as they don't
+    need to be filled with complex paths.
 
     </para>
 
@@ -369,20 +354,27 @@ x
     Notice the following:
 
     First, you can have files with the same names
-    in multiple directories, like main.c in the above example.
+    in multiple directories, like <filename>main.c</filename>
+    in the above example.
 
-    Second, unlike standard recursive use of &Make;,
+    Second, when building,
     &SCons; stays in the top-level directory
     (where the &SConstruct; file lives)
     and issues commands that use the path names
     from the top-level directory to the
     target and source files within the hierarchy.
+    This works because &SCons; reads all the SConscript files
+    in one pass, interpreting each in its local context,
+    building up a tree of information, before starting to
+    execute the needed builds in a second pass.
+    This is quite different than some other build tools
+    which implement a heirarcical build by recursing.
 
     </para>
 
   </section>
 
-  <section>
+  <section id="sect-sconscript-top-relative-paths">
   <title>Top-Relative Path Names in Subsidiary &SConscript; Files</title>
 
     <para>
@@ -465,7 +457,8 @@ x
         understand about it.  This becomes immediately obvious
         if you like to use <function>print</function> for debugging,
         or write a Python function that wants to evaluate a path.
-        You can force &SCons; to evaluate a top-relative path by
+        You can force &SCons; to evaluate a top-relative path 
+        and produce a string that can be used by &Python; code by
         creating a Node object from it:
 
         </para>
@@ -492,7 +485,7 @@ print("force-interpreted path =", Entry(path))
 
   </section>
 
-  <section>
+  <section id="sect-sconscript-absolute-paths">
   <title>Absolute Path Names</title>
 
     <para>
@@ -544,7 +537,7 @@ x
 
   </section>
 
-  <section>
+  <section id="sect-sconscript-sharing">
   <title>Sharing Environments (and Other Variables) Between &SConscript; Files</title>
 
     <para>
@@ -573,7 +566,7 @@ x
 
     </para>
 
-    <section>
+    <section id="sect-sconscript-export">
     <title>Exporting Variables</title>
 
       <para>
@@ -701,8 +694,7 @@ SConscript('src/SConscript', exports='env')
       </para>
 
       <sconstruct>
-SConscript(['src1/SConscript',
-            'src2/SConscript'], exports='env')
+SConscript(['src1/SConscript', 'src2/SConscript'], exports='env')
       </sconstruct>
 
       <para>
@@ -716,7 +708,7 @@ SConscript(['src1/SConscript',
 
     </section>
 
-    <section>
+    <section id="sect-sconscript-import">
     <title>Importing Variables</title>
 
       <para>
@@ -818,7 +810,7 @@ env.Program('prog', ['prog.c'])
 
     </section>
 
-    <section>
+    <section id="sect-sconscript-return">
     <title>Returning Values From an &SConscript; File</title>
 
       <para>

--- a/doc/user/separate.xml
+++ b/doc/user/separate.xml
@@ -1,4 +1,10 @@
 <?xml version='1.0'?>
+<!--
+SPDX-License-Identifier: MIT
+
+Copyright The SCons Foundation
+-->
+
 <!DOCTYPE sconsdoc [
     <!ENTITY % scons SYSTEM "../scons.mod">
     %scons;
@@ -17,98 +23,111 @@
          xmlns="http://www.scons.org/dbxsd/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
 <title>Separating Source and Build Trees: Variant Directories</title>
 
-<!--
-
-  __COPYRIGHT__
-
-  Permission is hereby granted, free of charge, to any person obtaining
-  a copy of this software and associated documentation files (the
-  "Software"), to deal in the Software without restriction, including
-  without limitation the rights to use, copy, modify, merge, publish,
-  distribute, sublicense, and/or sell copies of the Software, and to
-  permit persons to whom the Software is furnished to do so, subject to
-  the following conditions:
-
-  The above copyright notice and this permission notice shall be included
-  in all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
--->
-
   <para>
 
-  It's often useful to keep any built files completely
-  separate from the source files. Consider if you have a
-  project to build software for a variety of different
-  controller hardware.  The boards are able to share a
-  lot of code, so it makes sense to keep them in the same
-  source tree, but certain build options in the source code
-  and header files differ.  If you build "Controller A" first,
-  then "Controller B", on the "Controller B" build everything would
-  have to be rebuilt, because &SCons; recognizes that the build
-  instructions are different from those used in the "Controller A"
-  build for each target - the build instructions are part of
-  &SCons;'s out-of-date calculation.
-  Now when you go back and build for "Controller A",
-  things have to be rebuilt from scratch again for the same reason.
+  It is often useful to keep built files completely
+  separate from the source files. Two main benefits are
+  the ability to have different configurations simultaneously
+  without build conflicts, and being version-control friendly.
+
+  </para>
+
+  <para> 
+
+  Consider if you have a project to build an embedded
+  software system for a variety of different controller hardware.
+  The system is able to share a lot of code,
+  so it makes sense to use a common source tree,
+  but certain build options in the source code
+  and header files differ. For a regular in-place build,
+  the build outputs go in the same place as the source code.
+  If you build <emphasis>Controller A</emphasis> first,
+  followed by <emphasis>Controller B</emphasis>,
+  on the <emphasis>Controller B</emphasis> build everything that
+  uses different build options has to be rebuilt since those
+  objects will be different
+  (the build lines, including preprocessor defines, are part of
+  &SCons;'s out-of-date calculation for this reason).
+  If you go back and build for <emphasis>Controller A</emphasis> again,
+  things have to be rebuilt again for the same reason.
   However, if you can separate the locations of the output files,
+  so each controller has its own location for build outputs,
   this problem can be avoided.
-  You can even set up to do both builds in one invocation of &SCons;.
 
   </para>
 
   <para>
 
-  You can enable this separation by establishing one or more
-  <firstterm>variant directory</firstterm> trees
-  that are used to perform the build in, and thus provide a unique
-  home for object files, libraries, and executable programs, etc.
-  for a specific flavor, or variant, of build. &SCons; tracks
-  targets by their path, so when the variant directory is included,
-  objects belonging to "Controller A" can have different
-  build instructions than those belonging to "Controller B" without
-  triggering ping-ponging rebuilds.
+  Having a separated build also helps you keep your source tree clean -
+  there is less chance of accidentally checking in build products
+  to version control that were not intended to be checked in.
+  You can add a separated build directory to your
+  version control system's list of items not to track.
+  You can even remove the whole build tree with a single command without
+  risking removing any of the source code.
 
   </para>
 
   <para>
 
-  &SCons; provides two ways to do this,
-  one through the &f-link-SConscript; function that we've already seen,
+  The key to making this separation work is the ability to
+  do out-of-tree builds: building under a separate root
+  than the sources being built.
+  You set up out of tree builds by establishing what &SCons;
+  calls a <firstterm>variant directory</firstterm>,
+  a place where you can build a single variant of your software 
+  (of course you can define more than one of these if you need to).
+  Since &SCons; tracks targets by their path, it is able to distinguish
+  build products like <filename>build/A/network.obj</filename>
+  of the <emphasis>Controller A</emphasis> build
+  from <filename>build/B/network.obj</filename>
+  of the <emphasis>Controller B</emphasis> build,
+  thus avoiding conflicts.
+
+  </para>
+
+  <para>
+
+  &SCons; provides two ways to establish variant directories,
+  one through the &f-link-SConscript; function that we have already seen,
   and the second through a more flexible &f-link-VariantDir; function.
 
   </para>
 
   <para>
-
-  Historical note:  the &VariantDir; function
-  used to be called &BuildDir;, a name which was
-  removed because the &SCons; functionality
-  differs from a familiar model of a "build directory"
-  implemented by other build systems like GNU Autotools.
-  You might still find references to the old name on
-  the Internet in postings about &SCons;, but it no longer works.
+  
+  The variant directory mechanism does support doing multiple builds
+  in one invocation of &SCons;, but the remainder of this chapter
+  will focus on setting up a single build. You can combine these
+  techniques with ones from the previous chapter and elsewhere
+  in this Guide to set up more complex scenarios.
 
   </para>
 
-  <section>
+  <note> <para>
+
+  The &VariantDir; function used to be called &BuildDir;,
+  a name which was changed because it turned out to be confusing:
+  the &SCons; functionality
+  differs from a familiar model of a "build directory"
+  implemented by certain other build systems like GNU Autotools.
+  You might still find references to the old name on
+  the Internet in postings about &SCons;, but it no longer works.
+
+  </para> </note>
+
+  <section id="sect-variant-sconscript">
   <title>Specifying a Variant Directory Tree as Part of an &SConscript; Call</title>
 
     <para>
 
     The most straightforward way to establish a variant directory tree
-    relies the fact that the usual way to
+    relies on the fact that the usual way to
     set up a build hierarchy is to have an
-    SConscript file in the source subdirectory.
+    &SConscript; file in the source directory.
     If you pass a &variant_dir; argument to the
     &f-link-SConscript; function call:
 
@@ -130,7 +149,7 @@ int main() { printf("Hello, world!\n"); }
     <para>
 
     &SCons; will then build all of the files in
-    the &build; subdirectory:
+    the &build; directory:
 
     </para>
 
@@ -143,46 +162,73 @@ int main() { printf("Hello, world!\n"); }
 
     <para>
 
-    No files were built in &src;, they went to &build;.
-    The build output might show a bit of a surprise:
+    No files were built in &src;:
     the object file
     <filename>build/hello.o</filename>
     and the executable file
     <filename>build/hello</filename>
-    were built in the &build; subdirectory,
-    as expected.
-    But even though our &hello_c; file lives in the &src; subdirectory,
-    &SCons; has actually compiled a
+    were built in the &build; directory, as expected.
+    But notice that even though our &hello_c; file actually
+    lives in the &src; directory, &SCons; has compiled a
     <filename>build/hello.c</filename> file
     to create the object file,
     and that file is now seen in &build;.
-
+    
     </para>
 
     <para>
 
+    You can ask &SCons; to show the dependency tree to illustrate
+    a bit more:
+
+    </para>
+
+    <scons_output example="separate_ex1" suffix="2">
+      <scons_output_command>scons -Q --tree=prune</scons_output_command>
+    </scons_output>
+
+    <para>
+
     What's happened is that &SCons; has <emphasis>duplicated</emphasis>
-    the &hello_c; file from the &src; subdirectory
-    to the &build; subdirectory,
+    the &hello_c; file from the &src; directory
+    to the &build; directory,
     and built the program from there (it also duplicated &SConscript;).
     The next section explains why &SCons; does this.
 
     </para>
 
+    <para>
+
+    The nice thing about the &SConscript; approach is it is almost
+    invisible to you:
+    this build looks just like an ordinary in-place build
+    except for the extra &variant_dir; argument in the
+    &f-link-SConscript; call.
+    &SCons; handles all the path adjustments for the
+    out of tree &build; directory while it processes that SConscript file.
+
+    </para>
+
   </section>
 
-  <section>
+  <section id="sect-variant-duplication">
   <title>Why &SCons; Duplicates Source Files in a Variant Directory Tree</title>
 
     <para>
 
-    The important thing to understand is that when you set up a variant directory,
-    &SCons; performs the build <emphasis>in that directory</emphasis>.
-    It turns out it's easiest to ensure where build products end up
-    by just building in place.
-    Since the build is happening in a place different from where the
-    sources are, the most straightforward way to guarantee a correct build
-    is for &SCons; to copy them there.
+    When you set up a variant directory &SCons; conceptually behaves as
+    if you requested a build in that directory. 
+    As noted in the previous chapter,
+    all builds actually happen from the top level directory,
+    but as an aid to understanding how &SCons; operates, think
+    of it as <emphasis>build in place in the variant directory</emphasis>,
+    not <emphasis>build in source but send build artifacts
+    to the variant directory</emphasis>.
+    It turns out in place builds are easier to get right than out
+    of tree builds - so by default &SCons; simulates an in place build
+    by making the variant directory look just like the source directory.
+    The most straightforward way to do that is by making copies
+    of the files needed for the build.
 
     </para>
 
@@ -192,7 +238,11 @@ int main() { printf("Hello, world!\n"); }
     in variant directories
     is simply that some tools (mostly older versions)
     are written to only build their output files
-    in the same directory as the source files.
+    in the same directory as the source files - such tools often don't
+    have any option to specify the output file, and the tool just
+    uses a predefined output file name,
+    or uses a derived variant of the source file name,
+    dropping the result in the same directory.
     In this case, the choices are either
     to build the output file in the source directory
     and move it to the variant directory,
@@ -204,9 +254,9 @@ int main() { printf("Hello, world!\n"); }
 
     Additionally,
     relative references between files
-    can cause problems if we don't
-    just duplicate the hierarchy of source files
-    in the variant directory.
+    can cause problems which are resolved by
+    just duplicating the hierarchy of source files
+    into the variant directory.
     You can see this at work in
     use of the C preprocessor <literal>#include</literal>
     mechanism with double quotes, not angle brackets:
@@ -240,8 +290,8 @@ int main() { printf("Hello, world!\n"); }
     <para>
 
     Although source-file duplication guarantees a correct build
-    even in these end-cases,
-    it <emphasis>can</emphasis> usually be safely disabled.
+    even in these edge cases,
+    it can <emphasis>usually</emphasis> be safely disabled.
     The next section describes
     how you can disable the duplication of source files
     in the variant directory.
@@ -250,19 +300,19 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-variant-no-duplication">
   <title>Telling &SCons; to Not Duplicate Source Files in the Variant Directory Tree</title>
 
     <para>
 
     In most cases and with most tool sets,
-    &SCons; can place its target files in a build subdirectory
+    &SCons; can use sources directly from the source directory
     <emphasis>without</emphasis>
-    duplicating the source files
+    duplicating them into the variant directory before building,
     and everything will work just fine.
-    You can disable the default &SCons; behavior
+    You can disable the default &SCons; duplication behavior
     by specifying <literal>duplicate=False</literal>
-    when you call the &SConscript; function:
+    when you call the &f-link-SConscript; function:
 
     </para>
 
@@ -272,11 +322,11 @@ SConscript('src/SConscript', variant_dir='build', duplicate=False)
 
     <para>
 
-    When this flag is specified,
-    &SCons; uses the variant directory
-    like most people expect--that is,
-    the output files are placed in the variant directory
-    while the source files stay in the source directory:
+    When this flag is specified, the results of a build
+    look more like the mental model people may have from other
+    build systems - that is,
+    the output files end up in the variant directory
+    while the source files do not.
 
     </para>
 
@@ -292,14 +342,22 @@ hello
 hello.o
     </screen>
 
+    <para>
+
+    If disabling duplication causes any problems,
+    just return to the more cautious approach by letting
+    &SCons; go back to duplicating files.
+
+    </para>
+
   </section>
 
-  <section>
+  <section id="sect-variantdir-function">
   <title>The &VariantDir; Function</title>
 
     <para>
 
-    Use the &VariantDir; function to establish that target
+    Use the &f-link-VariantDir; function to establish that target
     files should be built in a separate directory
     from the source files:
 
@@ -318,8 +376,8 @@ int main() { printf("Hello, world!\n"); }
 
     <para>
 
-    Note that when you're not using
-    an &SConscript; file in the &src; subdirectory,
+    Note that when you are not using
+    an &SConscript; file in the &src; directory,
     you must actually specify that
     the program must be built from
     the <filename>build/hello.c</filename>
@@ -345,7 +403,7 @@ int main() { printf("Hello, world!\n"); }
     <para>
 
     You can specify the same <literal>duplicate=False</literal> argument
-    that you can specify for an &SConscript; call:
+    that you can specify for an &f-link-SConscript; call:
 
     </para>
 
@@ -375,12 +433,12 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-variantdir-sconscript">
   <title>Using &VariantDir; With an &SConscript; File</title>
 
     <para>
 
-    Even when using the &VariantDir; function,
+    Even when using the &f-link-VariantDir; function,
     it's more natural to use it with
     a subsidiary &SConscript; file,
     because then you don't have to adjust your individual
@@ -428,21 +486,26 @@ int main() { printf("Hello, world!\n"); }
 
     <para>
 
-    Notice that this is completely equivalent
-    to the use of &SConscript; that we
-    learned about in the previous section.
+    This is completely equivalent
+    to the use of &f-link-SConscript; with the
+    <parameter>variant_dir</parameter> argument
+    from earlier in this chapter,
+    but did require callng the SConscript using the already established
+    variant directory path to trigger that behavior.
+    If you use <userinput>SConscript('src/SConscript')</userinput>
+    you would get a normal in-place build in &src;.
 
     </para>
 
   </section>
 
-  <section>
+  <section id="sect-variantdir-glob">
   <title>Using &Glob; with &VariantDir;</title>
 
     <para>
 
     The &f-link-Glob; file name pattern matching function
-    works just as usual when using &VariantDir;.
+    works just as usual when using &f-link-VariantDir;.
     For example, if the
     <filename>src/SConscript</filename>
     looks like this:
@@ -496,7 +559,7 @@ const char * f2();
 
   <!--
 
-  <section>
+  <section id="sect-variantdir-over-sconscript">
   <title>Why You'd Want to Call &VariantDir; Instead of &SConscript;</title>
 
     <para>

--- a/doc/user/separate.xml
+++ b/doc/user/separate.xml
@@ -61,7 +61,7 @@ Copyright The SCons Foundation
 
   <para>
 
-  Having a separated build also helps you keep your source tree clean -
+  Having a separated build tree also helps you keep your source tree clean -
   there is less chance of accidentally checking in build products
   to version control that were not intended to be checked in.
   You can add a separated build directory to your

--- a/doc/user/separate.xml
+++ b/doc/user/separate.xml
@@ -35,7 +35,7 @@ Copyright The SCons Foundation
 
   </para>
 
-  <para> 
+  <para>
 
   Consider if you have a project to build an embedded
   software system for a variety of different controller hardware.
@@ -78,7 +78,7 @@ Copyright The SCons Foundation
   than the sources being built.
   You set up out of tree builds by establishing what &SCons;
   calls a <firstterm>variant directory</firstterm>,
-  a place where you can build a single variant of your software 
+  a place where you can build a single variant of your software
   (of course you can define more than one of these if you need to).
   Since &SCons; tracks targets by their path, it is able to distinguish
   build products like <filename>build/A/network.obj</filename>
@@ -98,7 +98,7 @@ Copyright The SCons Foundation
   </para>
 
   <para>
-  
+
   The variant directory mechanism does support doing multiple builds
   in one invocation of &SCons;, but the remainder of this chapter
   will focus on setting up a single build. You can combine these
@@ -173,7 +173,7 @@ int main() { printf("Hello, world!\n"); }
     <filename>build/hello.c</filename> file
     to create the object file,
     and that file is now seen in &build;.
-    
+
     </para>
 
     <para>
@@ -217,7 +217,7 @@ int main() { printf("Hello, world!\n"); }
     <para>
 
     When you set up a variant directory &SCons; conceptually behaves as
-    if you requested a build in that directory. 
+    if you requested a build in that directory.
     As noted in the previous chapter,
     all builds actually happen from the top level directory,
     but as an aid to understanding how &SCons; operates, think
@@ -357,8 +357,8 @@ hello.o
 
     <para>
 
-    Use the &f-link-VariantDir; function to establish that target
-    files should be built in a separate directory
+    You can also use the &f-link-VariantDir; function to establish
+    that target files should be built in a separate directory tree
     from the source files:
 
     </para>
@@ -376,13 +376,18 @@ int main() { printf("Hello, world!\n"); }
 
     <para>
 
-    Note that when you are not using
-    an &SConscript; file in the &src; directory,
-    you must actually specify that
-    the program must be built from
-    the <filename>build/hello.c</filename>
-    file that &SCons; will duplicate in the
-    &build; subdirectory.
+    When using this form, you have to tell &SCons; that
+    sources and targets are in the variant directory,
+    and those references will trigger the remapping,
+    necessary file copying, etc. for an already established
+    variant directory.  Here is the same example in a more
+    spelled out form to show this more clearly:
+
+    <programlisting language="python">
+VariantDir('build', 'src')
+env = Environment()
+env.Program(target='build/hello', source=['build/hello.c'])
+    </programlisting>
 
     </para>
 
@@ -439,7 +444,7 @@ int main() { printf("Hello, world!\n"); }
     <para>
 
     Even when using the &f-link-VariantDir; function,
-    it's more natural to use it with
+    it is more natural to use it with
     a subsidiary &SConscript; file,
     because then you don't have to adjust your individual
     build instructions to use the variant directory path.
@@ -492,7 +497,7 @@ int main() { printf("Hello, world!\n"); }
     from earlier in this chapter,
     but did require callng the SConscript using the already established
     variant directory path to trigger that behavior.
-    If you use <userinput>SConscript('src/SConscript')</userinput>
+    If you call <userinput>SConscript('src/SConscript')</userinput>
     you would get a normal in-place build in &src;.
 
     </para>

--- a/doc/user/variants.xml
+++ b/doc/user/variants.xml
@@ -1,4 +1,10 @@
 <?xml version='1.0'?>
+<!--
+SPDX-License-Identifier: MIT
+
+Copyright The SCons Foundation
+-->
+
 <!DOCTYPE sconsdoc [
     <!ENTITY % scons SYSTEM "../scons.mod">
     %scons;
@@ -13,36 +19,12 @@
     %variables-mod;
 ]>
 
-<section id="sect-variants"
+<section id="sect-variant-examples"
          xmlns="http://www.scons.org/dbxsd/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
 <title>Variant Build Examples</title>
-
-<!--
-
-  __COPYRIGHT__
-
-  Permission is hereby granted, free of charge, to any person obtaining
-  a copy of this software and associated documentation files (the
-  "Software"), to deal in the Software without restriction, including
-  without limitation the rights to use, copy, modify, merge, publish,
-  distribute, sublicense, and/or sell copies of the Software, and to
-  permit persons to whom the Software is furnished to do so, subject to
-  the following conditions:
-
-  The above copyright notice and this permission notice shall be included
-  in all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
--->
 
   <para>
 


### PR DESCRIPTION
Try to clarify some more about variant dirs (people are still getting confused), without getting too technical about it, in the spirit of the User Guide. Tried to undo some not-really-correct statements about where SCons is building (there may be other references).

Also, some stuff about hierarchical builds - both manpage and user guide.

User guide chunks that were modified anyway (three of them) had section IDs added. This is part of a plan to gradually get rid of horrible-looking auto-generated links which are not constant (problem when Google archives something and then maybe it doesn't work). May look like this in a browser:

https://scons.org/doc/production/HTML/scons-user.html#idp105548893220944

With assigned IDs, looks more like:

`.../HTML/scons-user.html#sect-variant-sconscript`

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
