### PR TITLE
Minor tex test fix

### DIFF
--- a/bin/scons_dev_master.py
+++ b/bin/scons_dev_master.py
@@ -42,7 +42,6 @@ BUILDING_PACKAGES = [
     
     # additional packages that Bill Deegan's web page suggests
     #'docbook-to-man',
-    #'docbook-xsl',
     #'docbook2x',
     #'tetex-bin',
     #'tetex-latex',
@@ -86,9 +85,13 @@ TESTING_PACKAGES = [
     'openjdk-8-jdk',
     'swig',
     'texlive-base-bin',
+    'texlive-font-utils',
     'texlive-extra-utils',
     'texlive-latex-base',
     'texlive-latex-extra',
+    'texlive-bibtex-extra',
+    'docbook-xsl',
+    'biber',
     'zip',
 ]
 

--- a/test/TEX/newglossary.py
+++ b/test/TEX/newglossary.py
@@ -87,12 +87,12 @@ Acronyms \gls{gnu} and glossary entries \gls{nix}.
 
 a definition \gls{defPower}
 
-\glossarystyle{index}
+\setglossarystyle{index}
 \printglossary[type=symbol]
 \printglossary[type=acronym]
 \printglossary[type=main]
 \printglossary[type=definition]
-\glossarystyle{super}
+\setglossarystyle{super}
 
 \end{document}""")
 


### PR DESCRIPTION
Syntax of selecting a glossary updated - apparently the late 2022.* texlive releases have started warning and prompting for action on this which appears to be what breaks the test.

Not directly related to this test, but to trying to get a reasonable set of tests to run, added some pkgs to `bin/scons_dev_master.py` - this has absolutely no effect on SCons itself.

So in terms of scons: a test-only change.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
