### PR TITLE
Correct warning type name

### DIFF
--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2341,7 +2341,7 @@ These warnings are enabled by default.</para>
   </varlistentry>
 
   <varlistentry>
-  <term><emphasis role="bold">target_not_build</emphasis></term>
+  <term><emphasis role="bold">target-not-built</emphasis></term>
   <listitem>
 <para>Warnings about a build rule not building the
  expected targets. These warnings are disabled by default.</para>


### PR DESCRIPTION
'target_not_build' -> 'target-not-built'.  Its class name is [TargetNotBuiltWarning](https://github.com/SCons/scons/blob/1a103470a13a83590b3fc06e8779494e2b99751d/SCons/Warnings.py#L40) and its separator is `-`([implementation](https://github.com/SCons/scons/blob/1a103470a13a83590b3fc06e8779494e2b99751d/SCons/Warnings.py#L207-L212)), not `_`. So its name should be `target-not-built`

```
% scons --warn=target_not_build # I got warning
No warning type: 'target_not_build'
scons: Reading SConscript files ...
scons: done reading SConscript files.
No warning type: 'target_not_build'
scons: Building targets ...
scons: `.' is up to date.
scons: done building targets.
sakura2:% scons --warn=target-not-built # no warnings
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: `.' is up to date.
scons: done building targets.                    
```


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
