### PR TITLE
Microsoft tools: change relative imports to top-level absolute imports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,6 +42,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       registry query that returns a path that does not exist.  Multiple invocation
       paths were not prepared to handle the MissingConfiguration exception.  The
       MissingConfiguration exception type was removed.
+    - The MSCommon module import was changed from a relative import to a top-level
+      absolute import in the following Microsoft tools: midl, mslib, mslink, mssdk, msvc,
+      msvs. Moving any of these tools that used relative imports to the scons site tools
+      folder would fail on import (i.e., the relative import paths become invalid when
+      moved).
 
   From Vitaly Cheptsov:
     - Fix race condition in `Mkdir` which can happen when two `SConscript`

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -120,6 +120,11 @@ IMPROVEMENTS
 ------------
 
 - Now tries to find mingw if it comes from Chocolatey install of msys2.
+- MSVC: Module imports were changed from a relative import to a top-level
+  absolute import in the following Microsoft tools: midl, mslib, mslink, mssdk, msvc,
+  msvs. Moving any of these tools that used relative imports to the scons site tools
+  folder would fail on import (i.e., the relative import paths become invalid when
+  moved).
 
 PACKAGING
 ---------

--- a/SCons/Tool/midl.py
+++ b/SCons/Tool/midl.py
@@ -37,7 +37,7 @@ import SCons.Defaults
 import SCons.Scanner.IDL
 import SCons.Util
 
-from .MSCommon import msvc_setup_env_tool
+from SCons.Tool.MSCommon import msvc_setup_env_tool
 
 tool_name = 'midl'
 

--- a/SCons/Tool/mslib.py
+++ b/SCons/Tool/mslib.py
@@ -41,7 +41,10 @@ import SCons.Tool.msvs
 import SCons.Tool.msvc
 import SCons.Util
 
-from .MSCommon import msvc_setup_env_tool, msvc_setup_env_once
+from SCons.Tool.MSCommon import (
+    msvc_setup_env_tool,
+    msvc_setup_env_once,
+)
 
 tool_name = 'mslib'
 

--- a/SCons/Tool/mslink.py
+++ b/SCons/Tool/mslink.py
@@ -43,8 +43,11 @@ import SCons.Tool.msvc
 import SCons.Tool.msvs
 import SCons.Util
 
-from .MSCommon import msvc_setup_env_once, msvc_setup_env_tool
-from .MSCommon.common import get_pch_node
+from SCons.Tool.MSCommon import (
+    msvc_setup_env_once,
+    msvc_setup_env_tool,
+)
+from SCons.Tool.MSCommon.common import get_pch_node
 
 tool_name = 'mslink'
 

--- a/SCons/Tool/mssdk.py
+++ b/SCons/Tool/mssdk.py
@@ -33,8 +33,10 @@ It will usually be imported through the generic SCons.Tool.Tool()
 selection method.
 """
 
-from .MSCommon import mssdk_exists, \
-                     mssdk_setup_env
+from SCons.Tool.MSCommon import (
+    mssdk_exists,
+    mssdk_setup_env,
+)
 
 def generate(env) -> None:
     """Add construction variables for an MS SDK to an Environment."""

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -44,8 +44,13 @@ import SCons.Util
 import SCons.Warnings
 import SCons.Scanner.RC
 
-from .MSCommon import msvc_setup_env_tool, msvc_setup_env_once, msvc_version_to_maj_min, msvc_find_vswhere
-from .MSCommon.common import get_pch_node
+from SCons.Tool.MSCommon import (
+    msvc_setup_env_tool,
+    msvc_setup_env_once,
+    msvc_version_to_maj_min,
+    msvc_find_vswhere,
+)
+from SCons.Tool.MSCommon.common import get_pch_node
 
 tool_name = 'msvc'
 

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -45,7 +45,10 @@ import SCons.Util
 import SCons.Warnings
 from SCons.Defaults import processDefines
 from SCons.compat import PICKLE_PROTOCOL
-from .MSCommon import msvc_setup_env_tool, msvc_setup_env_once
+from SCons.Tool.MSCommon import (
+    msvc_setup_env_tool,
+    msvc_setup_env_once,
+)
 
 tool_name = 'msvs'
 


### PR DESCRIPTION
Change the module imports from relative imports to top-level absolute imports for the Microsoft tools.

Moving any of the Microsoft tools that used relative imports to the scons site tools folder would fail on import (i.e., the relative import paths become invalid when the tools are moved).

Internal changes: no test and/or documentation changes necessary.

The first in a sequence of smaller PRs from #4409.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
