### PR TITLE
Adjust the appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,30 +17,32 @@ cache:
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 install:
-  # add python and python user-base to path for pip installs
+  # direct choco install supposed to work, but not? still doing in install.bat
+  #- cinst: dmd ldc swig vswhere ixsltproc winflexbison3
   - cmd: .\.appveyor\install.bat
+  - cmd: if %COVERAGE% equ 1 .\.appveyor\install-cov.bat
 
-# build matrix will be number of images multiplied by each '-' below,
-# less any exclusions.
-# split builds into sets of four jobs due to appveyor per-job time limit
-# Leaving the Coverage build on VS2017 for build-time reasons (1hr time limit)
-# Maybe move this one somewhere else in future to restore some flexibility.
+# Build matrix will be number of images multiplied by #entries in matrix:,
+# less any excludes.
+#
+# "Build" is kind of a misnomer - we are actually running the test suite,
+# and this is slow on Windows, so keep the matrix as small as possible.
+# Leaving the Coverage build on VS2017 for build-time reasons (1hr time limit).
+# maybe move coverage to github in future to restore some flexibility?
 environment:
+  COVERAGE: 0
+  SCONS_CACHE_MSVC_CONFIG: "true"
   matrix:
-
+    # Test oldest and newest supported Pythons, and a subset in between.
+    # Skipping 3.7 and 3.9 at this time
     - WINPYTHON: "Python311"
-      COVERAGE: 0
 
     - WINPYTHON: "Python310"
-      COVERAGE: 0
 
     - WINPYTHON: "Python38"
-      COVERAGE: 0
-          
+
     - WINPYTHON: "Python36"
       COVERAGE: 1
-
-    # skipping 3.7 and 3.9 at this time
 
 # remove sets of build jobs based on criteria below
 # to fine tune the number and platforms tested
@@ -68,21 +70,23 @@ matrix:
     - image: Visual Studio 2022
       WINPYTHON: "Python38"
 
-# remove some binaries we don't want to be found
+# Remove some binaries we don't want to be found
+# Note this is no longer needed, git-windows bin/ is quite minimal now.
 before_build:
     - ps: .\.appveyor\ignore_git_bins.ps1
 
 build: off
 
 build_script:
-
-  # exclude VS 10.0 because it hangs the testing until this is resolved:
-  # https://help.appveyor.com/discussions/problems/19283-visual-studio-2010-trial-license-has-expired
-  - ps: .\.appveyor\disable_msvc_10.ps1
+  # Image version-based excludes:
+  # No excludes at the moment, but the exclude script generates the
+  # (possibly empty) exclude_list.txt which is used in the following step,
+  # so leave the scheme in place in case we need to put back excludes later.
+  - ps: .\.appveyor\exclude_tests.ps1
 
   # setup coverage by creating the coverage config file, and adding coverage
   # to the sitecustomize so that all python processes start with coverage
-  - ps: .\.appveyor\coverage_setup.ps1
+  - ps: if ($env:COVERAGE -eq 1) { .\.appveyor\coverage_setup.ps1 }
 
   # NOTE: running powershell from cmd is intended because
   # it formats the output correctly
@@ -90,8 +94,7 @@ build_script:
 
 # run coverage even if there was a test failure
 on_finish:
-  - ps: .\.appveyor\coverage_report.ps1
-  # running codecov in powershell causes an error so running in platform
-  # shells
+  - ps: if ($env:COVERAGE -eq 1) { .\.appveyor\coverage_report.ps1 }
+  # running codecov in powershell causes an error so running in cmd
   - cmd: if %COVERAGE% equ 1 codecov -X gcov --file coverage_xml.xml
 

--- a/.appveyor/exclude_tests.ps1
+++ b/.appveyor/exclude_tests.ps1
@@ -1,4 +1,7 @@
 New-Item -Name exclude_list.txt -ItemType File;
+
+# exclude VS 10.0 because it hangs the testing until this is resolved:
+# https://help.appveyor.com/discussions/problems/19283-visual-studio-2010-trial-license-has-expired
 $workaround_image = "Visual Studio 2015";
 if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq $workaround_image) {
     Add-Content -Path 'exclude_list.txt' -Value 'test\MSVS\vs-10.0-exec.py';

--- a/.appveyor/install-cov.bat
+++ b/.appveyor/install-cov.bat
@@ -1,0 +1,2 @@
+for /F "tokens=*" %%g in ('C:\\%WINPYTHON%\\python.exe -c "import sys; print(sys.path[-1])"') do (set PYSITEDIR=%%g)
+C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off coverage codecov

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -1,12 +1,14 @@
 C:\\%WINPYTHON%\\python.exe --version
 for /F "tokens=*" %%g in ('C:\\%WINPYTHON%\\python.exe -c "import sys; print(sys.path[-1])"') do (set PYSITEDIR=%%g)
 REM use mingw 32 bit until #3291 is resolved
+REM add python and python user-base to path for pip installs
 set PATH=C:\\%WINPYTHON%;C:\\%WINPYTHON%\\Scripts;C:\\ProgramData\\chocolatey\\bin;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin;C:\\cygwin\\bin;C:\\msys64\\usr\\bin;C:\\msys64\\mingw64\\bin;%PATH%
 C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off pip setuptools wheel
-C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off coverage codecov
-set STATIC_DEPS=true & C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off lxml
-C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off -r requirements-dev.txt
-REM install 3rd party tools to test with
+REM No real use for lxml on Windows (and some versions don't have it):
+REM We don't install the docbook bits so those tests won't run anyway
+REM The Windows builds don't attempt to make the docs
+REM Adjust this as requirements-dev.txt changes.
+REM C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off -r requirements-dev.txt
+C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off ninja psutil
 choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc winflexbison3
-set SCONS_CACHE_MSVC_CONFIG=true
 set


### PR DESCRIPTION
Skip lxml if Python version doesn't have wheel yet Skip installing coverage if not a coverage run
Drop an uneeded test skip

Unsure if this will work...

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
