### PR TITLE
Add Java 18, 19, 20 to support list.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -130,6 +130,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix platform unit test on Windows for Py 3.12+. Fixes #4376.
     - More tweaking of test framework overview (which is duplicated onto
       the website, but not in the regular documentation section).
+    - Extend range of recognized Java versions to 20.
 
   From Jonathon Reinhart:
     - Fix another instance of `int main()` in CheckLib() causing failures

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -59,6 +59,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   batch file exists but an individual msvc toolset may not support the host/target
   architecture combination.  For example, when using VS2022 on arm64, the arm64 native
   tools are only installed for the 14.3x toolsets.
+- Extend range of recognized Java versions to 20.
 
 FIXES
 -----

--- a/SCons/Tool/JavaCommon.py
+++ b/SCons/Tool/JavaCommon.py
@@ -121,6 +121,9 @@ if java_parsing:
                 '15.0',
                 '16.0',
                 '17.0',
+                '18.0',
+                '19.0',
+                '20.0',
             ):
                 msg = "Java version %s not supported" % version
                 raise NotImplementedError(msg)
@@ -245,6 +248,9 @@ if java_parsing:
                 '15.0',
                 '16.0',
                 '17.0',
+                '18.0',
+                '19.0',
+                '20.0',
             ):
                 self.stackAnonClassBrackets.append(self.brackets)
                 className = []


### PR DESCRIPTION
JavaCommon updated to latest released version.

21 will be the next LTS release, due 2023-09-19. Not tested but maybe we should add this as well?

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
