### PR TITLE
MSVC: Fix unhandled MissingConfiguration exception.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       module was refactored.
     - Add arm64 to the MSVS supported architectures list for VS2017 and later to be
       consistent with the current documentation of MSVS_ARCH.
+    - Fix an issue with an unhandled MissingConfiguration exception due to an msvc
+      registry query that returns a path that does not exist.  Multiple invocation
+      paths were not prepared to handle the MissingConfiguration exception.  The
+      MissingConfiguration exception type was removed.
 
   From Vitaly Cheptsov:
     - Fix race condition in `Mkdir` which can happen when two `SConscript`

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -89,9 +89,6 @@ class MSVCUseSettingsError(MSVCUserError):
 class UnsupportedVersion(VisualCException):
     pass
 
-class MissingConfiguration(VisualCException):
-    pass
-
 class BatchFileExecutionError(VisualCException):
     pass
 
@@ -873,9 +870,8 @@ def find_vc_pdir(env, msvc_version):
 
     Raises:
         UnsupportedVersion: if the version is not known by this file.
-        MissingConfiguration: found version but the directory is missing.
 
-        Both exceptions inherit from VisualCException.
+        UnsupportedVersion inherits from VisualCException.
 
     """
     root = 'Software\\'
@@ -917,7 +913,6 @@ def find_vc_pdir(env, msvc_version):
                 return comps
             else:
                 debug('reg says dir is %s, but it does not exist. (ignoring)', comps)
-                raise MissingConfiguration(f"registry dir {comps} not found on the filesystem")
     return None
 
 def find_batch_file(msvc_version, host_arch, target_arch, pdir):
@@ -1343,9 +1338,6 @@ def msvc_find_valid_batch_script(env, version):
         pdir = find_vc_pdir(env, version)
     except UnsupportedVersion:
         # Unsupported msvc version (raise MSVCArgumentError?)
-        pass
-    except MissingConfiguration:
-        # Found version, directory missing
         pass
     debug('product directory: version=%s, pdir=%s', version, pdir)
 


### PR DESCRIPTION
Fix an issue with an unhandled MissingConfiguration exception due to an msvc registry query that returns a path that does not exist.  Multiple invocation paths were not prepared to handle the MissingConfiguration exception.  The MissingConfiguration exception type was removed.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
