### PR TITLE
trivial update to textfile markup  [skip appveyor]

### DIFF
--- a/SCons/Tool/textfile.xml
+++ b/SCons/Tool/textfile.xml
@@ -26,7 +26,7 @@ See its __doc__ string for a discussion of the format.
 <tool name="textfile">
 <summary>
 <para>
-Set &consvars; for the &b-Textfile; and &b-Substfile; builders.
+Set &consvars; for the &b-link-Textfile; and &b-link-Substfile; builders.
 </para>
 </summary>
 <sets>


### PR DESCRIPTION
Turn two refs into a live link.  Doc-only.  Seem too trivial to even add to CHANGES/RELEASE.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
