### PR TITLE
Add JAVAPROCESSORPATH construction variable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,6 +42,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       command lines using the generated tempfile for long command lines, instead of the full command line for
       the compilation step for the source/target pair.
 
+  From David H:
+    - Added JAVAPROCESSORPATH construction variable which populates -processorpath.
+    - Updated JavaScanner to scan JAVAPROCESSORPATH.
+
   From Dan Mezhiborsky:
     - Add newline to end of compilation db (compile_commands.json).
 

--- a/SCons/Scanner/Java.py
+++ b/SCons/Scanner/Java.py
@@ -59,9 +59,9 @@ def _collect_classes(classlist, dirname, files):
 
 
 def scan(node, env, libpath=()) -> list:
-    """Scan for files on the JAVACLASSPATH.
+    """Scan for files both on JAVACLASSPATH and JAVAPROCESSORPATH.
 
-    JAVACLASSPATH path can contain:
+    JAVACLASSPATH/JAVAPROCESSORPATH path can contain:
      - Explicit paths to JAR/Zip files
      - Wildcards (*)
      - Directories which contain classes in an unnamed package
@@ -70,8 +70,9 @@ def scan(node, env, libpath=()) -> list:
     Class path entries that are neither directories nor archives (.zip
     or JAR files) nor the asterisk (*) wildcard character are ignored.
     """
-    classpath = env.get('JAVACLASSPATH', [])
-    classpath = _subst_paths(env, classpath)
+    classpath = []
+    for var in ['JAVACLASSPATH', 'JAVAPROCESSORPATH']:
+        classpath += _subst_paths(env, env.get(var, []))
 
     result = []
     for path in classpath:

--- a/SCons/Scanner/JavaTests.py
+++ b/SCons/Scanner/JavaTests.py
@@ -179,6 +179,70 @@ class JavaScannerSearchPathClasspath(unittest.TestCase):
         deps_match(self, deps, expected)
 
 
+class JavaScannerEmptyProcessorpath(unittest.TestCase):
+    def runTest(self):
+        path = []
+        env = DummyEnvironment(JAVASUFFIXES=['.java'], JAVAPROCESSORPATH=path)
+        s = SCons.Scanner.Java.JavaScanner()
+        deps = s(DummyNode('dummy'), env)
+        expected = []
+        deps_match(self, deps, expected)
+
+
+class JavaScannerProcessorpath(unittest.TestCase):
+    def runTest(self):
+        env = DummyEnvironment(JAVASUFFIXES=['.java'],
+                               JAVAPROCESSORPATH=[test.workpath('classpath.jar')])
+        s = SCons.Scanner.Java.JavaScanner()
+        deps = s(DummyNode('dummy'), env)
+        expected = ['classpath.jar']
+        deps_match(self, deps, expected)
+
+
+class JavaScannerWildcardProcessorpath(unittest.TestCase):
+    def runTest(self):
+        env = DummyEnvironment(JAVASUFFIXES=['.java'],
+                               JAVAPROCESSORPATH=[test.workpath('*')])
+        s = SCons.Scanner.Java.JavaScanner()
+        deps = s(DummyNode('dummy'), env)
+        expected = ['bootclasspath.jar', 'classpath.jar', 'Test.class']
+        deps_match(self, deps, expected)
+
+
+class JavaScannerDirProcessorpath(unittest.TestCase):
+    def runTest(self):
+        env = DummyEnvironment(JAVASUFFIXES=['.java'],
+                               JAVAPROCESSORPATH=[test.workpath()])
+        s = SCons.Scanner.Java.JavaScanner()
+        deps = s(DummyNode('dummy'), env)
+        expected = ['Test.class', 'com/Test.class', 'java space/Test.class']
+        deps_match(self, deps, expected)
+
+
+class JavaScannerNamedDirProcessorpath(unittest.TestCase):
+    def runTest(self):
+        env = DummyEnvironment(
+            JAVASUFFIXES=['.java'],
+            JAVAPROCESSORPATH=[test.workpath('com'), test.workpath('java space')],
+        )
+        s = SCons.Scanner.Java.JavaScanner()
+        deps = s(DummyNode('dummy'), env)
+        expected = ['com/Test.class', 'java space/Test.class']
+        deps_match(self, deps, expected)
+
+
+class JavaScannerSearchPathProcessorpath(unittest.TestCase):
+    def runTest(self):
+        env = DummyEnvironment(
+            JAVASUFFIXES=['.java'],
+            JAVAPROCESSORPATH=os.pathsep.join([test.workpath('com'), test.workpath('java space')]),
+        )
+        s = SCons.Scanner.Java.JavaScanner()
+        deps = s(DummyNode('dummy'), env)
+        expected = ['com/Test.class', 'java space/Test.class']
+        deps_match(self, deps, expected)
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/SCons/Tool/javac.py
+++ b/SCons/Tool/javac.py
@@ -231,13 +231,15 @@ def generate(env):
         JAVABOOTCLASSPATH=[],
         JAVACLASSPATH=[],
         JAVASOURCEPATH=[],
+        JAVAPROCESSORPATH=[],
     )
     env['_javapathopt'] = pathopt
     env['_JAVABOOTCLASSPATH'] = '${_javapathopt("-bootclasspath", "JAVABOOTCLASSPATH")} '
+    env['_JAVAPROCESSORPATH'] = '${_javapathopt("-processorpath", "JAVAPROCESSORPATH")} '
     env['_JAVACLASSPATH'] = '${_javapathopt("-classpath", "JAVACLASSPATH")} '
     env['_JAVASOURCEPATH'] = '${_javapathopt("-sourcepath", "JAVASOURCEPATH", "_JAVASOURCEPATHDEFAULT")} '
     env['_JAVASOURCEPATHDEFAULT'] = '${TARGET.attributes.java_sourcedir}'
-    env['_JAVACCOM'] = '$JAVAC $JAVACFLAGS $_JAVABOOTCLASSPATH $_JAVACLASSPATH -d ${TARGET.attributes.java_classdir} $_JAVASOURCEPATH $SOURCES'
+    env['_JAVACCOM'] = '$JAVAC $JAVACFLAGS $_JAVABOOTCLASSPATH $_JAVAPROCESSORPATH $_JAVACLASSPATH -d ${TARGET.attributes.java_classdir} $_JAVASOURCEPATH $SOURCES'
     env['JAVACCOM'] = "${TEMPFILE('$_JAVACCOM','$JAVACCOMSTR')}"
 
 def exists(env):

--- a/SCons/Tool/javac.xml
+++ b/SCons/Tool/javac.xml
@@ -174,6 +174,9 @@ env['ENV']['LANG'] = 'en_GB.UTF-8'
                 to supply the path in a system-independent manner,
                 give &cv-JAVAPROCESSORPATH; as a list of paths instead.
             </para>
+            <para>
+                <emphasis>New in version 4.5.0</emphasis>
+            </para>
         </summary>
     </cvar>
 

--- a/SCons/Tool/javac.xml
+++ b/SCons/Tool/javac.xml
@@ -152,6 +152,31 @@ env['ENV']['LANG'] = 'en_GB.UTF-8'
         </summary>
     </cvar>
 
+    <cvar name="JAVAPROCESSORPATH">
+        <summary>
+            <para>
+                Specifies the location of the annotation processor class files.
+                Can be specified as a string or Node object,
+                or as a list of strings or Node objects.
+            </para>
+            <para>
+                The value will be added to the JDK command lines
+                via the <option>-processorpath</option> option,
+                which requires a system-specific search path separator.
+                This will be supplied by &SCons; as needed when it
+                constructs the command line if &cv-JAVAPROCESSORPATH; is
+                provided in list form.
+                If &cv-JAVAPROCESSORPATH; is a single string containing
+                search path separator characters
+                (<literal>:</literal> for POSIX systems or
+                <literal>;</literal> for Windows), it will not be modified;
+                and so is inherently system-specific;
+                to supply the path in a system-independent manner,
+                give &cv-JAVAPROCESSORPATH; as a list of paths instead.
+            </para>
+        </summary>
+    </cvar>
+
     <cvar name="JAVAINCLUDES">
         <summary>
             <para>

--- a/test/Java/JAVAPROCESSORPATH.py
+++ b/test/Java/JAVAPROCESSORPATH.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Verify that use of $JAVAPROCESSORPATH sets the -processorpath option
+on javac compilations.
+"""
+
+import os
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+where_javac, java_version = test.java_where_javac()
+
+test.write('SConstruct', """
+DefaultEnvironment(tools=[])
+env = Environment(tools=['javac'], JAVAPROCESSORPATH=['dir1', 'dir2'])
+j1 = env.Java(target='class', source='com/Example1.java')
+j2 = env.Java(target='class', source='com/Example2.java')
+""")
+
+test.subdir('com')
+
+test.write(['com', 'Example1.java'], """\
+package com;
+
+public class Example1
+{
+
+     public static void main(String[] args)
+     {
+
+     }
+
+}
+""")
+
+test.write(['com', 'Example2.java'], """\
+package com;
+
+public class Example2
+{
+
+     public static void main(String[] args)
+     {
+
+     }
+
+}
+""")
+
+# Setting -processorpath messes with the Java runtime environment, so
+# we'll just take the easy way out and examine the -n output to see if
+# the expected option shows up on the command line.
+
+processorpath = os.pathsep.join(['dir1', 'dir2'])
+
+expect = """\
+javac -processorpath %(processorpath)s -d class -sourcepath com com.Example1\\.java
+javac -processorpath %(processorpath)s -d class -sourcepath com com.Example2\\.java
+""" % locals()
+
+test.run(arguments = '-Q -n .', stdout = expect, match=TestSCons.match_re)
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Adds JAVAPROCESSORPATH construction variable; updates JavaScanner to scan JAVAPROCESSORPATH.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
