### PR TITLE
Fix issues in new scons_subproc_run

### DIFF
--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -2349,6 +2349,9 @@ class ObjectContentsTestCase(unittest.TestCase):
     @mock.patch("subprocess.run", mock_subprocess_run)
     def test_scons_subproc_run(self):
         """Test the argument remapping options."""
+        # set phony Python versions to trigger the logic in scons_subproc_run:
+        # any version greater than 3.6, really
+        save_info, sys.version_info = sys.version_info, (3, 11, 1)
         env = Environment()
         self.assertEqual(scons_subproc_run(env), {"check": False})
         with self.subTest():
@@ -2368,7 +2371,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             )
 
         # 3.6:
-        save_info, sys.version_info = sys.version_info, (3, 6, 2)
+        sys.version_info = (3, 6, 2)
         with self.subTest():
             self.assertEqual(
                 scons_subproc_run(env, capture_output=True),


### PR DESCRIPTION
The logic to handle the legacy `error` kwarg supported by the predecessor `_subproc` function had some problems. Reworked. 

A few minor lint tweaks also, mainly avoiding an `else:` clause where the `if:` block has returned unconditionally.

This updates a function added in the same release cycle, so no additional CHANGES/RELEASE entry seems needed

No external docs for this, but the docstring was updated.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
