### PR TITLE
Tweak a few tests "for form"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -144,6 +144,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Finish the change to make calling SConscript() with a nonexistent
       file an error. It has issued a warning since 3.0, with "warn instead
       of fail" deprecated since 3.1.  Fixes #3958.
+    - Minor (non-functional) cleanup of some tests, particuarly test/MSVC.
 
   From Jonathon Reinhart:
     - Fix another instance of `int main()` in CheckLib() causing failures

--- a/test/File/File-relpath.py
+++ b/test/File/File-relpath.py
@@ -60,3 +60,11 @@ if IS_WINDOWS:
     expected_stdout = expected_stdout.replace("/", os.sep)
 
 test.run("-Q", chdir="base", status=0, stdout=expected_stdout + "\n")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Java/DerivedSourceTest.py
+++ b/test/Java/DerivedSourceTest.py
@@ -75,6 +75,7 @@ test.write(
 """
 import os
 
+DefaultEnvironment(tools=[])
 env = Environment(
     tools = [
         'javac',
@@ -119,5 +120,12 @@ javac -d build -sourcepath org/sample org/sample/Sample.java
 )
 
 test.run( arguments = '--tree=derived', stdout = expected )
-
 test.up_to_date(arguments = '.')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/MSVC_BATCH-spaces-targetdir.py
+++ b/test/MSVC/MSVC_BATCH-spaces-targetdir.py
@@ -1,14 +1,35 @@
-# SPDX-License-Identifier: MIT
+#!/usr/bin/env python
+#
+# MIT License
 #
 # Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """Test that spaces in the target dir name doesn't break MSVC_BATCH."""
 
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
+
 test.dir_fixture('MSVC_BATCH-spaces-fixture')
 test.run(stderr=None)  # it's enough that the build didn't fail
 test.pass_test()

--- a/test/MSVC/MSVC_NOTFOUND_POLICY.py
+++ b/test/MSVC/MSVC_NOTFOUND_POLICY.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -28,7 +30,6 @@ Test the MSVC_NOTFOUND_POLICY construction variable and functions.
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 import textwrap
@@ -49,6 +50,7 @@ test.run(arguments='-Q -s', stdout='')
 # Test construction variable with invalid symbol
 test.write('SConstruct', textwrap.dedent(
     """
+    DefaultEnvironment(tools=[])
     env = Environment(MSVC_VERSION='12.9', MSVC_NOTFOUND_POLICY='Undefined', tools=['msvc'])
     """
 ))
@@ -61,6 +63,7 @@ test.write('SConstruct', textwrap.dedent(
     """
     from SCons.Tool.MSCommon import msvc_set_notfound_policy
     msvc_set_notfound_policy('Exception')
+    DefaultEnvironment(tools=[])
     env = Environment(MSVC_VERSION='12.9', tools=['msvc'])
     """
 ))
@@ -73,6 +76,7 @@ test.write('SConstruct', textwrap.dedent(
     """
     from SCons.Tool.MSCommon import msvc_set_notfound_policy
     msvc_set_notfound_policy('Exception')
+    DefaultEnvironment(tools=[])
     env = Environment(MSVC_VERSION='12.9', MSVC_NOTFOUND_POLICY=None, tools=['msvc'])
     """
 ))
@@ -83,6 +87,7 @@ test.must_contain_all(test.stderr(), expect)
 # Test environment construction with construction variable
 test.write('SConstruct', textwrap.dedent(
     """
+    DefaultEnvironment(tools=[])
     env = Environment(MSVC_VERSION='12.9', MSVC_NOTFOUND_POLICY='Error', tools=['msvc'])
     """
 ))
@@ -95,6 +100,7 @@ test.write('SConstruct', textwrap.dedent(
     """
     from SCons.Tool.MSCommon import msvc_set_notfound_policy
     msvc_set_notfound_policy('Warning')
+    DefaultEnvironment(tools=[])
     env = Environment(MSVC_VERSION='12.9', tools=['msvc'])
     """
 ))
@@ -105,6 +111,7 @@ test.must_contain_all(test.stderr(), expect)
 # Test environment construction with construction variable
 test.write('SConstruct', textwrap.dedent(
     """
+    DefaultEnvironment(tools=[])
     env = Environment(MSVC_VERSION='12.9', MSVC_NOTFOUND_POLICY='Warning', tools=['msvc'])
     """
 ))
@@ -117,6 +124,7 @@ test.write('SConstruct', textwrap.dedent(
     """
     from SCons.Tool.MSCommon import msvc_set_notfound_policy
     msvc_set_notfound_policy('Exception')
+    DefaultEnvironment(tools=[])
     env = Environment(MSVC_VERSION='12.9', MSVC_NOTFOUND_POLICY='Ignore', tools=['msvc'])
     """
 ))
@@ -124,3 +132,8 @@ test.run(arguments='-Q -s', stdout='')
 
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/MSVC_SCRIPTERROR_POLICY.py
+++ b/test/MSVC/MSVC_SCRIPTERROR_POLICY.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -31,11 +33,9 @@ import textwrap
 from SCons.Tool.MSCommon.vc import get_installed_vcs_components
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 installed_versions = get_installed_vcs_components()
-
 default_version = installed_versions[0]
 
 # Test construction variable with valid symbols
@@ -139,3 +139,8 @@ if default_version.msvc_vernum >= 14.1:
 
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/MSVC_SDK_VERSION.py
+++ b/test/MSVC/MSVC_SDK_VERSION.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -32,21 +34,16 @@ from SCons.Tool.MSCommon import msvc_toolset_versions
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
-
 installed_versions = get_installed_vcs_components()
-
 default_version = installed_versions[0]
-
 GE_VS2015_versions = [v for v in installed_versions if v.msvc_vernum >= 14.0]
 LT_VS2015_versions = [v for v in installed_versions if v.msvc_vernum < 14.0]
-
 default_sdk_versions_uwp = msvc_sdk_versions(version=None, msvc_uwp_app=True)
 default_sdk_versions_def = msvc_sdk_versions(version=None, msvc_uwp_app=False)
 
-have_140 = any([v.msvc_verstr == '14.0' for v in GE_VS2015_versions])
+have_140 = any(v.msvc_verstr == '14.0' for v in GE_VS2015_versions)
 
 def version_major(version):
     components = version.split('.')
@@ -239,3 +236,8 @@ if LT_VS2015_versions:
 
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/MSVC_SPECTRE_LIBS.py
+++ b/test/MSVC/MSVC_SPECTRE_LIBS.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -32,11 +34,9 @@ from SCons.Tool.MSCommon.vc import get_installed_vcs_components
 from SCons.Tool.MSCommon import msvc_toolset_versions_spectre
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 installed_versions = get_installed_vcs_components()
-
 GE_VS2017_versions = [v for v in installed_versions if v.msvc_vernum >= 14.1]
 LT_VS2017_versions = [v for v in installed_versions if v.msvc_vernum < 14.1]
 
@@ -150,3 +150,8 @@ if LT_VS2017_versions:
 
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/MSVC_TOOLSET_VERSION.py
+++ b/test/MSVC/MSVC_TOOLSET_VERSION.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -32,13 +34,10 @@ from SCons.Tool.MSCommon import msvc_toolset_versions
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 installed_versions = get_installed_vcs_components()
-
 default_version = installed_versions[0]
-
 GE_VS2017_versions = [v for v in installed_versions if v.msvc_vernum >= 14.1]
 LT_VS2017_versions = [v for v in installed_versions if v.msvc_vernum < 14.1]
 LT_VS2015_versions = [v for v in LT_VS2017_versions if v.msvc_vernum < 14.0]
@@ -231,3 +230,8 @@ if LT_VS2015_versions:
 
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/MSVC_USE_SCRIPT.py
+++ b/test/MSVC/MSVC_USE_SCRIPT.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -30,7 +32,6 @@ import TestSCons
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 test.write('SConstruct', """
@@ -38,7 +39,6 @@ env = Environment(tools=['msvc'], MSVC_USE_SCRIPT='nosuchscriptexists')
 """ % locals())
 
 test.run(arguments = ".", status=2, stderr=None)
-
 test.must_contain_all(test.stderr(), "Script specified by MSVC_USE_SCRIPT not found")
 
 test.pass_test()

--- a/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/SConstruct
+++ b/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/SConstruct
@@ -7,7 +7,11 @@ import os
 if 'SCONS_CACHE_MSVC_CONFIG' in os.environ:
     del os.environ['SCONS_CACHE_MSVC_CONFIG']
 
-os.environ['SCONS_MSCOMMON_DEBUG']='MSDEBUG_OUTPUT.log'
+os.environ['SCONS_MSCOMMON_DEBUG'] = 'MSDEBUG_OUTPUT.log'
 
 DefaultEnvironment(tools=[])
-env = Environment(tools=['msvc'], MSVC_USE_SCRIPT='fake_script.bat', MSVC_USE_SCRIPT_ARGS=['one','two'])
+env = Environment(
+    tools=['msvc'],
+    MSVC_USE_SCRIPT='fake_script.bat',
+    MSVC_USE_SCRIPT_ARGS=['one', 'two'],
+)

--- a/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/fake_script.bat
+++ b/test/MSVC/MSVC_USE_SCRIPT_ARGS-fixture/fake_script.bat
@@ -1,3 +1,7 @@
 @echo off
+:: SPDX-License-Identifier: MIT
+::
+:: Copyright The SCons Foundation
+::
 REM Fake msvc batch script for use in testing MSVC_USE_SCRIPT_ARGS
 echo ARG1: %1  ARG2: %2

--- a/test/MSVC/MSVC_USE_SCRIPT_ARGS.py
+++ b/test/MSVC/MSVC_USE_SCRIPT_ARGS.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -30,12 +32,11 @@ import TestSCons
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
+
 test.dir_fixture('MSVC_USE_SCRIPT_ARGS-fixture')
 
-test.run(arguments = ".", status=0, stderr=None)
-
+test.run(arguments=".", status=0, stderr=None)
 test.must_contain('MSDEBUG_OUTPUT.log', "Calling 'fake_script.bat one two'")
 
 test.pass_test()

--- a/test/MSVC/MSVC_USE_SETTINGS.py
+++ b/test/MSVC/MSVC_USE_SETTINGS.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -30,7 +32,6 @@ import TestSCons
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 test.write('SConstruct', """
@@ -47,26 +48,23 @@ if cl1 == cl3:
     print("CL.EXE PATHS MATCH")
 """ % locals())
 
-test.run(arguments = ".", status=0, stderr=None)
-
+test.run(arguments=".", status=0, stderr=None)
 test.must_contain_all(test.stdout(), "CL.EXE PATHS MATCH")
 
 test.write('SConstruct', """
 env = Environment(MSVC_USE_SETTINGS={})
 """ % locals())
 
-test.run(arguments = "--warn=visual-c-missing .", status=0, stderr=None)
-
+test.run(arguments="--warn=visual-c-missing .", status=0, stderr=None)
 test.must_contain_all(test.stderr(), "Could not find MSVC compiler 'cl'")
 
 test.write('SConstruct', """
 env = Environment(MSVC_USE_SETTINGS='dict or None')
 """ % locals())
-  
-test.run(arguments = ".", status=2, stderr=None)
-  
+
+test.run(arguments=".", status=2, stderr=None)
 test.must_contain_all(test.stderr(), "MSVCUseSettingsError: MSVC_USE_SETTINGS type error")
-  
+
 test.pass_test()
 
 # Local Variables:

--- a/test/MSVC/MSVC_UWP_APP.py
+++ b/test/MSVC/MSVC_UWP_APP.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -31,12 +33,9 @@ from SCons.Tool.MSCommon.vc import get_installed_vcs_components
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
-
 installed_versions = get_installed_vcs_components()
-
 GE_VS2015_versions = [v for v in installed_versions if v.msvc_vernum >= 14.0]
 LT_VS2015_versions = [v for v in installed_versions if v.msvc_vernum < 14.0]
 
@@ -55,7 +54,6 @@ re_lib_ge2017_2 = re.compile(r'\\lib\\x64\\store', re.IGNORECASE)
 
 
 def check_libpath(msvc, active, output):
-
     def _check_libpath(msvc, output):
         outdict = {key.strip(): val.strip() for key, val in [line.split('|') for line in output.splitlines()]}
         platform = outdict.get('PLATFORM', '')
@@ -90,11 +88,8 @@ def check_libpath(msvc, active, output):
 
 if GE_VS2015_versions:
     # VS2015 and later for uwp/store argument
-
     for supported in GE_VS2015_versions:
-
         for msvc_uwp_app in (True, '1', False, '0', None):
-
             active = msvc_uwp_app in (True, '1')
 
             # uwp using construction variable
@@ -141,11 +136,8 @@ if GE_VS2015_versions:
 
 if LT_VS2015_versions:
     # VS2013 and earlier for uwp/store error
-
     for unsupported in LT_VS2015_versions:
-
         for msvc_uwp_app in (True, '1', False, '0', None):
-
             active = msvc_uwp_app in (True, '1')
 
             # uwp using construction variable
@@ -165,3 +157,8 @@ if LT_VS2015_versions:
 
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/PCH-source.py
+++ b/test/MSVC/PCH-source.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test use of pre-compiled headers when the source .cpp file shows
@@ -34,10 +33,10 @@ Issue 2505:  http://github.com/SCons/scons/issues/2505
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment(tools=['msvc', 'mslink'])
 env['PCH'] = env.PCH('Source1.cpp')[0]
 env['PCHSTOP'] = 'Header1.hpp'
@@ -86,12 +85,11 @@ main(int argc, char *argv[])
 }
 """)
 
-test.run(arguments = ".")
-
-test.run(program=test.workpath('foo'+TestSCons._exe),
-         stdout="Source1.cpp\nSource2.cpp\nfoo.cpp\n")
-
-
+test.run(arguments=".")
+test.run(
+    program=test.workpath('foo' + TestSCons._exe),
+    stdout="Source1.cpp\nSource2.cpp\nfoo.cpp\n",
+)
 
 test.pass_test()
 

--- a/test/MSVC/PCHCOM.py
+++ b/test/MSVC/PCHCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $PCHCOM construction variable.
@@ -37,15 +36,16 @@ test = TestSCons.TestSCons()
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'msvc'],
-                  PCHCOM = r'%(_python_)s mycompile.py pch $TARGET $SOURCES')
-env.PCH(target = 'aaa', source = 'aaa.h')
+DefaultEnvironment(tools=[])
+env = Environment(
+    tools=['default', 'msvc'],
+    PCHCOM=r'%(_python_)s mycompile.py pch $TARGET $SOURCES'
+)
+env.PCH(target='aaa', source='aaa.h')
 """ % locals())
