### PR TITLE
MSCommon: add custom formatter for debug log records

### DIFF
--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -75,32 +75,86 @@ if LOGFILE:
             record.relfilename = relfilename
             return True
 
-    # Log format looks like:
-    #   00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3'        [file]
-    #   debug: 00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3' [stdout]
-    log_format=(
-        '%(relativeCreated)05dms'
-        ':%(relfilename)s'
-        ':%(funcName)s'
-        '#%(lineno)s'
-        ': %(message)s'
-    )
+    class _CustomFormatter(logging.Formatter):
+
+        # Log format looks like:
+        #   00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3'        [file]
+        #   debug: 00109ms:MSCommon/vc.py:find_vc_pdir#447: VC found '14.3' [stdout]
+
+        log_format=(
+            '%(relativeCreated)05dms'
+            ':%(relfilename)s'
+            ':%(funcName)s'
+            '#%(lineno)s'
+            ': %(message)s'
+        )
+
+        log_format_classname=(
+            '%(relativeCreated)05dms'
+            ':%(relfilename)s'
+            ':%(classname)s'
+            '.%(funcName)s'
+            '#%(lineno)s'
+            ': %(message)s'
+        )
+
+        def __init__(self, log_prefix):
+            super().__init__()
+            if log_prefix:
+                self.log_format = log_prefix + self.log_format
+                self.log_format_classname = log_prefix + self.log_format_classname
+            log_record = logging.LogRecord(
+                '',    # name (str)
+                0,     # level (int)
+                '',    # pathname (str)
+                0,     # lineno (int)
+                None,  # msg (Any)
+                {},    # args (tuple | dict[str, Any])
+                None   # exc_info (tuple[type[BaseException], BaseException, types.TracebackType] | None)
+            )
+            self.default_attrs = set(log_record.__dict__.keys())
+            self.default_attrs.add('relfilename')
+
+        def format(self, record):
+            extras = set(record.__dict__.keys()) - self.default_attrs
+            if 'classname' in extras:
+                log_format = self.log_format_classname
+            else:
+                log_format = self.log_format
+            formatter = logging.Formatter(log_format)
+            return formatter.format(record)
+
     if LOGFILE == '-':
-        log_format = 'debug: ' + log_format
+        log_prefix = 'debug: '
         log_handler = logging.StreamHandler(sys.stdout)
     else:
+        log_prefix = ''
         log_handler = logging.FileHandler(filename=LOGFILE)
-    log_formatter = logging.Formatter(log_format)
+    log_formatter = _CustomFormatter(log_prefix)
     log_handler.setFormatter(log_formatter)
     logger = logging.getLogger(name=__name__)
     logger.setLevel(level=logging.DEBUG)
     logger.addHandler(log_handler)
     logger.addFilter(_Debug_Filter())
     debug = logger.debug
+
+    def debug_extra(cls=None):
+        if cls:
+            extra = {'classname': cls.__qualname__}
+        else:
+            extra = None
+        return extra
+
+    DEBUG_ENABLED = True
+
 else:
-    def debug(x, *args):
+    def debug(x, *args, **kwargs):
         return None
 
+    def debug_extra(*args, **kwargs):
+        return None
+
+    DEBUG_ENABLED = False
 
 # SCONS_CACHE_MSVC_CONFIG is public, and is documented.
 CONFIG_CACHE = os.environ.get('SCONS_CACHE_MSVC_CONFIG', '')


### PR DESCRIPTION
Add a custom formatter to the MSCommon/common.py debug logging that accepts an optional class name.

Changes:
- Add support for optional extra dictionary for the python logging.
- Allow passing 'classname' via the extra dictionary and creating the log records with '%(classname)s.%(funcName)s' for class methods.
- Add a method to populate and return the extra dictionary.
- Add a boolean constant indicating if debugging is enabled or not.

Example code demonstrating functionality:
```
from SCons.Tool.MSCommon.common import (
    debug,
    debug_extra,
    DEBUG_ENABLED,
)

class DebugExample:

    debug_extra = None
    
    info = {
        '1': 'One',
        '2': 'Two',
        '3': 'Three',
    }

    @classmethod
    def setup(cls):
        cls.debug_extra = debug_extra(cls)

    @classmethod
    def debug_dump(cls):
        for key, val in cls.info.items():
            debug('info: key=%s, val=%s', key, val, extra=cls.debug_extra)

    @classmethod
    def hello_world(cls):
        debug('Hello, World!')
        debug('Hello, World!', extra=cls.debug_extra)
        if DEBUG_ENABLED:
            cls.debug_dump()

DebugExample.setup()
DebugExample.hello_world()
```
Example output (sent to stdout):
```
debug: 02338ms:SConstruct:hello_world#90: Hello, World!
debug: 02339ms:SConstruct:DebugExample.hello_world#91: Hello, World!
debug: 02339ms:SConstruct:DebugExample.debug_dump#86: info: key=1, val=One
debug: 02339ms:SConstruct:DebugExample.debug_dump#86: info: key=2, val=Two
debug: 02339ms:SConstruct:DebugExample.debug_dump#86: info: key=3, val=Three
```

The third in a sequence of smaller PRs from https://github.com/SCons/scons/pull/4409.

Internal changes only: no documentation or test updates necessary.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
