### PR TITLE
Build out manpage section on --debug=pdb

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,8 +24,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Python 3.9 dropped the alias base64.decodestring, deprecated since 3.1.
       Only used in msvs.py. Use base64.decodebytes instead.
     - When debugging (--debug=pdb), the filenames SConstruct and SConscript
-      are now recognized when manipulating breakpoints. Previously, only a
-      full pathname worked, as otherwise pdb required a .py extension on files.
+      are now recognized when manipulating breakpoints. Previously,
+      only a full pathname to an sconscript file worked, as pdb requires
+      a .py extension to open a file that is not an absolute path.
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       calls dunder method __call__. Invoke instance directly."
     - Python 3.9 dropped the alias base64.decodestring, deprecated since 3.1.
       Only used in msvs.py. Use base64.decodebytes instead.
+    - When debugging (--debug=pdb), the filenames SConstruct and SConscript
+      are now recognized when manipulating breakpoints. Previously, only a
+      full pathname worked, as otherwise pdb required a .py extension on files.
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/NEWS.d/changes/4306.bugfix
+++ b/NEWS.d/changes/4306.bugfix
@@ -1,0 +1,5 @@
+
+When debugging (--debug=pdb), the filenames SConstruct and SConscript
+are now recognized when manipulating breakpoints. Previously, only a
+full pathname worked, as otherwise pdb required a .py extension on files.
+

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -26,8 +26,10 @@ DEPRECATED FUNCTIONALITY
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 
-- List modifications to existing features, where the previous behavior
-  wouldn't actually be considered a bug
+- When debugging (--debug=pdb), the filenames SConstruct and SConscript
+  are now recognized when manipulating breakpoints. Previously,
+  only a full pathname to an sconscript file worked, as pdb requires
+  a .py extension to open a file that is not an absolute path.
 
 FIXES
 -----

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -76,6 +76,16 @@ KNOWN_SCONSTRUCT_NAMES = [
     'sconstruct.py',
 ]
 
+# list of names regognized by debugger as "SConscript files" (inc. SConstruct)
+# files suffixed .py always work so don't need to be in this list.
+KNOWN_SCONSCRIPTS = [
+    "SConstruct",
+    "Sconstruct",
+    "sconstruct",
+    "SConscript",
+    "sconscript",
+]
+
 # Global variables
 first_command_start = None
 last_command_end = None
@@ -1397,11 +1407,12 @@ def _exec_main(parser, values) -> None:
             def lookupmodule(self, filename: str) -> Optional[str]:
                 """Helper function for break/clear parsing -- SCons version.
 
-                translates (possibly incomplete) file or module name
-                into an absolute file name.
-
-                The SCons override recognizes common names for ``SConstruct``
-                and ``SConscript`` without requiring a ``.py`` suffix.
+                Translates (possibly incomplete) file or module name
+                into an absolute file name. The "possibly incomplete"
+                means adding a ``.py`` suffix if not present, which breaks
+                picking breakpoints in sconscript files, which often don't
+                have a suffix. This version fixes for some known names of
+                sconscript files that don't have the suffix.
 
                 .. versionadded:: 4.6.0
                 """
@@ -1411,11 +1422,8 @@ def _exec_main(parser, values) -> None:
                 if os.path.exists(f) and self.canonic(f) == self.mainpyfile:
                     return f
                 root, ext = os.path.splitext(filename)
-                SCONSCRIPTS = (
-                    "SConstruct Sconstruct sconstruct SConscript sconscript".split()
-                )
                 base = os.path.split(filename)[-1]
-                if ext == '' and base not in SCONSCRIPTS:  # SCons
+                if ext == '' and base not in KNOWN_SCONSCRIPTS:  # SCons mod
                     filename = filename + '.py'
                 if os.path.isabs(filename):
                     return filename

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1397,10 +1397,13 @@ def _exec_main(parser, values) -> None:
             def lookupmodule(self, filename: str) -> Optional[str]:
                 """Helper function for break/clear parsing -- SCons version.
 
-                Copy of the original, but recognizes common names for
-                SConstruct/SConscript without having to have them end in ``.py``
+                translates (possibly incomplete) file or module name
+                into an absolute file name.
 
-                .. versionadded:: 4.5.0
+                The SCons override recognizes common names for ``SConstruct``
+                and ``SConscript`` without requiring a ``.py`` suffix.
+
+                .. versionadded:: 4.6.0
                 """
                 if os.path.isabs(filename) and os.path.exists(filename):
                     return filename
@@ -1412,7 +1415,7 @@ def _exec_main(parser, values) -> None:
                     "SConstruct Sconstruct sconstruct SConscript sconscript".split()
                 )
                 base = os.path.split(filename)[-1]
