### PR TITLE
Fix problem when MergeFlags adds to existing CPPDEFINES

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,15 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Remove the redundant `wheel` dependency from `pyproject.toml`,
       as it is added automatically by the setuptools PEP517 backend.
 
+  From Mats Wichmann
+    -  Fix a problem (#4321) in 4.5.0/4.5.1 where ParseConfig could cause an
+       exception in MergeFlags when the result would be to add preprocessor
+       defines to existing CPPDEFINES. The following code illustrates the
+       circumstances that could trigger this:
+          env=Environment(CPPDEFINES=['a'])
+          env.Append(CPPDEFINES=['b'])
+          env.MergeFlags({'CPPDEFINES': 'c'})
+
 
 RELEASE 4.5.1 -  Mon, 06 Mar 2023 14:08:29 -0700
 

--- a/test/ParseConfig.py
+++ b/test/ParseConfig.py
@@ -33,6 +33,7 @@ test = TestSCons.TestSCons()
 test_config1 = test.workpath('test-config1')
 test_config2 = test.workpath('test-config2')
 test_config3 = test.workpath('test-config3')
+test_config4 = test.workpath('test-config4')
 
 # 'abc' is supposed to be a static lib; it is included in LIBS as a
 # File node.
@@ -49,6 +50,10 @@ print("-L foo -L lib_dir")
 # This is like what wxWidgets does on OSX w/ Universal Binaries
 test.write(test_config3, """\
 print("-L foo -L lib_dir -isysroot /tmp -arch ppc -arch i386")
+""")
+
+test.write(test_config4, """\
+print("-D_REENTRANT -lpulse -pthread")
 """)
 
 test.write('SConstruct1', """
@@ -85,6 +90,23 @@ print([str(x) for x in env['LIBS']])
 print(env['CCFLAGS'])
 """ % locals())
 
+# issue #4321: if CPPDEFINES has been promoted to deque, adding would fail
+test.write('SConstruct4', f"""\
+env = Environment(
+    CPPDEFINES="_REENTRANT",
+    LIBS=[],
+    CCFLAGS=[],
+    LINKFLAGS=[],
+    PYTHON=r'{_python_}',
+)
+env.Append(CPPDEFINES="TOOLS_ENABLED")
+env.ParseConfig(r"$PYTHON {test_config4} --libs --cflags")
+print([str(x) for x in env['CPPDEFINES']])
+print([str(x) for x in env['LIBS']])
+print(env['CCFLAGS'])
+print(env['LINKFLAGS'])
+""")
+
 good_stdout = """\
 ['/usr/include/fum', 'bar']
 ['/usr/fax', 'foo', 'lib_dir']
@@ -99,11 +121,20 @@ stdout3 = """\
 ['-pipe', '-Wall', ('-isysroot', '/tmp'), ('-arch', 'ppc'), ('-arch', 'i386')]
 """
 
+stdout4 = """\
+['_REENTRANT', 'TOOLS_ENABLED']
+['pulse']
+['-pthread']
+['-pthread']
+"""
+
 test.run(arguments = "-q -Q -f SConstruct1 .", stdout = good_stdout)
 
 test.run(arguments = "-q -Q -f SConstruct2 .", stdout = good_stdout)
 
 test.run(arguments = "-q -Q -f SConstruct3 .", stdout = stdout3)
+
+test.run(arguments = "-q -Q -f SConstruct4 .", stdout = stdout4)
 
 test.pass_test()
 

--- a/test/ParseConfig.py
+++ b/test/ParseConfig.py
@@ -122,7 +122,7 @@ stdout3 = """\
 """
 
 stdout4 = """\
-['_REENTRANT', 'TOOLS_ENABLED']
+['TOOLS_ENABLED', '_REENTRANT']
 ['pulse']
 ['-pthread']
 ['-pthread']


### PR DESCRIPTION
`MergeFlags` has a post-processing step if the *unique* flag evaluates True which loops through and removes the duplicates. This step uses slicing (`for v in orig[::-1]`), which fails if the item being cleaned is a deque - which `CPPDEFINES` can now be. It would also cause the deque to be replaced with a list.  Detect this case and handle separately.

Note the same post-processing step assures each modified object will be replaced - `Override(parse_flags=xxx)` silently counted on this, so it does not end up sharing variables with the overridden env. This situation remains, and is accounted for by the patch.

Unit test and e2e tests are extended to check that `MergeFlags` can now add correctly, and that `Override` leaves the variables independent, not shared.

Fixes #4321 

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
