### PR TITLE
Drop coverage from CI for now

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,7 @@ install:
 # Leaving the Coverage build on VS2017 for build-time reasons (1hr time limit).
 # maybe move coverage to github in future to restore some flexibility?
 environment:
+  # set COVERAGE to 1 for any builder that should run it
   COVERAGE: 0
   SCONS_CACHE_MSVC_CONFIG: "true"
   matrix:
@@ -42,7 +43,6 @@ environment:
     - WINPYTHON: "Python38"
 
     - WINPYTHON: "Python36"
-      COVERAGE: 1
 
 # remove sets of build jobs based on criteria below
 # to fine tune the number and platforms tested

--- a/.github/workflows/experimental_tests.yml
+++ b/.github/workflows/experimental_tests.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         # note: in the 2nd half of 2022 the setup-mingw was often failing on
         # windows-latest. revisit someday (perhaps when there's an @v3)
-        os: ['ubuntu-latest', 'windows-2019', 'macos-latest']
+        #os: ['ubuntu-latest', 'windows-2019', 'macos-latest']
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -33,11 +34,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Set up MinGW
-        uses: egor-tensin/setup-mingw@v2
-        if: matrix.os == 'windows-2019'
-        with:
-          platform: x64
+      # experiment: looks like we don't need this if we use windows-latest
+      #- name: Set up MinGW
+      #  uses: egor-tensin/setup-mingw@v2
+      #  if: matrix.os == 'windows-2019'
+      #  with:
+      #    platform: x64
 
       - name: Set up Python 3.11 ${{ matrix.os }}
         uses: actions/setup-python@v2

--- a/.github/workflows/experimental_tests.yml
+++ b/.github/workflows/experimental_tests.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         # note: in the 2nd half of 2022 the setup-mingw was often failing on
         # windows-latest. revisit someday (perhaps when there's an @v3)
-        #os: ['ubuntu-latest', 'windows-2019', 'macos-latest']
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        #os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'windows-2019', 'macos-latest']
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -34,12 +34,13 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # experiment: looks like we don't need this if we use windows-latest
-      #- name: Set up MinGW
-      #  uses: egor-tensin/setup-mingw@v2
-      #  if: matrix.os == 'windows-2019'
-      #  with:
-      #    platform: x64
+      # experiment: maybe don't need this?
+      # update: looks like we do: with this commented out, the build hung
+      - name: Set up MinGW
+        uses: egor-tensin/setup-mingw@v2
+        if: matrix.os == 'windows-2019'
+        with:
+          platform: x64
 
       - name: Set up Python 3.11 ${{ matrix.os }}
         uses: actions/setup-python@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ SCons.Tool.docbook = *.*
     sconsign.1
 
 [sdist]
-    dist_dir=build/dist
+dist_dir=build/dist
 
 [bdist_wheel]
     ; We're now py3 only


### PR DESCRIPTION
Experiment: coverage build broke because "codecov" package removed from PyPI on 12 Apr 2023.  We'll need to re-craft a coverage build, for now just don't set `COVERAGE` true for any appveyor build (leaving the framework in place to copy to the new setup).

Experiment: the setup of mingw for the github action for experimental features on Windows is failing for unknown reason ("error code 1"), possibly sourceforge failure, possibly something else. But - we shouldn't need to install mingw into an environment that is already provisioned with mingw.  Try that.

Apparently it's technically a syntax error for setup.cfg lines (that are not continuation lines) to be indented - had one tool gripe about this, which was made happy by dedenting one line. Including that in this PR, just because...

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
