### PR TITLE
Replace `int main()` with `int main(void)` in `CheckLib()`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -97,6 +97,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Cleaned up dblite module (checker warnings, etc.).
     - Some cleanup in the FortranCommon tool.
 
+  From Jonathon Reinhart:
+    - Fix another instance of `int main()` in CheckLib() causing failures
+      when using -Wstrict-prototypes.
+
 
 RELEASE 4.5.2 -  Sun, 21 Mar 2023 14:08:29 -0700
 

--- a/SCons/Conftest.py
+++ b/SCons/Conftest.py
@@ -676,8 +676,7 @@ char %s();
 
     # if no function to test, leave main() blank
     text = text + """
-int
-main() {
+int main(void) {
   %s
 return 0;
 }


### PR DESCRIPTION
This fixes another instance missed in #3096.

Fixes #4373

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
  * N/A: See https://github.com/SCons/scons/pull/3096#issuecomment-364804847
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
  * N/A