-
 test.write('aaa.h', "aaa.h\n/*pch*/\n")
 
 test.run(arguments = ".")
-
 test.must_match('aaa.pch', "aaa.h\n")
 
 test.pass_test()

--- a/test/MSVC/PCHCOMSTR.py
+++ b/test/MSVC/PCHCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $PCHCOMSTR construction variable allows you to customize
@@ -38,18 +37,20 @@ test = TestSCons.TestSCons()
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'msvc'],
-                  PCHCOM = r'%(_python_)s mycompile.py pch $TARGET $SOURCES',
-                  PCHCOMSTR = 'PCHing $TARGET from $SOURCE')
-env.PCH(target = 'aaa', source = 'aaa.h')
+DefaultEnvironment(tools=[])
+env = Environment(
+    tools=['default', 'msvc'],
+    PCHCOM=r'%(_python_)s mycompile.py pch $TARGET $SOURCES',
+    PCHCOMSTR='PCHing $TARGET from $SOURCE',
+)
+env.PCH(target='aaa', source='aaa.h')
 """ % locals())
 
 test.write('aaa.h', "aaa.h\n/*pch*/\n")
 
-test.run(stdout = test.wrap_stdout("""\
+test.run(stdout=test.wrap_stdout("""\
 PCHing aaa.pch from aaa.h
 """))
