### PR TITLE
Maint: turn ActionBase into abstract class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -64,6 +64,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       sufficient just to check the build worked. Renamed the fixture
       dir to follow naming convention in test/MSVC overall, and added
       a sconstest.skip file, also to follow convention.
+    - Class ActionBase is now an abstract base class to more accurately
+      reflect its usage. Derived _ActionAction inherits the ABC, so it
+      now declares (actually raises NotImplementedError) two methods it
+      doesn't use so it can be instantiated by unittests and others.
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -72,7 +72,10 @@ DEVELOPMENT
   to test files, which allows test lists, exclude lists, and tests on
   the command line to "not care" about the OS convention for pathname
   separators.
-
+- Class ActionBase is now an abstract base class to more accurately
+  reflect its usage. Derived _ActionAction inherits the ABC, so it
+  now declares (actually raises NotImplementedError) two methods it
+  doesn't use so it can be instantiated by unittests and others.
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================


### PR DESCRIPTION
Align some function sigs that were missing a kwarg. Sorted the imports.

This is internal - no doc impacts, test pass.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
