### PR TITLE
Add a copyright header to test files

### DIFF
--- a/test/AS/fixture/myas.py
+++ b/test/AS/fixture/myas.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 

--- a/test/AS/fixture/myas_args.py
+++ b/test/AS/fixture/myas_args.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 

--- a/test/Actions/addpost-link-fixture/strip.py
+++ b/test/Actions/addpost-link-fixture/strip.py
@@ -1,2 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
+
 print("strip.py: %s" % " ".join(sys.argv[1:]))

--- a/test/Actions/addpost-link-fixture/test1.c
+++ b/test/Actions/addpost-link-fixture/test1.c
@@ -1,4 +1,9 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 extern void test_lib_fn();
+
 int main(int argc, char **argv) {
   test_lib_fn();
   return 0;

--- a/test/Actions/addpost-link-fixture/test_lib.c
+++ b/test/Actions/addpost-link-fixture/test_lib.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 
 void test_lib_fn() {

--- a/test/Actions/append-fixture/foo.c
+++ b/test/Actions/append-fixture/foo.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 
 int main(void)

--- a/test/Actions/pre-post-fixture/work1/bar.c
+++ b/test/Actions/pre-post-fixture/work1/bar.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 
 int main(void)

--- a/test/Actions/pre-post-fixture/work1/foo.c
+++ b/test/Actions/pre-post-fixture/work1/foo.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 
 int main(void)

--- a/test/Actions/pre-post-fixture/work2/SConstruct
+++ b/test/Actions/pre-post-fixture/work2/SConstruct
@@ -1,13 +1,19 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def b(target, source, env):
     with open(str(target[0]), 'wb') as f:
         f.write((env['X'] + '\n').encode())
+
+DefaultEnvironment(tools=[])
 env1 = Environment(X='111', tools=[])
 env2 = Environment(X='222', tools=[])
-B = Builder(action = b, env = env1, multi=1)
+B = Builder(action=b, env=env1, multi=1)
 print("B =", B)
 print("B.env =", B.env)
-env1.Append(BUILDERS = {'B' : B})
-env2.Append(BUILDERS = {'B' : B})
+env1.Append(BUILDERS={'B': B})
+env2.Append(BUILDERS={'B': B})
 env3 = env1.Clone(X='333')
 print("env1 =", env1)
 print("env2 =", env2)
@@ -15,8 +21,10 @@ print("env3 =", env3)
 f1 = env1.B(File('file1.out'), [])
 f2 = env2.B('file2.out', [])
 f3 = env3.B('file3.out', [])
+
 def do_nothing(env, target, source):
     pass
+
 AddPreAction(f2[0], do_nothing)
 AddPostAction(f3[0], do_nothing)
 print("f1[0].builder =", f1[0].builder)

--- a/test/Actions/pre-post-fixture/work3/SConstruct
+++ b/test/Actions/pre-post-fixture/work3/SConstruct
@@ -1,10 +1,18 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def pre(target, source, env):
     pass
+
 def post(target, source, env):
     pass
+
 def build(target, source, env):
     with open(str(target[0]), 'wb') as f:
         f.write(b'build()\n')
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 AddPreAction('dir', pre)
 AddPostAction('dir', post)

--- a/test/Actions/pre-post-fixture/work4/build.py
+++ b/test/Actions/pre-post-fixture/work4/build.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
+
 with open(sys.argv[1], 'wb') as outfp:
     for f in sys.argv[2:]:
         with open(f, 'rb') as infp:

--- a/test/Actions/pre-post.py
+++ b/test/Actions/pre-post.py
@@ -43,7 +43,7 @@ test.write(['work1', 'SConstruct'], """
 import os.path
 import stat
 
-# DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 env = Environment(XXX='bar%(_exe)s')
 
 def before(env, target, source):

--- a/test/Actions/subst_shell_env-fixture/SConstruct
+++ b/test/Actions/subst_shell_env-fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 def custom_environment_expansion1(env, target, source, shell_env):
@@ -16,6 +20,7 @@ def expand_this_generator(env, target, source, for_signature):
 def expand_that_generator(env, target, source, for_signature):
     return str(target[0]) + "_is_from_expansion"
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=['textfile'])
 
 env['SHELL_ENV_GENERATORS'] = [custom_environment_expansion1, custom_environment_expansion2]

--- a/test/Actions/unicode-signature-fixture/SConstruct
+++ b/test/Actions/unicode-signature-fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 fnode = File(u'foo.txt')
 
 def funcact(target, source, env):
@@ -7,6 +11,6 @@ def funcact(target, source, env):
         pass
     return 0
 
+DefaultEnvironment(tools=[])
 env = Environment()
-
 env.Command(fnode, [], ["echo $TARGET", funcact])

--- a/test/Batch/SConstruct_changed_sources_alwaysBuild
+++ b/test/Batch/SConstruct_changed_sources_alwaysBuild
@@ -1,8 +1,10 @@
-# Testcase for tigris bug 2622
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+"""Testcase for tigris bug 2622"""
 
 obj = Object('changed_sources_main.cpp')
 AlwaysBuild(obj)
-
 program = Program('test', source=[obj])
-
 Default(program)

--- a/test/Batch/changed_sources_main.cpp
+++ b/test/Batch/changed_sources_main.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
 
 #include <iostream>
 

--- a/test/CC/CC-fixture/bar.c
+++ b/test/CC/CC-fixture/bar.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/CC/CC-fixture/foo.c
+++ b/test/CC/CC-fixture/foo.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/CC/CC-fixture/mycc.py
+++ b/test/CC/CC-fixture/mycc.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Phony cc command for testing SCons.
 

--- a/test/CC/CCVERSION-fixture/versioned.py
+++ b/test/CC/CCVERSION-fixture/versioned.py
@@ -1,5 +1,10 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import subprocess
 import sys
+
 if '-dumpversion' in sys.argv:
     print('3.9.9')
     sys.exit(0)

--- a/test/CC/gcc-non-utf8-fixture/gcc-non-utf8.py
+++ b/test/CC/gcc-non-utf8-fixture/gcc-non-utf8.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 if __name__ == '__main__':

--- a/test/CXX/CXX-fixture/myc++.py
+++ b/test/CXX/CXX-fixture/myc++.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Phony c++ command for testing SCons.
 

--- a/test/CacheDir/CACHEDIR_CLASS_fixture/SConstruct
+++ b/test/CacheDir/CACHEDIR_CLASS_fixture/SConstruct
@@ -1,11 +1,16 @@
-import SCons
-class CustomCacheDir(SCons.CacheDir.CacheDir):
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
+import SCons
+
+class CustomCacheDir(SCons.CacheDir.CacheDir):
     @classmethod
     def copy_to_cache(cls, env, src, dst):
         print("MY_CUSTOM_CACHEDIR_CLASS")
         super().copy_to_cache(env, src, dst)
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 env['CACHEDIR_CLASS'] = CustomCacheDir
 env.CacheDir('cache')

--- a/test/CacheDir/custom_cachedir_fixture/SConstruct
+++ b/test/CacheDir/custom_cachedir_fixture/SConstruct
@@ -1,11 +1,16 @@
-import SCons
-class CustomCacheDir(SCons.CacheDir.CacheDir):
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
+import SCons
+
+class CustomCacheDir(SCons.CacheDir.CacheDir):
     @classmethod
     def copy_to_cache(cls, env, src, dst):
         print("MY_CUSTOM_CACHEDIR_CLASS")
         super().copy_to_cache(env, src, dst)
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 env.CacheDir('cache', CustomCacheDir)
 env.Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))

--- a/test/CacheDir/double_cachedir_fixture/SConstruct
+++ b/test/CacheDir/double_cachedir_fixture/SConstruct
@@ -1,6 +1,10 @@
-import SCons
-class CustomCacheDir1(SCons.CacheDir.CacheDir):
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
+import SCons
+
+class CustomCacheDir1(SCons.CacheDir.CacheDir):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         print("INSTANCIATED %s" % str(type(self).__name__))
@@ -11,7 +15,6 @@ class CustomCacheDir1(SCons.CacheDir.CacheDir):
         super().copy_to_cache(env, src, dst)
 
 class CustomCacheDir2(SCons.CacheDir.CacheDir):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         print("INSTANCIATED %s" % str(type(self).__name__))
@@ -21,6 +24,7 @@ class CustomCacheDir2(SCons.CacheDir.CacheDir):
         print("MY_CUSTOM_CACHEDIR_CLASS2")
         super().copy_to_cache(env, src, dst)
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 env.CacheDir('cache1', CustomCacheDir1)
 env.CacheDir('cache2', CustomCacheDir2)

--- a/test/CacheDir/invalid_custom_cachedir_fixture/SConstruct
+++ b/test/CacheDir/invalid_custom_cachedir_fixture/SConstruct
@@ -1,6 +1,11 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 class CustomCacheDir:
     pass
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 env.CacheDir('cache', CustomCacheDir)
 env.Command('file.out', 'file.in', Copy('$TARGET', '$SOURCE'))

--- a/test/CacheDir/value_dependencies/SConstruct
+++ b/test/CacheDir/value_dependencies/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons.Node
 
 CacheDir('cache')
@@ -7,8 +11,7 @@ def b(target, source, env):
 		pass
 
 def scan(node, env, path):
-    # Have the node depend on a directory, which depends on an instance of
-    # SCons.Node.Python.Value.
+    """Have the node depend on a directory, which depends on a Value node."""
     sample_dir = env.fs.Dir('dir2')
     env.Depends(sample_dir, env.Value('c'))
     return [sample_dir, env.Value('d'), env.Value(b'\x03\x0F', name='name3')]
@@ -16,17 +19,16 @@ def scan(node, env, path):
 scanner = Scanner(function=scan, node_class=SCons.Node.Node)
 builder = Builder(action=b, source_scanner=scanner)
 
+DefaultEnvironment(tools=[])
 env = Environment()
 env.Append(BUILDERS={'B': builder})
 
 # Create a node and a directory that each depend on an instance of
 # SCons.Node.Python.Value.
 sample_dir = env.fs.Dir('dir1')
-env.Depends(sample_dir,
-            [env.Value('a'), env.Value(b'\x01\x0F', name='name1')])
+env.Depends(sample_dir, [env.Value('a'), env.Value(b'\x01\x0F', name='name1')])
 
 sample_file = env.fs.File('testfile')
-env.Depends(sample_file,
-            [env.Value('b'), env.Value(b'\x02\x0F', name='name2')])
+env.Depends(sample_file, [env.Value('b'), env.Value(b'\x02\x0F', name='name2')])
 
 env.B(target='File1.out', source=[sample_dir, sample_file])

--- a/test/CompilationDatabase/fixture/SConstruct
+++ b/test/CompilationDatabase/fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 DefaultEnvironment(tools=[])

--- a/test/CompilationDatabase/fixture/SConstruct_tempfile
+++ b/test/CompilationDatabase/fixture/SConstruct_tempfile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 DefaultEnvironment(tools=[])

--- a/test/CompilationDatabase/fixture/SConstruct_variant
+++ b/test/CompilationDatabase/fixture/SConstruct_variant
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 DefaultEnvironment(tools=[])

--- a/test/Configure/conftest_source_file/SConstruct
+++ b/test/Configure/conftest_source_file/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
 env = Environment()
 env.Append(CPPPATH=['.'])

--- a/test/Configure/conftest_source_file/header1.h
+++ b/test/Configure/conftest_source_file/header1.h
@@ -1,2 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #pragma once
 #include "header2.h"

--- a/test/Configure/conftest_source_file/header2.h
+++ b/test/Configure/conftest_source_file/header2.h
@@ -1,2 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #pragma once
 int test_header = 1;

--- a/test/Configure/conftest_source_file/header3.h
+++ b/test/Configure/conftest_source_file/header3.h
@@ -1,2 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #pragma once
 int test_header = 3;

--- a/test/Configure/conftest_source_file/main.c
+++ b/test/Configure/conftest_source_file/main.c
@@ -1,2 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "header1.h"
 int main(){return 0;}

--- a/test/Configure/fixture/SConstruct.issue-2906
+++ b/test/Configure/fixture/SConstruct.issue-2906
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
+DefaultEnvironment(tools=[])
 env = Environment()
 conf1 = Configure(env)
 env2 = Environment()

--- a/test/Configure/is_conftest/fixture/SConstruct
+++ b/test/Configure/is_conftest/fixture/SConstruct
@@ -1,9 +1,11 @@
-"""
-Test the nodes are created as conftest nodes in configure tests.
-"""
-import sys
-DefaultEnvironment(tools=[])
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
+"""Test the nodes are created as conftest nodes in configure tests."""
+import sys
+
+DefaultEnvironment(tools=[])
 env = Environment()
 
 conf = Configure(env)

--- a/test/Configure/issue-2906-useful-duplicate-configure-message.py
+++ b/test/Configure/issue-2906-useful-duplicate-configure-message.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify useful error message when you create a second Configure context without
@@ -44,7 +43,7 @@ expected_stdout = "scons: Reading SConscript files ...\n"
 expected_stderr = """
 scons: *** Configure() called while another Configure() exists.
             Please call .Finish() before creating and second Configure() context
-File "%s", line 5, in <module>\n"""%test_SConstruct_path
+File "%s", line 10, in <module>\n"""%test_SConstruct_path
 test.run(stderr=expected_stderr, stdout=expected_stdout, status=2)
 
 test.pass_test()

--- a/test/Configure/issue-3469/fixture/SConstruct
+++ b/test/Configure/issue-3469/fixture/SConstruct
@@ -8,7 +8,6 @@ Github issue #3469
 """
 
 DefaultEnvironment(tools=[])
-
 vars = Variables()
 vars.Add(BoolVariable('SKIP', 'Skip Middle Conf test', False))
 env = Environment(variables=vars)

--- a/test/D/AllAtOnce/Image/SConstruct_template
+++ b/test/D/AllAtOnce/Image/SConstruct_template
@@ -1,13 +1,19 @@
-# -*- coding:utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
 
+DefaultEnvironment(tools=[])
 environment = Environment(
     tools=['{}', 'link'],
 )
 
-environment.ProgramAllAtOnce('project', [
-'main.d',
-'amod.d',
-'bmod.d',
-])
+environment.ProgramAllAtOnce(
+    'project',
+    [
+        'main.d',
+        'amod.d',
+        'bmod.d',
+    ],
+)

--- a/test/D/AllAtOnce/Image/amod.d
+++ b/test/D/AllAtOnce/Image/amod.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio;
 
 void print_message() {

--- a/test/D/AllAtOnce/Image/bmod.d
+++ b/test/D/AllAtOnce/Image/bmod.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 int calculate_value() {
 	return 42;
 }

--- a/test/D/AllAtOnce/Image/main.d
+++ b/test/D/AllAtOnce/Image/main.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio: writefln;
 import amod: print_message;
 import bmod: calculate_value;

--- a/test/D/CoreScanner/Image/SConstruct_template
+++ b/test/D/CoreScanner/Image/SConstruct_template
@@ -1,8 +1,10 @@
-# -*- mode:python; coding:utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
 
-environment = Environment(
-    tools=['link', '{}'])
+DefaultEnvironment(tools=[])
+environment = Environment(tools=['link', '{}'])
 environment.Program('test1.d')
 environment.Program('test2.d')

--- a/test/D/CoreScanner/Image/ignored.d
+++ b/test/D/CoreScanner/Image/ignored.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module  ignored;
 
 int something;

--- a/test/D/CoreScanner/Image/module1.d
+++ b/test/D/CoreScanner/Image/module1.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module  module1;
 
 int something;

--- a/test/D/CoreScanner/Image/module2.d
+++ b/test/D/CoreScanner/Image/module2.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module  module2;
 
 int something;

--- a/test/D/CoreScanner/Image/p/ignored.d
+++ b/test/D/CoreScanner/Image/p/ignored.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module  p.ignored;
 
 int something;

--- a/test/D/CoreScanner/Image/p/submodule1.d
+++ b/test/D/CoreScanner/Image/p/submodule1.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module  p.submodule1;
 
 int something;

--- a/test/D/CoreScanner/Image/p/submodule2.d
+++ b/test/D/CoreScanner/Image/p/submodule2.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module p.submodule2;
 
 int something;

--- a/test/D/CoreScanner/Image/test1.d
+++ b/test/D/CoreScanner/Image/test1.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import module1;
 import module2;
 import module3;

--- a/test/D/CoreScanner/Image/test2.d
+++ b/test/D/CoreScanner/Image/test2.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import
    module1,
    module2,

--- a/test/D/HSTeoh/ArLibIssue/SConstruct_template
+++ b/test/D/HSTeoh/ArLibIssue/SConstruct_template
@@ -1,6 +1,10 @@
-env = Environment({})
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
-env['ENV']['HOME'] = os.environ['HOME']  # Hack for gdmd
 
+DefaultEnvironment(tools=[])
+env = Environment({})
+env['ENV']['HOME'] = os.environ['HOME']  # Hack for gdmd
 env.StaticLibrary('mylib', ['a.d', 'b.d'])

--- a/test/D/HSTeoh/LibCompileOptions/SConstruct_template
+++ b/test/D/HSTeoh/LibCompileOptions/SConstruct_template
@@ -1,12 +1,12 @@
-env = Environment({})
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
+
+DefaultEnvironment(tools=[])
+env = Environment({})
 env['ENV']['HOME'] = os.environ['HOME']  # Hack for gdmd
-
 env.Library('mylib', 'mylib.d')
-
-prog_env = env.Clone(
-    LIBS = ['mylib'],
-    LIBPATH = '#'
-    )
+prog_env = env.Clone(LIBS=['mylib'], LIBPATH='#')
 prog_env.Program('prog', 'prog.d')

--- a/test/D/HSTeoh/LibCompileOptions/prog.d
+++ b/test/D/HSTeoh/LibCompileOptions/prog.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 int main() {
     return 0;
 }

--- a/test/D/HSTeoh/LinkingProblem/SConstruct_template
+++ b/test/D/HSTeoh/LinkingProblem/SConstruct_template
@@ -1,20 +1,17 @@
-# -*- mode:python; coding=utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
 
-environment = Environment(
-    tools = ['cc', '{}', 'link'],
-    LIBS = ['ncurses'])
-
+DefaultEnvironment(tools=[])
+environment = Environment(tools=['cc', '{}', 'link'], LIBS=['ncurses'])
 environment['ENV']['HOME'] = os.environ['HOME']  # Hack for gdmd
-
 environment.Object('ncurs_impl.o', 'ncurs_impl.c')
-
 environment.Program('prog', Split("""
 	prog.d
 	ncurs_impl.o
 """))
-
 environment.Program('cprog', Split("""
 	cprog.c
 	ncurs_impl.o

--- a/test/D/HSTeoh/LinkingProblem/cprog.c
+++ b/test/D/HSTeoh/LinkingProblem/cprog.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 extern void ncurs_init();
 extern void ncurs_cleanup();
 

--- a/test/D/HSTeoh/LinkingProblem/ncurs_impl.c
+++ b/test/D/HSTeoh/LinkingProblem/ncurs_impl.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 /* Ncurses wrappers */
 #include <ncurses.h>
 

--- a/test/D/HSTeoh/LinkingProblem/prog.d
+++ b/test/D/HSTeoh/LinkingProblem/prog.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 /*
  * Simple D program that links to ncurses via a C wrapping file.
  */

--- a/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/SConstruct_template
+++ b/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/SConstruct_template
@@ -1,12 +1,17 @@
-# -*- mode:python; coding=utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
 
+DefaultEnvironment(tools=[])
 environment = Environment(
     tools=['link', '{}'],
-    # It might be thought that a single string can contain multiple options space separated. Actually this
-    # is deemed to be a single option, so leads to an error.
-    DFLAGS = '-m64 -O')
+    # It might be thought that a single string can contain multiple
+    # options space separated. Actually this is deemed to be a single option,
+    # so leads to an error.
+    DFLAGS='-m64 -O',
+)
 
 environment.Program('proj', Split("""
 proj.d

--- a/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/cmod.c
+++ b/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/cmod.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 /* This is a sample C module. */
 
 int csqr(int arg) {

--- a/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/mod1.d
+++ b/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/mod1.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module mod1;
 import std.stdio;
 

--- a/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/proj.d
+++ b/test/D/HSTeoh/SingleStringCannotBeMultipleOptions/proj.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio;
 import mod1;
 

--- a/test/D/HelloWorld/CompileAndLinkOneStep/Image/SConstruct_template
+++ b/test/D/HelloWorld/CompileAndLinkOneStep/Image/SConstruct_template
@@ -1,8 +1,9 @@
-# -*- mode:python; coding:utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
 
-environment = Environment(
-    tools=['link', '{}'])
-
+DefaultEnvironment(tools=[])
+environment = Environment(tools=['link', '{}'])
 environment.Program('helloWorld.d')

--- a/test/D/HelloWorld/CompileAndLinkOneStep/Image/helloWorld.d
+++ b/test/D/HelloWorld/CompileAndLinkOneStep/Image/helloWorld.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio;
 
 int main(immutable string[] args) {

--- a/test/D/HelloWorld/CompileThenLinkTwoSteps/Image/SConstruct_template
+++ b/test/D/HelloWorld/CompileThenLinkTwoSteps/Image/SConstruct_template
@@ -1,10 +1,10 @@
-# -*- mode:python; coding:utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
 
-environment = Environment(
-    tools=['link', '{}'])
-
+DefaultEnvironment(tools=[])
+environment = Environment(tools=['link', '{}'])
 objects = environment.Object('helloWorld.d')
-
 environment.Program('helloWorld', objects)

--- a/test/D/HelloWorld/CompileThenLinkTwoSteps/Image/helloWorld.d
+++ b/test/D/HelloWorld/CompileThenLinkTwoSteps/Image/helloWorld.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio;
 
 int main(immutable string[] args) {

--- a/test/D/Issues/2939_Ariovistus/Project/SConstruct_template
+++ b/test/D/Issues/2939_Ariovistus/Project/SConstruct_template
@@ -1,12 +1,12 @@
-from os.path import join
-
-environment = Environment({})
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
+from os.path import join
+
+DefaultEnvironment(tools=[])
+environment = Environment({})
 environment['ENV']['HOME'] = os.environ['HOME']  # Hack for gdmd
-
 Export('environment')
-
-environment.SConscript([
-    join("test","test1", "SConscript"),
-]);
+environment.SConscript([join("test","test1", "SConscript")]);

--- a/test/D/Issues/2939_Ariovistus/Project/test/test1/SConscript
+++ b/test/D/Issues/2939_Ariovistus/Project/test/test1/SConscript
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 Import('environment')
 
 env = Environment()

--- a/test/D/Issues/2939_Ariovistus/Project/test/test1/stuff.cpp
+++ b/test/D/Issues/2939_Ariovistus/Project/test/test1/stuff.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "stuff.h"
 
 X::X() {

--- a/test/D/Issues/2939_Ariovistus/Project/test/test1/stuff.h
+++ b/test/D/Issues/2939_Ariovistus/Project/test/test1/stuff.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 
 class X {
     public:

--- a/test/D/Issues/2939_Ariovistus/Project/test/test1/test1.cpp
+++ b/test/D/Issues/2939_Ariovistus/Project/test/test1/test1.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "stuff.h"
 
 int main() {

--- a/test/D/Issues/2939_Ariovistus/Project/test/test1/test2.d
+++ b/test/D/Issues/2939_Ariovistus/Project/test/test1/test2.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio;
 
 struct X {

--- a/test/D/Issues/2940_Ariovistus/Project/SConstruct_template
+++ b/test/D/Issues/2940_Ariovistus/Project/SConstruct_template
@@ -1,12 +1,12 @@
-from os.path import join
-
-environment = Environment({})
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
+from os.path import join
+
+DefaultEnvironment(tools=[])
+environment = Environment({})
 environment['ENV']['HOME'] = os.environ['HOME']  # Hack for gdmd
-
 Export('environment')
-
-environment.SConscript([
-    join("test","test1", "SConscript"),
-]);
+environment.SConscript([join("test","test1", "SConscript")])

--- a/test/D/Issues/2940_Ariovistus/Project/test/test1/SConscript
+++ b/test/D/Issues/2940_Ariovistus/Project/test/test1/SConscript
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 Import('environment')
 
 env = Environment()

--- a/test/D/Issues/2940_Ariovistus/Project/test/test1/stuff.cpp
+++ b/test/D/Issues/2940_Ariovistus/Project/test/test1/stuff.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "stuff.h"
 
 X::X() {

--- a/test/D/Issues/2940_Ariovistus/Project/test/test1/stuff.h
+++ b/test/D/Issues/2940_Ariovistus/Project/test/test1/stuff.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 
 class X {
     public:

--- a/test/D/Issues/2940_Ariovistus/Project/test/test1/test1.cpp
+++ b/test/D/Issues/2940_Ariovistus/Project/test/test1/test1.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "stuff.h"
 
 int main() {

--- a/test/D/Issues/2940_Ariovistus/Project/test/test1/test2.d
+++ b/test/D/Issues/2940_Ariovistus/Project/test/test1/test2.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio;
 
 struct X {

--- a/test/D/Issues/2994/Project/SConstruct_template
+++ b/test/D/Issues/2994/Project/SConstruct_template
@@ -1,5 +1,8 @@
-# -*- mode:python; coding:utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
+DefaultEnvironment(tools=[])
 env=Environment({})
 
 change = ARGUMENTS.get('change', 0)

--- a/test/D/Issues/2994/Project/main.d
+++ b/test/D/Issues/2994/Project/main.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 /* This program prints a
    hello world message
    to the console.  */

--- a/test/D/MixedDAndC/Image/SConstruct
+++ b/test/D/MixedDAndC/Image/SConstruct
@@ -1,9 +1,11 @@
-# -*- mode:python; coding:utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 import os
 
-environment = Environment(
-)
+DefaultEnvironment(tools=[])
+environment = Environment()
 #    CFLAGS=['-m64'],
 #    DLINKFLAGS=['-m64'],
 #    DFLAGS=['-m64', '-O'])

--- a/test/D/MixedDAndC/Image/cmod.c
+++ b/test/D/MixedDAndC/Image/cmod.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 int csqr(int arg) {
   return arg*arg;
 }

--- a/test/D/MixedDAndC/Image/dmod.d
+++ b/test/D/MixedDAndC/Image/dmod.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 module dmod;
 import std.stdio;
 

--- a/test/D/MixedDAndC/Image/proj.d
+++ b/test/D/MixedDAndC/Image/proj.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 import std.stdio;
 import dmod;
 

--- a/test/D/SharedObjects/Image/SConstruct_template
+++ b/test/D/SharedObjects/Image/SConstruct_template
@@ -1,4 +1,6 @@
-# -*- mode:python; coding:utf-8; -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 # The core difference between this test and the one of SharedObjectSuffixIssue
 # is that here we explicitly use the relevant D tool and things work.

--- a/test/D/SharedObjects/Image/code.d
+++ b/test/D/SharedObjects/Image/code.d
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 int returnTheAnswer() {
   return 42;
 }

--- a/test/Decider/MD5-winonly-fixture/SConstruct
+++ b/test/Decider/MD5-winonly-fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
 env=Environment()
 env.Decider('MD5-timestamp')

--- a/test/Dir/DriveAbsPath/SConstruct
+++ b/test/Dir/DriveAbsPath/SConstruct
@@ -1,32 +1,42 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import SCons
 
+DefaultEnvironment(tools=[])
 env = Environment()
 drive = os.path.splitdrive(os.getcwd())[0]
 drive_dir = env.fs.Dir(drive)
 
 if not isinstance(drive_dir, SCons.Node.FS.RootDir):
-	raise Exception('env.fs.Dir("%s") returned a %s instead of a RootDir' %
-					(drive, type(drive_dir)))
+    raise Exception(
+        f'env.fs.Dir("{drive}") returned a {type(drive_dir)} instead of a RootDir'
+    )
 
 drive_abspath1 = drive_dir._abspath
 drive_abspath2 = drive_dir.abspath
 if drive_abspath1 != drive_abspath2:
-	raise Exception('Calculated _abspath %s is not the same as abspath %s' %
-					(drive_abspath1, drive_abspath2))
+    raise Exception(
+        f'Calculated _abspath {drive_abspath1} is not the same as abspath {drive_abspath2}'
+    )
 elif not os.path.exists(drive_abspath1):
-	raise Exception('Calculated abspath %s does not exist' % drive_abspath1)
+    raise Exception(f'Calculated abspath {drive_abspath1} does not exist')
 elif drive.rstrip(os.path.sep) != drive_abspath1.rstrip(os.path.sep):
-	raise Exception('Real drive %s and calculated abspath %s are not the '
-					'same' % (drive, drive_abspath1))
+    raise Exception(
+        f'Real drive {drive} and calculated abspath {drive_abspath1} are not the same'
+    )
 
 drive_path1 = drive_dir._path
 drive_path2 = drive_dir.path
 if drive_path1 != drive_path2:
-	raise Exception('Calculated _path %s is not the same as path %s' %
-					(drive_path1, drive_path2))
+    raise Exception(
+        f'Calculated _path {drive_path1} is not the same as path {drive_path2}'
+    )
 elif not os.path.exists(drive_path1):
-	raise Exception('Calculated path %s does not exist' % drive_path1)
+    raise Exception(f'Calculated path {drive_path1} does not exist')
 elif drive.rstrip(os.path.sep) != drive_path1.rstrip(os.path.sep):
-	raise Exception('Real drive %s and calculated abspath %s are not the '
-					'same' % (drive, drive_abs))
+    raise Exception(
+        f'Real drive {drive} and calculated abspath {drive_abs} are not the same'
+    )

--- a/test/Dir/PyPackageDir/image/SConstruct
+++ b/test/Dir/PyPackageDir/image/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys, os
 
 oldsyspath = sys.path

--- a/test/Docbook/basedir/htmlchunked/image/SConstruct
+++ b/test/Docbook/basedir/htmlchunked/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookHtmlChunked('manual', xsl='html.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/htmlchunked/image/SConstruct.cmd
+++ b/test/Docbook/basedir/htmlchunked/image/SConstruct.cmd
@@ -1,2 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 env.DocbookHtmlChunked('manual', xsl='html.xsl', base_dir='output/')

--- a/test/Docbook/basedir/htmlhelp/image/SConstruct
+++ b/test/Docbook/basedir/htmlhelp/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookHtmlhelp('manual', xsl='htmlhelp.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/htmlhelp/image/SConstruct.cmd
+++ b/test/Docbook/basedir/htmlhelp/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 env.DocbookHtmlhelp('manual', xsl='htmlhelp.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/slideshtml/image/SConstruct
+++ b/test/Docbook/basedir/slideshtml/image/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import xsltver
 
 v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
@@ -7,6 +11,7 @@ if v >= (1, 78, 0):
     # Use namespace-aware input file
     ns_ext = 'ns'
     
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookSlidesHtml('virt'+ns_ext, xsl='slides.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/slideshtml/image/SConstruct.cmd
+++ b/test/Docbook/basedir/slideshtml/image/SConstruct.cmd
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import xsltver
 
 v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
@@ -7,6 +11,7 @@ if v >= (1, 78, 0):
     # Use namespace-aware input file
     ns_ext = 'ns'
 
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookSlidesHtml('virt'+ns_ext, xsl='slides.xsl', base_dir='output/')

--- a/test/Docbook/basedir/slideshtml/image/xsltver.py
+++ b/test/Docbook/basedir/slideshtml/image/xsltver.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import re
 

--- a/test/Docbook/basic/epub/image/SConstruct
+++ b/test/Docbook/basic/epub/image/SConstruct
@@ -1,2 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookEpub('manual')

--- a/test/Docbook/basic/epub/image/SConstruct.cmd
+++ b/test/Docbook/basic/epub/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:

--- a/test/Docbook/basic/html/image/SConstruct
+++ b/test/Docbook/basic/html/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookHtml('manual')
 

--- a/test/Docbook/basic/html/image/SConstruct.cmd
+++ b/test/Docbook/basic/html/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:

--- a/test/Docbook/basic/htmlchunked/image/SConstruct
+++ b/test/Docbook/basic/htmlchunked/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookHtmlChunked('manual')
 

--- a/test/Docbook/basic/htmlchunked/image/SConstruct.cmd
+++ b/test/Docbook/basic/htmlchunked/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:

--- a/test/Docbook/basic/htmlhelp/image/SConstruct
+++ b/test/Docbook/basic/htmlhelp/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookHtmlhelp('manual')
 

--- a/test/Docbook/basic/htmlhelp/image/SConstruct.cmd
+++ b/test/Docbook/basic/htmlhelp/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:

--- a/test/Docbook/basic/man/image/SConstruct
+++ b/test/Docbook/basic/man/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookMan('refdb')
 

--- a/test/Docbook/basic/man/image/SConstruct.cmd
+++ b/test/Docbook/basic/man/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:

--- a/test/Docbook/basic/pdf/image/SConstruct
+++ b/test/Docbook/basic/pdf/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookPdf('manual')
 

--- a/test/Docbook/basic/pdf/image/SConstruct.cmd
+++ b/test/Docbook/basic/pdf/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:

--- a/test/Docbook/basic/slideshtml/image/SConstruct
+++ b/test/Docbook/basic/slideshtml/image/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import xsltver
 
 v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
@@ -7,6 +11,9 @@ if v >= (1, 78, 0):
     # Use namespace-aware input file
     ns_ext = 'ns'
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
-env.DocbookSlidesHtml('virt'+ns_ext, xsl='/usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl')
-
+env.DocbookSlidesHtml(
+    'virt' + ns_ext,
+    xsl='/usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl',
+)

--- a/test/Docbook/basic/slideshtml/image/SConstruct.cmd
+++ b/test/Docbook/basic/slideshtml/image/SConstruct.cmd
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import xsltver
 
 v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
@@ -7,7 +11,10 @@ if v >= (1, 78, 0):
     # Use namespace-aware input file
     ns_ext = 'ns'
 
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
-env.DocbookSlidesHtml('virt'+ns_ext, xsl='/usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl')
-
+env.DocbookSlidesHtml(
+    'virt' + ns_ext,
+    xsl='/usr/share/xml/docbook/stylesheet/docbook-xsl/slides/xhtml/plain.xsl',
+)

--- a/test/Docbook/basic/slideshtml/image/xsltver.py
+++ b/test/Docbook/basic/slideshtml/image/xsltver.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import re
 

--- a/test/Docbook/basic/slidespdf/image/SConstruct
+++ b/test/Docbook/basic/slidespdf/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookSlidesPdf('virt')
 

--- a/test/Docbook/basic/slidespdf/image/SConstruct.cmd
+++ b/test/Docbook/basic/slidespdf/image/SConstruct.cmd
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookSlidesPdf('virt')

--- a/test/Docbook/basic/xinclude/image/SConstruct
+++ b/test/Docbook/basic/xinclude/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookXInclude('manual_xi.xml','manual.xml')
 

--- a/test/Docbook/basic/xslt/image/SConstruct
+++ b/test/Docbook/basic/xslt/image/SConstruct
@@ -1,9 +1,13 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 
 #
 # Create document
 #
-env.DocbookXslt('out.xml', 'in.xml', 
-                xsl='./to_docbook.xslt')
+env.DocbookXslt('out.xml', 'in.xml', xsl='./to_docbook.xslt')

--- a/test/Docbook/basic/xsltsubdir/image/SConstruct
+++ b/test/Docbook/basic/xsltsubdir/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 
 SConscript('subdir/SConscript', 'env')

--- a/test/Docbook/basic/xsltsubdir/image/subdir/SConscript
+++ b/test/Docbook/basic/xsltsubdir/image/subdir/SConscript
@@ -1,7 +1,10 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 Import('env')
 
 #
 # Create document
 #
-env.DocbookXslt('out.xml', 'in.xml', 
-                xsl='to_docbook.xslt')
+env.DocbookXslt('out.xml', 'in.xml', xsl='to_docbook.xslt')

--- a/test/Docbook/dependencies/xinclude/image/SConstruct
+++ b/test/Docbook/dependencies/xinclude/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookXInclude('manual_xi.xml','manual.xml')
 

--- a/test/Docbook/rootname/htmlchunked/image/SConstruct
+++ b/test/Docbook/rootname/htmlchunked/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookHtmlChunked('manual.html','manual', xsl='html.xsl')
 

--- a/test/Docbook/rootname/htmlhelp/image/SConstruct
+++ b/test/Docbook/rootname/htmlhelp/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookHtmlhelp('manual.html', 'manual', xsl='htmlhelp.xsl')
 

--- a/test/Docbook/rootname/slideshtml/image/SConstruct
+++ b/test/Docbook/rootname/slideshtml/image/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import xsltver
 
 v = xsltver.detectXsltVersion('/usr/share/xml/docbook/stylesheet/docbook-xsl')
@@ -7,6 +11,7 @@ if v >= (1, 78, 0):
     # Use namespace-aware input file
     ns_ext = 'ns'
     
+DefaultEnvironment(tools=[])
 env = Environment(tools=['docbook'])
 env.DocbookSlidesHtml('manual.html', 'virt'+ns_ext, xsl='slides.xsl')
 

--- a/test/Docbook/rootname/slideshtml/image/xsltver.py
+++ b/test/Docbook/rootname/slideshtml/image/xsltver.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import re
 

--- a/test/File/fixture/relpath/base/SConstruct
+++ b/test/File/fixture/relpath/base/SConstruct
@@ -1,22 +1,26 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 # Testcase to check that .relpath works on SOURCES,TARGETS, and the singular SOURCE
 # This is the SConstruct for test/File/File-relpath.py
-#
+
 DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 
 input_list = [
-        "${TARGETS.relpath}",
-        "${TARGETS.abspath}",
-        "${SOURCES.relpath}",
-        "${SOURCES.abspath}",
-        "${SOURCE.relpath}",
-        "${SOURCE.abspath}",
-    ]
+    "${TARGETS.relpath}",
+    "${TARGETS.abspath}",
+    "${SOURCES.relpath}",
+    "${SOURCES.abspath}",
+    "${SOURCE.relpath}",
+    "${SOURCE.abspath}",
+]
 outputs = env.subst(
-        input_list,
+    input_list,
     target=[File("../foo/dir"), File("build/file1")],
     source=[File("src/file")],
 )
 
-for i,s in zip(input_list,outputs):
-        print("%s=%s"%(i,s))
+for i, s in zip(input_list, outputs):
+    print("%s=%s" % (i, s))

--- a/test/Fortran/fixture/myfortran.py
+++ b/test/Fortran/fixture/myfortran.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import getopt
 import sys
 

--- a/test/Fortran/fixture/myfortran_flags.py
+++ b/test/Fortran/fixture/myfortran_flags.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import getopt
 import sys
 

--- a/test/Install/fixture/SConstruct-multi
+++ b/test/Install/fixture/SConstruct-multi
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 # first run creates a src file, makes it read-only, and installs.
 # second run updates src, Install should successfully replace
 # the previous install (read-only attr on Windows might fail it)

--- a/test/Install/multi-dir/src/SConstruct
+++ b/test/Install/multi-dir/src/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 # This tests for a bug where installing a sequence dirs and subdirs
 # outside the source tree can cause SCons to fail to create the dest
 # dir.

--- a/test/Java/Java-fixture/myjar.py
+++ b/test/Java/Java-fixture/myjar.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import fileinput
 import sys
 

--- a/test/Java/Java-fixture/myjavac.py
+++ b/test/Java/Java-fixture/myjavac.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
 args = sys.argv[1:]

--- a/test/Java/Java-fixture/myrmic.py
+++ b/test/Java/Java-fixture/myrmic.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import sys
 

--- a/test/Java/java_version_image/SConstruct
+++ b/test/Java/java_version_image/SConstruct
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 AddOption('--javac_path',
           dest='javac_path',
@@ -11,25 +14,20 @@ AddOption('--java_version',
           default='1.6',
           type='string')
 
-path=GetOption('javac_path')
+path = GetOption('javac_path')
 if path[0] == "'":
     path = path[1:-1]
 
 version = GetOption('java_version')
 
-env = Environment(tools = ['javac'],
-                  JAVAVERSION = version,
-                  )
+DefaultEnvironment(tools=[])
+env = Environment(tools=['javac'], JAVAVERSION=version)
 
-
-env.AppendENVPath('PATH',path)
-
+env.AppendENVPath('PATH', path)
 # print('PATH:%s'%env['ENV']['PATH'])
-
-
-env.Java(target = 'class1', source = 'com/sub/foo')
-env.Java(target = 'class2', source = 'com/sub/bar')
-env.Java(target = 'class3', source = ['src1', 'src2'])
-env.Java(target = 'class4', source = ['src4'])
-env.Java(target = 'class5', source = ['src5'])
-env.Java(target = 'class6', source = ['src6'])
+env.Java(target='class1', source='com/sub/foo')
+env.Java(target='class2', source='com/sub/bar')
+env.Java(target='class3', source=['src1', 'src2'])
+env.Java(target='class4', source=['src4'])
+env.Java(target='class5', source=['src5'])
+env.Java(target='class6', source=['src6'])

--- a/test/Java/java_version_image/com/sub/bar/Example4.java
+++ b/test/Java/java_version_image/com/sub/bar/Example4.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 package com.sub.bar;
 
 public class Example4

--- a/test/Java/java_version_image/com/sub/bar/Example5.java
+++ b/test/Java/java_version_image/com/sub/bar/Example5.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 package com.other;
 
 public class Example5

--- a/test/Java/java_version_image/com/sub/bar/Example6.java
+++ b/test/Java/java_version_image/com/sub/bar/Example6.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 package com.sub.bar;
 
 public class Example6

--- a/test/Java/java_version_image/com/sub/foo/Example1.java
+++ b/test/Java/java_version_image/com/sub/foo/Example1.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 package com.sub.foo;
 
 public class Example1

--- a/test/Java/java_version_image/com/sub/foo/Example2.java
+++ b/test/Java/java_version_image/com/sub/foo/Example2.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 package com.other;
 
 public class Example2

--- a/test/Java/java_version_image/com/sub/foo/Example3.java
+++ b/test/Java/java_version_image/com/sub/foo/Example3.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 package com.sub.foo;
 
 public class Example3

--- a/test/Java/java_version_image/src1/Example7.java
+++ b/test/Java/java_version_image/src1/Example7.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 public class Example7
 {
 

--- a/test/Java/java_version_image/src2/Test.java
+++ b/test/Java/java_version_image/src2/Test.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 class Empty {
 }
 

--- a/test/Java/java_version_image/src4/NestedExample.java
+++ b/test/Java/java_version_image/src4/NestedExample.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 // import java.util.*;
 
 public class NestedExample

--- a/test/Java/java_version_image/src5/TestSCons.java
+++ b/test/Java/java_version_image/src5/TestSCons.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 class TestSCons {
     public static void main(String[] args) {
         Foo[] fooArray = new Foo[] { new Foo() };

--- a/test/Java/java_version_image/src6/TestSCons.java
+++ b/test/Java/java_version_image/src6/TestSCons.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 class test
 {
     test()

--- a/test/LEX/lex_headerfile/spaced path/SConstruct
+++ b/test/LEX/lex_headerfile/spaced path/SConstruct
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
 SConscript("src/SConscript")

--- a/test/LEX/lex_headerfile/spaced path/src/SConscript
+++ b/test/LEX/lex_headerfile/spaced path/src/SConscript
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 env = Environment(tools=['lex'])
 
 def make_header_path(env, target, source, for_signature):

--- a/test/LINK/applelink_image/SConstruct_CurVers_CompatVers
+++ b/test/LINK/applelink_image/SConstruct_CurVers_CompatVers
@@ -1,13 +1,18 @@
-
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 vars = Variables(None, ARGUMENTS)
 vars.Add('SHLIBVERSION', 'Set the SHLIBVERSION', 0)
 vars.Add('APPLELINK_CURRENT_VERSION', 'Set APPLELINK_CURRENT_VERSION', 0)
 vars.Add('APPLELINK_COMPATIBILITY_VERSION', 'Set APPLELINK_COMPATIBILITY_VERSION', 0)
 vars.Add('APPLELINK_NO_CURRENT_VERSION', 'Set APPLELINK_NO_CURRENT_VERSION', 0)
-vars.Add('APPLELINK_NO_COMPATIBILITY_VERSION', 'Set APPLELINK_NO_COMPATIBILITY_VERSION', 0)
+vars.Add(
+    'APPLELINK_NO_COMPATIBILITY_VERSION', 'Set APPLELINK_NO_COMPATIBILITY_VERSION', 0
+)
 
-env = Environment(variables = vars, tools=['gcc', 'applelink'])
+DefaultEnvironment(tools=[])
+env = Environment(variables=vars, tools=['gcc', 'applelink'])
 
 if env['APPLELINK_NO_CURRENT_VERSION'] == '0':
     env['APPLELINK_NO_CURRENT_VERSION'] = 0
@@ -15,21 +20,30 @@ if env['APPLELINK_NO_CURRENT_VERSION'] == '0':
 if env['APPLELINK_NO_COMPATIBILITY_VERSION'] == '0':
     env['APPLELINK_NO_COMPATIBILITY_VERSION'] = 0
 
-
-print("SHLIBVERSION                      =[%s]"%env.get('SHLIBVERSION', False))
-print("APPLELINK_CURRENT_VERSION         =[%s]"%env.get('APPLELINK_CURRENT_VERSION', False))
-print("APPLELINK_COMPATIBILITY_VERSION   =[%s]"%env.get('APPLELINK_COMPATIBILITY_VERSION', False))
-print("APPLELINK_NO_CURRENT_VERSION      =[%s]"%env.get('APPLELINK_NO_CURRENT_VERSION', False))
-print("APPLELINK_NO_COMPATIBILITY_VERSION=[%s]"%env.get('APPLELINK_NO_COMPATIBILITY_VERSION', False))
+print(
+    "SHLIBVERSION                      =[%s]"
+    % env.get('SHLIBVERSION', False)
+)
+print(
+    "APPLELINK_CURRENT_VERSION         =[%s]"
+    % env.get('APPLELINK_CURRENT_VERSION', False)
+)
+print(
+    "APPLELINK_COMPATIBILITY_VERSION   =[%s]"
+    % env.get('APPLELINK_COMPATIBILITY_VERSION', False)
+)
+print(
+    "APPLELINK_NO_CURRENT_VERSION      =[%s]"
+    % env.get('APPLELINK_NO_CURRENT_VERSION', False)
+)
+print(
+    "APPLELINK_NO_COMPATIBILITY_VERSION=[%s]"
+    % env.get('APPLELINK_NO_COMPATIBILITY_VERSION', False)
+)
 
 obj = env.SharedObject('foo.c')
 sl = env.SharedLibrary('foo', obj)
 sl2 = env.SharedLibrary('foo2', obj, SONAME='libfoo.4.dynlib')
 lm = env.LoadableModule('fool', obj)
-
-env.InstallVersionedLib(target='#/install',
-                        source=sl)
-
-env.InstallVersionedLib(target='#/install',
-                        source=lm)
-
+env.InstallVersionedLib(target='#/install', source=sl)
+env.InstallVersionedLib(target='#/install', source=lm)

--- a/test/LINK/applelink_image/SConstruct_gh2580
+++ b/test/LINK/applelink_image/SConstruct_gh2580
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
 env = Environment(PLATFORM='darwin')
 env.Object(

--- a/test/LINK/applelink_image/foo.c
+++ b/test/LINK/applelink_image/foo.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 int

--- a/test/Libs/bug2903/SConstruct
+++ b/test/Libs/bug2903/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 # SConstruct for testing but #2903.
 # The test changes the lib name to make sure it rebuilds
 # when the name changes, even if the content of the lib is the same.
@@ -5,9 +9,15 @@
 # when other linker options change, and not when they don't.
 # (This doesn't specifically test LIBPATH, but there's a test for
 # that already.)
-env=Environment()
-libname=ARGUMENTS.get('libname', 'foo')
+DefaultEnvironment(tools=[])
+env = Environment()
+libname = ARGUMENTS.get('libname', 'foo')
 env.Append(SHLINKFLAGS=' $EXTRA_SHLINKFLAGS')
-shlinkflags=ARGUMENTS.get('shlinkflags', '')
-env.SharedLibrary('myshared', ['main.c'],
-                  LIBS=[libname], LIBPATH='.', EXTRA_SHLINKFLAGS=shlinkflags)
+shlinkflags = ARGUMENTS.get('shlinkflags', '')
+env.SharedLibrary(
+    'myshared',
+    ['main.c'],
+    LIBS=[libname],
+    LIBPATH='.',
+    EXTRA_SHLINKFLAGS=shlinkflags,
+)

--- a/test/Libs/bug2903/SConstruct-libs
+++ b/test/Libs/bug2903/SConstruct-libs
@@ -1,5 +1,11 @@
-env=Environment()
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
+env = Environment()
 libfoo = env.SharedLibrary('foo', 'lib.c')
 env.InstallAs('${SHLIBPREFIX}bar${SHLIBSUFFIX}', libfoo[0])
-if len(libfoo) > 1: # on Windows, there's an import lib (also a .exp, but we don't want that)
-   env.InstallAs('${LIBPREFIX}bar${LIBSUFFIX}', libfoo[1])
+if len(libfoo) > 1:
+    # on Windows, there's an import lib (also a .exp, but we don't want that)
+    env.InstallAs('${LIBPREFIX}bar${LIBSUFFIX}', libfoo[1])

--- a/test/Libs/bug2903/lib.c
+++ b/test/Libs/bug2903/lib.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/test/Libs/bug2903/main.c
+++ b/test/Libs/bug2903/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir.py
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir.py
@@ -1,11 +1,11 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import TestSCons
-
-
 
 test = TestSCons.TestSCons()
 
 test.skip_if_not_msvc()
-
-
 test.dir_fixture('MSVC_BATCH-spaces-targetdir')
 test.run()

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/SConstruct
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/SConstruct
@@ -1,8 +1,15 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os.path
 
-env=Environment(MSVC_BATCH=True)
+DefaultEnvironment(tools=[])
+env = Environment(MSVC_BATCH=True)
 
-td='tar ge tdir'
-VariantDir(td,'src')
-env.Program(os.path.join(td,'test_program'),
-            [os.path.join(td,a) for a in ['a.c','b.c','c.c']])
+td = 'tar ge tdir'
+VariantDir(td, 'src')
+env.Program(
+    os.path.join(td, 'test_program'),
+    [os.path.join(td, a) for a in ['a.c', 'b.c', 'c.c']],
+)

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/src/a.c
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/src/a.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 
 extern void myfuncb();

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/src/b.c
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/src/b.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 
 void myfuncb() {

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir/src/c.c
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir/src/c.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 
 void myfuncc() {

--- a/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/SConstruct
+++ b/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 
 if 'SCONS_CACHE_MSVC_CONFIG' in os.environ:

--- a/test/MSVC/VSWHERE-fixture/SConstruct
+++ b/test/MSVC/VSWHERE-fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import os.path
 
@@ -9,6 +13,7 @@ for vw_path in VSWHERE_PATHS:
 
 
 # Allow normal detection logic to find vswhere.exe
+DefaultEnvironment(tools=[])
 env1=Environment()
 print("VSWHERE-detect=%s" % env1['VSWHERE'])
 

--- a/test/MSVC/msvc_fixture/SConstruct
+++ b/test/MSVC/msvc_fixture/SConstruct
@@ -1,4 +1,8 @@
-# msvc_fixture's SConstruct
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+"""msvc_fixture's SConstruct"""
 
 DefaultEnvironment(tools=[])
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),

--- a/test/MSVC/msvc_fixture/StdAfx.cpp
+++ b/test/MSVC/msvc_fixture/StdAfx.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "StdAfx.h"
 #ifndef PCHDEF
 this line generates an error if PCHDEF is not defined!

--- a/test/MSVC/msvc_fixture/StdAfx.h
+++ b/test/MSVC/msvc_fixture/StdAfx.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <windows.h>
 #include <stdio.h>
 #include "resource.h"

--- a/test/MSVC/msvc_fixture/foo.cpp
+++ b/test/MSVC/msvc_fixture/foo.cpp
@@ -1,1 +1,5 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "StdAfx.h"

--- a/test/MSVC/msvc_fixture/resource.h
+++ b/test/MSVC/msvc_fixture/resource.h
@@ -1,1 +1,5 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #define IDS_TEST 2001

--- a/test/MSVC/msvc_fixture/test.cpp
+++ b/test/MSVC/msvc_fixture/test.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "StdAfx.h"
 #include "resource.h"
 

--- a/test/MSVC/pch_gen/fixture/SConstruct
+++ b/test/MSVC/pch_gen/fixture/SConstruct
@@ -1,26 +1,28 @@
-# pch_gen fixture's SConstruct
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+"""pch_gen fixture's SConstruct"""
 
 DefaultEnvironment(tools=[])
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
 
-
-VariantDir('output1','src')
-VariantDir('output2','src')
-
+VariantDir('output1', 'src')
+VariantDir('output2', 'src')
 
 # Add flag to cause pch_gen to return empty string
 # This will enable testing that PCH if subst'd yields empty string will stop
 # PCH from being enabled.
 vars = Variables(None, ARGUMENTS)
-vars.AddVariables(BoolVariable("DISABLE_PCH", help="Disable PCH functionality", default=False))
-
+vars.AddVariables(
+    BoolVariable("DISABLE_PCH", help="Disable PCH functionality", default=False)
+)
 
 env = Environment(variables=vars, tools=["mssdk", "msvc", "mslink"])
 env.Append(CCFLAGS="/DPCHDEF")
 env["PDB"] = File("output1/test.pdb")
 env["PCHSTOP"] = "StdAfx.h"
-
 
 def pch_gen(env, target, source, for_signature):
     if env['DISABLE_PCH']:
@@ -28,16 +30,16 @@ def pch_gen(env, target, source, for_signature):
     else:
         return "StdAfx-1.pch"
 
-
 env["PCH"] = pch_gen
 env.PCH("output1/StdAfx-1.pch", "output1/StdAfx.cpp")
-env.Program("output1/test", ["output1/test.cpp", env.RES("output1/test.rc")], LIBS=["user32"])
+env.Program(
+    "output1/test",
+    ["output1/test.cpp", env.RES("output1/test.rc")],
+    LIBS=["user32"],
+)
 
 env.Object("output1/fast", "output1/foo.cpp")
 env.Object("output1/slow", "output1/foo.cpp", PCH=0)
-
-
-
 env2 = env.Clone()
 
 def pch_gen2(env, target, source, for_signature):
@@ -45,9 +47,13 @@ def pch_gen2(env, target, source, for_signature):
         return ""
     else:
         return env.get('PCH_NODE')
+
 env2["PDB"] = File("output2/test.pdb")
 env2["PCHSTOP"] = "StdAfx.h"
 env2["PCH"] = pch_gen2
 env2['PCH_NODE'] = env2.PCH("output2/StdAfx-1.pch", "output2/StdAfx.cpp")[0]
-env2.Program("output2/test", ["output2/test.cpp", env.RES("output2/test.rc")], LIBS=["user32"])
-
+env2.Program(
+    "output2/test",
+    ["output2/test.cpp", env.RES("output2/test.rc")],
+    LIBS=["user32"],
+)

--- a/test/MinGW/bug_2799/SConstruct
+++ b/test/MinGW/bug_2799/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(
     tools=['mingw'],
     SHCCCOMSTR='SHCC $TARGET',
@@ -8,7 +13,5 @@ env = Environment(
     SHLIBPREFIX='lib',
     LDMODULESUFFIX='.so',
 )
-
 env.SharedLibrary('testlib', 'shlib.c')
-
 env.LoadableModule('testmodule', 'module.c')

--- a/test/MinGW/bug_2799/module.c
+++ b/test/MinGW/bug_2799/module.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 extern void bar(void)
 {
 }

--- a/test/MinGW/bug_2799/shlib.c
+++ b/test/MinGW/bug_2799/shlib.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 extern int foo(void)
 {
     return 0;

--- a/test/Parallel/failed-build/fixture/SConstruct
+++ b/test/Parallel/failed-build/fixture/SConstruct
@@ -1,12 +1,19 @@
-import sys
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
+import random
+import sys
 import threading
 
-import random
+from teststate import server_thread
+
 PORT = random.randint(10000, 60000)
 
 sys.path.append(os.getcwd())
-from teststate import server_thread
+
+DefaultEnvironment(tools=[])
 
 # this thread will setup a sever for the different tasks to talk to
 # and act as a manager of IPC and the different tasks progressing

--- a/test/Parallel/failed-build/fixture/mycopy.py
+++ b/test/Parallel/failed-build/fixture/mycopy.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import sys
 import time

--- a/test/Parallel/failed-build/fixture/myfail.py
+++ b/test/Parallel/failed-build/fixture/myfail.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import sys
 import time

--- a/test/Parallel/failed-build/fixture/teststate.py
+++ b/test/Parallel/failed-build/fixture/teststate.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import http.server
 import socketserver
 import time

--- a/test/Progress/multi_target_fixture/SConstruct
+++ b/test/Progress/multi_target_fixture/SConstruct
@@ -1,15 +1,20 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 
-
 class ProgressTest:
-
     def __call__(self, node):
         if node.get_state() == SCons.Node.executing:
             print(node)
 
-
+DefaultEnvironment(tools=[])
 env = Environment(tools=[])
-env.Command(target=['out1.txt', 'out2.txt'], source=['in.txt'], action=Action(
-    'echo $SOURCE > ${TARGETS[0]};echo $SOURCE > ${TARGETS[1]}', None))
+env.Command(
+    target=['out1.txt', 'out2.txt'],
+    source=['in.txt'],
+    action=Action('echo $SOURCE > ${TARGETS[0]};echo $SOURCE > ${TARGETS[1]}', None),
+)
 Progress(ProgressTest())
 

--- a/test/SConscript/fixture/SConstruct
+++ b/test/SConscript/fixture/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 from SCons.Warnings import _warningOut
 import sys

--- a/test/SConscript/must_exist_deprecation.py
+++ b/test/SConscript/must_exist_deprecation.py
@@ -44,7 +44,7 @@ warnmsg = """
 scons: warning: Calling missing SConscript without error is deprecated.
 Transition by adding must_exist=False to SConscript calls.
 Missing SConscript '{}'
-""".format(missing) + test.python_file_line(SConstruct_path, 14)
+""".format(missing) + test.python_file_line(SConstruct_path, 18)
 
 expect_stderr = warnmsg
 test.run(arguments=".", stderr=expect_stderr)

--- a/test/Scanner/Python/SConstruct
+++ b/test/Scanner/Python/SConstruct
@@ -1,5 +1,10 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=['python'])
 
 # Copy each file individually instead of copying the dir. This has the benefit

--- a/test/Scanner/Python/script.py
+++ b/test/Scanner/Python/script.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import package1  # noqa: F401
 import package2  # noqa: F401
 import sys

--- a/test/Scanner/Python/to_be_copied/__init__.py
+++ b/test/Scanner/Python/to_be_copied/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from . import helper  # noqa: F401

--- a/test/SideEffect/Issues/3013/files/SConscript
+++ b/test/SideEffect/Issues/3013/files/SConscript
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 Import('env')
 
 primary = env.make_file('output', 'test.cpp')

--- a/test/SideEffect/Issues/3013/files/SConstruct
+++ b/test/SideEffect/Issues/3013/files/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment()
 
 def make_file(target, source, env):

--- a/test/SideEffect/Issues/3013/files/test.cpp
+++ b/test/SideEffect/Issues/3013/files/test.cpp
@@ -1,2 +1,6 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 void some_function() {}
 

--- a/test/Subst/fixture/SConstruct.callable_exception
+++ b/test/Subst/fixture/SConstruct.callable_exception
@@ -1,9 +1,15 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 class TestCallable(object):
     def __init__(self, thing, makePathsRelative = True, debug = False):
         pass
+
     def __call__(self, target, source, env, for_signature):
        raise TypeError("User callable exception")
 
+DefaultEnvironment(tools=[])
 env = Environment()
 env["TESTCLASS"] = TestCallable
 env["CCCOM"] = "$CC $_CCCOMCOM $CCFLAGS -o ${TESTCLASS('$TARGET')} -c ${TESTCLASS('$SOURCES')}"

--- a/test/TEMPFILE/fixture/SConstruct-tempfile-actionlist
+++ b/test/TEMPFILE/fixture/SConstruct-tempfile-actionlist
@@ -1,6 +1,14 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
-env = Environment(tools=[],
-                  BUILDCOM=['${TEMPFILE("xxx.py -otempfile $SOURCE")}',
-                            '${TEMPFILE("yyy.py -o$TARGET tempfile")}'],
-                  MAXLINELENGTH=1)
+env = Environment(
+    tools=[],
+    BUILDCOM=[
+        '${TEMPFILE("xxx.py -otempfile $SOURCE")}',
+        '${TEMPFILE("yyy.py -o$TARGET tempfile")}',
+    ],
+    MAXLINELENGTH=1,
+)
 env.Command('file.output', 'file.input', '$BUILDCOM')

--- a/test/TEMPFILE/fixture/SConstruct.tempfiledir
+++ b/test/TEMPFILE/fixture/SConstruct.tempfiledir
@@ -1,7 +1,12 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 
 my_temp_dir = os.path.join(os.getcwd(), 'my_temp_files')
 
+DefaultEnvironment(tools=[])
 env = Environment(
     BUILDCOM='${TEMPFILE("xxx.py $TARGET $SOURCES")}',
     MAXLINELENGTH=16,

--- a/test/TaskMaster/bug_2811/fixture_dir/SConstruct
+++ b/test/TaskMaster/bug_2811/fixture_dir/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 This issue requires the following.
 1. Generated source file which outputs 2 (or more) files
@@ -29,17 +33,12 @@ def _dwo_emitter(target, source, env):
     return (targets, source)
 
 build_string = '$MYCOPY $SOURCE $TARGET'
-
-
 bld = Builder(action=build_string)
 
+DefaultEnvironment(tools=[])
 env = Environment(BUILDERS={'Foo': bld}, MYCOPY="%s mycopy.py"%sys.executable)
-
 env['SHCCCOM'] = '$MYCOPY $SOURCE $TARGET && $MYCOPY $SOURCE ${TARGETS[1]}'
-
 env['SHCCCOMSTR'] = env['SHCCCOM']
-
-
 suffixes = ['.c']
 
 for object_builder in SCons.Tool.createObjBuilders(env):

--- a/test/TaskMaster/bug_2811/fixture_dir/mycopy.py
+++ b/test/TaskMaster/bug_2811/fixture_dir/mycopy.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 import shutil
 

--- a/test/YACC/YACC-fixture/SConstruct_YACC_before
+++ b/test/YACC/YACC-fixture/SConstruct_YACC_before
@@ -1,4 +1,9 @@
-env=Environment(tools=[])
-env2=env.Clone(YACC="SOMETHING_DUMB")
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
+env2 = env.Clone(YACC="SOMETHING_DUMB")
 env2.Tool('yacc')
 env2.CFile('aaa.y')

--- a/test/YACC/YACC-fixture/myyacc.py
+++ b/test/YACC/YACC-fixture/myyacc.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import getopt
 import sys
 

--- a/test/YACC/YACCFLAGS-fixture/myyacc.py
+++ b/test/YACC/YACCFLAGS-fixture/myyacc.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import getopt
 import sys
 from pathlib import Path

--- a/test/fixture/SConstruct-check-valid-options
+++ b/test/fixture/SConstruct-check-valid-options
@@ -5,6 +5,8 @@
 import sys
 from SCons.Script.SConsOptions import SConsOptionParser, SConsBadOptionError
 
+DefaultEnvironment(tools=[])
+
 AddOption(
     '--testing',
     help='Test arg',

--- a/test/fixture/SConstruct_test_main.py
+++ b/test/fixture/SConstruct_test_main.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
 env = Environment()
 env.Program('main.exe', ['main.c'])

--- a/test/fixture/echo.py
+++ b/test/fixture/echo.py
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 print(sys.argv)

--- a/test/fixture/mycompile.py
+++ b/test/fixture/mycompile.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Phony compiler for testing SCons.
 

--- a/test/fixture/mygcc.py
+++ b/test/fixture/mygcc.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Phony compiler for testing SCons.
 

--- a/test/fixture/mylex.py
+++ b/test/fixture/mylex.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Phony lex for testing SCons.
 

--- a/test/fixture/mylink.py
+++ b/test/fixture/mylink.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Phony linker for testing SCons.
 

--- a/test/fixture/myrewrite.py
+++ b/test/fixture/myrewrite.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 r"""
 Phony tool to modify a file in place for testing SCons.
 

--- a/test/fixture/no_msvc/no_msvcs_sconstruct.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct.py
@@ -1,15 +1,21 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 import SCons.Tool.MSCommon
+
+DefaultEnvironment(tools=[])
 
 def DummyVsWhere(msvc_version, env):
     # not testing versions with vswhere, so return none
     return None
 
 for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
-    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key] = [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')
+    ]
 
 SCons.Tool.MSCommon.vc.find_vc_pdir_vswhere = DummyVsWhere
-
 env = SCons.Environment.Environment()
-
-print('MSVC_VERSION='+str(env.get('MSVC_VERSION')))
+print('MSVC_VERSION=' + str(env.get('MSVC_VERSION')))

--- a/test/fixture/no_msvc/no_msvcs_sconstruct_msvc_query_toolset_version.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct_msvc_query_toolset_version.py
@@ -1,15 +1,21 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 import SCons.Tool.MSCommon
+
+DefaultEnvironment(tools=[])
 
 def DummyVsWhere(msvc_version, env):
     # not testing versions with vswhere, so return none
     return None
 
 for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
-    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key] = [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')
+    ]
 
 SCons.Tool.MSCommon.vc.find_vc_pdir_vswhere = DummyVsWhere
-
 msvc_version, msvc_toolset_version = SCons.Tool.MSCommon.msvc_query_version_toolset()
-
-print('msvc_version={}, msvc_toolset_version={}'.format(repr(msvc_version), repr(msvc_toolset_version)))
+print(f'msvc_version={msvc_version!r}, msvc_toolset_version={msvc_toolset_version!r}')

--- a/test/fixture/no_msvc/no_msvcs_sconstruct_msvc_sdk_versions.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct_msvc_sdk_versions.py
@@ -1,15 +1,21 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 import SCons.Tool.MSCommon
+
+DefaultEnvironment(tools=[])
 
 def DummyVsWhere(msvc_version, env):
     # not testing versions with vswhere, so return none
     return None
 
 for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
-    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key] = [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')
+    ]
 
 SCons.Tool.MSCommon.vc.find_vc_pdir_vswhere = DummyVsWhere
-
 sdk_version_list = SCons.Tool.MSCommon.msvc_sdk_versions()
-
-print('sdk_version_list='+repr(sdk_version_list))
+print('sdk_version_list=' + repr(sdk_version_list))

--- a/test/fixture/no_msvc/no_msvcs_sconstruct_msvc_toolset_versions.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct_msvc_toolset_versions.py
@@ -1,15 +1,21 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 import SCons.Tool.MSCommon
+
+DefaultEnvironment(tools=[])
 
 def DummyVsWhere(msvc_version, env):
     # not testing versions with vswhere, so return none
     return None
 
 for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
-    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key] = [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')
+    ]
 
 SCons.Tool.MSCommon.vc.find_vc_pdir_vswhere = DummyVsWhere
-
 toolset_version_list = SCons.Tool.MSCommon.msvc_toolset_versions()
-
-print('toolset_version_list='+repr(toolset_version_list))
+print('toolset_version_list=' + repr(toolset_version_list))

--- a/test/fixture/no_msvc/no_msvcs_sconstruct_tools.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct_tools.py
@@ -1,14 +1,21 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 import SCons.Tool.MSCommon
+
+DefaultEnvironment(tools=[])
 
 def DummyVsWhere(msvc_version, env):
     # not testing versions with vswhere, so return none
     return None
 
 for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
-    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key] = [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')
+    ]
 
 SCons.Tool.MSCommon.vc.find_vc_pdir_vswhere = DummyVsWhere
