### PR TITLE
msvc config cache: add locking on cachefile

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -148,7 +148,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added more error handling while reading msvc config cache.
       (Enabled/specified by SCONS_CACHE_MSVC_CONFIG).
       The existing cache will be discarded if there's a decode error reading it.
-      It's possible there's a race condition creating this issue it in certain CI builds.
+      It's possible there's a race condition creating this issue in certain CI
+      builds.
+      Also add a simple filesystem-based locking protocol to try to
+      avoide the problem occuring.
 
   From Jonathon Reinhart:
     - Fix another instance of `int main()` in CheckLib() causing failures

--- a/SCons/Util/__init__.py
+++ b/SCons/Util/__init__.py
@@ -81,6 +81,7 @@ from .envs import (
     AddPathIfNotExists,
     AddMethod,
 )
+from .filelock import FileLock, SConsLockFailure
 
 
 # Note: the Util package cannot import other parts of SCons globally without

--- a/SCons/Util/filelock.py
+++ b/SCons/Util/filelock.py
@@ -1,0 +1,149 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+
+"""SCons file locking functions.
+
+Simple-minded filesystem-based locking. Provides a context manager
+which acquires a lock (or at least, permission) on entry and
+releases it on exit.
+
+Usage::
+
+    from SCons.Util.filelock import FileLock
+
+    with FileLock("myfile.txt", writer=True) as lock:
+        print(f"Lock on {lock.file} acquired.")
+        # work with the file as it is now locked
+"""
+
+# TODO: things to consider.
+#   Is raising an exception the right thing for failing to get lock?
+#   Is a filesystem lockfile scheme sufficient for our needs?
+#   - or is it better to put locks on the actual file (fcntl/windows-based)?
+#   ... Is that even viable in the case of a remote (network) file?
+#   Is this safe enough? Or do we risk dangling lockfiles?
+#   Permission issues in case of multi-user. This *should* be okay,
+#     the cache usually goes in user's homedir, plus you already have
+#     enough rights for the lockfile if the dir lets you create the cache.
+#   Need a forced break-lock method?
+#   The lock attributes could probably be made opaque. Showed one visible
+#     in the example above, but not sure the benefit of that.
+
+import os
+import time
+from typing import Optional
+
+
+class SConsLockFailure(Exception):
+    """Lock failure exception."""
+
+
+class FileLock:
+    """Lock a file using a lockfile.
+
+    Locking for the case where multiple processes try to hit an externally
+    shared resource that cannot depend on locking within a single SCons
+    process. SCons does not have a lot of those, but caches come to mind.
+
+    Cross-platform safe, does not use any OS-specific features.  Provides
+    context manager support, or can be called with :meth:`acquire_lock`
+    and :meth:`release_lock`.
+
+    Lock can be a write lock, which is held until released, or a read
+    lock, which releases immediately upon aquisition - the interesting
+    thing being to not read a file which somebody else may be writing,
+
+    TODO: Should default timeout be None (non-blocking), or 0 (block forever),
+       or some arbitrary number?
+
+    Arguments:
+       file: name of file to lock.
+       timeout: optional time (sec) to give up trying.
+          If ``None``, quit now if we failed to get the lock (non-blocking).
+          If 0, block forever (well, a long time).
+       delay: optional delay between tries [default 0.05s]
+       writer: if True, obtain the lock for safe writing. If False (default),
+          just wait till the lock is available, give it back right away.
+
+    Raises:
+        SConsLockFailure: if the operation "timed out", including the
+          non-blocking mode.
+    """
+
+    def __init__(
+        self,
+        file: str,
+        timeout: Optional[int] = None,
+        delay: Optional[float] = 0.05,
+        writer: bool = False,
+    ) -> None:
+        if timeout is not None and delay is None:
+            raise ValueError("delay cannot be None if timeout is None.")
+        # It isn't completely obvious where to put the lockfile.
+        # This scheme depends on diffrent processes using the same path
+        # to the lockfile, since the lockfile is the magic resource,
+        # not the file itself. getcwd() is no good for testcases, each of
+        # which run in a unique test directory. tempfile is no good,
+        # as those are (intentionally) unique per process.
+        # Our simple first guess is just put it where the file is.
+        self.file = file
+        self.lockfile = f"{file}.lock"
+        self.lock: Optional[int] = None
+        self.timeout = 999999 if timeout == 0 else timeout
+        self.delay = 0.0 if delay is None else delay
+        self.writer = writer
+
+    def acquire_lock(self) -> None:
+        """Acquire the lock, if possible.
+
+        If the lock is in use, check again every *delay* seconds.
+        Continue until lock acquired or *timeout* expires.
+        """
+        start_time = time.perf_counter()
+        while True:
+            try:
+                self.lock = os.open(self.lockfile, os.O_CREAT|os.O_EXCL|os.O_RDWR)
+            except FileExistsError as exc:
+                if self.timeout is None:
+                    raise SConsLockFailure(
+                        f"Could not acquire lock on {self.file!r}"
+                    ) from exc
+                if (time.perf_counter() - start_time) > self.timeout:
+                    raise SConsLockFailure(
+                        f"Timeout waiting for lock on {self.file!r}."
+                    ) from exc
+                time.sleep(self.delay)
+            else:
+                if not self.writer:
+                    # reader: waits to get lock, but doesn't hold it
+                    self.release_lock()
+                break
+
+    def release_lock(self) -> None:
+        """Release the lock by deleting the lockfile."""
+        if self.lock:
+            os.close(self.lock)
+            os.unlink(self.lockfile)
+            self.lock = None
+
+    def __enter__(self) -> "FileLock":
+        """Context manager entry: acquire lock if not holding."""
+        if not self.lock:
+            self.acquire_lock()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb) -> None:
+        """Context manager exit: release lock if holding."""
+        if self.lock:
+            self.release_lock()
+
+    def __repr__(self) -> str:
+        """Nicer display if someone repr's the lock class."""
+        return (
+            f"FileLock("
+            f"file={self.file!r}, "
+            f"timeout={self.timeout!r}, "
+            f"delay={self.delay!r}, "
+            f"writer={self.writer!r})"
+        )

