### PR TITLE
Bump dependency versions

### DIFF
--- a/bin/docs-create-example-outputs.py
+++ b/bin/docs-create-example-outputs.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 #
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 # Searches through the whole doc/user tree and creates
 # all output files for the single examples.
-#
+
 import os
 import sys
 import SConsExamples

--- a/bin/docs-update-generated.py
+++ b/bin/docs-update-generated.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 #
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 # Searches through the whole source tree and updates
 # the generated *.gen/*.mod files in the docs folder, keeping all
 # documentation for the tools, builders and functions...
 # as well as the entity declarations for them.
 # Uses scons-proc.py under the hood...
-#
+
 import os
 import sys
 import subprocess
@@ -63,8 +67,8 @@ def generate_all():
             print("Generation failed", file=sys.stderr)
             return False
     return True
-    
-    
+
+
 if __name__ == "__main__":
     if not generate_all():
         sys.exit(1)

--- a/bin/docs-validate.py
+++ b/bin/docs-validate.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 #
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+#
 # Searches through the whole source tree and validates all
 # documentation files against our own XSD in docs/xsd.
 #

--- a/doc/generated/variables.mod
+++ b/doc/generated/variables.mod
@@ -80,6 +80,10 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-DFLAGPREFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DFLAGPREFIX</envar>">
 <!ENTITY cv-DFLAGS "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DFLAGS</envar>">
 <!ENTITY cv-DFLAGSUFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DFLAGSUFFIX</envar>">
+<!ENTITY cv-DI_FILE_DIR "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DI_FILE_DIR</envar>">
+<!ENTITY cv-DI_FILE_DIR_PREFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DI_FILE_DIR_PREFIX</envar>">
+<!ENTITY cv-DI_FILE_DIR_SUFFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DI_FILE_DIR_SUFFFIX</envar>">
+<!ENTITY cv-DI_FILE_SUFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DI_FILE_SUFFIX</envar>">
 <!ENTITY cv-DINCPREFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DINCPREFIX</envar>">
 <!ENTITY cv-DINCSUFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$DINCSUFFIX</envar>">
 <!ENTITY cv-Dir "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$Dir</envar>">
@@ -662,6 +666,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-XGETTEXTPATHSUFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$XGETTEXTPATHSUFFIX</envar>">
 <!ENTITY cv-YACC "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$YACC</envar>">
 <!ENTITY cv-YACC_GRAPH_FILE "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$YACC_GRAPH_FILE</envar>">
+<!ENTITY cv-YACC_GRAPH_FILE_SUFFIX "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$YACC_GRAPH_FILE_SUFFIX</envar>">
 <!ENTITY cv-YACC_HEADER_FILE "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$YACC_HEADER_FILE</envar>">
 <!ENTITY cv-YACCCOM "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$YACCCOM</envar>">
 <!ENTITY cv-YACCCOMSTR "<envar xmlns='http://www.scons.org/dbxsd/v1.0'>$YACCCOMSTR</envar>">
@@ -756,6 +761,10 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-link-DFLAGPREFIX "<link linkend='cv-DFLAGPREFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DFLAGPREFIX</envar></link>">
 <!ENTITY cv-link-DFLAGS "<link linkend='cv-DFLAGS' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DFLAGS</envar></link>">
 <!ENTITY cv-link-DFLAGSUFFIX "<link linkend='cv-DFLAGSUFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DFLAGSUFFIX</envar></link>">
+<!ENTITY cv-link-DI_FILE_DIR "<link linkend='cv-DI_FILE_DIR' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DI_FILE_DIR</envar></link>">
+<!ENTITY cv-link-DI_FILE_DIR_PREFIX "<link linkend='cv-DI_FILE_DIR_PREFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DI_FILE_DIR_PREFIX</envar></link>">
+<!ENTITY cv-link-DI_FILE_DIR_SUFFFIX "<link linkend='cv-DI_FILE_DIR_SUFFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DI_FILE_DIR_SUFFFIX</envar></link>">
+<!ENTITY cv-link-DI_FILE_SUFFIX "<link linkend='cv-DI_FILE_SUFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DI_FILE_SUFFIX</envar></link>">
 <!ENTITY cv-link-DINCPREFIX "<link linkend='cv-DINCPREFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DINCPREFIX</envar></link>">
 <!ENTITY cv-link-DINCSUFFIX "<link linkend='cv-DINCSUFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$DINCSUFFIX</envar></link>">
 <!ENTITY cv-link-Dir "<link linkend='cv-Dir' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$Dir</envar></link>">
@@ -1338,6 +1347,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY cv-link-XGETTEXTPATHSUFFIX "<link linkend='cv-XGETTEXTPATHSUFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$XGETTEXTPATHSUFFIX</envar></link>">
 <!ENTITY cv-link-YACC "<link linkend='cv-YACC' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$YACC</envar></link>">
 <!ENTITY cv-link-YACC_GRAPH_FILE "<link linkend='cv-YACC_GRAPH_FILE' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$YACC_GRAPH_FILE</envar></link>">
+<!ENTITY cv-link-YACC_GRAPH_FILE_SUFFIX "<link linkend='cv-YACC_GRAPH_FILE_SUFFIX' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$YACC_GRAPH_FILE_SUFFIX</envar></link>">
 <!ENTITY cv-link-YACC_HEADER_FILE "<link linkend='cv-YACC_HEADER_FILE' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$YACC_HEADER_FILE</envar></link>">
 <!ENTITY cv-link-YACCCOM "<link linkend='cv-YACCCOM' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$YACCCOM</envar></link>">
 <!ENTITY cv-link-YACCCOMSTR "<link linkend='cv-YACCCOMSTR' xmlns='http://www.scons.org/dbxsd/v1.0'><envar>$YACCCOMSTR</envar></link>">

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@
 # for now keep pinning "known working" lxml,
 # it's been a troublesome component in the past.
 # Skip  lxml for win32 as no tests which require it currently pass on win32
-lxml==4.9.2; python_version < '3.12' and sys_platform != 'win32'
+lxml==4.9.3; python_version < '3.13' and sys_platform != 'win32'
 
 ninja
 

--- a/requirements-pkg.txt
+++ b/requirements-pkg.txt
@@ -8,7 +8,7 @@
 readme-renderer
 
 # sphinx pinned because it has broken several times on new releases
-sphinx < 6.0
+sphinx < 7.0
 sphinx-book-theme
 rst2pdf
 


### PR DESCRIPTION
`Sphinx` ceiling version bumped to 6.x. While it *works* with current Sphinx 7.x, `sphinx-book-theme` is actually pinned to <7, so to avoid install complaints, leave Sphinx down-rev for now.

`lxml` version pin bumped, and the fence for not installing on Python 3.12 is changed to 3.13 - PyPI packages for 3.12 are up.

Update doc/generated/variables.mod as it contains new construction variables from the 4.6 development: all the generated files will be updated at release time, but this allows a build *without* regenerating to not fail.

Contains no changes to SCons code or to doc contents, so no changelog entry.
