### PR TITLE
WIP: Try harder to generate deps for Fortran module files

### DIFF
--- a/.github/workflows/experimental_tests.yml
+++ b/.github/workflows/experimental_tests.yml
@@ -44,6 +44,7 @@ jobs:
           static: 0
 
       - name: Set up gfortran/gcc on MacOS
+        if: matrix.os == 'macos-latest'
         run: |
             brew update
             brew install gcc

--- a/.github/workflows/experimental_tests.yml
+++ b/.github/workflows/experimental_tests.yml
@@ -43,6 +43,11 @@ jobs:
           platform: x64
           static: 0
 
+      - name: Set up gfortran/gcc on MacOS
+        run: |
+            brew update
+            brew install gcc
+
       - name: Set up Python 3.11 ${{ matrix.os }}
         uses: actions/setup-python@v5.0.0
         with:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -59,7 +59,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Add support for Python 3.13 (as of alpha 2). So far only affects
       expected bytecodes in ActionTests.py.
-
+    - In the Fortran scanner, make sure the $FORTRANMODDIR is used when
+      creating dependencies for module files (.mod), otherwise
+      build order will be computed wrong.
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700
 

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -32,6 +32,7 @@ that can be used by scripts or modules looking for the canonical default.
 
 import codecs
 import fnmatch
+import functools
 import importlib.util
 import os
 import re
@@ -3779,16 +3780,22 @@ class FileFinder:
 
     @SCons.Memoize.CountDictCall(_find_file_key)
     def find_file(self, filename, paths, verbose=None):
-        """
-        Find a node corresponding to either a derived file or a file that exists already.
+        """Find a node corresponding to a filename.
 
-        Only the first file found is returned, and none is returned if no file is found.
+        Returns a node corresponding to either a derived file or a file that
+        exists already. Only the first file found is returned.
 
-        filename: A filename to find
-        paths: A list of directory path *nodes* to search in.  Can be represented as a list, a tuple, or a callable that is called with no arguments and returns the list or tuple.
+        Arguments:
+           filename: A filename to find
+           paths: A list of directory path *nodes* to search in.  Can be
+              represented as a list, a tuple, or a callable that is called
+              with no arguments and returns the list or tuple.
+           verbose: if true, emit information about node searches.
+              If a callable, is called with the diagnostic message,
+              else writes to ``sys.stdout``. Can use :func:`SCons.Debug.Trace`
+              as the verbose function.
 
-        returns The node created from the found file.
-
+        Returns: The node created from the found file or ``None``.
         """
         memo_key = self._find_file_key(filename, paths)
         try:
@@ -3829,6 +3836,8 @@ class FileFinder:
         return result
 
 find_file = FileFinder().find_file
+# Alternative for debugging:
+# find_file = functools.partial(FileFinder().find_file, verbose=Trace)
 
 
 def invalidate_node_memos(targets) -> None:

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -591,7 +591,9 @@ class Node(metaclass=NoSlotsPyPy):
         self.cached = 0 # is this node pulled from cache?
         self.always_build = None
         self.includes = None
-        self.attributes = self.Attrs() # Generic place to stick information about the Node.
+        # Place to store arbitrary (non-generic) data in the node since we
+        # cannot just add node attributes from outside, due to using slots:
+        self.attributes = self.Attrs()
         self.side_effect = 0 # true iff this node is a side effect
         self.side_effects = [] # the side effects of building this target
         self.linked = 0 # is this node linked to the variant directory?

--- a/test/Fortran/USE-MODULE-live.py
+++ b/test/Fortran/USE-MODULE-live.py
@@ -36,12 +36,23 @@ gets smarter.
 
 import TestSCons
 
+from SCons.Tool.gfortran import compilers
+
 _python_ = TestSCons._python_
 _exe = TestSCons._exe
 
 test = TestSCons.TestSCons()
-if not test.where_is('gfortran'):
-    test.skip_test("Could not find 'gfortran', skipping test.\n")
+
+# Handle multiple possible gfortran binary names
+found = False
+for c in compilers:
+    if test.where_is(c):
+        found = True
+        break
+
+if not found:
+    compiler_list = " or ".join(compilers)
+    test.skip_test(f"Could not find {compiler_list}, skipping test.\n")
 
 test.file_fixture(['fixture-mod', 'SConstruct'])
 test.file_fixture(['fixture-mod', 'main.f90'], dstfile=['src', 'main.f90'])

--- a/test/Fortran/USE-MODULE-live.py
+++ b/test/Fortran/USE-MODULE-live.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test Fortran module use, organized in such a way that
+module files will be "not found" unless dependencies have been forced.
+See PR #4452.
+
+This is a "live" test - uses an actual Fortran compiler, as the
+mock compiler would need to have a sophisticated regex to catch
+the situation. Possibly we could convert later if the mock fortran.py
+gets smarter.
+"""
+
+import TestSCons
+
+_python_ = TestSCons._python_
+_exe = TestSCons._exe
+
+test = TestSCons.TestSCons()
+if not test.where_is('gfortran'):
+    test.skip_test("Could not find 'gfortran', skipping test.\n")
+
+test.file_fixture(['fixture-mod', 'SConstruct'])
+test.file_fixture(['fixture-mod', 'main.f90'], dstfile=['src', 'main.f90'])
+test.file_fixture(
+    ['fixture-mod', 'module0.f90'],
+    dstfile=['src', 'module0.f90'],
+)
+test.file_fixture(
+    ['fixture-mod', 'module1.f90'],
+    dstfile=['src', 'module1.f90'],
+)
+test.file_fixture(
+    ['fixture-mod', 'module2.f90'],
+    dstfile=['src', 'module2.f90'],
+)
+test.file_fixture(
+    ['fixture-mod', 'util_module.f90'],
+    dstfile=['src', 'utils', 'util_module.f90'],
+)
+test.run(arguments='.', stderr=None)
+test.must_exist(["fortran_mods", "module0.mod"])
+test.must_exist(["fortran_mods", "module1.mod"])
+test.must_exist(["fortran_mods", "module2.mod"])
+test.must_exist(["fortran_mods", "util_module.mod"])
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Fortran/fixture-mod/SConstruct
+++ b/test/Fortran/fixture-mod/SConstruct
@@ -1,0 +1,16 @@
+import sys
+
+if sys.platform == "win32":
+    tool_list = ['mingw', 'gfortran', 'gnulink']
+else:
+    tool_list = ['default']
+
+env = Environment(
+    tools=tool_list,
+    F90='gfortran',
+    LINK='gfortran',
+    LINKFLAGS='',
+    FORTRANMODDIR='fortran_mods',
+)
+sources = env.Glob('src/*.f90') + env.Glob('src/utils/*.f90')
+env.Program('main', sources)

