### PR TITLE
Remove script path in PlatformTests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -124,6 +124,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Cleaned up dblite module (checker warnings, etc.).
     - Some cleanup in the FortranCommon tool.
     - Changed the message about scons -H to clarify it shows built-in options.
+    - Fix platform unit test on Windows for Py 3.12+. Fixes #4376.
 
   From Jonathon Reinhart:
     - Fix another instance of `int main()` in CheckLib() causing failures


### PR DESCRIPTION
For Python 3.12+, cpython module `posixpath` test-imports`posix`, expecting it to fail on win32. However, for this one test program, since it's in `SCons/Platform`, that directory as the "script path" is in `sys.path`, and it finds our `posix` module, thus breaking things. This removes that element from the path - it's not put back because we don't actually need it here.

Fixes #4376

Unrelated - `UtilTests.py` is moved down into `SCons/Util`, to follow the usual naming conventions where the unit test is in the package dir.

This is a test-only change, no impacts on SCons itself.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