-
 test.must_match('aaa.pch', "aaa.h\n")
 
 test.pass_test()

--- a/test/MSVC/PCHSTOP-errors.py
+++ b/test/MSVC/PCHSTOP-errors.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 # Test error reporting
@@ -32,12 +31,10 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 import TestSCons
 
 test = TestSCons.TestSCons(match = TestSCons.match_re)
-
 test.skip_if_not_msvc()
 
-SConstruct_path = test.workpath('SConstruct')
-
-test.write(SConstruct_path, """\
+test.write("SConstruct", """\
+DefaultEnvironment(tools=[])
 env = Environment()
 env['PDB'] = File('test.pdb')
 env['PCH'] = env.PCH('StdAfx.cpp')[0]
@@ -46,23 +43,15 @@ if int(ARGUMENTS.get('SET_PCHSTOP')):
 env.Program('test', 'test.cpp')
 """)
 
-
-
 expect_stderr = r'''
 scons: \*\*\* The PCHSTOP construction must be defined if PCH is defined.
 ''' + TestSCons.file_expr
-
 test.run(arguments='SET_PCHSTOP=0', status=2, stderr=expect_stderr)
-
-
 
 expect_stderr = r'''
 scons: \*\*\* The PCHSTOP construction variable must be a string: .+
 ''' + TestSCons.file_expr
-
 test.run(arguments='SET_PCHSTOP=1', status=2, stderr=expect_stderr)
-
-
 
 test.pass_test()
 

--- a/test/MSVC/RCCOM.py
+++ b/test/MSVC/RCCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $RCCOM construction variable
@@ -38,15 +37,17 @@ test = TestSCons.TestSCons()
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'msvc'],
-                  RCCOM = r'%(_python_)s mycompile.py rc $TARGET $SOURCES')
-env.RES(target = 'aaa', source = 'aaa.rc')
+DefaultEnvironment(tools=[])
+env = Environment(
+    tools=['default', 'msvc'],
+    RCCOM=r'%(_python_)s mycompile.py rc $TARGET $SOURCES'
+)
+env.RES(target='aaa', source='aaa.rc')
 """ % locals())
 
 test.write('aaa.rc', "aaa.rc\n/*rc*/\n")
 
-test.run(arguments = ".")
-
+test.run(arguments=".")
 test.must_match('aaa.res', "aaa.rc\n")
 
 test.pass_test()

--- a/test/MSVC/RCCOMSTR.py
+++ b/test/MSVC/RCCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $RCCOMSTR construction variable allows you to customize
@@ -46,7 +45,7 @@ env.RES(target = 'aaa', source = 'aaa.rc')
 
 test.write('aaa.rc', "aaa.rc\n/*rc*/\n")
 