-
 env = SCons.Environment.Environment(tools=['myignoredefaultmsvctool'])
 

--- a/test/fixture/no_msvc/no_msvcs_sconstruct_version.py
+++ b/test/fixture/no_msvc/no_msvcs_sconstruct_version.py
@@ -1,19 +1,21 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 import SCons.Tool.MSCommon
 
+DefaultEnvironment(tools=[])
 
 def DummyVsWhere(msvc_version, env):
     # not testing versions with vswhere, so return none
     return None
 
-
 for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
-    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key] = [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')
+    ]
 
 SCons.Tool.MSCommon.vc.find_vc_pdir_vswhere = DummyVsWhere
-
 SCons.Tool.MSCommon.msvc_set_notfound_policy('error')
-
 env = SCons.Environment.Environment(MSVC_VERSION='14.3')
-
-

--- a/test/fixture/no_msvc/no_regs_sconstruct.py
+++ b/test/fixture/no_msvc/no_regs_sconstruct.py
@@ -1,7 +1,15 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 import SCons.Tool.MSCommon
 
+DefaultEnvironment(tools=[])
+
 for key in SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR:
-    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key]=[(SCons.Util.HKEY_LOCAL_MACHINE, r'')]
+    SCons.Tool.MSCommon.vc._VCVER_TO_PRODUCT_DIR[key] = [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')
+    ]
 
 env = SCons.Environment.Environment()

