### PR TITLE
maintenance: update/cleanup dblite module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -91,7 +91,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       name, to match actual current behavior (only affects if target
       explicitly requested with a different base name
       than source).  Docs updated.  Fixes #4326 and #4327.
-    - Cleanud up dblite module (checker warnings, etc.).
+    - Cleaned up dblite module (checker warnings, etc.).
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -91,6 +91,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       name, to match actual current behavior (only affects if target
       explicitly requested with a different base name
       than source).  Docs updated.  Fixes #4326 and #4327.
+    - Cleanud up dblite module (checker warnings, etc.).
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -88,10 +88,10 @@ DEVELOPMENT
   now declares (actually raises NotImplementedError) two methods it
   doesn't use so it can be instantiated by unittests and others.
 - Added more type annotations to internal routines.
-- Cleanud up dblite module (checker warnings, etc.).
+- Cleaned up dblite module (checker warnings, etc.).
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================
 .. code-block:: text
 
-    git shortlog --no-merges -ns 4.0.1..HEAD
+    git shortlog --no-merges -ns 4.5.2..HEAD

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -88,6 +88,7 @@ DEVELOPMENT
   now declares (actually raises NotImplementedError) two methods it
   doesn't use so it can be instantiated by unittests and others.
 - Added more type annotations to internal routines.
+- Cleanud up dblite module (checker warnings, etc.).
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/SCons/SConsign.py
+++ b/SCons/SConsign.py
@@ -23,7 +23,7 @@
 
 """Operations on signature database files (.sconsign). """
 
-import SCons.compat
+import SCons.compat  # pylint: disable=wrong-import-order
 
 import os
 import pickle
@@ -69,11 +69,10 @@ def current_sconsign_filename():
     # eg .sconsign_sha1, etc.
     if hash_format is None and current_hash_algorithm == 'md5':
         return ".sconsign"
-    else:
-        return ".sconsign_" + current_hash_algorithm
+    return ".sconsign_" + current_hash_algorithm
 
 def Get_DataBase(dir):
-    global DataBase, DB_Module, DB_Name
+    global DB_Name
 
     if DB_Name is None:
         DB_Name = current_sconsign_filename()
@@ -117,8 +116,6 @@ normcase = os.path.normcase
 
 
 def write() -> None:
-    global sig_files
-
     if print_time():
         start_time = time.perf_counter()
 
@@ -284,7 +281,6 @@ class DB(Base):
             self.set_entry = self.do_not_set_entry
             self.store_info = self.do_not_store_info
 
-        global sig_files
         sig_files.append(self)
 
     def write(self, sync: int=1) -> None:
@@ -316,9 +312,7 @@ class DB(Base):
 
 class Dir(Base):
     def __init__(self, fp=None, dir=None) -> None:
-        """
-        fp - file pointer to read entries from
-        """
+        """fp - file pointer to read entries from."""
         super().__init__()
 
         if not fp:
@@ -335,13 +329,9 @@ class Dir(Base):
 
 
 class DirFile(Dir):
-    """
-    Encapsulates reading and writing a per-directory .sconsign file.
-    """
+    """Encapsulates reading and writing a per-directory .sconsign file."""
     def __init__(self, dir) -> None:
-        """
-        dir - the directory for the file
-        """
+        """dir - the directory for the file."""
 
         self.dir = dir
         self.sconsign = os.path.join(dir.get_internal_path(), current_sconsign_filename())
@@ -364,12 +354,10 @@ class DirFile(Dir):
         except AttributeError:
             pass
 
-        global sig_files
         sig_files.append(self)
 
     def write(self, sync: int=1) -> None:
-        """
-        Write the .sconsign file to disk.
+        """Write the .sconsign file to disk.
 
         Try to write to a temporary file first, and rename it if we
         succeed.  If we can't write to the temporary file, it's

--- a/SCons/SConsign.py
+++ b/SCons/SConsign.py
@@ -112,6 +112,7 @@ def Reset() -> None:
     sig_files = []
     DB_sync_list = []
 
+
 normcase = os.path.normcase
 
 


### PR DESCRIPTION
A bit of restructuring to quiet several checker complaints.

The name of the internal class does change, so it more properly looks private. This should be opaque - you "get into" this by using the module-level `open` function, you don't instantiate the class from outside. Only the self-test code (which is not used at SCons runtime, that all happens in `_exercise`, if you run it as a script - in other words, called only `if __name__ == "__main__"`) reaches inside.  As a side question - the self-test code in this module is a bit strange, shouldn't it move to a unit test?

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