-test.run(stdout = test.wrap_stdout("""\
+test.run(stdout=test.wrap_stdout("""\
 RCing aaa.res from aaa.rc
 """))
 

--- a/test/MSVC/TARGET_ARCH.py
+++ b/test/MSVC/TARGET_ARCH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $TARGET_ARCH construction variable.
@@ -33,46 +32,44 @@ import TestSCons
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 test.write('SConstruct', """
-env_64 = Environment(tools=['default', 'msvc'],
-                  TARGET_ARCH = 'amd64')
-env_32 = Environment(tools=['default', 'msvc'],
-                  TARGET_ARCH = 'x86')
+DefaultEnvironment(tools=[])
+env_64 = Environment(tools=['default', 'msvc'], TARGET_ARCH='amd64')
+env_32 = Environment(tools=['default', 'msvc'], TARGET_ARCH='x86')
 """ % locals())
 
-test.run(arguments = ".")
+test.run(arguments=".")
 
 # test.pass_test()
 
 test.write('SConstruct', """
-env_xx = Environment(tools=['default', 'msvc'],
-                  TARGET_ARCH = 'nosucharch')
+DefaultEnvironment(tools=[])
+env_xx = Environment(tools=['default', 'msvc'], TARGET_ARCH='nosucharch')
 """ % locals())
 
-test.run(arguments = ".", status=2, stderr=None)
+test.run(arguments=".", status=2, stderr=None)
 test.must_contain_any_line(test.stderr(), "Unrecognized target architecture")
 test.must_contain_any_line(test.stderr(), "Valid architectures")
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'msvc'],
-                  TARGET_ARCH = 'arm', MSVC_VERSION='11.0')
+DefaultEnvironment(tools=[])
+env = Environment(tools=['default', 'msvc'], TARGET_ARCH='arm', MSVC_VERSION='11.0')
 if env.Detect('cl'):
     env.Command('checkarm', [], 'cl')
 """ % locals())
-test.run(arguments = ".", stderr = None)
+test.run(arguments=".", stderr=None)
 if test.stderr().strip() != "" and "ARM" not in test.stderr():
     test.fail_test()
 
 test.write('SConstruct', """
-env = Environment(tools=['default', 'msvc'],
-                  TARGET_ARCH = 'arm64', MSVC_VERSION='11.0')
+DefaultEnvironment(tools=[])
+env = Environment(tools=['default', 'msvc'], TARGET_ARCH='arm64', MSVC_VERSION='11.0')
 if env.Detect('cl'):
     env.Command('checkarm64', [], 'cl')
 """ % locals())
-test.run(arguments = ".", stderr = None)
+test.run(arguments=".", stderr=None)
 if test.stderr().strip() != "" and "ARM64" not in test.stderr():
     test.fail_test()
 

--- a/test/MSVC/VSWHERE-fixture/SConstruct
+++ b/test/MSVC/VSWHERE-fixture/SConstruct
@@ -9,12 +9,12 @@ from SCons.Tool.MSCommon.vc import VSWHERE_PATHS
 
 # Dump out expected paths
 for vw_path in VSWHERE_PATHS:
-    print("VSWHERE_PATH=%s"%vw_path)
+    print("VSWHERE_PATH=%s" % vw_path)
 
 
 # Allow normal detection logic to find vswhere.exe
 DefaultEnvironment(tools=[])
-env1=Environment()
+env1 = Environment()
 print("VSWHERE-detect=%s" % env1['VSWHERE'])
 
 # Copy found vswhere.exe to current dir
@@ -22,6 +22,5 @@ v_local = os.path.join(os.getcwd(), 'vswhere.exe')
 Execute(Copy(os.path.join(os.getcwd(), 'vswhere.exe'), env1['VSWHERE']))
 
 # With VSWHERE set to copied vswhere.exe (see above), find vswhere.exe
-env=Environment(VSWHERE=v_local)
+env = Environment(VSWHERE=v_local)
 print("VSWHERE-env=%s" % env['VSWHERE'])
-

--- a/test/MSVC/VSWHERE.py
+++ b/test/MSVC/VSWHERE.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $VSWHERE construction variable.
@@ -34,9 +33,9 @@ import TestSCons
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
+test.skip_if_not_msvc()
 test.verbose_set(1)
 
-test.skip_if_not_msvc()
 test.dir_fixture('VSWHERE-fixture')
 
 test.run(arguments=".")
@@ -65,26 +64,27 @@ for l in lines:
 # print("V-E:%s" % env_path)
 
 
-test.fail_test(len(default_locations) == 0,
-               message='No default vswhere.exe locations found')
 test.fail_test(
-    detected_path is None, message='No vswhere.exe detected in default paths :%s' % default_locations)
-test.fail_test(detected_path not in default_locations,
-               message='detected path [%s] not in default locations[%s]' % (detected_path, default_locations))
+    len(default_locations) == 0, message='No default vswhere.exe locations found'
+)
+test.fail_test(
+    detected_path is None,
+    message='No vswhere.exe detected in default paths :%s' % default_locations,
+)
+test.fail_test(
+    detected_path not in default_locations,
+    message='detected path [%s] not in default locations [%s]' % (detected_path, default_locations),
+)
 
 expected_env_path = os.path.join(test.workdir, 'vswhere.exe')
-test.fail_test(env_path != expected_env_path,
-               message='VSWHERE not\n\t%s\n\t but\n\t%s' % (expected_env_path, env_path))
-
+test.fail_test(
+    env_path != expected_env_path,
+    message='VSWHERE not\n\t%s\n\t but\n\t%s' % (expected_env_path, env_path),
+)
 
 test.pass_test()
 