--- a/test/fixture/python_scanner/curdir_reference/script.py
+++ b/test/fixture/python_scanner/curdir_reference/script.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from . import helper

--- a/test/fixture/python_scanner/from_import_simple_package_module1.py
+++ b/test/fixture/python_scanner/from_import_simple_package_module1.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from simple_package import module1

--- a/test/fixture/python_scanner/from_import_simple_package_module1_as.py
+++ b/test/fixture/python_scanner/from_import_simple_package_module1_as.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from simple_package import module1 as m1

--- a/test/fixture/python_scanner/from_import_simple_package_module1_func.py
+++ b/test/fixture/python_scanner/from_import_simple_package_module1_func.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from simple_package.module1 import somefunc  # noqa: F401

--- a/test/fixture/python_scanner/from_import_simple_package_modules_no_space.py
+++ b/test/fixture/python_scanner/from_import_simple_package_modules_no_space.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from simple_package import module1,module2

--- a/test/fixture/python_scanner/from_import_simple_package_modules_with_space.py
+++ b/test/fixture/python_scanner/from_import_simple_package_modules_with_space.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from simple_package import module1, module2

--- a/test/fixture/python_scanner/from_nested1_import_multiple.py
+++ b/test/fixture/python_scanner/from_nested1_import_multiple.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from nested1 import module, nested2  # noqa: F401

