### PR TITLE
Fixed Improper Method Call: Replaced `NotImplementedError`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix of the --debug=sconscript option to return exist statements when using return
       statement with stop flag enabled
 
+  From Ataf Fazledin Ahamed:
+    - Use of NotImplemented instead of NotImplementedError for special methods
+      of _ListVariable class
+
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700
 
   From Max Bachmann:

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -38,9 +38,8 @@ FIXES
 IMPROVEMENTS
 ------------
 
-- List improvements that wouldn't be visible to the user in the
-  documentation:  performance improvements (describe the circumstances
-  under which they would be observed), or major code cleanups
+- Use of NotImplemented instead of NotImplementedError for special methods
+  of _ListVariable class
 
 PACKAGING
 ---------

--- a/SCons/Variables/ListVariable.py
+++ b/SCons/Variables/ListVariable.py
@@ -70,22 +70,22 @@ class _ListVariable(collections.UserList):
         self.allowedElems = sorted(allowedElems)
 
     def __cmp__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __eq__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __ge__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __gt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __le__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __lt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __str__(self) -> str:
         if not len(self):


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation


## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [ListVariable.py](https://github.com/SCons/scons/blob/master/SCons/Variables/ListVariable.py#L88), class: `_ListVariable`, there is a special method `__lt__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should return NotImplemented. On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__lt__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is here.


### Related Documentation
- [docs.python.org - NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented)
- [docs.python.org - NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError)
- [docs.python.org - Implementing Arithmetic Operators](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations)


## Changes
Since the class `_ListVariable` is not an abstract class, the `NotImplementedError` has been replaced with `NotImplemented`


## Previously Found & Fixed
- https://www.github.com/SciTools/iris/pull/5544
- https://www.github.com/cupy/cupy/pull/7900
- https://www.github.com/ethereum/web3.py/pull/3080


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