-# Local Variables:
-# tab-width:4
-# indent-tabs-mode:nil
-# End:
-# vim: set expandtab tabstop=4 shiftwidth=4:
-
+# here for reference, unused
 expected = r"""
 PS C:\Users\Bill\AppData\Local\Temp\testcmd.11256.1ae1_as5> py -3.8 C:\Users\Bill\devel\scons\git\scons-2\scripts\scons.py
 scons: Reading SConscript files ...
@@ -99,3 +99,9 @@ scons: Building targets ...
 scons: `.' is up to date.
 scons: done building targets.
 """
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/batch-longlines.py
+++ b/test/MSVC/batch-longlines.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify operation of Visual C/C++ batch builds with long lines.
@@ -33,7 +32,6 @@ Only runs on Windows.
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 _python_ = TestSCons._python_
@@ -43,13 +41,13 @@ for i in range(1,200):
                '/* source file %d */\nint var%d;\n'%(i,i))
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(tools=['msvc', 'mslink'],
                   MSVC_BATCH=ARGUMENTS.get('MSVC_BATCH'))
 env.SharedLibrary('mylib', Glob('source*.cxx'))
 """ % locals())
 
-test.run(arguments = 'MSVC_BATCH=1 .')
-
+test.run(arguments='MSVC_BATCH=1 .')
 test.must_exist('mylib.dll')
 
 test.pass_test()

--- a/test/MSVC/batch.py
+++ b/test/MSVC/batch.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify operation of Visual C/C++ batch builds.
@@ -81,7 +80,7 @@ DefaultEnvironment(tools=[])
 cccom = r'%(_python_)s fake_cl.py $_MSVC_OUTPUT_FLAG $CHANGED_SOURCES'
 linkcom = r'%(_python_)s fake_link.py ${TARGET.windows} $SOURCES'
 env = Environment(tools=['msvc', 'mslink'],
-                  CCCOM=cccom, 
+                  CCCOM=cccom,
                   LINKCOM=linkcom,
                   PROGSUFFIX='.exe',
                   OBJSUFFIX='.obj',
@@ -96,41 +95,27 @@ test.write('prog.c', "prog.c\n")
 test.write('f1.c', "f1.c\n")
 test.write('f2.c', "f2.c\n")
 
-
-
-test.run(arguments = 'MSVC_BATCH=1 .')
-
+test.run(arguments='MSVC_BATCH=1 .')
 test.must_match('prog.exe', "prog.c\nf1.c\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
 /Fo.%s prog.c f1.c f2.c
 """%os.sep, mode='r')
-
-test.up_to_date(options = 'MSVC_BATCH=1', arguments = '.')
-
-
+test.up_to_date(options='MSVC_BATCH=1', arguments='.')
 
 test.write('f1.c', "f1.c 2\n")
 
-test.run(arguments = 'MSVC_BATCH=1 .')
-
+test.run(arguments='MSVC_BATCH=1 .')
 test.must_match('prog.exe', "prog.c\nf1.c 2\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
 /Fo.%s prog.c f1.c f2.c
 /Fo.%s f1.c
 """%(os.sep, os.sep), mode='r')
+test.up_to_date(options='MSVC_BATCH=1', arguments='.')
 
-test.up_to_date(options = 'MSVC_BATCH=1', arguments = '.')
-
-
-
-test.run(arguments = '-c .')
-
+test.run(arguments='-c .')
 test.unlink('fake_cl.log')
 
-
-
-test.run(arguments = '. MSVC_BATCH=0')
-
+test.run(arguments='. MSVC_BATCH=0')
 test.must_match('prog.exe', "prog.c\nf1.c 2\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
 /Fof1.obj f1.c
@@ -138,25 +123,20 @@ test.must_match('fake_cl.log', """\
 /Foprog.obj prog.c
 """, mode='r')
 
-test.run(arguments = '-c .')
+test.run(arguments='-c .')
 test.unlink('fake_cl.log')
 
-
-test.run(arguments = '. MSVC_BATCH=False')
-
+test.run(arguments='. MSVC_BATCH=False')
 test.must_match('prog.exe', "prog.c\nf1.c 2\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
 /Fof1.obj f1.c
 /Fof2.obj f2.c
 /Foprog.obj prog.c
 """, mode='r')
-
-
 
 test.write('f1.c', "f1.c 3\n")
 
