### PR TITLE
MSVC: adjust the compiler search and warning message when configuring the environment.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,6 +42,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       registry query that returns a path that does not exist.  Multiple invocation
       paths were not prepared to handle the MissingConfiguration exception.  The
       MissingConfiguration exception type was removed.
+    - The detection of the msvc compiler executable (cl.exe) has been modified.  The
+      compiler detection no longer considers the host os environment path.  In addition,
+      existence of the msvc compiler executable is checked in the detection dictionary
+      and the scons ENV path before the detection dictionary is merged into the scons
+      ENV.  Different warnings are produced when the msvc compiler is not detected in the
+      detection dictionary based on whether or not an msvc compiler was detected in the
+      scons ENV path (i.e., already exists in the user's ENV path prior to detection).
 
   From Vitaly Cheptsov:
     - Fix race condition in `Mkdir` which can happen when two `SConscript`

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,13 +47,24 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       msvs. Moving any of these tools that used relative imports to the scons site tools
       folder would fail on import (i.e., the relative import paths become invalid when
       moved).
-    - The detection of the msvc compiler executable (cl.exe) has been modified.  The
-      compiler detection no longer considers the host os environment path.  In addition,
-      existence of the msvc compiler executable is checked in the detection dictionary
-      and the scons ENV path before the detection dictionary is merged into the scons
-      ENV.  Different warnings are produced when the msvc compiler is not detected in the
-      detection dictionary based on whether or not an msvc compiler was detected in the
-      scons ENV path (i.e., already exists in the user's ENV path prior to detection).
+    - The detection of the msvc compiler executable (cl.exe) has been modified:
+        * The host os environment path is no longer evaluated for the existence of the
+          msvc compiler executable when searching the detection dictionary.
+        * The existence of the msvc compiler executable is checked in the detection
+          dictionary and the scons ENV path before the detection dictionary is merged
+          into the scons ENV.
+        * Different warnings are produced when the msvc compiler is not detected in the
+          detection dictionary based on whether or not an msvc compiler was detected in
+          the scons ENV path (i.e., a msvc compiler executable already exists in the
+          user's ENV path prior to detection).
+        * The warning message issued when a msvc compiler executable is not found in the
+          detection dictionary was modified by adding the word "requested":
+            Old warning: "Could not find MSVC compiler 'cl'."
+            New warning: "Could not find requested MSVC compiler 'cl'.".
+        * An additonal sentence is appended to the warning message issued when an msvc
+          compiler executable is not found in the msvc detection dictionary and is found
+          in the user's ENV path prior to detection:
+            " A 'cl' was found on the scons ENV path which may be erroneous."
 
   From Vitaly Cheptsov:
     - Fix race condition in `Mkdir` which can happen when two `SConscript`

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -59,6 +59,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   batch file exists but an individual msvc toolset may not support the host/target
   architecture combination.  For example, when using VS2022 on arm64, the arm64 native
   tools are only installed for the 14.3x toolsets.
+- MSVC: When the msvc compiler executable is not found during setup of the msvc
+  environment, the warning message issued takes into account whether or not a
+  possibly erroneous compiler executable was already present in the scons environment
+  path.
 - Extend range of recognized Java versions to 20.
 - Builder calls (like Program()) now accept pathlib objects in source lists.
 - The Help() function now takes an additional keyword argument keep_local:
@@ -101,6 +105,8 @@ FIXES
 - MSVC: Erroneous construction of the installed msvc list (as described above) caused an
   index error in the msvc support code.  An explicit check was added to prevent indexing
   into an empty list.  Fixes #4312.
+- MSVC: The search for the msvc compiler executable (cl.exe) no longer inspects the
+  OS system path in certain situations when setting up the msvc environment.
 - MSCommon: Test SConfTests.py would fail when mscommon debugging was enabled via the
   MSVC_MSCOMMON_DEBUG environment variable.  The mscommon logging filter class registered
   with the python logging module was refactored to prevent test failure.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -62,7 +62,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - MSVC: When the msvc compiler executable is not found during setup of the msvc
   environment, the warning message issued takes into account whether or not a
   possibly erroneous compiler executable was already present in the scons environment
-  path.
+  path.  See CHANGES.txt for details.
 - Extend range of recognized Java versions to 20.
 - Builder calls (like Program()) now accept pathlib objects in source lists.
 - The Help() function now takes an additional keyword argument keep_local:

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -1515,19 +1515,32 @@ def msvc_setup_env(env):
         SCons.Warnings.warn(SCons.Warnings.VisualCMissingWarning, warn_msg)
         return None
 
+    found_cl_path = None
+    found_cl_envpath = None
+
+    seen_path = False
     for k, v in d.items():
+        if not seen_path and k == 'PATH':
+            seen_path = True
+            found_cl_path = SCons.Util.WhereIs('cl', v)
+            found_cl_envpath = SCons.Util.WhereIs('cl', env['ENV'].get(k, []))
         env.PrependENVPath(k, v, delete_existing=True)
         debug("env['ENV']['%s'] = %s", k, env['ENV'][k])
 
-    # final check to issue a warning if the compiler is not present
-    if not find_program_path(env, 'cl'):
-        debug("did not find %s", _CL_EXE_NAME)
+    debug("cl paths: d['PATH']=%s, ENV['PATH']=%s", repr(found_cl_path), repr(found_cl_envpath))
+
+    # final check to issue a warning if the requested compiler is not present
+    if not found_cl_path:
         if CONFIG_CACHE:
             propose = f"SCONS_CACHE_MSVC_CONFIG caching enabled, remove cache file {CONFIG_CACHE} if out of date."
         else:
             propose = "It may need to be installed separately with Visual Studio."
-        warn_msg = f"Could not find MSVC compiler 'cl'. {propose}"
-        SCons.Warnings.warn(SCons.Warnings.VisualCMissingWarning, warn_msg)
+        warn_msg = "Could not find requested MSVC compiler 'cl'."
+        if found_cl_envpath:
+            warn_msg += " A 'cl' was found on the scons ENV path which may be erroneous."
+        warn_msg += " %s"
+        debug(warn_msg, propose)
+        SCons.Warnings.warn(SCons.Warnings.VisualCMissingWarning, warn_msg % propose)
 
 def msvc_exists(env=None, version=None):
     vcs = get_installed_vcs(env)

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -1531,16 +1531,15 @@ def msvc_setup_env(env):
 
     # final check to issue a warning if the requested compiler is not present
     if not found_cl_path:
-        if CONFIG_CACHE:
-            propose = f"SCONS_CACHE_MSVC_CONFIG caching enabled, remove cache file {CONFIG_CACHE} if out of date."
-        else:
-            propose = "It may need to be installed separately with Visual Studio."
         warn_msg = "Could not find requested MSVC compiler 'cl'."
+        if CONFIG_CACHE:
+            warn_msg += f" SCONS_CACHE_MSVC_CONFIG caching enabled, remove cache file {CONFIG_CACHE} if out of date."
+        else:
+            warn_msg += " It may need to be installed separately with Visual Studio."
         if found_cl_envpath:
             warn_msg += " A 'cl' was found on the scons ENV path which may be erroneous."
-        warn_msg += " %s"
-        debug(warn_msg, propose)
-        SCons.Warnings.warn(SCons.Warnings.VisualCMissingWarning, warn_msg % propose)
+        debug(warn_msg)
+        SCons.Warnings.warn(SCons.Warnings.VisualCMissingWarning, warn_msg)
 
 def msvc_exists(env=None, version=None):
     vcs = get_installed_vcs(env)

--- a/test/MSVC/MSVC_USE_SETTINGS.py
+++ b/test/MSVC/MSVC_USE_SETTINGS.py
@@ -56,7 +56,7 @@ env = Environment(MSVC_USE_SETTINGS={})
 """ % locals())
 
 test.run(arguments="--warn=visual-c-missing .", status=0, stderr=None)
-test.must_contain_all(test.stderr(), "Could not find MSVC compiler 'cl'")
+test.must_contain_all(test.stderr(), "Could not find requested MSVC compiler 'cl'")
 
 test.write('SConstruct', """
 env = Environment(MSVC_USE_SETTINGS='dict or None')


### PR DESCRIPTION
This PR closes existing loopholes when searching for a msvc compiler executable (cl.exe) in the configured msvc dictionary and the target scons environment.

Changes:
* The search for the msvc compiler executable (cl.exe) no longer inspects the OS system path in certain situations when setting up the msvc environment.
* When the msvc compiler executable is not found during setup of the msvc environment, the warning message issued takes into account whether or not a possibly erroneous compiler executable was already present in the scons environment path.

The second in a sequence of smaller PRs from https://github.com/SCons/scons/pull/4409.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