-                if ext == '' and base not in SCONSCRIPTS:
+                if ext == '' and base not in SCONSCRIPTS:  # SCons
                     filename = filename + '.py'
                 if os.path.isabs(filename):
                     return filename

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -76,7 +76,7 @@ KNOWN_SCONSTRUCT_NAMES = [
     'sconstruct.py',
 ]
 
-# list of names regognized by debugger as "SConscript files" (inc. SConstruct)
+# list of names recognized by debugger as "SConscript files" (inc. SConstruct)
 # files suffixed .py always work so don't need to be in this list.
 KNOWN_SCONSCRIPTS = [
     "SConstruct",

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -959,9 +959,53 @@ of the various classes used internally by SCons.</para>
   <varlistentry>
   <term><emphasis role="bold">pdb</emphasis></term>
   <listitem>
-<para>Re-run &scons; under the control of the
+<para>Run &scons; under control of the
 <systemitem>pdb</systemitem>
 &Python; debugger.</para>
+<screen>
+$ <userinput>scons --debug=pdb</userinput>
+> /usr/lib/python3.11/site-packages/SCons/Script/Main.py(869)_main()
+-> options = parser.values
+(Pdb)
+</screen>
+<note>
+<para><systemitem>pdb</systemitem> will stop at the
+beginning of the &scons; main routine on startup.
+The search path (<systemitem>sys.path</systemitem>)
+at that point will include the location of the running &scons;,
+but not of the project itself -
+if you need to set breakpoints in your project files,
+you will either need to add to the path,
+or use absolute pathnames when referring to project files.
+A <filename>.pdbrc</filename> file in the project root
+can be used to add the current directory to the search path
+to avoid having to enter it by hand,
+along these lines:
+</para>
+<programlisting language="python">
+sys.path.append('.')
+</programlisting>
+<para>
+Due to the implementation of the
+<systemitem>pdb</systemitem> module,
+the <command>break</command>,
+<command>tbreak</command>
+and <command>clear</command>
+commands only understand references to filenames
+which end in a <filename>.py</filename> suffix
+(although that suffix does not have to be typed),
+<emphasis>except</emphasis> if you use an absolute path.
+As a special exception to that rule, the names
+&SConstruct; and &SConscript; are recognized without
+needing the <filename>.py</filename> extension.
+</para>
+<para>
+<emphasis>Changed in version 4.5.0</emphasis>:
+The names &SConstruct; and &SConscript; are now
+recognized without needing to have a
+<filename>.py</filename> suffix.
+</para>
+</note>
   </listitem>
   </varlistentry>
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -973,8 +973,8 @@ $ <userinput>scons --debug=pdb</userinput>
 beginning of the &scons; main routine on startup.
 The search path (<systemitem>sys.path</systemitem>)
 at that point will include the location of the running &scons;,
-but not of the project itself -
-if you need to set breakpoints in your project files,
+but not of the project itself.
+If you need to set breakpoints in your project files,
 you will either need to add to the path,
 or use absolute pathnames when referring to project files.
 A <filename>.pdbrc</filename> file in the project root
@@ -992,17 +992,17 @@ the <command>break</command>,
 <command>tbreak</command>
 and <command>clear</command>
 commands only understand references to filenames
-which end in a <filename>.py</filename> suffix
-(although that suffix does not have to be typed),
+which have a <filename>.py</filename> extension.
+(although the suffix itself can be omitted),
 <emphasis>except</emphasis> if you use an absolute path.
 As a special exception to that rule, the names
 &SConstruct; and &SConscript; are recognized without
 needing the <filename>.py</filename> extension.
 </para>
 <para>
-<emphasis>Changed in version 4.5.0</emphasis>:
+<emphasis>Changed in version 4.6.0</emphasis>:
 The names &SConstruct; and &SConscript; are now
-recognized without needing to have a
+recognized without requiring
 <filename>.py</filename> suffix.
 </para>
 </note>
@@ -4005,7 +4005,7 @@ it will not be added again. The default is <literal>False</literal>.
 <parameter>library</parameter> can be a list of library names,
 or <constant>None</constant> (the default if the argument is omitted).
 If the former, <parameter>symbol</parameter> is checked against
-each library name in order, returning 
+each library name in order, returning
 (and reporting success) on the first
 successful test; if the latter,
 it is checked with the current value of &cv-LIBS;


### PR DESCRIPTION
Tried to address some surprise that `pdb` can't find the `SConstruct` when you start up in debugger mode.

No functional changes - doc-only.

*Updated*:  now updates the code so names for SConstruct/SConscript that don't end in .py can be used to manipulate breakpoints.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
