### PR TITLE
TeX tests: skip if no makeindex

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -168,7 +168,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       builds.  Also add a simple filesystem-based locking protocol to try to
       avoid the problem occuring.
     - Update the first two chapters on building with SCons in the User Guide.
-    - TeX tests: skip tests that use makeindex command when not found.
+    - TeX tests: skip tests that use makeindex or epstopdf not installed, or
+      if `kpsewhich glossaries.sty` fails.
+
 
   From Jonathon Reinhart:
     - Fix another instance of `int main()` in CheckLib() causing failures

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -168,6 +168,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       builds.  Also add a simple filesystem-based locking protocol to try to
       avoid the problem occuring.
     - Update the first two chapters on building with SCons in the User Guide.
+    - TeX tests: skip tests that use makeindex command when not found.
 
   From Jonathon Reinhart:
     - Fix another instance of `int main()` in CheckLib() causing failures

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -147,6 +147,8 @@ DEVELOPMENT
   doesn't use so it can be instantiated by unittests and others.
 - Added more type annotations to internal routines.
 - Cleaned up dblite module (checker warnings, etc.).
+- TeX tests: skip tests that use makeindex or epstopdf not installed, or
+  if `kpsewhich glossaries.sty` fails.
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/test/DVIPDF/makeindex.py
+++ b/test/DVIPDF/makeindex.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -37,10 +36,14 @@ if not dvipdf:
 tex = test.where_is('tex')
 if not tex:
     test.skip_test("Could not find 'tex'; skipping test(s).\n")
- 
+
 latex = test.where_is('latex')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 
 

--- a/test/DVIPS/DVIPS.py
+++ b/test/DVIPS/DVIPS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -114,8 +113,9 @@ test.must_match('test3.ps', "This is a .ltx test.\n", mode='r')
 test.must_match('test4.ps', "This is a .latex test.\n", mode='r')
 
 
-have_latex = test.where_is('latex')
-if not have_latex:
+# TODO: split this test? Taking a skip here invalidates the above, too
+latex = test.where_is('latex')
+if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 dvips = test.where_is('dvips')

