### PR TITLE
Doc: update msvc, add version table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -106,6 +106,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       not be cached because the emitted filename contained a '$' and when
       looked up through a node ended up generating a Python SyntaxError
       because it was passed through scons_subst().
+    - Updated MSVC documentation - adds "version added" annotations on recently
+      added construction variables and provides a version-mapping table.
+
 
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -117,6 +117,8 @@ DOCUMENTATION
 - Updated the User Guide chapter on variant directories with more
   explanation, and the introduction of terms like "out of tree" that
   may help in forming a mental model.
+- Updated MSVC documentation - adds "version added" annotations on recently
+  added construction variables and provides a version-mapping table.
 
 DEVELOPMENT
 -----------

--- a/SCons/Tool/msvc.xml
+++ b/SCons/Tool/msvc.xml
@@ -1,31 +1,10 @@
 <?xml version="1.0"?>
 <!--
- MIT License
-
- Copyright The SCons Foundation
-
- Permission is hereby granted, free of charge, to any person obtaining
- a copy of this software and associated documentation files (the
- "Software"), to deal in the Software without restriction, including
- without limitation the rights to use, copy, modify, merge, publish,
- distribute, sublicense, and/or sell copies of the Software, and to
- permit persons to whom the Software is furnished to do so, subject to
- the following conditions:
-
- The above copyright notice and this permission notice shall be included
- in all copies or substantial portions of the Software.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
- KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
- WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright The SCons Foundation
+SPDX-FileType: DOCUMENTATION
 
 This file is processed by the bin/SConsDoc.py module.
