### PR TITLE
Adjust help message about -H

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -96,6 +96,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       than source).  Docs updated.  Fixes #4326 and #4327.
     - Cleaned up dblite module (checker warnings, etc.).
     - Some cleanup in the FortranCommon tool.
+    - Changed the message about scons -H to clarify it shows built-in options.
 
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -16,10 +16,10 @@ Here is a summary of the changes since 4.5.2:
 NEW FUNCTIONALITY
 -----------------
 
-- D compilers : added support for generation of .di interface files. 
+- D compilers : added support for generation of .di interface files.
   New variables DI_FILE_DIR, DI_FILE_DIR_PREFIX, DI_FILE_DIR_SUFFIX,
   DI_FILE_SUFFIX.
-  
+
 DEPRECATED FUNCTIONALITY
 ------------------------
 
@@ -77,6 +77,7 @@ DOCUMENTATION
   if the previous *targets* parameter had been used as a keyword argument,
   the results would be incorrect (does not apply to positional argument
   usage, which had no problem).
+- Changed the message about scons -H to clarify it shows built-in options only.
 
 DEVELOPMENT
 -----------

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1131,7 +1131,7 @@ def _main(parser):
             raise SConsPrintHelpException
         else:
             print(help_text)
-            print("Use scons -H for help about command-line options.")
+            print("Use scons -H for help about SCons built-in command-line options.")
         exit_status = 0
         return
 

--- a/test/Help.py
+++ b/test/Help.py
@@ -39,7 +39,7 @@ scons: done reading SConscript files.
 Help text
 goes here.
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """
 
 test.run(arguments = '-h', stdout = expect)
@@ -55,7 +55,7 @@ scons: done reading SConscript files.
 Even more
 help text!
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """
 
 test.run(arguments = '-h', stdout = expect)
@@ -77,7 +77,7 @@ Multiline
 help
 text!
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """
 
 test.run(arguments = '-h', stdout = expect)
@@ -138,7 +138,7 @@ buildmod: List of modules to build
     default: none
     actual: None
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """
 
 test.run(arguments = '-h', stdout = expect)

--- a/test/SCONSFLAGS.py
+++ b/test/SCONSFLAGS.py
@@ -40,7 +40,7 @@ expect = """scons: Reading SConscript files ...
 scons: done reading SConscript files.
 Help text.
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """
 
 os.environ['SCONSFLAGS'] = ''

--- a/test/Variables/Variables.py
+++ b/test/Variables/Variables.py
@@ -197,7 +197,7 @@ UNSPECIFIED: An option with no value
     default: None
     actual: None
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """%(cc, ccflags and ccflags + ' -O' or '-O', cc))
 
 # Test saving of variables and multi loading
@@ -355,7 +355,7 @@ UNSPECIFIED: An option with no value
     default: None
     actual: None
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """%cc)
 
 test.write('SConstruct', """

--- a/test/Variables/help.py
+++ b/test/Variables/help.py
@@ -43,7 +43,7 @@ libdirvar = os.path.join('$qtdir', 'lib')
 
 test.subdir(qtpath)
 test.subdir(libpath)
-         
+
 test.write('SConstruct', """
 from SCons.Variables import (
     BoolVariable,
@@ -148,7 +148,7 @@ qt_libraries: where the Qt library is installed ( /path/to/qt_libraries )
     default: %(libdirvar)s
     actual: %(libpath)s
 
-Use scons -H for help about command-line options.
+Use scons -H for help about SCons built-in command-line options.
 """ % locals())
 
 


### PR DESCRIPTION
As noted in issue #2356 (which this change does not complete/close), the final line of help if the help message has been modified is `'Use scons -H for help about command-line options.'` This fails to mention that `-H` prints only those options that are defined in SCons itself, not options added via `AddOption`. Adjust the message to better indicate this.

Marking this as a "documentation" PR as it's only about help, although it doesn't actually appear in the online docs.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