--- a/test/Fortran/fixture-mod/SConstruct
+++ b/test/Fortran/fixture-mod/SConstruct
@@ -3,12 +3,10 @@ import sys
 if sys.platform == "win32":
     tool_list = ['mingw', 'gfortran', 'gnulink']
 else:
-    tool_list = ['default']
+    tool_list = ['gfortran', 'gnulink']
 
 env = Environment(
     tools=tool_list,
-    F90='gfortran',
-    LINK='gfortran',
     LINKFLAGS='',
     FORTRANMODDIR='fortran_mods',
 )

--- a/test/Fortran/fixture-mod/main.f90
+++ b/test/Fortran/fixture-mod/main.f90
@@ -1,0 +1,13 @@
+
+program main
+    use module0
+    use module1
+    use module2
+    use util_module
+    implicit none
+    write(*,*) 'Main program using modules!'
+    call module0_subroutine()
+    call module1_subroutine()
+    call module2_subroutine()
+    call util_subroutine()
+end program main

--- a/test/Fortran/fixture-mod/module0.f90
+++ b/test/Fortran/fixture-mod/module0.f90
@@ -1,0 +1,10 @@
+
+module module0
+    use module1
+    use module2
+    implicit none
+contains
+    subroutine module0_subroutine()
+        write(*,*) 'This is module0 subroutine.'
+    end subroutine module0_subroutine
+end module module0

--- a/test/Fortran/fixture-mod/module1.f90
+++ b/test/Fortran/fixture-mod/module1.f90
@@ -1,0 +1,8 @@
+
+module module1
+    implicit none
+contains
+    subroutine module1_subroutine()
+        write(*,*) 'This is module1 subroutine.'
+    end subroutine module1_subroutine
+end module module1

--- a/test/Fortran/fixture-mod/module2.f90
+++ b/test/Fortran/fixture-mod/module2.f90
@@ -1,0 +1,8 @@
+
+module module2
+    implicit none
+contains
+    subroutine module2_subroutine()
+        write(*,*) 'This is module2 subroutine.'
+    end subroutine module2_subroutine
+end module module2

--- a/test/Fortran/fixture-mod/util_module.f90
+++ b/test/Fortran/fixture-mod/util_module.f90
@@ -1,0 +1,7 @@
+module util_module                                                             
+    implicit none                                                              
+contains                                                                       
+    subroutine util_subroutine()                                               
+        write(*,*) 'This is a utility subroutine.'                             
+    end subroutine util_subroutine                                             
+end module util_module 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1463,6 +1463,8 @@ class TestCmd:
         """
         if is_List(srcfile):
             srcfile = os.path.join(*srcfile)
+        if is_List(dstfile):
+            dstfile = os.path.join(*dstfile)
 
         srcpath, srctail = os.path.split(srcfile)
         spath = srcfile


### PR DESCRIPTION
The Fortran Scanner finds `INCLUDE` and `USE` statements, and treats them the same - no dependency is generated if the indicated file does not exist.  This is correct for include files, but not for module files - at least ones that are built as part of the project; if no dependency, the `.mod` file may not exist before it is used, and if so, SCons will abort with an error (like: `Fatal Error: Cannot open module file 'module1.mod' for reading at (1): No such file or directory`). With this change, module `USE` statements are treated differently: the dependency is created even if the module file does not yet exist.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
