### PR TITLE
Py311 lxml win32 requirements fix

### DIFF
--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -4,11 +4,10 @@ REM use mingw 32 bit until #3291 is resolved
 REM add python and python user-base to path for pip installs
 set PATH=C:\\%WINPYTHON%;C:\\%WINPYTHON%\\Scripts;C:\\ProgramData\\chocolatey\\bin;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin;C:\\cygwin\\bin;C:\\msys64\\usr\\bin;C:\\msys64\\mingw64\\bin;%PATH%
 C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off pip setuptools wheel
-REM No real use for lxml on Windows (and some versions don't have it):
-REM We don't install the docbook bits so those tests won't run anyway
-REM The Windows builds don't attempt to make the docs
-REM Adjust this as requirements-dev.txt changes.
-REM C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off -r requirements-dev.txt
-C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off ninja psutil
+
+REM requirements-dev.txt will skip installing lxml for windows and py 3.11+, where there's
+REM no current binary wheel
+C:\\%WINPYTHON%\\python.exe -m pip install -U --progress-bar off -r requirements-dev.txt
+
 choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc winflexbison3
 set

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,9 +4,8 @@
 
 # for now keep pinning "known working" lxml,
 # it's been a troublesome component in the past.
-# Skip  lxml for python 3.11+ on win32 as there's no binary wheel as of 01/22/2023
-lxml==4.9.2 ; python_version < '3.12' and sys_platform == 'win32'
-lxml==4.9.2 ; sys_platform != 'win32'
+# Skip  lxml for win32 as no tests which require it currently pass on win32
+lxml==4.9.2; python_version < 3.12 and sys_platform != 'win32'
 
 ninja
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,9 @@
 
 # for now keep pinning "known working" lxml,
 # it's been a troublesome component in the past.
-lxml==4.9.1
+# Skip  lxml for python 3.11+ on win32 as there's no binary wheel as of 01/22/2023
+lxml==4.9.1 ; python_version < '3.11' and sys_platform != 'win32'
+
 ninja
 
 # Needed for test/Parallel/failed-build/failed-build.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,8 @@
 # for now keep pinning "known working" lxml,
 # it's been a troublesome component in the past.
 # Skip  lxml for python 3.11+ on win32 as there's no binary wheel as of 01/22/2023
-lxml==4.9.1 ; python_version < '3.11' and sys_platform != 'win32'
+lxml==4.9.2 ; python_version < '3.12' and sys_platform == 'win32'
+lxml==4.9.2 ; sys_platform != 'win32'
 
 ninja
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@
 # for now keep pinning "known working" lxml,
 # it's been a troublesome component in the past.
 # Skip  lxml for win32 as no tests which require it currently pass on win32
-lxml==4.9.2; python_version < 3.12 and sys_platform != 'win32'
+lxml==4.9.2; python_version < '3.12' and sys_platform != 'win32'
 
 ninja
 

--- a/requirements-pkg.txt
+++ b/requirements-pkg.txt
@@ -8,6 +8,6 @@
 readme-renderer
 
 # sphinx pinned because it has broken several times on new releases
-sphinx>=5.1.1
+sphinx < 6.0
 sphinx-book-theme
 rst2pdf


### PR DESCRIPTION
Add conditonal logic to requirements-dev.txt to skip lxml for win32 and python 3.11+


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