--- a/SCons/Util/filelock.py
+++ b/SCons/Util/filelock.py
@@ -58,7 +58,7 @@ class FileLock:
        or some arbitrary number?
 
     Arguments:
-       file: name of file to lock.
+       file: name of file to lock. Only used to build the lockfile name.
        timeout: optional time (sec) to give up trying.
           If ``None``, quit now if we failed to get the lock (non-blocking).
           If 0, block forever (well, a long time).
@@ -104,7 +104,7 @@ class FileLock:
         while True:
             try:
                 self.lock = os.open(self.lockfile, os.O_CREAT|os.O_EXCL|os.O_RDWR)
-            except FileExistsError as exc:
+            except (FileExistsError, PermissionError) as exc:
                 if self.timeout is None:
                     raise SConsLockFailure(
                         f"Could not acquire lock on {self.file!r}"

--- a/test/ParseDepends.py
+++ b/test/ParseDepends.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 
@@ -40,18 +39,19 @@ with open(sys.argv[1], 'wb') as f, open(sys.argv[2], 'rb') as afp2, open(sys.arg
     f.write(afp2.read() + afp3.read())
 """)
 
-test.write('SConstruct', """
-Foo = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES subdir/foo.dep')
-Bar = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES subdir/bar.dep')
-env = Environment(BUILDERS = { 'Foo' : Foo, 'Bar' : Bar }, SUBDIR='subdir')
+test.write('SConstruct', """\
+Foo = Builder(action=r'%(_python_)s build.py $TARGET $SOURCES subdir/foo.dep')
+Bar = Builder(action=r'%(_python_)s build.py $TARGET $SOURCES subdir/bar.dep')
+DefaultEnvironment(tools=[])
+env = Environment(tools=[], BUILDERS={'Foo': Foo, 'Bar': Bar}, SUBDIR='subdir')
 env.ParseDepends('foo.d')
 env.ParseDepends('bar.d')
-env.Foo(target = 'f1.out', source = 'f1.in')
-env.Foo(target = 'f2.out', source = 'f2.in')
-env.Bar(target = 'subdir/f3.out', source = 'f3.in')
+env.Foo(target='f1.out', source='f1.in')
+env.Foo(target='f2.out', source='f2.in')
+env.Bar(target='subdir/f3.out', source='f3.in')
 SConscript('subdir/SConscript', "env")
-env.Foo(target = 'f5.out', source = 'f5.in')
-env.Bar(target = 'sub2/f6.out', source = 'f6.in')
+env.Foo(target='f5.out', source='f5.in')
+env.Bar(target='sub2/f6.out', source='f6.in')
 """ % locals())
 
 test.write('foo.d', "f1.out f2.out: %s\n" % os.path.join('subdir', 'foo.dep'))
@@ -137,14 +137,16 @@ test.must_match(['sub2', 'f6.out'], "f6.in 3\nsubdir/bar.dep 3\n")
 
 
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 ParseDepends('nonexistent_file')
 """)
 
 test.run()
 
-test.write('SConstruct', """
-ParseDepends('nonexistent_file', must_exist=1)
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+ParseDepends('nonexistent_file', must_exist=True)
 """)
 
 test.run(status=2, stderr=None)


### PR DESCRIPTION
Following on from #4402, which tries to recover from races that might either cause a corrupt msvc cache file, or an incomplete read happening while a write is still in process, add a simple-minded locking protocol to try to prevent the problem in the first place.  For writing, a lockfile is created with exclusive access. For reading, the same is done but immediately released: we only wanted to wait that it's not currently locked, we don't need to keep it locked at this point. 

This is addressing what's mainly an issue for testing, when there can be many concurrent SCons instance each running a test - we don't think this is likely in normal developer usage.  The concurrent or near-concurrent write, if it's happening, can lead to inefficient use: consider if process *A* gathers data for one compiler and *B* for another, both starting from the same base information. *A* writes and then *B* writes immediately after, then *A*'s information would be wiped out and have to recomputed again later.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
