### PR TITLE
Update assembly code in one test

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -179,6 +179,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Python stdlib types module.
     - TeX tests: skip tests that use makeindex or epstopdf not installed, or
       if `kpsewhich glossaries.sty` fails.
+    - Added a .note.GNU-stack section to the test assembler files to
+      avoid the GNU linker issuing warnings for its absence.
 
 
   From Jonathon Reinhart:


### PR DESCRIPTION
Avoids warnings, which fail the test.

Fixes #4238

No external impacts - test only.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
