### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,9 +9,9 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
-
-        - Whatever John Doe did.
+  From Michał Górny:
+    - Remove the redundant `wheel` dependency from `pyproject.toml`,
+      as it is added automatically by the setuptools PEP517 backend.
 
 
 RELEASE 4.5.1 -  Mon, 06 Mar 2023 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,7 +44,8 @@ IMPROVEMENTS
 PACKAGING
 ---------
 
-- List changes in the way SCons is packaged and/or released
+- Remove the redundant `wheel` dependency from `pyproject.toml`,
+  as it is added automatically by the setuptools PEP517 backend.
 
 DOCUMENTATION
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 
 # for black and mypy, set the lowest Python version supported
 [tool.black]


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality. (n/a)
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation (n/a)
