### PR TITLE
Elminate http: references

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -186,6 +186,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       if `kpsewhich glossaries.sty` fails.
     - Added a .note.GNU-stack section to the test assembler files to
       avoid the GNU linker issuing warnings for its absence.
+    - Eliminate more http: references (mostly in comments/docstrings where
+      they really weren't harmful). A few links labeled dead with no alt.
 
 
   From Jonathon Reinhart:

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -81,9 +81,8 @@ try:
     # This locked version of spawnve works around a Windows
     # MSVCRT bug, because its spawnve is not thread-safe.
     # Without this, python can randomly crash while using -jN.
-    # See the python bug at http://bugs.python.org/issue6476
-    # and SCons issue at
-    # https://github.com/SCons/scons/issues/2449
+    # See the python bug at https://github.com/python/cpython/issues/50725
+    # and SCons issue at https://github.com/SCons/scons/issues/2449
     def spawnve(mode, file, args, env):
         spawn_lock.acquire()
         try:

--- a/SCons/Script/Interactive.py
+++ b/SCons/Script/Interactive.py
@@ -346,7 +346,7 @@ version                 Prints SCons version information.
             argv = os.environ[self.shell_variable]
         try:
             # Per "[Python-Dev] subprocess insufficiently platform-independent?"
-            # http://mail.python.org/pipermail/python-dev/2008-August/081979.html "+
+            # https://mail.python.org/pipermail/python-dev/2008-August/081979.html "+
             # Doing the right thing with an argument list currently
             # requires different shell= values on Windows and Linux.
             p = subprocess.Popen(argv, shell=(sys.platform=='win32'))

--- a/SCons/Tool/MSCommon/sdk.py
+++ b/SCons/Tool/MSCommon/sdk.py
@@ -45,10 +45,9 @@ from .common import debug, read_reg
 # seem to be any sane registry key, so the precise location is hardcoded.
 #
 # For versions below 2003R1, it seems the PSDK is included with Visual Studio?
-#
-# Also, per the following:
-#     http://benjamin.smedbergs.us/blog/tag/atl/
 # VC++ Professional comes with the SDK, VC++ Express does not.
+#
+# Of course, all this changed again after Express was phased out (2005).
 
 # Location of the SDK (checked for 6.1 only)
 _CURINSTALLED_SDK_HKEY_ROOT = \

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -1,12 +1,5 @@
-"""
-Implements the ability for SCons to emit a compilation database for the MongoDB project. See
-http://clang.llvm.org/docs/JSONCompilationDatabase.html for details on what a compilation
-database is, and why you might want one. The only user visible entry point here is
-'env.CompilationDatabase'. This method takes an optional 'target' to name the file that
-should hold the compilation database, otherwise, the file defaults to compile_commands.json,
-which is the name that most clang tools search for by default.
-"""
-
+# MIT License
+#
 # Copyright 2020 MongoDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -27,7 +20,17 @@ which is the name that most clang tools search for by default.
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+
+"""Compilation Database
+
+Implements the ability for SCons to emit a compilation database for a
+project. See https://clang.llvm.org/docs/JSONCompilationDatabase.html
+for details on what a compilation database is, and why you might want one.
+The only user visible entry point here is ``env.CompilationDatabase``.
+This method takes an optional *target* to name the file that should hold
+the compilation database, otherwise, the file defaults to
+``compile_commands.json``, the name that most clang tools search for by default.
+"""
 
 import json
 import itertools

--- a/SCons/Tool/cyglink.py
+++ b/SCons/Tool/cyglink.py
@@ -1,6 +1,29 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 """SCons.Tool.cyglink
 
-Customization of gnulink for Cygwin (http://www.cygwin.com/)
+Customization of gnulink for Cygwin (https://www.cygwin.com/)
 
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()

--- a/SCons/Tool/dmd.py
+++ b/SCons/Tool/dmd.py
@@ -24,7 +24,7 @@
 """SCons.Tool.dmd
 
 Tool-specific initialization for the Digital Mars D compiler.
-(http://digitalmars.com/d)
+(https://digitalmars.com/d)
 
 Originally coded by Andy Friesen (andy@ikagames.com)
 15 November 2003

--- a/SCons/Tool/docbook/__init__.py
+++ b/SCons/Tool/docbook/__init__.py
@@ -155,8 +155,8 @@ def __create_output_dir(base_dir) -> None:
 xsltproc_com_priority = ['xsltproc', 'saxon', 'saxon-xslt', 'xalan']
 
 # TODO: Set minimum version of saxon-xslt to be 8.x (lower than this only supports xslt 1.0.
-#       see: http://saxon.sourceforge.net/saxon6.5.5/
-#       see: http://saxon.sourceforge.net/
+#       see: https://saxon.sourceforge.net/saxon6.5.5/
+#       see: https://saxon.sourceforge.net/
 xsltproc_com = {'xsltproc' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE',
                 'saxon' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE $DOCBOOK_XSLTPROCPARAMS',
                 # Note if saxon-xslt is version 5.5 the proper arguments are: (swap order of docbook_xsl and source)

--- a/SCons/Tool/mingw.py
+++ b/SCons/Tool/mingw.py
@@ -23,7 +23,7 @@
 
 """SCons.Tool.gcc
 
-Tool-specific initialization for MinGW (http://www.mingw.org/)
+Tool-specific initialization for MinGW (https://www.mingw.org/)
 
 There normally shouldn't be any need to import this module directly.
 It will usually be imported through the generic SCons.Tool.Tool()

--- a/SCons/cpp.py
+++ b/SCons/cpp.py
@@ -561,8 +561,7 @@ class PreProcessor:
                      [('scons_current_file', self.current_file)]
         self.tuples[:] = new_tuples + self.tuples
 
-    # Date: Tue, 22 Nov 2005 20:26:09 -0500
-    # From: Stefan Seefeld <seefeld@sympatico.ca>
+    # From: Stefan Seefeld <seefeld@sympatico.ca> (22 Nov 2005)
     #
     # By the way, #include_next is not the same as #include. The difference
     # being that #include_next starts its search in the path following the
@@ -570,10 +569,12 @@ class PreProcessor:
     # include paths are ['/foo', '/bar'], and you are looking at a header
     # '/foo/baz.h', it might issue an '#include_next <baz.h>' which would
     # correctly resolve to '/bar/baz.h' (if that exists), but *not* see
-    # '/foo/baz.h' again. See http://www.delorie.com/gnu/docs/gcc/cpp_11.html
-    # for more reasoning.
+    # '/foo/baz.h' again. See
+    # https://gcc.gnu.org/onlinedocs/cpp/Wrapper-Headers.html for more notes.
     #
-    # I have no idea in what context 'import' might be used.
+    # I have no idea in what context #import might be used.
+    # Update: possibly these notes?
+    # https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/preprocessor/hash-import-directive-cpp.md
 
     # XXX is #include_next really the same as #include ?
     do_include_next = do_include

--- a/test/Docbook/basic/man/image/refdb.xml
+++ b/test/Docbook/basic/man/image/refdb.xml
@@ -65,13 +65,13 @@
     <title>See also</title>
     <para><emphasis remap="B">RefDB</emphasis> (7),
     <emphasis remap="B"><link linkend="refentry-refdbd">refdbd</link></emphasis> (1)
-    <emphasis remap="B"><link linkend="refentry-refdbctl">refdbctl</link></emphasis> (1).</para> 
+    <emphasis remap="B"><link linkend="refentry-refdbctl">refdbctl</link></emphasis> (1).</para>
 
     <para><emphasis remap="I">RefDB manual (local copy) </emphasis> &lt;prefix&gt;/share/doc/refdb-&lt;version&gt;/refdb-manual/index.html</para>
 
-    <para><emphasis remap="I">RefDB manual (web) </emphasis> &lt;<ulink url="http://refdb.sourceforge.net/manual/index.html">http://refdb.sourceforge.net/manual/index.html</ulink>&gt;</para>
+    <para><emphasis remap="I">RefDB manual (web) </emphasis> &lt;<ulink url="https://refdb.sourceforge.net/manual/index.html">https://refdb.sourceforge.net/manual/index.html</ulink>&gt;</para>
 
-    <para><emphasis remap="I">RefDB on the web </emphasis> &lt;<ulink url="http://refdb.sourceforge.net/">http://refdb.sourceforge.net/</ulink>&gt;</para>
+    <para><emphasis remap="I">RefDB on the web </emphasis> &lt;<ulink url="https://refdb.sourceforge.net/">https://refdb.sourceforge.net/</ulink>&gt;</para>
   </refsect1>
 
   <refsect1 id="refdb-author">

--- a/test/LINK/VersionedLib-j2.py
+++ b/test/LINK/VersionedLib-j2.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,14 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Ensure that SharedLibrary builder works with SHLIBVERSION and -j2.
 This is regression test for:
-http://article.gmane.org/gmane.comp.programming.tools.scons.user/27049
+https://article.gmane.org/gmane.comp.programming.tools.scons.user/27049
+(historical - dead link)
 """
 
 import TestSCons

--- a/test/LINK/VersionedLib-subdir.py
+++ b/test/LINK/VersionedLib-subdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,16 +22,14 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Ensure that SharedLibrary builder with SHLIBVERSION='0.1.2' can build its target
-in a subdirectory containing .so.0.1.2 in name. 
+in a subdirectory containing .so.0.1.2 in name.
 
 This is regression test for issue mentioned in:
-http://thread.gmane.org/gmane.comp.programming.tools.scons.user/27081
+https://thread.gmane.org/gmane.comp.programming.tools.scons.user/27081
+(historical - dead link)
 """
 
 import TestSCons

--- a/test/MSVC/PCH-source.py
+++ b/test/MSVC/PCH-source.py
@@ -27,7 +27,7 @@
 Test use of pre-compiled headers when the source .cpp file shows
 up in both the env.PCH() and the env.Program() source list.
 
-Issue 2505:  http://github.com/SCons/scons/issues/2505
+Issue 2505:  https://github.com/SCons/scons/issues/2505
 """
 
 import TestSCons

--- a/test/SWIG/SWIG.py
+++ b/test/SWIG/SWIG.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the swig tool generates file names that we expect.
@@ -55,7 +54,7 @@ for opt, arg in opts:
         print("")
         print("Configured options: +pcre")
         print("")
-        print("Please see http://www.swig.org for reporting bugs "
+        print("Please see https://www.swig.org for reporting bugs "
               "and further information")
         sys.exit(0)
 

--- a/test/TEX/generated_files.py
+++ b/test/TEX/generated_files.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 r"""
 Test creation of a Tex document with generated tex files
@@ -87,7 +86,7 @@ test.write(['src','literatura.bib'],r"""
     month = {March},
     publisher = {Morgan Kaufmann},
     title = {The Art of Multiprocessor Programming},
-    url = {http://www.worldcat.org/isbn/0123705916},
+    url = {https://www.worldcat.org/isbn/0123705916},
     year = {2008}
 }
 
@@ -106,7 +105,7 @@ test.write(['src','literatura.bib'],r"""
     keywords = {books, model\_checking},
     publisher = {The MIT Press},
     title = {Principles of Model Checking},
-    url = {http://www.worldcat.org/isbn/026202649X},
+    url = {https://www.worldcat.org/isbn/026202649X},
     year = {2008}
 }
 

--- a/test/TEX/variant_dir.py
+++ b/test/TEX/variant_dir.py
@@ -160,7 +160,7 @@ r"""\begin{picture}(0,0)%
 
 test.write(['docs', 'test.bib'], """\
 %% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
+%% https://bibdesk.sourceforge.net/
 
 
 %% Created for Rob Managan at 2006-11-15 12:53:16 -0800

--- a/test/TEX/variant_dir_bibunit.py
+++ b/test/TEX/variant_dir_bibunit.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 r"""
 Test creation of a fully-featured TeX document (with bibunit
@@ -151,7 +150,7 @@ after the last unit another ref \cite{gnu:1998} and then a second \cite{gnu:2003
 
 test.write(['src', 'units.bib'], """\
 %% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
+%% https://bibdesk.sourceforge.net/
 
 @techreport{gnu:1998,
     Author = {A. N. Author},

--- a/test/TEX/variant_dir_dup0.py
+++ b/test/TEX/variant_dir_dup0.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 r"""
 Test creation of a fully-featured TeX document (with bibliography
@@ -160,7 +159,7 @@ r"""\begin{picture}(0,0)%
 
 test.write(['docs', 'test.bib'], """\
 %% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
+%% https://bibdesk.sourceforge.net/
 
 %% Saved with string encoding Western (ASCII)
 

--- a/test/TEX/variant_dir_style_dup0.py
+++ b/test/TEX/variant_dir_style_dup0.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 r"""
 Test creation of a fully-featured TeX document (with bibliography
@@ -87,7 +86,7 @@ test2pdf   = env.PDF(target='pdfoutput.xyz',source=test2_dvi)
 
 test.write(['docs', 'test.bib'], r"""
 % This BibTeX bibliography file was created using BibDesk.
-% http://bibdesk.sourceforge.net/
+% https://bibdesk.sourceforge.net/
 
 @techreport{AnAuthor:2006fk,
 	Author = {A. N. Author},

--- a/test/packaging/ipkg.py
+++ b/test/packaging/ipkg.py
@@ -65,7 +65,7 @@ may modify if you wish.
 When you modify this example, be sure to change the Package, Version,
 Maintainer, Depends, and Description fields.''',
 
-             SOURCE_URL       = 'http://gnu.org/foo-0.0.tar.gz',
+             SOURCE_URL       = 'https://gnu.org/foo-0.0.tar.gz',
              X_IPK_SECTION    = 'extras',
              X_IPK_PRIORITY   = 'optional',
              ARCHITECTURE     = 'arm',
@@ -102,7 +102,7 @@ test.write( [ 'foo-0.0', 'CONTROL', 'control' ], r"""
 Package: foo
 Priority: optional
 Section: extras
-Source: http://gnu.org/foo-0.0.tar.gz
+Source: https://gnu.org/foo-0.0.tar.gz
 Version: 0.0
 Architecture: arm
 Maintainer: Familiar User <user@somehost.net>

--- a/test/packaging/option--package-type.py
+++ b/test/packaging/option--package-type.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the --package-type option.
@@ -65,7 +64,7 @@ env.Package( NAME           = 'foo',
              X_RPM_INSTALL  = r'%(_python_)s %(scons)s --install-sandbox="$RPM_BUILD_ROOT" "$RPM_BUILD_ROOT"',
              DESCRIPTION    = 'this should be really long',
              source         = [ prog ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz',
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz',
              ARCHITECTURE   = 'noarch'
             )
 """ % locals())

--- a/test/packaging/rpm/cleanup.py
+++ b/test/packaging/rpm/cleanup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Assert that files created by the RPM packager will be removed by 'scons -c'.
@@ -71,7 +70,7 @@ env.Package( NAME           = 'foo',
              X_RPM_INSTALL  = r'%(_python_)s %(scons)s --install-sandbox="$RPM_BUILD_ROOT" "$RPM_BUILD_ROOT"',
              DESCRIPTION    = 'this should be really really long',
              source         = [ prog ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz'
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz'
             )
 
 env.Alias( 'install', prog )

--- a/test/packaging/rpm/explicit-target.py
+++ b/test/packaging/rpm/explicit-target.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to create a rpm package from a explicit target name.
@@ -72,7 +71,7 @@ env.Package( NAME           = 'foo',
              DESCRIPTION    = 'this should be really really long',
              source         = [ prog ],
              target         = "my_rpm_package.rpm",
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz'
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz'
         )
 """ % locals())
 

--- a/test/packaging/rpm/internationalization.py
+++ b/test/packaging/rpm/internationalization.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to handle internationalized package and file meta-data.
@@ -78,7 +77,7 @@ env.Package( NAME           = 'foo',
              DESCRIPTION_de = 'das sollte wirklich lang sein',
              DESCRIPTION_fr = 'ceci devrait être vraiment long',
              source         = [ prog ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz'
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz'
             )
 
 env.Alias ( 'install', prog )
@@ -156,7 +155,7 @@ env.Package( NAME           = 'foo',
              DESCRIPTION_de = 'das sollte wirklich lang sein',
              DESCRIPTION_fr = 'ceci devrait être vraiment long',
              source         = [ prog, man_pages ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz',
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz',
             )
 
 env.Alias ( 'install', [ prog, man_pages ] )

--- a/test/packaging/rpm/multipackage.py
+++ b/test/packaging/rpm/multipackage.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to create more than rpm file with different package root
@@ -70,7 +69,7 @@ env.Package( NAME           = 'foo',
              X_RPM_INSTALL  = r'%(_python_)s %(scons)s --tree=all --install-sandbox="$RPM_BUILD_ROOT" "$RPM_BUILD_ROOT"',
              DESCRIPTION    = 'this should be really really long',
              source         = [ prog ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz'
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz'
         )
 
 env.Package( NAME           = 'foo2',

--- a/test/packaging/rpm/package.py
+++ b/test/packaging/rpm/package.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to create a really simple rpm package.
@@ -69,7 +68,7 @@ env.Package( NAME           = 'foo',
              X_RPM_INSTALL  = r'%(_python_)s %(scons)s --tree=all --install-sandbox="$RPM_BUILD_ROOT" "$RPM_BUILD_ROOT"',
              DESCRIPTION    = 'this should be really really long',
              source         = [ prog ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz'
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz'
         )
 
 env.Alias( 'install', prog )

--- a/test/packaging/rpm/tagging.py
+++ b/test/packaging/rpm/tagging.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to add file tags
@@ -75,7 +74,7 @@ env.Package( NAME           = 'foo',
              X_RPM_INSTALL  = r'%(_python_)s %(scons)s --install-sandbox="$RPM_BUILD_ROOT" "$RPM_BUILD_ROOT"',
              DESCRIPTION    = 'this should be really really long',
              source         = [ prog_install ],
-             SOURCE_URL     = 'http://foo.org/foo-1.2.3.tar.gz'
+             SOURCE_URL     = 'https://foo.org/foo-1.2.3.tar.gz'
           )
 """ % locals())
 

--- a/test/rebuild-generated.py
+++ b/test/rebuild-generated.py
@@ -26,7 +26,8 @@
 """
 Test case for the bug report:
 "[ 1088979 ] Unnecessary rebuild with generated header file"
-(<http://sourceforge.net/tracker/index.php?func=detail&aid=1088979&group_id=30337&atid=398971>).
+(<https://sourceforge.net/tracker/index.php?func=detail&aid=1088979&group_id=30337&atid=398971>).
+(historical - dead link)
 
 Unnecessary rebuild with generated header file
 Scons rebuilds some nodes when invoked twice. The

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -802,7 +802,7 @@ else:
 
 # From Josiah Carlson,
 # ASPN : Python Cookbook : Module to allow Asynchronous subprocess use on Windows and Posix platforms
-# http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/440554
+# https://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/440554
 
 if sys.platform == 'win32':  # and subprocess.mswindows:
     try:

--- a/testing/framework/TestUnit/taprunner.py
+++ b/testing/framework/TestUnit/taprunner.py
@@ -1,6 +1,6 @@
 """
 Format unittest results in Test Anything Protocol (TAP).
-http://testanything.org/tap-version-13-specification.html
+https://testanything.org/tap-version-13-specification.html
 
 Public domain work by:
   anatoly techtonik <techtonik@gmail.com>


### PR DESCRIPTION
Most remaining `http:` references are either changed to `https:` or removed or changed in case they were also stale links, and a replacement was findable.

Does not affect schema and stylesheet references, which can remain `http:`

Does not change SCons behavior.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