-See its __doc__ string for a discussion of the format.
 -->
 
 <!DOCTYPE sconsdoc [
@@ -48,7 +27,7 @@ See its __doc__ string for a discussion of the format.
 <tool name="msvc">
 <summary>
 <para>
-Sets construction variables for the Microsoft Visual C/C++ compiler.
+Sets &consvars; for the Microsoft Visual C/C++ compiler.
 </para>
 </summary>
 <sets>
@@ -96,7 +75,17 @@ Sets construction variables for the Microsoft Visual C/C++ compiler.
 <item>PCH</item>
 <item>PCHSTOP</item>
 <item>PDB</item>
+<item>MSVC_VERSION</item>
+<item>MSVC_USE_SCRIPT</item>
+<item>MSVC_USE_SCRIPT_ARGS</item>
+<item>MSVC_USE_SETTINGS</item>
 <item>MSVC_NOTFOUND_POLICY</item>
+<item>MSVC_SCRIPTERROR_POLICY</item>
+<item>MSVC_SCRIPT_ARGS</item>
+<item>MSVC_SDK_VERSION</item>
+<item>MSVC_TOOLSET_VERSION</item>
+<item>MSVC_SPECTRE_LIBS</item>
+
 </uses>
 </tool>
 
@@ -110,7 +99,7 @@ file as the second element. Normally the object file is ignored.
 This builder is only
 provided when Microsoft Visual C++ is being used as the compiler.
 The &b-PCH; builder is generally used in
-conjunction with the &cv-link-PCH; construction variable to force object files to use
+conjunction with the &cv-link-PCH; &consvar; to force object files to use
 the precompiled header:
 </para>
 
@@ -148,7 +137,7 @@ Options added to the compiler command line
 to support building with precompiled headers.
 The default value expands expands to the appropriate
 Microsoft Visual C++ command-line options
-when the &cv-link-PCH; construction variable is set.
+when the &cv-link-PCH; &consvar; is set.
 </para>
 </summary>
 </cvar>
@@ -161,7 +150,7 @@ to support storing debugging information in a
 Microsoft Visual C++ PDB file.
 The default value expands expands to appropriate
 Microsoft Visual C++ command-line options
-when the &cv-link-PDB; construction variable is set.
+when the &cv-link-PDB; &consvar; is set.
 </para>
 
 <para>
@@ -208,11 +197,11 @@ compilation of object files
 when calling the Microsoft Visual C/C++ compiler.
 All compilations of source files from the same source directory
 that generate target files in a same output directory
-and were configured in SCons using the same construction environment
+and were configured in SCons using the same &consenv;
 will be built in a single call to the compiler.
 Only source files that have changed since their
 object files were built will be passed to each compiler invocation
-(via the &cv-link-CHANGED_SOURCES; construction variable).
+(via the &cv-link-CHANGED_SOURCES; &consvar;).
 Any compilations where the object (target) file base name
 (minus the <filename>.obj</filename>)
 does not match the source file base name
@@ -261,9 +250,9 @@ If this is not set, then &cv-link-PCHCOM; (the command line) is displayed.
 <cvar name="PCHPDBFLAGS">
 <summary>
 <para>
-A construction variable that, when expanded,
+A &consvar; that, when expanded,
 adds the <option>/yD</option> flag to the command line
-only if the &cv-link-PDB; construction variable is set.
+only if the &cv-link-PDB; &consvar; is set.
 </para>
 </summary>
 </cvar>
@@ -324,7 +313,7 @@ The flags passed to the resource compiler by the &b-link-RES; builder.
 <cvar name="RCINCFLAGS">
 <summary>
 <para>
-An automatically-generated construction variable
+An automatically-generated &consvar;
 containing the command-line options
 for specifying directories to be searched
 by the resource compiler.
@@ -343,7 +332,7 @@ of each directory in &cv-link-CPPPATH;.
 The prefix (flag) used to specify an include directory
 on the resource compiler command line.
 This will be prepended to the beginning of each directory
-in the &cv-link-CPPPATH; construction variable
+in the &cv-link-CPPPATH; &consvar;
 when the &cv-link-RCINCFLAGS; variable is expanded.
 </para>
 </summary>
@@ -355,7 +344,7 @@ when the &cv-link-RCINCFLAGS; variable is expanded.
 The suffix used to specify an include directory
 on the resource compiler command line.
 This will be appended to the end of each directory
-in the &cv-link-CPPPATH; construction variable
+in the &cv-link-CPPPATH; &consvar;
 when the &cv-link-RCINCFLAGS; variable is expanded.
 </para>
 </summary>
@@ -365,12 +354,10 @@ when the &cv-link-RCINCFLAGS; variable is expanded.
 <summary>
 <para>
 Sets the preferred  version of Microsoft Visual C/C++ to use.
-</para>
-
-<para>
+If the specified version is unavailable (not installed,
+or not discoverable), tool initialization will fail.
 If &cv-MSVC_VERSION; is not set, SCons will (by default) select the
-latest version of Visual C/C++ installed on your system.  If the
-specified version isn't installed, tool initialization will fail.
+latest version of Visual C/C++ installed on your system.
 </para>
 
 <para>
@@ -383,28 +370,186 @@ loaded into the environment.
 </para>
 
 <para>
-Valid values for Windows are
-<literal>14.3</literal>,
-<literal>14.2</literal>,
-<literal>14.1</literal>,
-<literal>14.1Exp</literal>,
-<literal>14.0</literal>,
-<literal>14.0Exp</literal>,
-<literal>12.0</literal>,
-<literal>12.0Exp</literal>,
-<literal>11.0</literal>,
-<literal>11.0Exp</literal>,
-<literal>10.0</literal>,
-<literal>10.0Exp</literal>,
-<literal>9.0</literal>,
-<literal>9.0Exp</literal>,
-<literal>8.0</literal>,
-<literal>8.0Exp</literal>,
-<literal>7.1</literal>,
-<literal>7.0</literal>,
-and <literal>6.0</literal>.
-Versions ending in <literal>Exp</literal> refer to "Express" or
-"Express for Desktop" editions.
+The valid values for &cv-MSVC_VERSION; represent major versions
+of the compiler, except that versions ending in <literal>Exp</literal>
+refer to "Express" or "Express for Desktop" Visual Studio editions,
+which require distict entries because they use a different
+filesystem layout and have some feature limitations compared to
+the full version.
+The following table shows correspondence
+of the selector string to various version indicators
+('x' is used as a placeholder for
+a single digit that can vary).
+Note that it is not necessary to install Visual Studio
+to build with &SCons; (for example, you can install only
+Build Tools), but if Visual Studio is installed,
+additional builders such as &b-link-MSVSSolution; and
+&b-link-MSVSProject; become avaialable and will
+correspond to the indicated versions.
+</para>
+
+<informaltable>
+  <tgroup cols="5">
+    <colspec align="left" />
+    <colspec align="center" />
+    <colspec align="center" />
+    <colspec align="left" />
+    <colspec align="center" />
+    <thead>
+      <row>
+        <entry> SCons Key </entry>
+        <entry> MSVC++ Version </entry>
+        <entry> <literal>_MSVC_VER</literal> </entry>
+        <entry> VS Product </entry>
+        <entry> MSBuild/VS Version </entry>
+      </row>
+    </thead>
+    <tbody>
+      <row>
+        <entry> <literal>14.3</literal> </entry>
+        <entry> 14.3x </entry>
+        <entry> 193x </entry>
+        <entry> Visual Studio 2022 </entry>
+        <entry> 17.x </entry>
+      </row>
+      <row>
+        <entry> <literal>14.2</literal> </entry>
+        <entry> 14.2x </entry>
+        <entry> 192x </entry>
+        <entry> Visual Studio 2019 </entry>
+        <entry> 16.x, 16.1x </entry>
+      </row>
+      <row>
+        <entry> <literal>14.1</literal> </entry>
+        <entry> 14.1 or 14.1x </entry>
+        <entry> 191x </entry>
+        <entry> Visual Studio 2017 </entry>
+        <entry> 15.x </entry>
+      </row>
+      <row>
+        <entry> <literal>14.1Exp</literal> </entry>
+        <entry> 14.1 </entry>
+        <entry> 1910 </entry>
+        <entry> Visual Studio 2017 Express </entry>
+        <entry> 15.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>14.0</literal> </entry>
+        <entry> 14.0 </entry>
+        <entry> 1900 </entry>
+        <entry> Visual Studio 2015 </entry>
+        <entry> 14.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>14.0Exp</literal> </entry>
+        <entry> 14.0 </entry>
+        <entry> 1900 </entry>
+        <entry> Visual Studio 2015 Express </entry>
+        <entry> 14.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>12.0</literal> </entry>
+        <entry> 12.0 </entry>
+        <entry> 1800 </entry>
+        <entry> Visual Studio 2013 </entry>
+        <entry> 12.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>12.0Exp</literal> </entry>
+        <entry> 12.0 </entry>
+        <entry> 1800 </entry>
+        <entry> Visual Studio 2013 Express </entry>
+        <entry> 12.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>11.0</literal> </entry>
+        <entry> 11.0 </entry>
+        <entry> 1700 </entry>
+        <entry> Visual Studio 2012 </entry>
+        <entry> 11.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>11.0Exp</literal> </entry>
+        <entry> 11.0 </entry>
+        <entry> 1700 </entry>
+        <entry> Visual Studio 2012 Express </entry>
+        <entry> 11.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>10.0</literal> </entry>
+        <entry> 10.0 </entry>
+        <entry> 1600 </entry>
+        <entry> Visual Studio 2010 </entry>
+        <entry> 10.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>10.0Exp</literal> </entry>
+        <entry> 10.0 </entry>
+        <entry> 1600 </entry>
+        <entry> Visual C++ Express 2010 </entry>
+        <entry> 10.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>9.0</literal> </entry>
+        <entry> 9.0 </entry>
+        <entry> 1500 </entry>
+        <entry> Visual Studio 2008 </entry>
+        <entry> 9.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>9.0Exp</literal> </entry>
+        <entry> 9.0 </entry>
+        <entry> 1500 </entry>
+        <entry> Visual C++ Express 2008 </entry>
+        <entry> 9.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>8.0</literal> </entry>
+        <entry> 8.0 </entry>
+        <entry> 1400 </entry>
+        <entry> Visual Studio 2005 </entry>
+        <entry> 8.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>8.0Exp</literal> </entry>
+        <entry> 8.0 </entry>
+        <entry> 1400 </entry>
+        <entry> Visual C++ Express 2005 </entry>
+        <entry> 8.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>7.1</literal> </entry>
+        <entry> 7.1 </entry>
+        <entry> 1300 </entry>
+        <entry> Visual Studio .NET 2003 </entry>
+        <entry> 7.1 </entry>
+      </row>
+      <row>
+        <entry> <literal>7.0</literal> </entry>
+        <entry> 7.0 </entry>
+        <entry> 1200 </entry>
+        <entry> Visual Studio .NET 2002 </entry>
+        <entry> 7.0 </entry>
+      </row>
+      <row>
+        <entry> <literal>6.0</literal> </entry>
+        <entry> 6.0 </entry>
+        <entry> 1100 </entry>
+        <entry> Visual Studio 6.0 </entry>
+        <entry> 6.0 </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</informaltable>
+
+<para>
+The compilation environment can be further or more precisely specified through the
+use of several other &consvars;: see the descriptions of
+&cv-link-MSVC_TOOLSET_VERSION;,
+&cv-link-MSVC_SDK_VERSION;,
+&cv-link-MSVC_USE_SCRIPT;,
+&cv-link-MSVC_USE_SCRIPT_ARGS;,
+and &cv-link-MSVC_USE_SETTINGS;.
 </para>
 
 </summary>
@@ -433,7 +578,7 @@ This can be useful to force the use of a compiler version that
 Setting
 &cv-MSVC_USE_SCRIPT; to <constant>None</constant> bypasses the
 Visual Studio autodetection entirely;
-use this if you are running SCons in a Visual Studio <command>cmd</command>
+use this if you are running &SCons; in a Visual Studio <command>cmd</command>
 window and importing the shell's environment variables - that
 is, if you are sure everything is set correctly already and
 you don't want &SCons; to change anything.
@@ -441,6 +586,12 @@ you don't want &SCons; to change anything.
 <para>
 &cv-MSVC_USE_SCRIPT; ignores &cv-link-MSVC_VERSION; and &cv-link-TARGET_ARCH;.
 </para>
+
+<para><emphasis>Changed in version 4.4:</emphasis>
+new &cv-link-MSVC_USE_SCRIPT_ARGS; provides a
+way to pass arguments.
+</para>
+
 </summary>
 </cvar>
 
@@ -449,6 +600,9 @@ you don't want &SCons; to change anything.
 <para>
 Provides arguments passed to the script &cv-link-MSVC_USE_SCRIPT;.
 </para>
+
+<para><emphasis>New in version 4.4</emphasis></para>
+
 </summary>
 </cvar>
 
@@ -529,10 +683,14 @@ therefore may change at any time.
 </emphasis>
 The burden is on the user to ensure the dictionary contents are minimally sufficient to
 ensure successful builds.
-</para></listitem>
+</para>
+
+</listitem>
 
 </itemizedlist>
 </para>
+
+<para><emphasis>New in version 4.4</emphasis></para>
 
 </summary>
 </cvar>
@@ -780,6 +938,8 @@ When &cv-MSVC_NOTFOUND_POLICY; is not specified, the default &scons; behavior is
 subject to the conditions listed above. The default &scons; behavior may change in the future.
 </para>
 
+<para><emphasis>New in version 4.4</emphasis></para>
+
 </summary>
 </cvar>
 
@@ -831,6 +991,9 @@ Issue a warning when msvc batch file errors are detected.
 <para>
 Suppress msvc batch file error messages.
 </para>
+
+<para><emphasis>New in version 4.4</emphasis></para>
+
 </listitem>
 </varlistentry>
 
@@ -905,6 +1068,8 @@ when setting the script error policy to raise an exception (e.g., <literal>'Erro
 </itemizedlist>
 </para>
 
+<para><emphasis>New in version 4.4</emphasis></para>
+
 </summary>
 </cvar>
 
@@ -916,8 +1081,8 @@ Pass user-defined arguments to the Visual C++ batch file determined via autodete
 
 <para>
 &cv-MSVC_SCRIPT_ARGS; is available for msvc batch file arguments that do not have first-class support
-via construction variables or when there is an issue with the appropriate construction variable validation.
-When available, it is recommended to use the appropriate construction variables (e.g., &cv-link-MSVC_TOOLSET_VERSION;)
+via &consvars; or when there is an issue with the appropriate &consvar; validation.
+When available, it is recommended to use the appropriate &consvars; (e.g., &cv-link-MSVC_TOOLSET_VERSION;)
 rather than &cv-MSVC_SCRIPT_ARGS; arguments.
 </para>
 
@@ -1041,6 +1206,8 @@ and compatible with the version of msvc selected.
 </itemizedlist>
 </para>
 
+<para><emphasis>New in version 4.4</emphasis></para>
+
 </summary>
 </cvar>
 
@@ -1158,6 +1325,8 @@ specify a Windows 10 SDK (e.g., <literal>'10.0.20348.0'</literal>) for the build
 
 </itemizedlist>
 </para>
+
+<para><emphasis>New in version 4.4</emphasis></para>
 
 </summary>
 </cvar>
@@ -1329,6 +1498,8 @@ The burden is on the user to ensure the requisite toolset target architecture bu
 </itemizedlist>
 </para>
 
+<para><emphasis>New in version 4.4</emphasis></para>
+
 </summary>
 </cvar>
 
@@ -1408,6 +1579,8 @@ The burden is on the user to ensure the requisite libraries with spectre mitigat
 
 </itemizedlist>
 </para>
+
+<para><emphasis>New in version 4.4</emphasis></para>
 
 </summary>
 </cvar>


### PR DESCRIPTION
The changes in 4.4 didn't mark new construction variables with the now preferred version add marker, so added these.

The references to different versions gets so confusing that to try to help added a version correspondence table to the `MSVC_VERSION` construction variable doc.

Doc-only change.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
