### PR TITLE
Properly initialize SCons to use gfortran if gfortran tool is loaded

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -46,6 +46,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Obsoleted YACCVCGFILESUFFIX, being replaced by YACC_GRAPH_FILE_SUFFIX.
       If YACC_GRAPH_FILE_SUFFIX is not set, it will respect YACCVCGFILESUFFIX.
 
+  From Philipp Maierhöfer:
+    - Fix gfortran tool initialization. Defaults to using binary named gfortran 
+      as would be expected, and properly set's SHFORTRAN flags to include -fPIC
+      where previously it was only doing so for the other fortran versions (F77,..)
+
   From Mats Wichmann
     - C scanner's dictifyCPPDEFINES routine did not understand the possible
       combinations of CPPDEFINES - not aware of a "name=value" string either

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -100,6 +100,10 @@ FIXES
   with the python logging module was refactored to prevent test failure.
 - MSVS: Add arm64 to the MSVS supported architectures list for VS2017 and later to be
   consistent with the current documentation of MSVS_ARCH.
+- FORTRAN: Fix gfortran tool initialization. Defaults to using binary named gfortran 
+  as would be expected, and properly set's SHFORTRAN flags to include -fPIC
+  where previously it was only doing so for the other fortran versions (F77,..)
+
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/gfortran.py
+++ b/SCons/Tool/gfortran.py
@@ -30,19 +30,24 @@ selection method.
 """
 
 from SCons.Util import CLVar
+from SCons.Tool.FortranCommon import add_all_to_env, add_fortran_to_env
 
-from . import fortran
+compilers = ['gfortran']
 
 
 def generate(env) -> None:
     """Add Builders and construction variables for gfortran."""
-    fortran.generate(env)
+
+    add_all_to_env(env)
+    add_fortran_to_env(env)
+
+    compiler = env.Detect(compilers) or 'gfortran'
 
     # fill in other dialects (FORTRAN dialect set by fortran.generate(),
     # but don't overwrite if they have been set manually.
-    for dialect in ['F77', 'F90', 'F95', 'F03', 'F08']:
+    for dialect in ['FORTRAN', 'F77', 'F90', 'F95', 'F03', 'F08']:
         if dialect not in env:
-            env[f'{dialect}'] = 'gfortran'
+            env[f'{dialect}'] = compiler
         if f'SH{dialect}' not in env:
             env[f'SH{dialect}'] = f'${dialect}'
 

--- a/test/Fortran/F03.py
+++ b/test/Fortran/F03.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Fortran/fixture/SConstruct_gfortran_shared
+++ b/test/Fortran/fixture/SConstruct_gfortran_shared
@@ -1,0 +1,3 @@
+DefaultEnvironment(tools=[])
+env = Environment(tools = ['gfortran', 'gnulink'])
+env.SharedLibrary('gfortran_shared', ['gfortran_shared.f'])

--- a/test/Fortran/fixture/gfortran_shared.f
+++ b/test/Fortran/fixture/gfortran_shared.f
@@ -1,0 +1,3 @@
+      SUBROUTINE gfortran_shared
+      WRITE(*,*) "Hi from subroutine gfortran_shared!"
+      END SUBROUTINE gfortran_shared

--- a/test/Fortran/gfortran.py
+++ b/test/Fortran/gfortran.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the gfortran tool compiles a .f90 file to an executable,
@@ -97,6 +96,14 @@ test.must_exist('test2' + _exe)
 test.must_exist(['modules', 'test2mod.mod'])
 
 test.up_to_date(arguments = '.')
+
+
+# Now test if shared library build works.
+test.file_fixture('fixture/gfortran_shared.f')
+test.file_fixture('fixture/SConstruct_gfortran_shared')
+test.run(arguments = '-f SConstruct_gfortran_shared')
+test.fail_test('gfortran ' not in test.stdout(), message="SCons didn't use gfortran")
+
 
 test.pass_test()
 


### PR DESCRIPTION
Added logic to properly initilize SCons to use gfortran if tool gfortran is loaded. 

Also initialize FORTRAN properly to use -fPIC as it does for F77, F90,.... Patch initially from discord user maiphi


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