--- a/test/TEX/LATEX.py
+++ b/test/TEX/LATEX.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Validate that we can set the LATEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.
@@ -38,7 +37,13 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
+latex = test.where_is('latex')
+if not latex:
+    test.skip_test("Could not find 'latex'; skipping test.\n")
 
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 test.write('mylatex.py', r"""
 import sys
@@ -95,8 +100,8 @@ test.must_not_exist('test2.log')
 
 
 
+# TODO: split this test? We already bailed above so check is useless.
 latex = test.where_is('latex')
-
 if latex:
 
     test.file_fixture('wrapper.py')

--- a/test/TEX/LATEX2.py
+++ b/test/TEX/LATEX2.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Validate that we can produce several .pdf at once from several sources.
 """
 
@@ -36,7 +35,14 @@ test = TestSCons.TestSCons()
 
 
 latex = test.where_is('latex')
+if not latex:
+    test.skip_test("Could not find 'latex'; skipping test.\n")
 
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
+
+# TODO: reformat, check is now unneeded.
 if latex:
 
     test.write('SConstruct', """

--- a/test/TEX/LATEXFLAGS.py
+++ b/test/TEX/LATEXFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -75,8 +74,8 @@ test.must_match('test2.dvi', " -t\nThis is a .latex test.\n", mode='r')
 
 
 
+# TODO: split this test? Taking a skip here invalidates the above, too
 latex = test.where_is('latex')
-
 if latex:
 
     test.file_fixture('wrapper.py')

--- a/test/TEX/TEX.py
+++ b/test/TEX/TEX.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,13 +23,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-r"""
+"""
 Validate that we can set the TEX string to our own utility, that
 the produced .dvi, .aux and .log files get removed by the -c option,
 and that we can use this to wrap calls to the real latex utility.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -35,9 +35,9 @@ _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
 
-have_latex = test.where_is('latex')
-if not have_latex:
-    test.skip_test("Could not find 'latex'; skipping test(s).\n")
+latex = test.where_is('latex')
+if not latex:
+    test.skip_test("Could not find 'latex'; skipping test.\n")
 
 
 test.write('mytex.py', r"""
@@ -82,8 +82,8 @@ test.must_not_exist('test.log')
 
 
 
+# TODO: split this test? Taking a skip here invalidates the above, too
 tex = test.where_is('tex')
-
 if tex:
 
     test.file_fixture('wrapper.py')

--- a/test/TEX/TEXFLAGS.py
+++ b/test/TEX/TEXFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -68,8 +67,8 @@ test.must_match('test.dvi'," -x\nThis is a test.\n", mode='r')
 
 
 
+# TODO: split this test? Taking a skip here invalidates the above, too
 tex = test.where_is('tex')
-
 if tex:
 
     test.file_fixture('wrapper.py')

--- a/test/TEX/bibliography.py
+++ b/test/TEX/bibliography.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Validate that use of \bibliography in TeX source files causes SCons to
 be aware of the necessary created bibliography files.
 
@@ -36,7 +35,6 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 dvips = test.where_is('dvips')
-
 if not dvips:
     test.skip_test("Could not find 'dvips'; skipping test(s).\n")
 
@@ -44,8 +42,8 @@ bibtex = test.where_is('bibtex')
 if not bibtex:
     test.skip_test("Could not find 'bibtex'; skipping test(s).\n")
 
-have_latex = test.where_is('latex')
-if not have_latex:
+latex = test.where_is('latex')
+if not latex:
     test.skip_test("Could not find 'latex'; skipping test(s).\n")
 
 

--- a/test/TEX/glossaries.py
+++ b/test/TEX/glossaries.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Validate that use of \glossaries in TeX source files causes SCons to
 be aware of the necessary created glossary files.
 
@@ -38,13 +37,16 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 latex = test.where_is('latex')
-
 if not latex:
-    test.skip_test("Could not find 'latex'; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 cp = subprocess.run('kpsewhich glossaries.sty', shell=True)
 if cp.returncode:
-    test.skip_test("glossaries.sty not installed; skipping test(s).\n")
+    test.skip_test("glossaries.sty not installed; skipping test.\n")
 
 test.write('SConstruct', """\
 import os

--- a/test/TEX/multi-run.py
+++ b/test/TEX/multi-run.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Validate that both .tex and .ltx files can handle a LaTeX-style
 bibliography (by calling $BIBTEX to generate a .bbl file) and
 correctly re-run to resolve undefined references.
@@ -130,6 +129,8 @@ bibfile = r"""
 }
 """
 
+# TODO: check is useless: we already bailed at top if tex not found.
+#   Should we split test into plain and -live instead?
 if tex:
 
     test.write(['work1', 'SConstruct'], """\
@@ -165,6 +166,7 @@ env.DVI( "foo3.tex" )
 
 
 
+# TODO: split this test? this check is useless after skip above
 if latex:
 
     test.write(['work2', 'SConstruct'], """\

--- a/test/TEX/multiple_include.py
+++ b/test/TEX/multiple_include.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Test creation of a fully-featured TeX document (with bibliography
 and index) in a variant_dir.
 
@@ -36,12 +35,16 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 latex = test.where_is('latex')
-epstopdf = test.where_is('epstopdf')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test.\n")
 
+epstopdf = test.where_is('epstopdf')
 if not epstopdf:
     test.skip_test("Could not find 'epstopdf'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 test.subdir(['docs'])
 

--- a/test/TEX/multiple_include_subdir.py
+++ b/test/TEX/multiple_include_subdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Test creation of a Tex document with nested includes in a
 subdir that needs to create a fig.pdf.
 
@@ -36,12 +35,16 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 latex = test.where_is('latex')
-epstopdf = test.where_is('epstopdf')
 if not latex:
     test.skip_test("Could not find 'latex'; skipping test.\n")
 
+epstopdf = test.where_is('epstopdf')
 if not epstopdf:
     test.skip_test("Could not find 'epstopdf'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 test.subdir(['docs'])
 

--- a/test/TEX/newglossary.py
+++ b/test/TEX/newglossary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Validate that use of \newglossary in TeX source files causes SCons to
 be aware of the necessary created glossary files.
 
@@ -38,13 +37,16 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 latex = test.where_is('latex')
-
 if not latex:
-    test.skip_test("Could not find 'latex'; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 cp = subprocess.run('kpsewhich glossaries.sty', shell=True)
 if cp.returncode:
-    test.skip_test("glossaries.sty not installed; skipping test(s).\n")
+    test.skip_test("glossaries.sty not installed; skipping test.\n")
 
 test.write('SConstruct', """\
 import os

--- a/test/TEX/subdir_variantdir_include.py
+++ b/test/TEX/subdir_variantdir_include.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Verify that we execute TeX in a subdirectory (if that's where the document
 resides) by checking that all the auxiliary files get created there and
 not in the top-level directory. Test this when variantDir is used
@@ -45,6 +44,10 @@ if not latex:
 pdflatex = test.where_is('pdflatex')
 if not pdflatex:
     test.skip_test("Could not find 'pdflatex'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 test.subdir('docs')
 test.subdir(['docs','sub'])

--- a/test/TEX/subdir_variantdir_include2.py
+++ b/test/TEX/subdir_variantdir_include2.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Verify that we execute TeX in a subdirectory (if that's where the document
 resides) by checking that all the auxiliary files get created there and
 not in the top-level directory. Test this when variantDir is used
@@ -46,6 +45,10 @@ if not latex:
 pdflatex = test.where_is('pdflatex')
 if not pdflatex:
     test.skip_test("Could not find 'pdflatex'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 test.subdir('docs')
 test.subdir(['docs','content'])

--- a/test/TEX/subdir_variantdir_input.py
+++ b/test/TEX/subdir_variantdir_input.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Verify that we execute TeX in a subdirectory (if that's where the document
 resides) by checking that all the auxiliary files get created there and
 not in the top-level directory. Test this when variantDir is used
@@ -45,6 +44,10 @@ if not latex:
 pdflatex = test.where_is('pdflatex')
 if not pdflatex:
     test.skip_test("Could not find 'pdflatex'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 test.subdir('docs')
 test.subdir(['docs','sub'])

--- a/test/TEX/variant_dir.py
+++ b/test/TEX/variant_dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Test creation of a fully-featured TeX document (with bibliography
 and index) in a variant_dir.
 
@@ -36,9 +35,16 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 latex = test.where_is('latex')
+if not latex:
+    test.skip_test("Could not find 'latex'; skipping test.\n")
+
 dvipdf = test.where_is('dvipdf')
-if not all((latex, dvipdf)):
-    test.skip_test("Could not find 'latex' and/or 'dvipdf'; skipping test(s).\n")
+if not dvipdf:
+    test.skip_test("Could not find 'dvipdf'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 test.subdir(['docs'])
 

--- a/test/TEX/variant_dir_newglossary.py
+++ b/test/TEX/variant_dir_newglossary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,11 +22,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
-r"""
+"""
 Validate the use of \newglossary in TeX source files in conjunction
 with variant_dir.
 
@@ -38,14 +37,16 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 latex = test.where_is('latex')
-
 if not latex:
-    test.skip_test("Could not find 'latex'; skipping test(s).\n")
+    test.skip_test("Could not find 'latex'; skipping test.\n")
+
+makeindex = test.where_is('makeindex')
+if not makeindex:
+    test.skip_test("Could not find 'makeindex'; skipping test.\n")
 
 cp = subprocess.run('kpsewhich glossaries.sty', shell=True)
 if cp.returncode:
-    test.skip_test("glossaries.sty not installed; skipping test(s).\n")
-
+    test.skip_test("glossaries.sty not installed; skipping test.\n")
 
 test.subdir(['src'])
 


### PR DESCRIPTION
A number of tests fail if the `makeindex` command is not installed, as there were not skip checks for them. Added.

Also dropped in some TODOs for future work - trying to keep this change to the minimum.

Test-only change.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
