### PR TITLE
Drop dead code from unit tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,6 +32,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       that if arg was a list, a ListAction was *always* returned; mention
       default Decider and sort the names of available decider functions,
       and add a version marking.  Minor fiddling with Alias.py docstrings.
+    - Remove dead code: some mocked classes in unit tests had methods
+      which have been removed from the Node class they're mocking,
+      there's no need to shadow those any more as there are no callers.
+      The methods are depends_on (base functionality removed in 2005)
+      and is_pseudeo_derived (base functionality removed in 2006). There
+      may well be more!
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/SCons/SConfTests.py
+++ b/SCons/SConfTests.py
@@ -199,8 +199,6 @@ class SConfTestCase(unittest.TestCase):
                         self.state = state
                     def alter_targets(self):
                         return [], None
-                    def depends_on(self, nodes):
-                        return None
                     def postprocess(self) -> None:
                         pass
                     def clear(self) -> None:

--- a/SCons/Taskmaster/TaskmasterTests.py
+++ b/SCons/Taskmaster/TaskmasterTests.py
@@ -197,17 +197,8 @@ class Node:
     def store_bsig(self) -> None:
         pass
 
-    def is_pseudo_derived(self) -> None:
-        pass
-
     def is_up_to_date(self):
         return self._current_val
-
-    def depends_on(self, nodes) -> int:
-        for node in nodes:
-            if node in self.kids:
-                return 1
-        return 0
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
Remove dead code: some mocked classes in unit tests had methods which have been removed from the Node class they're mocking, there's no need to shadow those anymore as there are no callers.  The methods are `depends_on` (base functionality removed in 2005 in 62e2f021a) and `is_pseudeo_derived` (base functionality removed in 2006 in d43c3fa04).

This is test-only, no impacts to run-time SCons or docs.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