--- a/test/fixture/python_scanner/import_simple_package_module1.py
+++ b/test/fixture/python_scanner/import_simple_package_module1.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import simple_package.module1

--- a/test/fixture/python_scanner/import_simple_package_module1_as.py
+++ b/test/fixture/python_scanner/import_simple_package_module1_as.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import simple_package.module1 as m1

--- a/test/fixture/python_scanner/imports_nested3.py
+++ b/test/fixture/python_scanner/imports_nested3.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import nested1.nested2.nested3

--- a/test/fixture/python_scanner/imports_simple_package.py
+++ b/test/fixture/python_scanner/imports_simple_package.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import simple_package

--- a/test/fixture/python_scanner/imports_unknown_files.py
+++ b/test/fixture/python_scanner/imports_unknown_files.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import doesntexist  # noqa: F401
 import notthere.something  # noqa: F401
 from notthere import a, few, things  # noqa: F401

--- a/test/fixture/python_scanner/nested1/nested2/nested3/imports_grandparent_module.py
+++ b/test/fixture/python_scanner/nested1/nested2/nested3/imports_grandparent_module.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from ... import module

--- a/test/fixture/python_scanner/nested1/nested2/nested3/imports_parent_module.py
+++ b/test/fixture/python_scanner/nested1/nested2/nested3/imports_parent_module.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from .. import module

