### PR TITLE
Remove incorrect dependencies from `setup.cfg`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,9 +9,8 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
-
-        - Whatever John Doe did.
+  From Michał Górny:
+    - Remove unecessary dependencies on pypi packages from setup.cfg
 
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,7 +44,7 @@ IMPROVEMENTS
 PACKAGING
 ---------
 
-- List changes in the way SCons is packaged and/or released
+- Remove unecessary dependencies on pypi packages from setup.cfg
 
 DOCUMENTATION
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,6 @@ classifiers =
 [options]
 zip_safe = False
 python_requires = >=3.6
-install_requires = setuptools
-setup_requires =
-    setuptools
-    build
 include_package_data = True
 packages = find:
 


### PR DESCRIPTION
Remove the `install_requires` on `setuptools`.  This key is used to specify packages that are needed at runtime.  SCons nowhere in its code does import `setuptools` or `pkg_resources`.

Remove the `setup_requires` on `build`.  `build` is a frontend package and a detail of how the build is invoked, while `setup_requires` are used to specify backend dependencies (i.e. packages that are installed after `build` is invoked).

Remove the `setup_requires` on `setuptools`.  It is a key specific to setuptools, so for it to be interpreted `setuptools` need to be installed already.  The actual backend dependency on `setuptools` is specified in `pyproject.toml`, so the dependency is entirely redundant.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
