### PR TITLE
Drop unused environment signature methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,6 +32,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       that if arg was a list, a ListAction was *always* returned; mention
       default Decider and sort the names of available decider functions,
       and add a version marking.  Minor fiddling with Alias.py docstrings.
+    - Added copyright headers to files in test/ that didn't have them.
+    - Drop three unused methods from the Environment Base class:
+      get_src_sig_type and get_tgt_sig_type, as well as "private"
+      _changed_source. These were orphaned when the long-deprecated
+      Source Signatures and Target Signatures were removed, these were
+      missed at that time.
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -26,8 +26,10 @@ DEPRECATED FUNCTIONALITY
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 
-- List modifications to existing features, where the previous behavior
-  wouldn't actually be considered a bug
+- Three unused non-public methods of the Environment Base class
+  were dropped: get_src_sig_type, get_tgt_sig_type, _changed_source.
+  These were unused remnants of the previously removed SourceSignatures
+  and TargetSignatures features (dropped in 3.1.2).
 
 FIXES
 -----

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1399,23 +1399,6 @@ class Base(SubstitutionEnvironment):
             if k not in self._dict:
                 self._dict[k] = v
 
-
-    def get_src_sig_type(self):
-        try:
-            return self.src_sig_type
-        except AttributeError:
-            t = SCons.Defaults.DefaultEnvironment().src_sig_type
-            self.src_sig_type = t
-            return t
-
-    def get_tgt_sig_type(self):
-        try:
-            return self.tgt_sig_type
-        except AttributeError:
-            t = SCons.Defaults.DefaultEnvironment().tgt_sig_type
-            self.tgt_sig_type = t
-            return t
-
     #######################################################################
     # Public methods for manipulating an Environment.  These begin with
     # upper-case letters.  The essential characteristic of methods in
@@ -1626,14 +1609,6 @@ class Base(SubstitutionEnvironment):
 
     def _changed_content(self, dependency, target, prev_ni, repo_node=None):
         return dependency.changed_content(target, prev_ni, repo_node)
-
-    def _changed_source(self, dependency, target, prev_ni, repo_node=None):
-        target_env = dependency.get_build_env()
-        type = target_env.get_tgt_sig_type()
-        if type == 'source':
-            return target_env.decide_source(dependency, target, prev_ni, repo_node)
-        else:
-            return target_env.decide_target(dependency, target, prev_ni, repo_node)
 
     def _changed_timestamp_then_content(self, dependency, target, prev_ni, repo_node=None):
         return dependency.changed_timestamp_then_content(target, prev_ni, repo_node)


### PR DESCRIPTION
Drop three unused methods from the Environment Base class: get_src_sig_type and get_tgt_sig_type, as well as "private" _changed_source which no longer was mapped to any decider. These were orphaned when the long-deprecated Source Signatures and Target Signatures were removed in #9c4e6c7a3 - missing this change.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