--- a/test/fixture/python_scanner/nested1/nested2/nested3/imports_parent_then_submodule.py
+++ b/test/fixture/python_scanner/nested1/nested2/nested3/imports_parent_then_submodule.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from ...nested2a import module

--- a/test/fixture/python_scanner/simple_package/module1.py
+++ b/test/fixture/python_scanner/simple_package/module1.py
@@ -1,2 +1,6 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def somefunc():
     return

--- a/test/fixture/test_main.c
+++ b/test/fixture/test_main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 int main( int argc, char* argv[] )
 {
   return 0;

--- a/test/fixture/wrapper.py
+++ b/test/fixture/wrapper.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Command wrapper, for testing SCons.
 

--- a/test/fixture/wrapper_with_args.py
+++ b/test/fixture/wrapper_with_args.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Command wrapper taking arguments, for testing SCons.
 

--- a/test/ninja/ninja-fixture/bar.c
+++ b/test/ninja/ninja-fixture/bar.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/ninja/ninja-fixture/foo.c
+++ b/test/ninja/ninja-fixture/foo.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/ninja/ninja-fixture/gen_source.c
+++ b/test/ninja/ninja-fixture/gen_source.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/ninja/ninja-fixture/test1.c
+++ b/test/ninja/ninja-fixture/test1.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/ninja/ninja-fixture/test2.cpp
+++ b/test/ninja/ninja-fixture/test2.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "test2.hpp"
 
 int

--- a/test/ninja/ninja-fixture/test_impl.c
+++ b/test/ninja/ninja-fixture/test_impl.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/ninja/ninja_test_sconscripts/ninja_conftest
+++ b/test/ninja/ninja_test_sconscripts/ninja_conftest
@@ -1,10 +1,13 @@
-SetOption('experimental','ninja')
-DefaultEnvironment(tools=[])
+# MIT License
+#
+# Copyright The SCons Foundation
 
 import sys 
 
-env = Environment()
+SetOption('experimental','ninja')
+DefaultEnvironment(tools=[])
 
+env = Environment()
 conf = Configure(env)
 env.Tool('ninja')
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_control_c_ninja
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_control_c_ninja
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import os
 import signal
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_default_targets
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_default_targets
@@ -1,12 +1,14 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 
 env = Environment(tools=[])
-
 env.Tool('ninja')
-
 env.Command('out1.txt', 'foo.c', 'echo test > $TARGET' )
 out2_node = env.Command('out2.txt', 'foo.c', 'echo test > $TARGET', NINJA_FORCE_SCONS_BUILD=True)
 alias = env.Alias('def', out2_node)

--- a/test/ninja/ninja_test_sconscripts/sconstruct_force_scons_callback
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_force_scons_callback
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 SetOption("experimental", "ninja")
 DefaultEnvironment(tools=[])
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_generate_and_build
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_generate_and_build
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_generate_and_build_cxx
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_generate_and_build_cxx
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 env = Environment()

--- a/test/ninja/ninja_test_sconscripts/sconstruct_generated_sources_alias
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_generated_sources_alias
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 
 SetOption('experimental','ninja')

--- a/test/ninja/ninja_test_sconscripts/sconstruct_mingw_command_generator_action
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_mingw_command_generator_action
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_mingw_depfile_format
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_mingw_depfile_format
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_ninja_command_line
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_ninja_command_line
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_ninja_determinism
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_ninja_determinism
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import random
 
 SetOption('experimental', 'ninja')

--- a/test/ninja/ninja_test_sconscripts/sconstruct_no_for_sig_subst
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_no_for_sig_subst
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import SCons
 
 SetOption('experimental','ninja')

--- a/test/ninja/ninja_test_sconscripts/sconstruct_response_file
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_response_file
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 SetOption('experimental','ninja')
 DefaultEnvironment(tools=[])
 

--- a/test/option/fixture/SConstruct__experimental
+++ b/test/option/fixture/SConstruct__experimental
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from SCons.Script.SConsOptions import experimental_features
 
 print("All Features=%s" % ','.join(sorted(experimental_features)))

--- a/test/option/fixture/SConstruct__taskmastertrace
+++ b/test/option/fixture/SConstruct__taskmastertrace
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 

--- a/test/option/hash-format/SConstruct
+++ b/test/option/hash-format/SConstruct
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import atexit
 import sys
 

--- a/test/option/hash-format/build.py
+++ b/test/option/hash-format/build.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys
 with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as infp:
     f.write(infp.read())

--- a/test/packaging/convenience-functions/image/SConstruct
+++ b/test/packaging/convenience-functions/image/SConstruct
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env  = Environment(tools=['default', 'packaging'])
 prog = env.Install( 'bin/', ["f1", "f2"] )
 env.File( "f3" )

--- a/test/packaging/rpm/src/main.c
+++ b/test/packaging/rpm/src/main.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 
 int main( int argc, char* argv[] )
 {

--- a/test/packaging/sandbox-test/SConstruct
+++ b/test/packaging/sandbox-test/SConstruct
@@ -1,19 +1,27 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
 from glob import glob
 
-src_files = glob( 'src/*.c' )
-include_files = glob( 'src/*.h' )
+src_files = glob('src/*.c')
+include_files = glob('src/*.h')
 
-SharedLibrary( 'foobar', src_files )
+SharedLibrary('foobar', src_files)
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=['default', 'packaging'])
 
-env.Package( NAME        = 'libfoobar',
-             VERSION     = '1.2.3',
-             PACKAGETYPE = 'targz',
-             source      = src_files + include_files )
+env.Package(
+    NAME='libfoobar',
+    VERSION='1.2.3',
+    PACKAGETYPE='targz',
+    source=src_files + include_files,
+)
 
-env.Package( NAME        = 'libfoobar',
-             VERSION     = '1.2.3',
-             PACKAGETYPE = 'zip',
-             source      = src_files + include_files )
+env.Package(
+    NAME='libfoobar',
+    VERSION='1.2.3',
+    PACKAGETYPE='zip',
+    source=src_files + include_files,
+)

--- a/test/textfile/fixture/SConstruct
+++ b/test/textfile/fixture/SConstruct
@@ -1,5 +1,8 @@
-DefaultEnvironment(tools=[])
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 
+DefaultEnvironment(tools=[])
 env = Environment(tools=['textfile'])
 data0 = ['Goethe', 'Schiller']
 data = ['lalala', 42, data0, 'tanteratei',
@@ -11,9 +14,11 @@ env.Textfile('foo1a.txt', data + [''])
 env.Textfile('foo2a.txt', data + [''], LINESEPARATOR='|*')
 
 issue_4021_textfile = r'<HintPath>..\..\..\@HINT_PATH@\Datalogics.PDFL.dll</HintPath>'
-env.Textfile('issue-4021.txt', issue_4021_textfile,
-             SUBST_DICT={'@HINT_PATH@': r'NETCore\bin\$$(Platform)\$$(Configuration)'})
-
+env.Textfile(
+    'issue-4021.txt',
+    issue_4021_textfile,
+    SUBST_DICT={'@HINT_PATH@': r'NETCore\bin\$$(Platform)\$$(Configuration)'},
+)
 # recreate the list with the data wrapped in Value()
 data0 = list(map(Value, data0))
 data = list(map(Value, data))

--- a/test/textfile/fixture/SConstruct.2
+++ b/test/textfile/fixture/SConstruct.2
@@ -1,9 +1,14 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
 
-textlist = ['This line has no substitutions',
-            'This line has @subst@ substitutions',
-            'This line has %subst% substitutions',
-            ]
+textlist = [
+    'This line has no substitutions',
+    'This line has @subst@ substitutions',
+    'This line has %subst% substitutions',
+]
 
 sub1 = {'@subst@': 'most'}
 sub2 = {'%subst%': 'many'}

--- a/test/textfile/fixture/SConstruct.issue-3540
+++ b/test/textfile/fixture/SConstruct.issue-3540
@@ -1,17 +1,16 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 """
 Test for GH Issue 3540
 
 textfile()'s action is not sensitive to changes in TEXTFILESUFFIX (rather was sensitive to SUBSTFILESUFFIX)
-
 """
 
-DefaultEnvironment(tools=[])
-
 text_file_suffix = ARGUMENTS.get('text_file_suffix', 'DEFAULTSUFFIX')
-
-env = Environment(tools=['textfile'],
-                  TEXTFILESUFFIX=text_file_suffix)
-
+DefaultEnvironment(tools=[])
+env = Environment(tools=['textfile'], TEXTFILESUFFIX=text_file_suffix)
 env['FOO_PATH'] = "test-value-1"
 
 foo = env.Substfile(
@@ -19,5 +18,5 @@ foo = env.Substfile(
     source="substfile.in",
     SUBST_DICT={
         "@foo_path@": "$FOO_PATH",
-    }
+    },
 )

--- a/test/textfile/fixture/SConstruct.issue-3550
+++ b/test/textfile/fixture/SConstruct.issue-3550
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 DefaultEnvironment(tools=[])
 env = Environment(tools=['textfile'])
 

--- a/test/textfile/fixture/SConstruct.issue-4037
+++ b/test/textfile/fixture/SConstruct.issue-4037
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment()
 
 def generator(source, target, env, for_signature):
@@ -9,10 +14,6 @@ env['GENERATOR'] = generator
 
 env.Textfile(
     target="target",
-    source=[
-        "@generated@",
-    ],
-    SUBST_DICT={
-        '@generated@' : '$GENERATOR',
-    },
+    source=["@generated@"],
+    SUBST_DICT={'@generated@' : '$GENERATOR'},
 )

--- a/test/toolpath/nested/image/Libs/tools_example/Toolpath_TestTool1.py
+++ b/test/toolpath/nested/image/Libs/tools_example/Toolpath_TestTool1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/Libs/tools_example/Toolpath_TestTool2/__init__.py
+++ b/test/toolpath/nested/image/Libs/tools_example/Toolpath_TestTool2/__init__.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool2'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/Libs/tools_example/subdir1/Toolpath_TestTool1_1.py
+++ b/test/toolpath/nested/image/Libs/tools_example/subdir1/Toolpath_TestTool1_1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool1_1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/Libs/tools_example/subdir1/Toolpath_TestTool1_2/__init__.py
+++ b/test/toolpath/nested/image/Libs/tools_example/subdir1/Toolpath_TestTool1_2/__init__.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool1_2'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/Libs/tools_example/subdir1/subdir2/Toolpath_TestTool2_1.py
+++ b/test/toolpath/nested/image/Libs/tools_example/subdir1/subdir2/Toolpath_TestTool2_1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool2_1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/Libs/tools_example/subdir1/subdir2/Toolpath_TestTool2_2/__init__.py
+++ b/test/toolpath/nested/image/Libs/tools_example/subdir1/subdir2/Toolpath_TestTool2_2/__init__.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool2_2'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/SConstruct
+++ b/test/toolpath/nested/image/SConstruct
@@ -1,39 +1,47 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 import sys, os
 
-toollist = ['Toolpath_TestTool1',
-            'Toolpath_TestTool2',
-            'subdir1.Toolpath_TestTool1_1',
-            'subdir1.Toolpath_TestTool1_2',
-            'subdir1.subdir2.Toolpath_TestTool2_1',
-            'subdir1.subdir2.Toolpath_TestTool2_2',
-	    ]
+DefaultEnvironment(tools=[])
+
+toollist = [
+    'Toolpath_TestTool1',
+    'Toolpath_TestTool2',
+    'subdir1.Toolpath_TestTool1_1',
+    'subdir1.Toolpath_TestTool1_2',
+    'subdir1.subdir2.Toolpath_TestTool2_1',
+    'subdir1.subdir2.Toolpath_TestTool2_2',
+]
 
 print('Test where tools are located under site_scons/site_tools')
 env1 = Environment(tools=toollist)
-print("env1['Toolpath_TestTool1'] = %s"%env1.get('Toolpath_TestTool1'))
-print("env1['Toolpath_TestTool2'] = %s"%env1.get('Toolpath_TestTool2'))
-print("env1['Toolpath_TestTool1_1'] = %s"%env1.get('Toolpath_TestTool1_1'))
-print("env1['Toolpath_TestTool1_2'] = %s"%env1.get('Toolpath_TestTool1_2'))
-print("env1['Toolpath_TestTool2_1'] = %s"%env1.get('Toolpath_TestTool2_1'))
-print("env1['Toolpath_TestTool2_2'] = %s"%env1.get('Toolpath_TestTool2_2'))
+print("env1['Toolpath_TestTool1'] = %s" % env1.get('Toolpath_TestTool1'))
+print("env1['Toolpath_TestTool2'] = %s" % env1.get('Toolpath_TestTool2'))
+print("env1['Toolpath_TestTool1_1'] = %s" % env1.get('Toolpath_TestTool1_1'))
+print("env1['Toolpath_TestTool1_2'] = %s" % env1.get('Toolpath_TestTool1_2'))
+print("env1['Toolpath_TestTool2_1'] = %s" % env1.get('Toolpath_TestTool2_1'))
+print("env1['Toolpath_TestTool2_2'] = %s" % env1.get('Toolpath_TestTool2_2'))
 
 print('Test where toolpath is set in the env constructor')
 env2 = Environment(tools=toollist, toolpath=['Libs/tools_example'])
-print("env2['Toolpath_TestTool1'] = %s"%env2.get('Toolpath_TestTool1'))
-print("env2['Toolpath_TestTool2'] = %s"%env2.get('Toolpath_TestTool2'))
-print("env2['Toolpath_TestTool1_1'] = %s"%env2.get('Toolpath_TestTool1_1'))
-print("env2['Toolpath_TestTool1_2'] = %s"%env2.get('Toolpath_TestTool1_2'))
-print("env2['Toolpath_TestTool2_1'] = %s"%env2.get('Toolpath_TestTool2_1'))
-print("env2['Toolpath_TestTool2_2'] = %s"%env2.get('Toolpath_TestTool2_2'))
+print("env2['Toolpath_TestTool1'] = %s" % env2.get('Toolpath_TestTool1'))
+print("env2['Toolpath_TestTool2'] = %s" % env2.get('Toolpath_TestTool2'))
+print("env2['Toolpath_TestTool1_1'] = %s" % env2.get('Toolpath_TestTool1_1'))
+print("env2['Toolpath_TestTool1_2'] = %s" % env2.get('Toolpath_TestTool1_2'))
+print("env2['Toolpath_TestTool2_1'] = %s" % env2.get('Toolpath_TestTool2_1'))
+print("env2['Toolpath_TestTool2_2'] = %s" % env2.get('Toolpath_TestTool2_2'))
 
 print('Test a Clone')
 base = Environment(tools=[], toolpath=['Libs/tools_example'])
 derived = base.Clone(tools=['subdir1.Toolpath_TestTool1_1'])
-print("derived['Toolpath_TestTool1_1'] = %s"%derived.get('Toolpath_TestTool1_1'))
-
-
+print("derived['Toolpath_TestTool1_1'] = %s" % derived.get('Toolpath_TestTool1_1'))
 print('Test using syspath as the toolpath')
-print('Lets pretend that tools_example within Libs is actually a module installed via pip')
+print(
+    'Lets pretend that tools_example within Libs '
+    'is actually a module installed via pip'
+)
 oldsyspath = sys.path
 dir_path = Dir('.').srcnode().abspath
 dir_path = os.path.join(dir_path, 'Libs')
@@ -43,27 +51,29 @@ searchpaths = []
 for item in sys.path:
     if os.path.isdir(item): searchpaths.append(item)
 
-toollist = ['tools_example.Toolpath_TestTool1',
-            'tools_example.Toolpath_TestTool2',
-            'tools_example.subdir1.Toolpath_TestTool1_1',
-            'tools_example.subdir1.Toolpath_TestTool1_2',
-            'tools_example.subdir1.subdir2.Toolpath_TestTool2_1',
-            'tools_example.subdir1.subdir2.Toolpath_TestTool2_2',
-	    ]
+toollist = [
+    'tools_example.Toolpath_TestTool1',
+    'tools_example.Toolpath_TestTool2',
+    'tools_example.subdir1.Toolpath_TestTool1_1',
+    'tools_example.subdir1.Toolpath_TestTool1_2',
+    'tools_example.subdir1.subdir2.Toolpath_TestTool2_1',
+    'tools_example.subdir1.subdir2.Toolpath_TestTool2_2',
+]
 
 env3 = Environment(tools=toollist, toolpath=searchpaths)
-print("env3['Toolpath_TestTool1'] = %s"%env3.get('Toolpath_TestTool1'))
-print("env3['Toolpath_TestTool2'] = %s"%env3.get('Toolpath_TestTool2'))
-print("env3['Toolpath_TestTool1_1'] = %s"%env3.get('Toolpath_TestTool1_1'))
-print("env3['Toolpath_TestTool1_2'] = %s"%env3.get('Toolpath_TestTool1_2'))
-print("env3['Toolpath_TestTool2_1'] = %s"%env3.get('Toolpath_TestTool2_1'))
-print("env3['Toolpath_TestTool2_2'] = %s"%env3.get('Toolpath_TestTool2_2'))
-
+print("env3['Toolpath_TestTool1'] = %s" % env3.get('Toolpath_TestTool1'))
+print("env3['Toolpath_TestTool2'] = %s" % env3.get('Toolpath_TestTool2'))
+print("env3['Toolpath_TestTool1_1'] = %s" % env3.get('Toolpath_TestTool1_1'))
+print("env3['Toolpath_TestTool1_2'] = %s" % env3.get('Toolpath_TestTool1_2'))
+print("env3['Toolpath_TestTool2_1'] = %s" % env3.get('Toolpath_TestTool2_1'))
+print("env3['Toolpath_TestTool2_2'] = %s" % env3.get('Toolpath_TestTool2_2'))
 
 print('Test using PyPackageDir')
 toollist = ['Toolpath_TestTool2_1', 'Toolpath_TestTool2_2']
-env4 = Environment(tools = toollist, toolpath = [PyPackageDir('tools_example.subdir1.subdir2')])
-print("env4['Toolpath_TestTool2_1'] = %s"%env4.get('Toolpath_TestTool2_1'))
-print("env4['Toolpath_TestTool2_2'] = %s"%env4.get('Toolpath_TestTool2_2'))
+env4 = Environment(
+    tools=toollist, toolpath=[PyPackageDir('tools_example.subdir1.subdir2')]
+)
+print("env4['Toolpath_TestTool2_1'] = %s" % env4.get('Toolpath_TestTool2_1'))
+print("env4['Toolpath_TestTool2_2'] = %s" % env4.get('Toolpath_TestTool2_2'))
 
 sys.path = oldsyspath

--- a/test/toolpath/nested/image/site_scons/site_tools/Toolpath_TestTool1.py
+++ b/test/toolpath/nested/image/site_scons/site_tools/Toolpath_TestTool1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/site_scons/site_tools/Toolpath_TestTool2/__init__.py
+++ b/test/toolpath/nested/image/site_scons/site_tools/Toolpath_TestTool2/__init__.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool2'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/site_scons/site_tools/subdir1/Toolpath_TestTool1_1.py
+++ b/test/toolpath/nested/image/site_scons/site_tools/subdir1/Toolpath_TestTool1_1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool1_1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/site_scons/site_tools/subdir1/Toolpath_TestTool1_2/__init__.py
+++ b/test/toolpath/nested/image/site_scons/site_tools/subdir1/Toolpath_TestTool1_2/__init__.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool1_2'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/site_scons/site_tools/subdir1/subdir2/Toolpath_TestTool2_1.py
+++ b/test/toolpath/nested/image/site_scons/site_tools/subdir1/subdir2/Toolpath_TestTool2_1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool2_1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/nested/image/site_scons/site_tools/subdir1/subdir2/Toolpath_TestTool2_2/__init__.py
+++ b/test/toolpath/nested/image/site_scons/site_tools/subdir1/subdir2/Toolpath_TestTool2_2/__init__.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['Toolpath_TestTool2_2'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/relative_import/image/SConstruct
+++ b/test/toolpath/relative_import/image/SConstruct
@@ -1,10 +1,15 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+DefaultEnvironment(tools=[])
 env = Environment(tools=['TestTool1', 'TestTool1.TestTool1_2'], toolpath=['tools'])
 
 # Test a relative import within the root of the tools directory
-print("env['TestTool1'] = %s"%env.get('TestTool1'))
-print("env['TestTool1_1'] = %s"%env.get('TestTool1_1'))
+print("env['TestTool1'] = %s" % env.get('TestTool1'))
+print("env['TestTool1_1'] = %s" % env.get('TestTool1_1'))
 
 # Test a relative import within a sub dir
-print("env['TestTool1_2'] = %s"%env.get('TestTool1_2'))
-print("env['TestTool1_2_1'] = %s"%env.get('TestTool1_2_1'))
-print("env['TestTool1_2_2'] = %s"%env.get('TestTool1_2_2'))
+print("env['TestTool1_2'] = %s" % env.get('TestTool1_2'))
+print("env['TestTool1_2_1'] = %s" % env.get('TestTool1_2_1'))
+print("env['TestTool1_2_2'] = %s" % env.get('TestTool1_2_2'))

--- a/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_1.py
+++ b/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['TestTool1_1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_2/TestTool1_2_1.py
+++ b/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_2/TestTool1_2_1.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['TestTool1_2_1'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_2/TestTool1_2_2/__init__.py
+++ b/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_2/TestTool1_2_2/__init__.py
@@ -1,4 +1,9 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 def generate(env):
     env['TestTool1_2_2'] = 1
+
 def exists(env):
     return 1

--- a/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_2/__init__.py
+++ b/test/toolpath/relative_import/image/tools/TestTool1/TestTool1_2/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from . import TestTool1_2_1
 from . import TestTool1_2_2
 
@@ -5,6 +9,7 @@ def generate(env):
     env['TestTool1_2'] = 1
     TestTool1_2_1.generate(env)
     TestTool1_2_2.generate(env)
+
 def exists(env):
     TestTool1_2_1.exists(env)
     TestTool1_2_2.exists(env)

--- a/test/toolpath/relative_import/image/tools/TestTool1/__init__.py
+++ b/test/toolpath/relative_import/image/tools/TestTool1/__init__.py
@@ -1,9 +1,14 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
 from . import TestTool1_1
 
 def generate(env):
     env['TestTool1'] = 1
     # Include another tool within the same directory
     TestTool1_1.generate(env)
+
 def exists(env):
     TestTool1_1.exists(env)
     return 1


### PR DESCRIPTION
Somewhat niggly maintenance task: a lot of files that are not the main test scripts had no license/copyright headers.  This change adds those.

In a few cases, this necessitated a change to an expected line number from a failure/exception message (usually not in the same test file as the change).

Along the way, some tests are lightly reformatted and some add a `DefaultEnvironment` call.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
