### PR TITLE
Fix test/textfile/textfile.py test failing (only on windows)

### DIFF
--- a/test/textfile/textfile.py
+++ b/test/textfile/textfile.py
@@ -34,7 +34,8 @@ test = TestSCons.TestSCons()
 # foo1a = test.workpath('foo1a.txt')
 # foo2a = test.workpath('foo2a.txt')
 
-match_mode = 'r'
+# Must be read binary as now we're including unicode characters in our textparts
+match_mode = 'rb'
 
 test.file_fixture('fixture/SConstruct', 'SConstruct')
 


### PR DESCRIPTION
We needed to switch generated file comparison from r (text) to rb (read binary) since we now include unicode, and test logic assumes r = ascii

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
