### PR TITLE
Find choco msys mingw

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,6 +25,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Only used in msvs.py. Use base64.decodebytes instead.
     - SCons test runner now uses pathlib to normalize and compare paths
       to test files.
+    - Fixed: when using the mingw tool, if an msys2 Python is used (os.sep
+      is '/' rather than the Windows default '\'), certain Configure checks
+      could fail due to the construction of the path to run the compiled check.
+    - Added effort to find mingw if it comes from Chocolatey install of msys2.
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700
@@ -198,9 +202,6 @@ RELEASE 4.5.0 -  Sun, 05 Mar 2023 14:08:29 -0700
         We take advantage that their order is now stable based on insertion order
         in Python 3.5+
       - Added/modifed unit and system tests to verify these changes.
-    - Fixed: when using the mingw tool, if an msys2 Python is used (os.sep
-      is '/' rather than the Windows default '\'), certain Configure checks
-      could fail due to the construction of the path to run the compiled check.
 
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -32,7 +32,6 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
-
 - Fixed: when using the mingw tool, if an msys2 Python is used (os.sep
   is '/' rather than the Windows default '\'), certain Configure checks
   could fail due to the construction of the path to run the compiled check.
@@ -45,9 +44,7 @@ FIXES
 IMPROVEMENTS
 ------------
 
-- List improvements that wouldn't be visible to the user in the
-  documentation:  performance improvements (describe the circumstances
-  under which they would be observed), or major code cleanups
+- Now tries to find mingw if it comes from Chocolatey install of msys2.
 
 PACKAGING
 ---------

--- a/SCons/Tool/mingw.py
+++ b/SCons/Tool/mingw.py
@@ -41,6 +41,8 @@ import SCons.Defaults
 import SCons.Tool
 import SCons.Util
 
+# TODO: should this be synced with SCons/Platform/mingw.py:MINGW_DEFAULTPATHS
+#  i.e. either keep the same, or make sure there's only one?
 mingw_base_paths = [
     r'c:\MinGW\bin',
     r'C:\cygwin64\bin',
@@ -48,9 +50,14 @@ mingw_base_paths = [
     r'C:\msys64\mingw64\bin',
     r'C:\cygwin\bin',
     r'C:\msys',
+    # Chocolatey mingw (pkg name for MinGW-w64) does not use ChocolateyToolsLocation
     r'C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin',
-    os.path.expandvars(r'%LocalAppData%\Programs\msys64\usr\bin'),
 ]
+# Chocolatey msys2 uses envvar ChocolateyToolsLocation to base the install
+# location (unless the user supplied additional params). Try to reproduce:
+choco = os.environ.get('ChocolateyToolsLocation')
+if choco:
+    mingw_base_paths.append(choco + r'\msys64\bin')
 
 
 def shlib_generator(target, source, env, for_signature):


### PR DESCRIPTION
4c835c4 introduced an effort to find mingw if installed as part of the msys2 chocolatey package. Unfortunately that change worked only for one specific user (me) who had set environment variable `%ChocolateyToolsLocation%` to a prefix in that path. Instead, reference the environment variable to try to find it. Usually we don't like environment variables, but this one actually makes the lookup *less* system-specific, as it extracts the best possible guess where chocolatey has put the files on that system (it has a default value, so is unlikely to ever be unset).

Also moved the `CHANGES.txt` entry matching the referenced change, that had gotten merged listed under an earlier release (submission of that PR had been before 4.5 went out)

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
