### PR TITLE
man: add a "New in..." to ValidateOptions  [skip appveyor]

### DIFF
--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -1000,9 +1000,9 @@ scons --compilers=mingw (the correct flag is --compiler)
                 Could cause SCons to run configure steps with the incorrect compiler. Costing developer time trying to
                 track down why the configure logic failed with a compiler which should work.
             </para>
-
-
-
+            <para>
+                <emphasis>New in version 4.5.0</emphasis>
+            </para>
         </summary>
     </scons_function>
 


### PR DESCRIPTION
The new `ValidateOptions` had a `:versionadded:` in the docstring, but just noticed the actual manpage entry didn't have similar.

Doc-only - this is just "release polish", no changes.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
