### PR TITLE
Fixed using --diskcheck=none from command line. 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       read packaging/etc/README.txt if you are interested.
     - Added --experimental=tm_v2, which enables Andrew Morrow's new NewParallel Job implementation.
       This should scale much better for highly parallel builds. You can also enable this via SetOption().
+    - Fixed setting diskcheck to 'none' via command line works --diskcheck=none. Apparently it has never worked
+      even though SetOption('diskcheck','none') did work.
 
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,8 +34,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       read packaging/etc/README.txt if you are interested.
     - Added --experimental=tm_v2, which enables Andrew Morrow's new NewParallel Job implementation.
       This should scale much better for highly parallel builds. You can also enable this via SetOption().
-    - Fixed setting diskcheck to 'none' via command line works --diskcheck=none. Apparently it has never worked
-      even though SetOption('diskcheck','none') did work.
+    - Fixed command line argument --diskcheck: previously a value of 'none' was ignored.
+      SetOption('diskcheck','none') is unaffected, as it did not have the problem.
 
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -64,6 +64,8 @@ FIXES
 - Ninja: Fix execution environment sanitation for launching ninja. Previously if you set an
   execution environment variable set to a python list it would crash. Now it
   will create a string joining the list with os.pathsep
+- Fixed setting diskcheck to 'none' via command line works --diskcheck=none. Apparently it has never worked
+  even though SetOption('diskcheck','none') did work.
 
 IMPROVEMENTS
 ------------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -64,8 +64,8 @@ FIXES
 - Ninja: Fix execution environment sanitation for launching ninja. Previously if you set an
   execution environment variable set to a python list it would crash. Now it
   will create a string joining the list with os.pathsep
-- Fixed setting diskcheck to 'none' via command line works --diskcheck=none. Apparently it has never worked
-  even though SetOption('diskcheck','none') did work.
+- Fixed command line argument --diskcheck: previously a value of 'none' was ignored.
+  SetOption('diskcheck','none') is unaffected, as it did not have the problem.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -380,8 +380,10 @@ else:
 
 class DiskChecker:
     """
-    This Class will hold various types of logic for checking if a file/dir on disk matches
-    the type which is expected. And allow Options to decide to enable or disable said check
+    Implement disk check variation.
+
+    This Class will hold functions to determine what this particular disk
+    checking implementation should do when enabled or disabled.
     """
     def __init__(self, disk_check_type, do_check_function, ignore_check_function):
         self.disk_check_type = disk_check_type
@@ -392,7 +394,12 @@ class DiskChecker:
     def __call__(self, *args, **kw):
         return self.func(*args, **kw)
 
-    def set(self, disk_check_type_list):
+    def enable(self, disk_check_type_list):
+        """
+        If the current object's disk_check_type matches any in the list passed
+        :param disk_check_type_list: List of disk checks to enable
+        :return:
+        """
         if self.disk_check_type in disk_check_type_list:
             self.func = self.do_check_function
         else:
@@ -429,7 +436,7 @@ diskcheckers = [
 
 def set_diskcheck(enabled_checkers):
     for dc in diskcheckers:
-        dc.set(enabled_checkers)
+        dc.enable(enabled_checkers)
 
 
 def diskcheck_types():

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -54,7 +54,10 @@ def diskcheck_convert(value):
         if v == 'all':
             result = diskcheck_all
         elif v == 'none':
-            result = []
+            # Don't use an empty list here as that fails the normal check
+            # to see if an optparse parser of if parser.argname:
+            # Changed to ['none'] as diskcheck expects a list value
+            result = ['none']
         elif v in diskcheck_all:
             result.append(v)
         else:

--- a/test/diskcheck.py
+++ b/test/diskcheck.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the --diskcheck option and SetOption('diskcheck') correctly
@@ -41,16 +41,23 @@ test.write('file', "file\n")
 
 
 test.write('SConstruct', """
-SetOption('diskcheck', 'none')
+
+if GetOption('diskcheck') == ['match'] or ARGUMENTS.get('setoption_none',0):
+    SetOption('diskcheck', 'none')
 File('subdir')
 """)
 
-test.run()
+test.run(status=2, stderr=None)
+test.must_contain_all_lines(test.stderr(), ["found where file expected"])
 
 test.run(arguments='--diskcheck=match', status=2, stderr=None)
 test.must_contain_all_lines(test.stderr(), ["found where file expected"])
 
+# Test that setting --diskcheck to none via command line also works.
+test.run(arguments='--diskcheck=none')
 
+# Test that SetOption('diskcheck','none') works to override default as well
+test.run(arguments='setoption_none=1')
 
 test.pass_test()
 


### PR DESCRIPTION
Fixed using --diskcheck=none from command line. 
It was always broken SetOption('diskcheck','none') has been working all along. Also refactored the DiskChecker class to have more meaningful properties and not shadow default python objects (list, dir)..

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
