### PR TITLE
Further mod on msvc config cache locking

### DIFF
--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -119,10 +119,12 @@ def read_script_env_cache() -> dict:
     p = Path(CONFIG_CACHE)
     if not CONFIG_CACHE or not p.is_file():
         return envcache
-    with SCons.Util.FileLock(CONFIG_CACHE, timeout=5), p.open('r') as f:
+    with SCons.Util.FileLock(CONFIG_CACHE, timeout=5, writer=True), p.open('r') as f:
         # Convert the list of cache entry dictionaries read from
         # json to the cache dictionary. Reconstruct the cache key
         # tuple from the key list written to json.
+        # Note we need to take a write lock on the cachefile, as if there's
+        # an error and we try to remove it, that's "writing" on Windows.
         try:
             envcache_list = json.load(f)
         except json.JSONDecodeError:


### PR DESCRIPTION
In the first iteration, we took a read lock in the read case. A fail was observed where the reader took a json decode error, and then tried to remove the cachefile in case it's really corrupt. That failed as the file was "busy" - on Windows removing is essentially writing the file - so take a write lock here too.

This is a tweak to an internal detail that is not yet in an SCons release, so no further changes to CHANGES/RELEASE; no doc impacts.  We don't have a test that can force this case, waiting for CI runs for more info.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
