### PR TITLE
Change base64 decodestring -> decodebytes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       not use these, so was not affected.  [fixes #4193]
     - Simplify some code due to pylint observation: "C2801: Unnecessarily
       calls dunder method __call__. Invoke instance directly."
+    - Python 3.9 dropped the alias base64.decodestring, deprecated since 3.1.
+      Only used in msvs.py. Use base64.decodebytes instead.
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -777,7 +777,7 @@ class _GenerateV6DSP(_DSPGenerator):
 
         # OK, we've found our little pickled cache of data.
         try:
-            datas = base64.decodestring(datas)
+            datas = base64.decodebytes(datas)
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
@@ -798,7 +798,7 @@ class _GenerateV6DSP(_DSPGenerator):
         # OK, we've found our little pickled cache of data.
         # it has a "# " in front of it, so we strip that.
         try:
-            datas = base64.decodestring(datas)
+            datas = base64.decodebytes(datas)
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
@@ -1095,7 +1095,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
 
         # OK, we've found our little pickled cache of data.
         try:
-            datas = base64.decodestring(datas)
+            datas = base64.decodebytes(datas)
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
@@ -1115,7 +1115,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
 
         # OK, we've found our little pickled cache of data.
         try:
-            datas = base64.decodestring(datas)
+            datas = base64.decodebytes(datas)
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
@@ -1592,7 +1592,7 @@ class _GenerateV7DSW(_DSWGenerator):
 
         # OK, we've found our little pickled cache of data.
         try:
-            datas = base64.decodestring(datas)
+            datas = base64.decodebytes(datas)
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise


### PR DESCRIPTION
The former was an alias in Python 3, deprecated since 3.1. Use the replacement.

There are no behavioral impacts (so no docs or test changes).

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
