### PR TITLE
Fixup one test framework test

### DIFF
--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -1601,10 +1601,10 @@ class rmdir_TestCase(TestCmdTestCase):
 
         try:
             test.rmdir(['no', 'such', 'dir'])
-        except EnvironmentError:
+        except FileNotFoundError:
             pass
         else:
-            raise Exception("did not catch expected SConsEnvironmentError")
+            raise Exception("did not catch expected FileNotFoundError")
 
         test.subdir(['sub'],
                     ['sub', 'dir'],
@@ -1616,19 +1616,19 @@ class rmdir_TestCase(TestCmdTestCase):
 
         try:
             test.rmdir(['sub'])
-        except EnvironmentError:
+        except OSError:
             pass
         else:
-            raise Exception("did not catch expected SConsEnvironmentError")
+            raise Exception("did not catch expected OSError")
 
         assert os.path.isdir(s_d_o), f"{s_d_o} is gone?"
 
         try:
             test.rmdir(['sub'])
-        except EnvironmentError:
+        except OSError:
             pass
         else:
-            raise Exception("did not catch expected SConsEnvironmentError")
+            raise Exception("did not catch expected OSError")
 
         assert os.path.isdir(s_d_o), f"{s_d_o} is gone?"
 
@@ -1645,7 +1645,6 @@ class rmdir_TestCase(TestCmdTestCase):
         test.rmdir('sub')
 
         assert not os.path.exists(s), f"{s} exists?"
-
 
 
 class run_TestCase(TestCmdTestCase):


### PR DESCRIPTION
Minor: looking at wrong exceptions for possible rmdir failures. `TestCmdTests` passes for me with this change.

Limited CI since the framework tests aren't actually run by the CI.  


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
