### PR TITLE
Fixing a bug with --debug=sconscript 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Sten Grüner:
-    - Fix of --debug=sconscript option to return exist statements when using return
+    - Fix of the --debug=sconscript option to return exist statements when using return
       statement with stop flag enabled
 
   From Michał Górny:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer supported
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
+  From Sten Grüner:
+    - Fix of --debug=sconscript option to return exist statements when using return
+      statement with stop flag enabled
 
   From Michał Górny:
     - Remove unecessary dependencies on pypi packages from setup.cfg

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,13 +8,12 @@ NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
 NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer supported
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
-  From Sten Grüner:
-    - Fix of the --debug=sconscript option to return exist statements when using return
-      statement with stop flag enabled
-
   From Michał Górny:
     - Remove unecessary dependencies on pypi packages from setup.cfg
 
+  From Sten Grüner:
+    - Fix of the --debug=sconscript option to return exist statements when using return
+      statement with stop flag enabled
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -32,7 +32,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
-- List fixes of outright bugs
+- Fix of the --debug=sconscript option to return exist statements when using return
+  statement with stop flag enabled
 
 IMPROVEMENTS
 ------------

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -280,7 +280,10 @@ def _SConscript(fs, *files, **kw):
                             if SCons.Debug.sconscript_trace:
                                 print("scons: Exiting "+str(scriptname))
                         except SConscriptReturn:
-                            print("scons: Exiting "+str(scriptname))
+                            if SCons.Debug.sconscript_trace:
+                                print("scons: Exiting "+str(scriptname))
+                            else:
+                                pass
                     finally:
                         if Main.print_time:
                             elapsed = time.perf_counter() - start_time

--- a/SCons/Script/SConscript.py
+++ b/SCons/Script/SConscript.py
@@ -280,7 +280,7 @@ def _SConscript(fs, *files, **kw):
                             if SCons.Debug.sconscript_trace:
                                 print("scons: Exiting "+str(scriptname))
                         except SConscriptReturn:
-                            pass
+                            print("scons: Exiting "+str(scriptname))
                     finally:
                         if Main.print_time:
                             elapsed = time.perf_counter() - start_time

--- a/test/option/debug-sconscript.py
+++ b/test/option/debug-sconscript.py
@@ -51,6 +51,18 @@ expect = [
     'scons: Exiting %s%sSConstruct' % (wpath, os.sep)
 ]
 test.must_contain_all_lines(test.stdout(), expect)
+
+# Ensure that reutrns with stop are handled properly
+
+test.write('SConstruct', """\
+foo = "bar"
+Return("foo", stop=True)
+print("SConstruct")
+""")
+
+test.run(arguments="--debug=sconscript .")
+test.must_contain_all_lines(test.stdout(), expect)
+
 test.pass_test()
 
 # Local Variables:


### PR DESCRIPTION
Fixing a bug with --debug=sconscript  where no exit message was emitted on exception catch

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
already present
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
already present
* [x] I have updated the appropriate documentation
already present
