### PR TITLE
Adding tracing of SConscript calls

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer supported
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
+  From Sten Grüner
+    - The --debug flag has a 'sconscript-trace' option allowint to trace
+      files included via SConscript call.
 
   From Max Bachmann:
     - Add missing directories to searched paths for mingw installs

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Sten Grüner
-    - The --debug flag has a 'sconscript' option allowint to trace
+    - The --debug flag has a 'sconscript' option allowing to trace
       files included via SConscript call.
 
   From Max Bachmann:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Sten Grüner
-    - The --debug flag has a 'sconscript-trace' option allowint to trace
+    - The --debug flag has a 'sconscript' option allowint to trace
       files included via SConscript call.
 
   From Max Bachmann:

--- a/SCons/Debug.py
+++ b/SCons/Debug.py
@@ -41,6 +41,9 @@ import inspect
 track_instances = False
 # List of currently tracked classes
 tracked_classes = {}
+# Global variable that gets set to 'True' by the Main script
+# when SConscript call tracing should be enabled.
+sconscript_trace = False
 
 def logInstanceCreation(instance, name=None) -> None:
     if name is None:

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -725,7 +725,7 @@ def _set_debug_values(options) -> None:
         SCons.Node.print_duplicate = True
     if "json" in debug_values:
         ENABLE_JSON = True
-    if "sconscript-trace" in debug_values:
+    if "sconscript" in debug_values:
         SCons.Debug.sconscript_trace = True
 
 def _create_path(plist):

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -725,6 +725,8 @@ def _set_debug_values(options) -> None:
         SCons.Node.print_duplicate = True
     if "json" in debug_values:
         ENABLE_JSON = True
+    if "sconscript-trace" in debug_values:
+        SCons.Debug.sconscript_trace = True
 
 def _create_path(plist):
     path = '.'

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -752,7 +752,7 @@ def Parser(version):
     debug_options = ["count", "duplicate", "explain", "findlibs",
                      "includes", "memoizer", "memory", "objects",
                      "pdb", "prepare", "presub", "stacktrace",
-                     "time", "action-timestamps", "json"]
+                     "time", "action-timestamps", "json", "sconscript-trace"]
 
     def opt_debug(option, opt, value__, parser,
                   debug_options=debug_options,

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -752,7 +752,7 @@ def Parser(version):
     debug_options = ["count", "duplicate", "explain", "findlibs",
                      "includes", "memoizer", "memory", "objects",
                      "pdb", "prepare", "presub", "stacktrace",
-                     "time", "action-timestamps", "json", "sconscript-trace"]
+                     "time", "action-timestamps", "json", "sconscript"]
 
     def opt_debug(option, opt, value__, parser,
                   debug_options=debug_options,

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -274,10 +274,10 @@ def _SConscript(fs, *files, **kw):
                             scriptdata = _file_.read()
                             scriptname = _file_.name
                             _file_.close()
-                            if "SCONS_CALL_TRACING" in os.environ:
+                            if SCons.Debug.sconscript_trace:
                                 print("scons-entering>"+str(scriptname))
                             exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
-                            if "SCONS_CALL_TRACING" in os.environ:
+                            if SCons.Debug.sconscript_trace:
                                 print("scons-exiting>"+str(scriptname))
                         except SConscriptReturn:
                             pass

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -274,7 +274,11 @@ def _SConscript(fs, *files, **kw):
                             scriptdata = _file_.read()
                             scriptname = _file_.name
                             _file_.close()
+                            if "SCONS_CALL_TRACING" in os.environ:
+                                print("scons-entering>"+str(scriptname))
                             exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
+                            if "SCONS_CALL_TRACING" in os.environ:
+                                print("scons-exiting>"+str(scriptname))
                         except SConscriptReturn:
                             pass
                     finally:

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1119,6 +1119,12 @@ should take place in parallel.)
 </para>
   </listitem>
   </varlistentry>
+  <varlistentry>
+  <term><emphasis role="bold">sconscript</emphasis></term>
+  <listitem>
+<para>Augments the output of SCons with markers to track included SConscript files.</para>
+  </listitem>
+  </varlistentry>
   </variablelist> <!-- end nested list -->
   </listitem>
   </varlistentry>

--- a/test/SConscript/SConscriptTrace.py
+++ b/test/SConscript/SConscriptTrace.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+
+import os
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+
+test.write('SConstruct', """\
+print("SConstruct")
+""")
+
+wpath = test.workpath()
+
+test.run(arguments = ".")
+unexpect = [
+    'scons-entering>%s%sSConstruct'%(wpath, os.sep),
+    'scons-exiting>%s%sSConstruct'%(wpath, os.sep)
+]
+test.must_not_contain_any_line(test.stdout(), unexpect)
+
+test.run(arguments = "--debug=sconscript-trace .")
+expect = [
+    'scons-entering>%s%sSConstruct'%(wpath, os.sep),
+    'scons-exiting>%s%sSConstruct'%(wpath, os.sep)
+]
+test.must_contain_all_lines(test.stdout(), expect)
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/SConscript/SConscriptTrace.py
+++ b/test/SConscript/SConscriptTrace.py
@@ -43,7 +43,7 @@ unexpect = [
 ]
 test.must_not_contain_any_line(test.stdout(), unexpect)
 
-test.run(arguments = "--debug=sconscript-trace .")
+test.run(arguments = "--debug=sconscript .")
 expect = [
     'scons-entering>%s%sSConstruct'%(wpath, os.sep),
     'scons-exiting>%s%sSConstruct'%(wpath, os.sep)


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation

Sorry to be so ignorant with respect to checklist, but I wanted to make sure it this PR is able to be accepted at all. I am coming from the discussion here: https://stackoverflow.com/questions/76520575/scons-overriding-sconscript-function-to-get-a-list-all-loaded-sconscripts . So is there hope that our approach can go into the main line?