-test.run(arguments = '. MSVC_BATCH=0')
-
+test.run(arguments='. MSVC_BATCH=0')
 test.must_match('prog.exe', "prog.c\nf1.c 3\nf2.c\n", mode='r')
 test.must_match('fake_cl.log', """\
 /Fof1.obj f1.c
@@ -164,8 +144,6 @@ test.must_match('fake_cl.log', """\
 /Foprog.obj prog.c
 /Fof1.obj f1.c
 """, mode='r')
-
-
 
 test.pass_test()
 

--- a/test/MSVC/embed-manifest.py
+++ b/test/MSVC/embed-manifest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that manifest files get embedded correctly in EXEs and DLLs
@@ -39,17 +38,24 @@ test = TestSCons.TestSCons()
 test.skip_if_not_msvc()
 
 test.write('SConstruct', """\
-env=Environment(WINDOWS_EMBED_MANIFEST=True)
-env.Append(CCFLAGS = '/MD')
-env.Append(LINKFLAGS = '/MANIFEST')
-env.Append(SHLINKFLAGS = '/MANIFEST')
-exe=env.Program('test.cpp')
-dll=env.SharedLibrary('testdll.cpp')
-env.Command('exe-extracted.manifest', exe,
-  '$MT /nologo -inputresource:${SOURCE};1 -out:${TARGET}')
-env.Command('dll-extracted.manifest', dll,
-  '$MT /nologo -inputresource:${SOURCE};2 -out:${TARGET}')
-env2=Environment(WINDOWS_EMBED_MANIFEST=True) # no /MD here
+DefaultEnvironment(tools=[])
+env = Environment(WINDOWS_EMBED_MANIFEST=True)
+env.Append(CCFLAGS='/MD')
+env.Append(LINKFLAGS='/MANIFEST')
+env.Append(SHLINKFLAGS='/MANIFEST')
+exe = env.Program('test.cpp')
+dll = env.SharedLibrary('testdll.cpp')
+env.Command(
+    'exe-extracted.manifest',
+    exe,
+    '$MT /nologo -inputresource:${SOURCE};1 -out:${TARGET}',
+)
+env.Command(
+    'dll-extracted.manifest',
+    dll,
+    '$MT /nologo -inputresource:${SOURCE};2 -out:${TARGET}',
+)
+env2 = Environment(WINDOWS_EMBED_MANIFEST=True)  # no /MD here
 env2.Program('test-nomanifest', env2.Object('test-nomanifest', 'test.cpp'))
 """)
 

--- a/test/MSVC/generate-rc.py
+++ b/test/MSVC/generate-rc.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test adding a src_builder to the RES builder so that RC files can
@@ -32,13 +31,13 @@ be generated.
 import TestSCons
 
 _python_ = TestSCons._python_
-
 test = TestSCons.TestSCons()
 
 fake_rc = test.workpath('fake_rc.py')
 
 test.write(fake_rc, """\
 import sys
+
 with open(sys.argv[1], 'w') as fo, open(sys.argv[2], 'r') as fi:
     fo.write("fake_rc.py\\n" + fi.read())
 """)
@@ -50,11 +49,11 @@ def generate_rc(target, source, env):
     with open(t, 'w') as fo, open(s, 'r') as fi:
         fo.write('generate_rc\\n' + fi.read())
 
-env = Environment(tools=['msvc'],
-                  RCCOM=r'%(_python_)s %(fake_rc)s $TARGET $SOURCE')
-env['BUILDERS']['GenerateRC'] = Builder(action=generate_rc,
-                                        suffix='.rc',
-                                        src_suffix='.in')
+DefaultEnvironment(tools=[])
+env = Environment(tools=['msvc'], RCCOM=r'%(_python_)s %(fake_rc)s $TARGET $SOURCE')
+env['BUILDERS']['GenerateRC'] = Builder(
+    action=generate_rc, suffix='.rc', src_suffix='.in'
+)
 env['BUILDERS']['RES'].src_builder.append('GenerateRC')
 
 env.RES('my.in')
@@ -62,8 +61,7 @@ env.RES('my.in')
 
 test.write('my.in', "my.in\n")
 
-test.run(arguments = '.')
-
+test.run(arguments='.')
 test.must_match('my.rc', "generate_rc\nmy.in\n", mode='r')
 test.must_match('my.res', "fake_rc.py\ngenerate_rc\nmy.in\n", mode='r')
 

--- a/test/MSVC/hierarchical.py
+++ b/test/MSVC/hierarchical.py
@@ -29,10 +29,8 @@ Verify use of Visual Studio with a hierarchical build.
 
 import TestSCons
 
-test = TestSCons.TestSCons(match = TestSCons.match_re)
-
+test = TestSCons.TestSCons(match=TestSCons.match_re)
 test.skip_if_not_msvc()
-
 test.subdir('src', 'build', 'out')
 
 test.write('SConstruct', """
@@ -44,6 +42,7 @@ SConscript('build/SConscript')
 test.write('src/SConscript',"""
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
+DefaultEnvironment(tools=[])
 env = Environment(tools=['mssdk', 'msvc', 'mslink'])
 env['PCH'] = File('StdAfx.pch')
 env['PDB'] = '#out/test.pdb'
@@ -55,8 +54,8 @@ env.Program('#out/test.exe', 'test.cpp')
 test.write('src/test.cpp', '''
 #include "StdAfx.h"
 
-int main(void) 
-{ 
+int main(void)
+{
     return 1;
 }
 ''')
@@ -70,18 +69,14 @@ test.write('src/StdAfx.cpp', '''
 ''')
 
 test.run(arguments='out', stderr=None)
-
 test.must_exist(test.workpath('out/test.pdb'))
 test.must_exist(test.workpath('build/StdAfx.pch'))
 test.must_exist(test.workpath('build/StdAfx.obj'))
 
 test.run(arguments='-c out')
-
 test.must_not_exist(test.workpath('out/test.pdb'))
 test.must_not_exist(test.workpath('build/StdAfx.pch'))
 test.must_not_exist(test.workpath('build/StdAfx.obj'))
-
-
 
 test.pass_test()
 

--- a/test/MSVC/mssdk.py
+++ b/test/MSVC/mssdk.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,33 +27,27 @@
 Simple test to make sure mssdk works.
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 #####
 # Test the basics
 
-test.write('SConstruct',"""
+test.write('SConstruct',"""\
 import os
+
 DefaultEnvironment(tools=[])
 # TODO:  this is order-dependent (putting 'mssdk' second or third breaks),
 # and ideally we shouldn't need to specify the tools= list anyway.
 env = Environment(tools=['mssdk', 'msvc', 'mslink'])
 env.Tool('mssdk')
-
 """)
-
 
 #  Visual Studio 8 has deprecated the /Yd option and prints warnings
 #  about it, so ignore stderr when running SCons.
 test.run(stderr=None, stdout=None)
-
 
 test.pass_test()
 

--- a/test/MSVC/msvc.py
+++ b/test/MSVC/msvc.py
@@ -33,7 +33,7 @@ import time
 
 import TestSCons
 
-test = TestSCons.TestSCons(match = TestSCons.match_re)
+test = TestSCons.TestSCons(match=TestSCons.match_re)
 
 test.skip_if_not_msvc()
 
@@ -46,7 +46,6 @@ test.dir_fixture('msvc_fixture')
 #  about it, so ignore stderr when running SCons.
 
 test.run(arguments='test.exe', stderr=None)
-
 test.must_exist(test.workpath('test.exe'))
 test.must_exist(test.workpath('test.res'))
 test.must_exist(test.workpath('test.pdb'))
@@ -64,7 +63,7 @@ test.run(program=test.workpath('test.exe'), stdout='2002 test 1\n')
 test.write('test.rc', '''
 #include "resource.h"
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_TEST "test 2"
 END
@@ -73,7 +72,6 @@ test.run(arguments='test.exe', stderr=None)
 test.run(program=test.workpath('test.exe'), stdout='2002 test 2\n')
 
 test.run(arguments='-c .')
-
 test.must_not_exist(test.workpath('test.exe'))
 test.must_not_exist(test.workpath('test.pdb'))
 test.must_not_exist(test.workpath('test.res'))
@@ -81,7 +79,6 @@ test.must_not_exist(test.workpath('StdAfx.pch'))
 test.must_not_exist(test.workpath('StdAfx.obj'))
 
 test.run(arguments='test.exe', stderr=None)
-
 test.must_exist(test.workpath('test.pdb'))
 test.must_exist(test.workpath('StdAfx.pch'))
 test.must_exist(test.workpath('StdAfx.obj'))
@@ -94,7 +91,6 @@ test.must_not_exist(test.workpath('StdAfx.pch'))
 test.must_not_exist(test.workpath('StdAfx.obj'))
 
 test.run(arguments='StdAfx.pch', stderr=None)
-
 test.must_not_exist(test.workpath('test.pdb'))
 test.must_exist(test.workpath('StdAfx.pch'))
 test.must_exist(test.workpath('StdAfx.obj'))
@@ -110,7 +106,6 @@ test.run(arguments='test.obj', stderr=None)
 test.must_not_exist(test.workpath('test.pdb'))
 test.must_exist(test.workpath('test.obj'))
 
-
 start = time.perf_counter()
 test.run(arguments='fast.obj', stderr=None)
 fast = time.perf_counter() - start
@@ -118,7 +113,6 @@ fast = time.perf_counter() - start
 start = time.perf_counter()
 test.run(arguments='slow.obj', stderr=None)
 slow = time.perf_counter() - start
-
 
 # TODO: Reevaluate if having this part of the test makes sense any longer
 # using precompiled headers should be faster
@@ -138,8 +132,6 @@ test.not_up_to_date(arguments='test.res', stderr=None)
 test.not_up_to_date(arguments='StdAfx.pch', stderr=None)
 test.not_up_to_date(arguments='test.exe', stderr=None)
 test.run(program=test.workpath('test.exe'), stdout='2003 test 2\n')
-
-
 
 test.pass_test()
 

--- a/test/MSVC/msvc_badversion.py
+++ b/test/MSVC/msvc_badversion.py
@@ -33,10 +33,6 @@ import TestSCons
 import SCons.Tool.MSCommon.vc as msvc
 
 test = TestSCons.TestSCons()
-
-if sys.platform != 'win32':
-    test.skip_test("Not win32 platform. Skipping test\n")
-
 test.skip_if_not_msvc()
 
 installed_msvc_versions = msvc.get_installed_vcs()
@@ -71,7 +67,6 @@ test.write('SConstruct', """\
 env = Environment(MSVC_VERSION='12.9', MSVC_NOTFOUND_POLICY='bad_value')
 """)
 test.run(arguments='-Q -s', status=2, stderr=r"^.* Value specified for MSVC_NOTFOUND_POLICY.+", match=TestSCons.match_re_dotall)
-
 
 test.pass_test()
 

--- a/test/MSVC/msvc_cache_force_defaults.py
+++ b/test/MSVC/msvc_cache_force_defaults.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -31,50 +33,53 @@ from SCons.Tool.MSCommon.vc import get_installed_vcs_components
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
 
 installed_versions = get_installed_vcs_components()
-
 default_version = installed_versions[0]
+if default_version.msvc_vernum < 14.0:
+    test.skip_test("MSVC version earlier than 14.0, skipping.")
 
-if default_version.msvc_vernum >= 14.0:
-    # VS2015 and later
+# VS2015 and later
+# force SDK version and toolset version as msvc batch file arguments
+test.write('SConstruct', textwrap.dedent(
+    """
+    import os
+    import json
 
-    # force SDK version and toolset version as msvc batch file arguments
-    test.write('SConstruct', textwrap.dedent(
-        """
-        import os
-        import json
+    cache_file = 'MSCACHE.json'
 
-        cache_file = 'MSCACHE.json'
+    os.environ['SCONS_CACHE_MSVC_CONFIG']=cache_file
+    os.environ['SCONS_CACHE_MSVC_FORCE_DEFAULTS']='1'
 
-        os.environ['SCONS_CACHE_MSVC_CONFIG']=cache_file
-        os.environ['SCONS_CACHE_MSVC_FORCE_DEFAULTS']='1'
+    DefaultEnvironment(tools=[])
+    env = Environment(tools=['msvc'])
 
-        DefaultEnvironment(tools=[])
-        env = Environment(tools=['msvc'])
+    envcache_keys = []
+    with open(cache_file, 'r') as file:
+        envcache_list = json.load(file)
+        envcache_keys = [tuple(d['key']) for d in envcache_list]
 
-        envcache_keys = []
-        with open(cache_file, 'r') as file:
-            envcache_list = json.load(file)
-            envcache_keys = [tuple(d['key']) for d in envcache_list]
+    if envcache_keys:
+        # key = (script, arguments)
+        print("SCRIPT_ARGS: {}".format(envcache_keys[0][-1]))
+    """
+))
+test.run(arguments="-Q -s", status=0, stdout=None)
+cache_arg = test.stdout().strip()
+if default_version.msvc_verstr == '14.0':
+    # VS2015: target_arch msvc_sdk_version
+    expect = r'^SCRIPT_ARGS: .* [0-9.]+$'
+else:
+    # VS2017+ msvc_sdk_version msvc_toolset_version
+    expect = r'^SCRIPT_ARGS: [0-9.]+ -vcvars_ver=[0-9.]+$'
 
-        if envcache_keys:
-            # key = (script, arguments)
-            print("SCRIPT_ARGS: {}".format(envcache_keys[0][-1]))
-        """
-    ))
-    test.run(arguments = "-Q -s", status=0, stdout=None)
+test.must_contain_all(cache_arg, expect, find=TestSCons.match_re)
 
-    cache_arg = test.stdout().strip()
+test.pass_test()
 
-    if default_version.msvc_verstr == '14.0':
-        # VS2015: target_arch msvc_sdk_version
-        expect = r'^SCRIPT_ARGS: .* [0-9.]+$'
-    else:
-        # VS2017+ msvc_sdk_version msvc_toolset_version
-        expect = r'^SCRIPT_ARGS: [0-9.]+ -vcvars_ver=[0-9.]+$'
-
-    test.must_contain_all(cache_arg, expect, find=TestSCons.match_re)
-
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/msvc_fixture/test.rc
+++ b/test/MSVC/msvc_fixture/test.rc
@@ -1,6 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright The SCons Foundation
+
 #include "resource.h"
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_TEST "test 1"
 END

--- a/test/MSVC/multiple-pdb.py
+++ b/test/MSVC/multiple-pdb.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that setting $PDB to '${TARGET}.pdb allows us to build multiple
@@ -35,14 +34,13 @@ list(s).
 
 import TestSCons
 
+test = TestSCons.TestSCons()
+test.skip_if_not_msvc()
 _exe = TestSCons._exe
 
-test = TestSCons.TestSCons()
-
-test.skip_if_not_msvc()
-
 test.write('SConstruct', """\
-env = Environment(PDB = '${TARGET.base}.pdb')
+DefaultEnvironment(tools=[])
+env = Environment(PDB='${TARGET.base}.pdb')
 env.Program('test1.cpp')
 env.Program('test2.cpp')
 """)
@@ -69,8 +67,7 @@ main(int argc, char *argv)
 }
 """)
 
-test.run(arguments = '.')
-
+test.run(arguments='.')
 test.must_exist('test1%s' % _exe)
 test.must_exist('test1.pdb')
 test.must_exist('test2%s' % _exe)

--- a/test/MSVC/no_msvc.py
+++ b/test/MSVC/no_msvc.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test scons when no MSVCs are present.
@@ -33,7 +32,6 @@ import sys
 import TestSCons
 
 test = TestSCons.TestSCons()
-
 if sys.platform != 'win32':
     test.skip_test("Not win32 platform. Skipping test\n")
 
@@ -44,7 +42,6 @@ test.run(arguments='-Q -s', stdout='')
 # test no msvc's
 test.file_fixture('no_msvc/no_msvcs_sconstruct.py', 'SConstruct')
 test.run(arguments='-Q -s')
-
 if 'MSVC_VERSION=None' not in test.stdout():
     test.fail_test()
 
@@ -63,7 +60,6 @@ def generate(env):
 def exists(env):
     return 1
 """)
-
 test.file_fixture('no_msvc/no_msvcs_sconstruct_tools.py', 'SConstruct')
 test.run(arguments='-Q -s')
 
@@ -84,3 +80,8 @@ test.must_contain_all(test.stdout(), 'msvc_version=None, msvc_toolset_version=No
 
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/MSVC/pch-basics.py
+++ b/test/MSVC/pch-basics.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,57 +22,53 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
- 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
- 
+
 """
 Verify PCH works to build a simple exe and a simple dll.
 """
- 
- 
+
 import TestSCons
- 
-test = TestSCons.TestSCons(match = TestSCons.match_re)
- 
+
+test = TestSCons.TestSCons(match=TestSCons.match_re)
 test.skip_if_not_msvc()
- 
+
 test.write('Main.cpp', """\
 #include "Precompiled.h"
- 
+
 int main(void)
 {
     return testf();
 }
 """)
- 
+
 test.write('Precompiled.cpp', """\
 #include "Precompiled.h"
 """)
- 
+
 test.write('Precompiled.h', """\
 #pragma once
- 
+
 static int testf()
 {
     return 0;
 }
 """)
- 
+
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
- 
+
 env['PCHSTOP'] = 'Precompiled.h'
 env['PCH'] = env.PCH('Precompiled.cpp')[0]
- 
+
 env.SharedLibrary('pch_dll', 'Main.cpp')
 env.Program('pch_exe', 'Main.cpp')
 """)
- 
+
 test.run(arguments='.', stderr=None)
- 
+
 test.pass_test()
- 
+
 # Local Variables:
 # tab-width:4
 # indent-tabs-mode:nil

--- a/test/MSVC/pch-spaces-subdir.py
+++ b/test/MSVC/pch-spaces-subdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify PCH works if variant dir has spaces in its name
@@ -31,8 +30,7 @@ Verify PCH works if variant dir has spaces in its name
 
 import TestSCons
 
-test = TestSCons.TestSCons(match = TestSCons.match_re)
-
+test = TestSCons.TestSCons(match=TestSCons.match_re)
 test.skip_if_not_msvc()
 
 test.write('Main.cpp', """\

--- a/test/MSVC/pdb-VariantDir-path.py
+++ b/test/MSVC/pdb-VariantDir-path.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that .pdb files get put in a variant_dir correctly.
@@ -33,9 +32,7 @@ import TestSCons
 _exe = TestSCons._exe
 
 test = TestSCons.TestSCons()
-
 test.skip_if_not_msvc()
-
 test.subdir('src')
 
 test.write('SConstruct', """\
@@ -64,7 +61,7 @@ main(int argc, char *argv)
 }
 """)
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
 test.must_exist(['.build', 'test%s'     % _exe])
 test.must_exist(['.build', 'test%s.pdb' % _exe])

--- a/test/MSVC/pdb-manifest.py
+++ b/test/MSVC/pdb-manifest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that .pdb files work correctly in conjunction with manifest files.
@@ -30,17 +29,16 @@ Verify that .pdb files work correctly in conjunction with manifest files.
 
 import TestSCons
 
+test = TestSCons.TestSCons()
+test.skip_if_not_msvc()
+
 _exe = TestSCons._exe
 _dll = TestSCons._dll
 _lib = TestSCons._lib
 
-test = TestSCons.TestSCons()
-
-test.skip_if_not_msvc()
-
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
-
 env['WINDOWS_INSERT_DEF'] = True
 env['WINDOWS_INSERT_MANIFEST'] = True
 env['PDB'] = '${TARGET.base}.pdb'
@@ -64,13 +62,10 @@ test.write('sharedlib.def', """\
 """)
 
 test.run(arguments = '.')
-
 test.must_exist('test%s' % _exe)
 test.must_exist('test.pdb')
-
 test.must_exist('sharedlib%s' % _dll)
 test.must_exist('sharedlib.pdb')
-
 test.must_exist('staticlib%s' % _lib)
 test.must_not_exist('staticlib.pdb')
 

--- a/test/MSVC/query_vcbat.py
+++ b/test/MSVC/query_vcbat.py
@@ -1,5 +1,8 @@
+#!/usr/bin/python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,14 +22,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
-test = TestSCons.TestSCons(match = TestSCons.match_re)
+# TODO: this test seems to have been stripped to the basics...
+#   is it still worth keeping?
 
+test = TestSCons.TestSCons(match = TestSCons.match_re)
 test.skip_if_not_msvc()
 
 #####
@@ -37,8 +39,8 @@ test.write('SConstruct', """
 #                                       ParseBatFile, \\
 #                                       MergeMSVSBatFile
 from SCons.Tool.MSCommon import query_versions
-#env = Environment(tools = ['mingw'])
-DefaultEnvironment(tools = [])
+#env = Environment(tools=['mingw'])
+DefaultEnvironment(tools=[])
 #for v in [9, 8, 7.1, 7]:
 #    print " ==== Testing for version %s ==== " % str(v)
 #    bat = FindMSVSBatFile(v)
@@ -52,7 +54,7 @@ DefaultEnvironment(tools = [])
 print(query_versions())
 """)
 
-test.run(stderr = None)
+test.run(stderr=None)
 test.pass_test()
 
 # Local Variables:


### PR DESCRIPTION
Three testcases did not call the required `test.pass_test()` at the end, meaning they report no official status on success:
```
  test/File/File-relpath.py
  test/Java/DerivedSourceTest.py
  test/MSVC/msvc_cache_force_defaults.py
```

One test (`test/MSVC/msvc_badversion.py`) first checked for win32, then checked for `not_msvc` - the win32 feature-test isn't relevant, since we'll bail on `not_msvc` anyway - dropped that bit.

Actual testcases are marked runnable scripts (start with shebang line). A few were missing this.

Added the conventional (to SCons, though no longer very important) tail stanza of editor config comments. Note we have the `.editorconfig` file now, which is an actual standard, so someday we can probably trim all of these, but for now, keep consistency.

For files otherwise being fiddled, do the copyright update and trim a few unneeded blank lines, and change some kwargs from x = y to x=y.

These changes are all no-op, except for the three calls to `pass_test`, which just have to do with collected data at the end, not the running of the tests.


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
