### PR TITLE
Make the NewParallel scheduler the default, even for -j1 builds

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,15 +56,15 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Prabhu S. Khalsa:
     - Fix typo in user documentation (issue #4458)
 
-  From Mats Wichmann:
-    - Add support for Python 3.13 (as of alpha 2). So far only affects
-      expected bytecodes in ActionTests.py.
-
-
   From Andrew Morrow:
     - The NewParallel scheduler is now the default, the `tm_v2` flag is removed,
       and the old scheduler is opt-in under `--experimental=legacy_sched`. Additionally,
       the new scheduler is now used for -j1 builds as well.
+
+  From Mats Wichmann:
+    - Add support for Python 3.13 (as of alpha 2). So far only affects
+      expected bytecodes in ActionTests.py.
+
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -61,6 +61,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       expected bytecodes in ActionTests.py.
 
 
+  From Andrew Morrow:
+    - The NewParallel scheduler is now the default, the `tm_v2` flag is removed,
+      and the old scheduler is opt-in under `--experimental=legacysched`. Additionally,
+      the new scheduler is now used for -j1 builds as well.
+
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700
 
   From Max Bachmann:
@@ -7950,4 +7955,3 @@ A brief overview of important functionality available in release 0.01:
   - Linux packages available in RPM and Debian format.
 
   - Windows installer available.
-

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - The NewParallel scheduler is now the default, the `tm_v2` flag is removed,
       and the old scheduler is opt-in under `--experimental=legacy_sched`. Additionally,
       the new scheduler is now used for -j1 builds as well.
+    - A python interpreter with support for the `threading` package is now required,
+      and this is enforced on startup. SCons currently sets its minimum supported
+      Python to 3.6, and it was not until Python 3.7 where `threading` became
+      default supported. In practice, we expect most real world Python 3.6 deployments
+      will have `threading` support enabled, so this will not be an issue.
 
   From Mats Wichmann:
     - Add support for Python 3.13 (as of alpha 2). So far only affects

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,7 +63,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Andrew Morrow:
     - The NewParallel scheduler is now the default, the `tm_v2` flag is removed,
-      and the old scheduler is opt-in under `--experimental=legacysched`. Additionally,
+      and the old scheduler is opt-in under `--experimental=legacy_sched`. Additionally,
       the new scheduler is now used for -j1 builds as well.
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -33,6 +33,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   that the generated function argument list matches the function's
   prototype when including a header file. Fixes GH Issue #4320
 - Now supports pre-release Python 3.13
+- Support for Python versions without support for the `threading` package has been removed
 
 FIXES
 -----

--- a/SCons/SConf.py
+++ b/SCons/SConf.py
@@ -253,8 +253,7 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
         # ConfigureCacheError and if yes, reraise the exception
         exc_type = self.exc_info()[0]
         if issubclass(exc_type, SConfError):
-            # TODO pylint E0704: bare raise not inside except
-            raise
+            raise self.exc_info()[1]
         elif issubclass(exc_type, SCons.Errors.BuildError):
             # we ignore Build Errors (occurs, when a test doesn't pass)
             # Clear the exception to prevent the contained traceback

--- a/SCons/SConf.py
+++ b/SCons/SConf.py
@@ -251,9 +251,9 @@ class SConfBuildTask(SCons.Taskmaster.AlwaysTask):
     def failed(self):
         # check, if the reason was a ConfigureDryRunError or a
         # ConfigureCacheError and if yes, reraise the exception
-        exc_type = self.exc_info()[0]
+        exc_type, exc, _ = self.exc_info()
         if issubclass(exc_type, SConfError):
-            raise self.exc_info()[1]
+            raise exc
         elif issubclass(exc_type, SCons.Errors.BuildError):
             # we ignore Build Errors (occurs, when a test doesn't pass)
             # Clear the exception to prevent the contained traceback

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1447,6 +1447,13 @@ def main() -> None:
         sys.stderr.write("scons: *** Minimum Python version is %d.%d.%d\n" %minimum_python_version)
         sys.exit(1)
 
+    try:
+        import threading
+    except ImportError:
+        msg = "scons: *** SCons version %s requires a Python interpreter with support for the `threading` package"
+        sys.stderr.write(msg % SConsVersion)
+        sys.exit(1)
+
     parts = ["SCons by Steven Knight et al.:\n"]
     try:
         import SCons

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -40,7 +40,7 @@ SUPPRESS_HELP = optparse.SUPPRESS_HELP
 
 diskcheck_all = SCons.Node.FS.diskcheck_types()
 
-experimental_features = {'warp_speed', 'transporter', 'ninja', 'legacysched'}
+experimental_features = {'warp_speed', 'transporter', 'ninja', 'legacy_sched'}
 
 
 def diskcheck_convert(value):

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -40,7 +40,7 @@ SUPPRESS_HELP = optparse.SUPPRESS_HELP
 
 diskcheck_all = SCons.Node.FS.diskcheck_types()
 
-experimental_features = {'warp_speed', 'transporter', 'ninja', 'tm_v2'}
+experimental_features = {'warp_speed', 'transporter', 'ninja', 'legacysched'}
 
 
 def diskcheck_convert(value):

--- a/SCons/Taskmaster/Job.py
+++ b/SCons/Taskmaster/Job.py
@@ -74,7 +74,7 @@ class Jobs:
     def __init__(self, num, taskmaster) -> None:
         """
         Create 'num' jobs using the given taskmaster. The exact implementation
-        used varies with the number of jobs requested and the state of the `legacysched` flag
+        used varies with the number of jobs requested and the state of the `legacy_sched` flag
         to `--experimental`.
         """
 
@@ -88,7 +88,7 @@ class Jobs:
             stack_size = default_stack_size
 
         experimental_option = GetOption('experimental') or []
-        if 'legacysched' in experimental_option:
+        if 'legacy_sched' in experimental_option:
             if num > 1:
                 self.job = LegacyParallel(taskmaster, num, stack_size)
             else:

--- a/SCons/Taskmaster/Job.py
+++ b/SCons/Taskmaster/Job.py
@@ -505,7 +505,7 @@ class NewParallel:
         for _ in range(self.num_workers):
             self.workers.append(NewParallel.Worker(self))
         self._restore_stack_size(prev_size)
-        _work()
+        self._work()
 
     def _adjust_stack_size(self):
         try:

--- a/SCons/Taskmaster/Job.py
+++ b/SCons/Taskmaster/Job.py
@@ -31,6 +31,7 @@ import SCons.compat
 
 import logging
 import os
+import queue
 import signal
 import sys
 import threading
@@ -95,16 +96,13 @@ class Jobs:
             if stack_size is None:
                 stack_size = default_stack_size
 
-            try:
-                experimental_option = GetOption('experimental')
-                if 'tm_v2' in experimental_option:
-                    self.job = NewParallel(taskmaster, num, stack_size)
-                else:
-                    self.job = LegacyParallel(taskmaster, num, stack_size)
+            experimental_option = GetOption('experimental')
+            if 'tm_v2' in experimental_option:
+                self.job = NewParallel(taskmaster, num, stack_size)
+            else:
+                self.job = LegacyParallel(taskmaster, num, stack_size)
 
-                self.num_jobs = num
-            except NameError:
-                pass
+            self.num_jobs = num
         if self.job is None:
             self.job = Serial(taskmaster)
             self.num_jobs = 1
@@ -239,505 +237,496 @@ class Serial:
         self.taskmaster.cleanup()
 
 
-# Trap import failure so that everything in the Job module but the
-# Parallel class (and its dependent classes) will work if the interpreter
-# doesn't support threads.
-try:
-    import queue
-    import threading
-except ImportError:
-    pass
-else:
-    class Worker(threading.Thread):
-        """A worker thread waits on a task to be posted to its request queue,
-        dequeues the task, executes it, and posts a tuple including the task
-        and a boolean indicating whether the task executed successfully. """
+class Worker(threading.Thread):
+    """A worker thread waits on a task to be posted to its request queue,
+    dequeues the task, executes it, and posts a tuple including the task
+    and a boolean indicating whether the task executed successfully. """
 
-        def __init__(self, requestQueue, resultsQueue, interrupted) -> None:
-            super().__init__()
-            self.daemon = True
-            self.requestQueue = requestQueue
-            self.resultsQueue = resultsQueue
-            self.interrupted = interrupted
-            self.start()
+    def __init__(self, requestQueue, resultsQueue, interrupted) -> None:
+        super().__init__()
+        self.daemon = True
+        self.requestQueue = requestQueue
+        self.resultsQueue = resultsQueue
+        self.interrupted = interrupted
+        self.start()
 
-        def run(self):
-            while True:
-                task = self.requestQueue.get()
+    def run(self):
+        while True:
+            task = self.requestQueue.get()
 
+            if task is None:
+                # The "None" value is used as a sentinel by
+                # ThreadPool.cleanup().  This indicates that there
+                # are no more tasks, so we should quit.
+                break
+
+            try:
+                if self.interrupted():
+                    raise SCons.Errors.BuildError(
+                        task.targets[0], errstr=interrupt_msg)
+                task.execute()
+            except Exception:
+                task.exception_set()
+                ok = False
+            else:
+                ok = True
+
+            self.resultsQueue.put((task, ok))
+
+class ThreadPool:
+    """This class is responsible for spawning and managing worker threads."""
+
+    def __init__(self, num, stack_size, interrupted) -> None:
+        """Create the request and reply queues, and 'num' worker threads.
+
+        One must specify the stack size of the worker threads. The
+        stack size is specified in kilobytes.
+        """
+        self.requestQueue = queue.Queue(0)
+        self.resultsQueue = queue.Queue(0)
+
+        try:
+            prev_size = threading.stack_size(stack_size * 1024)
+        except AttributeError as e:
+            # Only print a warning if the stack size has been
+            # explicitly set.
+            if explicit_stack_size is not None:
+                msg = "Setting stack size is unsupported by this version of Python:\n    " + \
+                    e.args[0]
+                SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
+        except ValueError as e:
+            msg = "Setting stack size failed:\n    " + str(e)
+            SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
+
+        # Create worker threads
+        self.workers = []
+        for _ in range(num):
+            worker = Worker(self.requestQueue, self.resultsQueue, interrupted)
+            self.workers.append(worker)
+
+        if 'prev_size' in locals():
+            threading.stack_size(prev_size)
+
+    def put(self, task) -> None:
+        """Put task into request queue."""
+        self.requestQueue.put(task)
+
+    def get(self):
+        """Remove and return a result tuple from the results queue."""
+        return self.resultsQueue.get()
+
+    def preparation_failed(self, task) -> None:
+        self.resultsQueue.put((task, False))
+
+    def cleanup(self) -> None:
+        """
+        Shuts down the thread pool, giving each worker thread a
+        chance to shut down gracefully.
+        """
+        # For each worker thread, put a sentinel "None" value
+        # on the requestQueue (indicating that there's no work
+        # to be done) so that each worker thread will get one and
+        # terminate gracefully.
+        for _ in self.workers:
+            self.requestQueue.put(None)
+
+        # Wait for all of the workers to terminate.
+        #
+        # If we don't do this, later Python versions (2.4, 2.5) often
+        # seem to raise exceptions during shutdown.  This happens
+        # in requestQueue.get(), as an assertion failure that
+        # requestQueue.not_full is notified while not acquired,
+        # seemingly because the main thread has shut down (or is
+        # in the process of doing so) while the workers are still
+        # trying to pull sentinels off the requestQueue.
+        #
+        # Normally these terminations should happen fairly quickly,
+        # but we'll stick a one-second timeout on here just in case
+        # someone gets hung.
+        for worker in self.workers:
+            worker.join(1.0)
+        self.workers = []
+
+class LegacyParallel:
+    """This class is used to execute tasks in parallel, and is somewhat
+    less efficient than Serial, but is appropriate for parallel builds.
+
+    This class is thread safe.
+    """
+
+    def __init__(self, taskmaster, num, stack_size) -> None:
+        """Create a new parallel job given a taskmaster.
+
+        The taskmaster's next_task() method should return the next
+        task that needs to be executed, or None if there are no more
+        tasks. The taskmaster's executed() method will be called
+        for each task when it is successfully executed, or failed()
+        will be called if the task failed to execute (i.e. execute()
+        raised an exception).
+
+        Note: calls to taskmaster are serialized, but calls to
+        execute() on distinct tasks are not serialized, because
+        that is the whole point of parallel jobs: they can execute
+        multiple tasks simultaneously. """
+
+        self.taskmaster = taskmaster
+        self.interrupted = InterruptState()
+        self.tp = ThreadPool(num, stack_size, self.interrupted)
+
+        self.maxjobs = num
+
+    def start(self):
+        """Start the job. This will begin pulling tasks from the
+        taskmaster and executing them, and return when there are no
+        more tasks. If a task fails to execute (i.e. execute() raises
+        an exception), then the job will stop."""
+
+        jobs = 0
+
+        while True:
+            # Start up as many available tasks as we're
+            # allowed to.
+            while jobs < self.maxjobs:
+                task = self.taskmaster.next_task()
                 if task is None:
-                    # The "None" value is used as a sentinel by
-                    # ThreadPool.cleanup().  This indicates that there
-                    # are no more tasks, so we should quit.
                     break
 
+                try:
+                    # prepare task for execution
+                    task.prepare()
+                except Exception:
+                    task.exception_set()
+                    task.failed()
+                    task.postprocess()
+                else:
+                    if task.needs_execute():
+                        # dispatch task
+                        self.tp.put(task)
+                        jobs += 1
+                    else:
+                        task.executed()
+                        task.postprocess()
+
+            if not task and not jobs:
+                break
+
+            # Let any/all completed tasks finish up before we go
+            # back and put the next batch of tasks on the queue.
+            while True:
+                task, ok = self.tp.get()
+                jobs -= 1
+
+                if ok:
+                    task.executed()
+                else:
+                    if self.interrupted():
+                        try:
+                            raise SCons.Errors.BuildError(
+                                task.targets[0], errstr=interrupt_msg)
+                        except Exception:
+                            task.exception_set()
+
+                    # Let the failed() callback function arrange
+                    # for the build to stop if that's appropriate.
+                    task.failed()
+
+                task.postprocess()
+
+                if self.tp.resultsQueue.empty():
+                    break
+
+        self.tp.cleanup()
+        self.taskmaster.cleanup()
+
+# An experimental new parallel scheduler that uses a leaders/followers pattern.
+class NewParallel:
+
+    class State(Enum):
+        READY = 0
+        SEARCHING = 1
+        STALLED = 2
+        COMPLETED = 3
+
+    class Worker(threading.Thread):
+        def __init__(self, owner) -> None:
+            super().__init__()
+            self.daemon = True
+            self.owner = owner
+            self.start()
+
+        def run(self) -> None:
+            self.owner._work()
+
+    def __init__(self, taskmaster, num, stack_size) -> None:
+        self.taskmaster = taskmaster
+        self.num_workers = num
+        self.stack_size = stack_size
+        self.interrupted = InterruptState()
+        self.workers = []
+
+        # The `tm_lock` is what ensures that we only have one
+        # thread interacting with the taskmaster at a time. It
+        # also protects access to our state that gets updated
+        # concurrently. The `can_search_cv` is associated with
+        # this mutex.
+        self.tm_lock = threading.Lock()
+
+        # Guarded under `tm_lock`.
+        self.jobs = 0
+        self.state = NewParallel.State.READY
+
+        # The `can_search_cv` is used to manage a leader /
+        # follower pattern for access to the taskmaster, and to
+        # awaken from stalls.
+        self.can_search_cv = threading.Condition(self.tm_lock)
+
+        # The queue of tasks that have completed execution. The
+        # next thread to obtain `tm_lock`` will retire them.
+        self.results_queue_lock = threading.Lock()
+        self.results_queue = []
+
+        if self.taskmaster.trace:
+            self.trace = self._setup_logging()
+        else:
+            self.trace = False
+
+    def _setup_logging(self):
+        jl = logging.getLogger("Job")
+        jl.setLevel(level=logging.DEBUG)
+        jl.addHandler(self.taskmaster.trace.log_handler)
+        return jl
+
+    def trace_message(self, message) -> None:
+        # This grabs the name of the function which calls trace_message()
+        method_name = sys._getframe(1).f_code.co_name + "():"
+        thread_id=threading.get_ident()
+        self.trace.debug('%s.%s [Thread:%s] %s' % (type(self).__name__, method_name, thread_id, message))
+        # print('%-15s %s' % (method_name, message))
+
+    def start(self) -> None:
+        self._start_workers()
+        for worker in self.workers:
+            worker.join()
+        self.workers = []
+        self.taskmaster.cleanup()
+
+    def _start_workers(self) -> None:
+        prev_size = self._adjust_stack_size()
+        for _ in range(self.num_workers):
+            self.workers.append(NewParallel.Worker(self))
+        self._restore_stack_size(prev_size)
+
+    def _adjust_stack_size(self):
+        try:
+            prev_size = threading.stack_size(self.stack_size * 1024)
+            return prev_size
+        except AttributeError as e:
+            # Only print a warning if the stack size has been
+            # explicitly set.
+            if explicit_stack_size is not None:
+                msg = "Setting stack size is unsupported by this version of Python:\n    " + \
+                    e.args[0]
+                SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
+        except ValueError as e:
+            msg = "Setting stack size failed:\n    " + str(e)
+            SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
+
+        return None
+
+    def _restore_stack_size(self, prev_size) -> None:
+        if prev_size is not None:
+            threading.stack_size(prev_size)
+
+    def _work(self):
+
+        task = None
+
+        while True:
+
+            # Obtain `tm_lock`, granting exclusive access to the taskmaster.
+            with self.can_search_cv:
+
+                if self.trace:
+                    self.trace_message("Gained exclusive access")
+
+                # Capture whether we got here with `task` set,
+                # then drop our reference to the task as we are no
+                # longer interested in the actual object.
+                completed_task = (task is not None)
+                task = None
+
+                # We will only have `completed_task` set here if
+                # we have looped back after executing a task. If
+                # we have completed a task and find that we are
+                # stalled, we should speculatively indicate that
+                # we are no longer stalled by transitioning to the
+                # 'ready' state which will bypass the condition
+                # wait so that we immediately process the results
+                # queue and hopefully light up new
+                # work. Otherwise, stay stalled, and we will wait
+                # in the condvar. Some other thread will come back
+                # here with a completed task.
+                if self.state == NewParallel.State.STALLED and completed_task:
+                    if self.trace:
+                        self.trace_message("Detected stall with completed task, bypassing wait")
+                    self.state = NewParallel.State.READY
+
+                # Wait until we are neither searching nor stalled.
+                while self.state == NewParallel.State.SEARCHING or self.state == NewParallel.State.STALLED:
+                    if self.trace:
+                        self.trace_message("Search already in progress, waiting")
+                    self.can_search_cv.wait()
+
+                # If someone set the completed flag, bail.
+                if self.state == NewParallel.State.COMPLETED:
+                    if self.trace:
+                        self.trace_message("Completion detected, breaking from main loop")
+                    break
+
+                # Set the searching flag to indicate that a thread
+                # is currently in the critical section for
+                # taskmaster work.
+                #
+                if self.trace:
+                    self.trace_message("Starting search")
+                self.state = NewParallel.State.SEARCHING
+
+                # Bulk acquire the tasks in the results queue
+                # under the result queue lock, then process them
+                # all outside that lock. We need to process the
+                # tasks in the results queue before looking for
+                # new work because we might be unable to find new
+                # work if we don't.
+                results_queue = []
+                with self.results_queue_lock:
+                    results_queue, self.results_queue = self.results_queue, results_queue
+
+                if self.trace:
+                    self.trace_message("Found {len(results_queue)} completed tasks to process")
+                for (rtask, rresult) in results_queue:
+                    if rresult:
+                        rtask.executed()
+                    else:
+                        if self.interrupted():
+                            try:
+                                raise SCons.Errors.BuildError(
+                                    rtask.targets[0], errstr=interrupt_msg)
+                            except Exception:
+                                rtask.exception_set()
+
+                        # Let the failed() callback function arrange
+                        # for the build to stop if that's appropriate.
+                        rtask.failed()
+
+                    rtask.postprocess()
+                    self.jobs -= 1
+
+                # We are done with any task objects that were in
+                # the results queue.
+                results_queue.clear()
+
+                # Now, turn the crank on the taskmaster until we
+                # either run out of tasks, or find a task that
+                # needs execution. If we run out of tasks, go idle
+                # until results arrive if jobs are pending, or
+                # mark the walk as complete if not.
+                while self.state == NewParallel.State.SEARCHING:
+                    if self.trace:
+                        self.trace_message("Searching for new tasks")
+                    task = self.taskmaster.next_task()
+
+                    if task:
+                        # We found a task. Walk it through the
+                        # task lifecycle. If it does not need
+                        # execution, just complete the task and
+                        # look for the next one. Otherwise,
+                        # indicate that we are no longer searching
+                        # so we can drop out of this loop, execute
+                        # the task outside the lock, and allow
+                        # another thread in to search.
+                        try:
+                            task.prepare()
+                        except Exception:
+                            task.exception_set()
+                            task.failed()
+                            task.postprocess()
+                        else:
+                            if not task.needs_execute():
+                                if self.trace:
+                                    self.trace_message("Found internal task")
+                                task.executed()
+                                task.postprocess()
+                            else:
+                                self.jobs += 1
+                                if self.trace:
+                                    self.trace_message("Found task requiring execution")
+                                self.state = NewParallel.State.READY
+                                self.can_search_cv.notify()
+
+                    else:
+                        # We failed to find a task, so this thread
+                        # cannot continue turning the taskmaster
+                        # crank. We must exit the loop.
+                        if self.jobs:
+                            # No task was found, but there are
+                            # outstanding jobs executing that
+                            # might unblock new tasks when they
+                            # complete. Transition to the stalled
+                            # state. We do not need a notify,
+                            # because we know there are threads
+                            # outstanding that will re-enter the
+                            # loop.
+                            #
+                            if self.trace:
+                                self.trace_message("Found no task requiring execution, but have jobs: marking stalled")
+                            self.state = NewParallel.State.STALLED
+                        else:
+                            # We didn't find a task and there are
+                            # no jobs outstanding, so there is
+                            # nothing that will ever return
+                            # results which might unblock new
+                            # tasks. We can conclude that the walk
+                            # is complete. Update our state to
+                            # note completion and awaken anyone
+                            # sleeping on the condvar.
+                            #
+                            if self.trace:
+                                self.trace_message("Found no task requiring execution, and have no jobs: marking complete")
+                            self.state = NewParallel.State.COMPLETED
+                            self.can_search_cv.notify_all()
+
+            # We no longer hold `tm_lock` here. If we have a task,
+            # we can now execute it. If there are threads waiting
+            # to search, one of them can now begin turning the
+            # taskmaster crank in NewParallel.
+            if task:
+                if self.trace:
+                    self.trace_message("Executing task")
+                ok = True
                 try:
                     if self.interrupted():
                         raise SCons.Errors.BuildError(
                             task.targets[0], errstr=interrupt_msg)
                     task.execute()
                 except Exception:
-                    task.exception_set()
                     ok = False
-                else:
-                    ok = True
-
-                self.resultsQueue.put((task, ok))
-
-    class ThreadPool:
-        """This class is responsible for spawning and managing worker threads."""
-
-        def __init__(self, num, stack_size, interrupted) -> None:
-            """Create the request and reply queues, and 'num' worker threads.
-
-            One must specify the stack size of the worker threads. The
-            stack size is specified in kilobytes.
-            """
-            self.requestQueue = queue.Queue(0)
-            self.resultsQueue = queue.Queue(0)
-
-            try:
-                prev_size = threading.stack_size(stack_size * 1024)
-            except AttributeError as e:
-                # Only print a warning if the stack size has been
-                # explicitly set.
-                if explicit_stack_size is not None:
-                    msg = "Setting stack size is unsupported by this version of Python:\n    " + \
-                        e.args[0]
-                    SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
-            except ValueError as e:
-                msg = "Setting stack size failed:\n    " + str(e)
-                SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
-
-            # Create worker threads
-            self.workers = []
-            for _ in range(num):
-                worker = Worker(self.requestQueue, self.resultsQueue, interrupted)
-                self.workers.append(worker)
-
-            if 'prev_size' in locals():
-                threading.stack_size(prev_size)
-
-        def put(self, task) -> None:
-            """Put task into request queue."""
-            self.requestQueue.put(task)
-
-        def get(self):
-            """Remove and return a result tuple from the results queue."""
-            return self.resultsQueue.get()
-
-        def preparation_failed(self, task) -> None:
-            self.resultsQueue.put((task, False))
-
-        def cleanup(self) -> None:
-            """
-            Shuts down the thread pool, giving each worker thread a
-            chance to shut down gracefully.
-            """
-            # For each worker thread, put a sentinel "None" value
-            # on the requestQueue (indicating that there's no work
-            # to be done) so that each worker thread will get one and
-            # terminate gracefully.
-            for _ in self.workers:
-                self.requestQueue.put(None)
-
-            # Wait for all of the workers to terminate.
-            #
-            # If we don't do this, later Python versions (2.4, 2.5) often
-            # seem to raise exceptions during shutdown.  This happens
-            # in requestQueue.get(), as an assertion failure that
-            # requestQueue.not_full is notified while not acquired,
-            # seemingly because the main thread has shut down (or is
-            # in the process of doing so) while the workers are still
-            # trying to pull sentinels off the requestQueue.
-            #
-            # Normally these terminations should happen fairly quickly,
-            # but we'll stick a one-second timeout on here just in case
-            # someone gets hung.
-            for worker in self.workers:
-                worker.join(1.0)
-            self.workers = []
-
-    class LegacyParallel:
-        """This class is used to execute tasks in parallel, and is somewhat
-        less efficient than Serial, but is appropriate for parallel builds.
-
-        This class is thread safe.
-        """
-
-        def __init__(self, taskmaster, num, stack_size) -> None:
-            """Create a new parallel job given a taskmaster.
-
-            The taskmaster's next_task() method should return the next
-            task that needs to be executed, or None if there are no more
-            tasks. The taskmaster's executed() method will be called
-            for each task when it is successfully executed, or failed()
-            will be called if the task failed to execute (i.e. execute()
-            raised an exception).
-
-            Note: calls to taskmaster are serialized, but calls to
-            execute() on distinct tasks are not serialized, because
-            that is the whole point of parallel jobs: they can execute
-            multiple tasks simultaneously. """
-
-            self.taskmaster = taskmaster
-            self.interrupted = InterruptState()
-            self.tp = ThreadPool(num, stack_size, self.interrupted)
-
-            self.maxjobs = num
-
-        def start(self):
-            """Start the job. This will begin pulling tasks from the
-            taskmaster and executing them, and return when there are no
-            more tasks. If a task fails to execute (i.e. execute() raises
-            an exception), then the job will stop."""
-
-            jobs = 0
-
-            while True:
-                # Start up as many available tasks as we're
-                # allowed to.
-                while jobs < self.maxjobs:
-                    task = self.taskmaster.next_task()
-                    if task is None:
-                        break
-
-                    try:
-                        # prepare task for execution
-                        task.prepare()
-                    except Exception:
-                        task.exception_set()
-                        task.failed()
-                        task.postprocess()
-                    else:
-                        if task.needs_execute():
-                            # dispatch task
-                            self.tp.put(task)
-                            jobs += 1
-                        else:
-                            task.executed()
-                            task.postprocess()
-
-                if not task and not jobs:
-                    break
-
-                # Let any/all completed tasks finish up before we go
-                # back and put the next batch of tasks on the queue.
-                while True:
-                    task, ok = self.tp.get()
-                    jobs -= 1
-
-                    if ok:
-                        task.executed()
-                    else:
-                        if self.interrupted():
-                            try:
-                                raise SCons.Errors.BuildError(
-                                    task.targets[0], errstr=interrupt_msg)
-                            except Exception:
-                                task.exception_set()
-
-                        # Let the failed() callback function arrange
-                        # for the build to stop if that's appropriate.
-                        task.failed()
-
-                    task.postprocess()
-
-                    if self.tp.resultsQueue.empty():
-                        break
-
-            self.tp.cleanup()
-            self.taskmaster.cleanup()
-
-    # An experimental new parallel scheduler that uses a leaders/followers pattern.
-    class NewParallel:
-
-        class State(Enum):
-            READY = 0
-            SEARCHING = 1
-            STALLED = 2
-            COMPLETED = 3
-
-        class Worker(threading.Thread):
-            def __init__(self, owner) -> None:
-                super().__init__()
-                self.daemon = True
-                self.owner = owner
-                self.start()
-
-            def run(self) -> None:
-                self.owner._work()
-
-        def __init__(self, taskmaster, num, stack_size) -> None:
-            self.taskmaster = taskmaster
-            self.num_workers = num
-            self.stack_size = stack_size
-            self.interrupted = InterruptState()
-            self.workers = []
-
-            # The `tm_lock` is what ensures that we only have one
-            # thread interacting with the taskmaster at a time. It
-            # also protects access to our state that gets updated
-            # concurrently. The `can_search_cv` is associated with
-            # this mutex.
-            self.tm_lock = threading.Lock()
-
-            # Guarded under `tm_lock`.
-            self.jobs = 0
-            self.state = NewParallel.State.READY
-
-            # The `can_search_cv` is used to manage a leader /
-            # follower pattern for access to the taskmaster, and to
-            # awaken from stalls.
-            self.can_search_cv = threading.Condition(self.tm_lock)
-
-            # The queue of tasks that have completed execution. The
-            # next thread to obtain `tm_lock`` will retire them.
-            self.results_queue_lock = threading.Lock()
-            self.results_queue = []
-
-            if self.taskmaster.trace:
-                self.trace = self._setup_logging()
-            else:
-                self.trace = False
-
-        def _setup_logging(self):
-            jl = logging.getLogger("Job")
-            jl.setLevel(level=logging.DEBUG)
-            jl.addHandler(self.taskmaster.trace.log_handler)
-            return jl
-
-        def trace_message(self, message) -> None:
-            # This grabs the name of the function which calls trace_message()
-            method_name = sys._getframe(1).f_code.co_name + "():"
-            thread_id=threading.get_ident()
-            self.trace.debug('%s.%s [Thread:%s] %s' % (type(self).__name__, method_name, thread_id, message))
-            # print('%-15s %s' % (method_name, message))
-
-        def start(self) -> None:
-            self._start_workers()
-            for worker in self.workers:
-                worker.join()
-            self.workers = []
-            self.taskmaster.cleanup()
-
-        def _start_workers(self) -> None:
-            prev_size = self._adjust_stack_size()
-            for _ in range(self.num_workers):
-                self.workers.append(NewParallel.Worker(self))
-            self._restore_stack_size(prev_size)
-
-        def _adjust_stack_size(self):
-            try:
-                prev_size = threading.stack_size(self.stack_size * 1024)
-                return prev_size
-            except AttributeError as e:
-                # Only print a warning if the stack size has been
-                # explicitly set.
-                if explicit_stack_size is not None:
-                    msg = "Setting stack size is unsupported by this version of Python:\n    " + \
-                        e.args[0]
-                    SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
-            except ValueError as e:
-                msg = "Setting stack size failed:\n    " + str(e)
-                SCons.Warnings.warn(SCons.Warnings.StackSizeWarning, msg)
-
-            return None
-
-        def _restore_stack_size(self, prev_size) -> None:
-            if prev_size is not None:
-                threading.stack_size(prev_size)
-
-        def _work(self):
-
-            task = None
-
-            while True:
-
-                # Obtain `tm_lock`, granting exclusive access to the taskmaster.
-                with self.can_search_cv:
-
-                    if self.trace:
-                        self.trace_message("Gained exclusive access")
-
-                    # Capture whether we got here with `task` set,
-                    # then drop our reference to the task as we are no
-                    # longer interested in the actual object.
-                    completed_task = (task is not None)
-                    task = None
-
-                    # We will only have `completed_task` set here if
-                    # we have looped back after executing a task. If
-                    # we have completed a task and find that we are
-                    # stalled, we should speculatively indicate that
-                    # we are no longer stalled by transitioning to the
-                    # 'ready' state which will bypass the condition
-                    # wait so that we immediately process the results
-                    # queue and hopefully light up new
-                    # work. Otherwise, stay stalled, and we will wait
-                    # in the condvar. Some other thread will come back
-                    # here with a completed task.
-                    if self.state == NewParallel.State.STALLED and completed_task:
-                        if self.trace:
-                            self.trace_message("Detected stall with completed task, bypassing wait")
-                        self.state = NewParallel.State.READY
-
-                    # Wait until we are neither searching nor stalled.
-                    while self.state == NewParallel.State.SEARCHING or self.state == NewParallel.State.STALLED:
-                        if self.trace:
-                            self.trace_message("Search already in progress, waiting")
-                        self.can_search_cv.wait()
-
-                    # If someone set the completed flag, bail.
-                    if self.state == NewParallel.State.COMPLETED:
-                        if self.trace:
-                            self.trace_message("Completion detected, breaking from main loop")
-                        break
-
-                    # Set the searching flag to indicate that a thread
-                    # is currently in the critical section for
-                    # taskmaster work.
-                    #
-                    if self.trace:
-                        self.trace_message("Starting search")
-                    self.state = NewParallel.State.SEARCHING
-
-                    # Bulk acquire the tasks in the results queue
-                    # under the result queue lock, then process them
-                    # all outside that lock. We need to process the
-                    # tasks in the results queue before looking for
-                    # new work because we might be unable to find new
-                    # work if we don't.
-                    results_queue = []
-                    with self.results_queue_lock:
-                        results_queue, self.results_queue = self.results_queue, results_queue
-
-                    if self.trace:
-                        self.trace_message("Found {len(results_queue)} completed tasks to process")
-                    for (rtask, rresult) in results_queue:
-                        if rresult:
-                            rtask.executed()
-                        else:
-                            if self.interrupted():
-                                try:
-                                    raise SCons.Errors.BuildError(
-                                        rtask.targets[0], errstr=interrupt_msg)
-                                except Exception:
-                                    rtask.exception_set()
-
-                            # Let the failed() callback function arrange
-                            # for the build to stop if that's appropriate.
-                            rtask.failed()
-
-                        rtask.postprocess()
-                        self.jobs -= 1
-
-                    # We are done with any task objects that were in
-                    # the results queue.
-                    results_queue.clear()
-
-                    # Now, turn the crank on the taskmaster until we
-                    # either run out of tasks, or find a task that
-                    # needs execution. If we run out of tasks, go idle
-                    # until results arrive if jobs are pending, or
-                    # mark the walk as complete if not.
-                    while self.state == NewParallel.State.SEARCHING:
-                        if self.trace:
-                            self.trace_message("Searching for new tasks")
-                        task = self.taskmaster.next_task()
-
-                        if task:
-                            # We found a task. Walk it through the
-                            # task lifecycle. If it does not need
-                            # execution, just complete the task and
-                            # look for the next one. Otherwise,
-                            # indicate that we are no longer searching
-                            # so we can drop out of this loop, execute
-                            # the task outside the lock, and allow
-                            # another thread in to search.
-                            try:
-                                task.prepare()
-                            except Exception:
-                                task.exception_set()
-                                task.failed()
-                                task.postprocess()
-                            else:
-                                if not task.needs_execute():
-                                    if self.trace:
-                                        self.trace_message("Found internal task")
-                                    task.executed()
-                                    task.postprocess()
-                                else:
-                                    self.jobs += 1
-                                    if self.trace:
-                                        self.trace_message("Found task requiring execution")
-                                    self.state = NewParallel.State.READY
-                                    self.can_search_cv.notify()
-
-                        else:
-                            # We failed to find a task, so this thread
-                            # cannot continue turning the taskmaster
-                            # crank. We must exit the loop.
-                            if self.jobs:
-                                # No task was found, but there are
-                                # outstanding jobs executing that
-                                # might unblock new tasks when they
-                                # complete. Transition to the stalled
-                                # state. We do not need a notify,
-                                # because we know there are threads
-                                # outstanding that will re-enter the
-                                # loop.
-                                #
-                                if self.trace:
-                                    self.trace_message("Found no task requiring execution, but have jobs: marking stalled")
-                                self.state = NewParallel.State.STALLED
-                            else:
-                                # We didn't find a task and there are
-                                # no jobs outstanding, so there is
-                                # nothing that will ever return
-                                # results which might unblock new
-                                # tasks. We can conclude that the walk
-                                # is complete. Update our state to
-                                # note completion and awaken anyone
-                                # sleeping on the condvar.
-                                #
-                                if self.trace:
-                                    self.trace_message("Found no task requiring execution, and have no jobs: marking complete")
-                                self.state = NewParallel.State.COMPLETED
-                                self.can_search_cv.notify_all()
-
-                # We no longer hold `tm_lock` here. If we have a task,
-                # we can now execute it. If there are threads waiting
-                # to search, one of them can now begin turning the
-                # taskmaster crank in NewParallel.
-                if task:
-                    if self.trace:
-                        self.trace_message("Executing task")
-                    ok = True
-                    try:
-                        if self.interrupted():
-                            raise SCons.Errors.BuildError(
-                                task.targets[0], errstr=interrupt_msg)
-                        task.execute()
-                    except Exception:
-                        ok = False
-                        task.exception_set()
-
-                    # Grab the results queue lock and enqueue the
-                    # executed task and state. The next thread into
-                    # the searching loop will complete the
-                    # postprocessing work under the taskmaster lock.
-                    #
-                    if self.trace:
-                        self.trace_message("Enqueueing executed task results")
-                    with self.results_queue_lock:
-                        self.results_queue.append((task, ok))
-
-                # Tricky state "fallthrough" here. We are going back
-                # to the top of the loop, which behaves differently
-                # depending on whether `task` is set. Do not perturb
-                # the value of the `task` variable if you add new code
-                # after this comment.
+                    task.exception_set()
+
+                # Grab the results queue lock and enqueue the
+                # executed task and state. The next thread into
+                # the searching loop will complete the
+                # postprocessing work under the taskmaster lock.
+                #
+                if self.trace:
+                    self.trace_message("Enqueueing executed task results")
+                with self.results_queue_lock:
+                    self.results_queue.append((task, ok))
+
+            # Tricky state "fallthrough" here. We are going back
+            # to the top of the loop, which behaves differently
+            # depending on whether `task` is set. Do not perturb
+            # the value of the `task` variable if you add new code
+            # after this comment.
 
 # Local Variables:
 # tab-width:4

--- a/SCons/Taskmaster/Job.py
+++ b/SCons/Taskmaster/Job.py
@@ -74,7 +74,7 @@ class Jobs:
     def __init__(self, num, taskmaster) -> None:
         """
         Create 'num' jobs using the given taskmaster. The exact implementation
-        used varies with the number of jobs requested and the state of the `tm_v2` flag
+        used varies with the number of jobs requested and the state of the `legacysched` flag
         to `--experimental`.
         """
 
@@ -88,13 +88,14 @@ class Jobs:
             stack_size = default_stack_size
 
         experimental_option = GetOption('experimental') or []
-        if 'tm_v2' in experimental_option:
-            self.job = NewParallel(taskmaster, num, stack_size)
-        else:
+        if 'legacysched' in experimental_option:
             if num > 1:
                 self.job = LegacyParallel(taskmaster, num, stack_size)
             else:
                 self.job = Serial(taskmaster)
+        else:
+            self.job = NewParallel(taskmaster, num, stack_size)
+
         self.num_jobs = num
 
     def run(self, postfunc=lambda: None) -> None:
@@ -617,7 +618,7 @@ class NewParallel:
                     results_queue, self.results_queue = self.results_queue, results_queue
 
                 if self.trace:
-                    self.trace_message("Found {len(results_queue)} completed tasks to process")
+                    self.trace_message(f"Found {len(results_queue)} completed tasks to process")
                 for (rtask, rresult) in results_queue:
                     if rresult:
                         rtask.executed()

--- a/SCons/Taskmaster/Job.py
+++ b/SCons/Taskmaster/Job.py
@@ -449,7 +449,7 @@ class NewParallel:
 
     def __init__(self, taskmaster, num, stack_size) -> None:
         self.taskmaster = taskmaster
-        self.num_workers = num
+        self.num_workers = num - 1
         self.stack_size = stack_size
         self.interrupted = InterruptState()
         self.workers = []
@@ -505,6 +505,7 @@ class NewParallel:
         for _ in range(self.num_workers):
             self.workers.append(NewParallel.Worker(self))
         self._restore_stack_size(prev_size)
+        _work()
 
     def _adjust_stack_size(self):
         try:

--- a/SCons/Taskmaster/JobTests.py
+++ b/SCons/Taskmaster/JobTests.py
@@ -348,34 +348,6 @@ class SerialTestCase(unittest.TestCase):
                     "some task(s) failed to execute")
 
 
-class NoParallelTestCase(JobTestCase):
-
-    def runTest(self) -> None:
-        """test handling lack of parallel support"""
-        def NoParallel(tm, num, stack_size):
-            raise NameError
-        save_Parallel = SCons.Taskmaster.Job.LegacyParallel
-        SCons.Taskmaster.Job.LegacyParallel = NoParallel
-        try:
-            taskmaster = Taskmaster(num_tasks, self, RandomTask)
-            jobs = SCons.Taskmaster.Job.Jobs(2, taskmaster)
-            self.assertTrue(jobs.num_jobs == 1,
-                            "unexpected number of jobs %d" % jobs.num_jobs)
-            jobs.run()
-            self.assertTrue(taskmaster.tasks_were_serial(),
-                            "the tasks were not executed in series")
-            self.assertTrue(taskmaster.all_tasks_are_executed(),
-                            "all the tests were not executed")
-            self.assertTrue(taskmaster.all_tasks_are_iterated(),
-                            "all the tests were not iterated over")
-            self.assertTrue(taskmaster.all_tasks_are_postprocessed(),
-                            "all the tests were not postprocessed")
-            self.assertFalse(taskmaster.num_failed,
-                        "some task(s) failed to execute")
-        finally:
-            SCons.Taskmaster.Job.LegacyParallel = save_Parallel
-
-
 class SerialExceptionTestCase(unittest.TestCase):
     def runTest(self) -> None:
         """test a serial job with tasks that raise exceptions"""

--- a/SCons/Taskmaster/JobTests.py
+++ b/SCons/Taskmaster/JobTests.py
@@ -483,7 +483,7 @@ class SerialTaskTest(_SConsTaskTest):
         self._test_seq(1)
 
         # Now run test with LegacyParallel
-        OptionsParser.values.experimental=['legacysched']
+        OptionsParser.values.experimental=['legacy_sched']
         self._test_seq(1)
 
 class ParallelTaskTest(_SConsTaskTest):
@@ -492,7 +492,7 @@ class ParallelTaskTest(_SConsTaskTest):
         self._test_seq(num_jobs)
 
         # Now run test with LegacyParallel
-        OptionsParser.values.experimental=['legacysched']
+        OptionsParser.values.experimental=['legacy_sched']
         self._test_seq(num_jobs)
 
 

--- a/SCons/Taskmaster/JobTests.py
+++ b/SCons/Taskmaster/JobTests.py
@@ -202,6 +202,7 @@ class Taskmaster:
         self.parallel_list = [0] * (n+1)
         self.found_parallel = False
         self.Task = Task
+        self.trace = False
 
         # 'guard' guards 'task_begin_list' and 'task_end_list'
         try:
@@ -283,50 +284,6 @@ class ParallelTestCase(JobTestCase):
                         "all the tests were not postprocessed")
         self.assertFalse(taskmaster.num_failed,
                     "some task(s) failed to execute")
-
-        # Verify that parallel jobs will pull all of the completed tasks
-        # out of the queue at once, instead of one by one.  We do this by
-        # replacing the default ThreadPool class with one that records the
-        # order in which tasks are put() and get() to/from the pool, and
-        # which sleeps a little bit before call get() to let the initial
-        # tasks complete and get their notifications on the resultsQueue.
-
-        class SleepTask(Task):
-            def _do_something(self) -> None:
-                time.sleep(0.01)
-
-        global SaveThreadPool
-        SaveThreadPool = SCons.Taskmaster.Job.ThreadPool
-
-        class WaitThreadPool(SaveThreadPool):
-            def put(self, task):
-                ThreadPoolCallList.append('put(%s)' % task.i)
-                return SaveThreadPool.put(self, task)
-            def get(self):
-                time.sleep(0.05)
-                result = SaveThreadPool.get(self)
-                ThreadPoolCallList.append('get(%s)' % result[0].i)
-                return result
-
-        SCons.Taskmaster.Job.ThreadPool = WaitThreadPool
-
-        try:
-            taskmaster = Taskmaster(3, self, SleepTask)
-            jobs = SCons.Taskmaster.Job.Jobs(2, taskmaster)
-            jobs.run()
-
-            # The key here is that we get(1) and get(2) from the
-            # resultsQueue before we put(3), but get(1) and get(2) can
-            # be in either order depending on how the first two parallel
-            # tasks get scheduled by the operating system.
-            expect = [
-                ['put(1)', 'put(2)', 'get(1)', 'get(2)', 'put(3)', 'get(3)'],
-                ['put(1)', 'put(2)', 'get(2)', 'get(1)', 'put(3)', 'get(3)'],
-            ]
-            assert ThreadPoolCallList in expect, ThreadPoolCallList
-
-        finally:
-            SCons.Taskmaster.Job.ThreadPool = SaveThreadPool
 
 class SerialTestCase(unittest.TestCase):
     def runTest(self) -> None:

--- a/SCons/Taskmaster/JobTests.py
+++ b/SCons/Taskmaster/JobTests.py
@@ -313,7 +313,9 @@ class ParallelTestCase(JobTestCase):
 
         try:
             taskmaster = Taskmaster(3, self, SleepTask)
+            OptionsParser.values.experimental.append('legacy_sched')
             jobs = SCons.Taskmaster.Job.Jobs(2, taskmaster)
+            OptionsParser.values.experimental.pop()
             jobs.run()
 
             # The key here is that we get(1) and get(2) from the

--- a/SCons/Taskmaster/JobTests.py
+++ b/SCons/Taskmaster/JobTests.py
@@ -525,14 +525,17 @@ class SerialTaskTest(_SConsTaskTest):
         """test serial jobs with actual Taskmaster and Task"""
         self._test_seq(1)
 
+        # Now run test with LegacyParallel
+        OptionsParser.values.experimental=['legacysched']
+        self._test_seq(1)
 
 class ParallelTaskTest(_SConsTaskTest):
     def runTest(self) -> None:
         """test parallel jobs with actual Taskmaster and Task"""
         self._test_seq(num_jobs)
 
-        # Now run test with NewParallel() instead of LegacyParallel
-        OptionsParser.values.experimental=['tm_v2']
+        # Now run test with LegacyParallel
+        OptionsParser.values.experimental=['legacysched']
         self._test_seq(num_jobs)
 
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1212,7 +1212,7 @@ the mechanisms in the specified order.</para>
         The default setting is <literal>none</literal>.</para>
       <para>Current available features are:
         <literal>ninja</literal> (<emphasis>New in version 4.2</emphasis>),
-        <literal>tm_v2</literal> (<emphasis>New in version 4.4.1</emphasis>).
+        <literal>legacysched</literal> (<emphasis>New in version 4.6.0</emphasis>).
       </para>
       <caution><para>
         No Support offered for any features or tools enabled by this flag.

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1212,7 +1212,7 @@ the mechanisms in the specified order.</para>
         The default setting is <literal>none</literal>.</para>
       <para>Current available features are:
         <literal>ninja</literal> (<emphasis>New in version 4.2</emphasis>),
-        <literal>legacysched</literal> (<emphasis>New in version 4.6.0</emphasis>).
+        <literal>legacy_sched</literal> (<emphasis>New in version 4.6.0</emphasis>).
       </para>
       <caution><para>
         No Support offered for any features or tools enabled by this flag.

--- a/test/Interactive/taskmastertrace.py
+++ b/test/Interactive/taskmastertrace.py
@@ -43,7 +43,7 @@ Command('2', [], Touch('$TARGET'))
 test.write('foo.in', "foo.in 1\n")
 
 
-scons = test.start(arguments = '-Q --interactive')
+scons = test.start(arguments = '-Q --interactive --experimental=legacy_sched')
 
 scons.send("build foo.out 1\n")
 

--- a/test/option/fixture/taskmaster_expected_new_parallel.txt
+++ b/test/option/fixture/taskmaster_expected_new_parallel.txt
@@ -1,6 +1,6 @@
 Job.NewParallel._work(): [Thread:XXXXX] Gained exclusive access
 Job.NewParallel._work(): [Thread:XXXXX] Starting search
-Job.NewParallel._work(): [Thread:XXXXX] Found {len(results_queue)} completed tasks to process
+Job.NewParallel._work(): [Thread:XXXXX] Found 0 completed tasks to process
 Job.NewParallel._work(): [Thread:XXXXX] Searching for new tasks
 
 Taskmaster: Looking for a node to evaluate

--- a/test/option/option--experimental.py
+++ b/test/option/option--experimental.py
@@ -37,7 +37,7 @@ tests = [
     ('.', []),
     ('--experimental=ninja', ['ninja']),
     ('--experimental=legacysched', ['legacysched']),
-    ('--experimental=all', ['ninja', 'legacysched', 'transporter', 'warp_speed']),
+    ('--experimental=all', ['legacysched', 'ninja', 'transporter', 'warp_speed']),
     ('--experimental=none', []),
 ]
 
@@ -51,7 +51,7 @@ Experimental=%s
 test.run(arguments='--experimental=warp_drive',
          stderr="""usage: scons [OPTIONS] [VARIABLES] [TARGETS]
 
-SCons Error: option --experimental: invalid choice: 'warp_drive' (choose from 'all','none','legacysched',ninja','transporter','warp_speed')
+SCons Error: option --experimental: invalid choice: 'warp_drive' (choose from 'all','none','legacysched','ninja','transporter','warp_speed')
 """,
          status=2)
 

--- a/test/option/option--experimental.py
+++ b/test/option/option--experimental.py
@@ -36,13 +36,13 @@ test.file_fixture('fixture/SConstruct__experimental', 'SConstruct')
 tests = [
     ('.', []),
     ('--experimental=ninja', ['ninja']),
-    ('--experimental=tm_v2', ['tm_v2']),
-    ('--experimental=all', ['ninja', 'tm_v2', 'transporter', 'warp_speed']),
+    ('--experimental=legacysched', ['legacysched']),
+    ('--experimental=all', ['ninja', 'legacysched', 'transporter', 'warp_speed']),
     ('--experimental=none', []),
 ]
 
 for args, exper in tests:
-    read_string = """All Features=ninja,tm_v2,transporter,warp_speed
+    read_string = """All Features=legacysched,ninja,transporter,warp_speed
 Experimental=%s
 """ % (exper)
     test.run(arguments=args,
@@ -51,7 +51,7 @@ Experimental=%s
 test.run(arguments='--experimental=warp_drive',
          stderr="""usage: scons [OPTIONS] [VARIABLES] [TARGETS]
 
-SCons Error: option --experimental: invalid choice: 'warp_drive' (choose from 'all','none','ninja','tm_v2','transporter','warp_speed')
+SCons Error: option --experimental: invalid choice: 'warp_drive' (choose from 'all','none','legacysched',ninja','transporter','warp_speed')
 """,
          status=2)
 

--- a/test/option/option--experimental.py
+++ b/test/option/option--experimental.py
@@ -36,13 +36,13 @@ test.file_fixture('fixture/SConstruct__experimental', 'SConstruct')
 tests = [
     ('.', []),
     ('--experimental=ninja', ['ninja']),
-    ('--experimental=legacysched', ['legacysched']),
-    ('--experimental=all', ['legacysched', 'ninja', 'transporter', 'warp_speed']),
+    ('--experimental=legacy_sched', ['legacy_sched']),
+    ('--experimental=all', ['legacy_sched', 'ninja', 'transporter', 'warp_speed']),
     ('--experimental=none', []),
 ]
 
 for args, exper in tests:
-    read_string = """All Features=legacysched,ninja,transporter,warp_speed
+    read_string = """All Features=legacy_sched,ninja,transporter,warp_speed
 Experimental=%s
 """ % (exper)
     test.run(arguments=args,
@@ -51,7 +51,7 @@ Experimental=%s
 test.run(arguments='--experimental=warp_drive',
          stderr="""usage: scons [OPTIONS] [VARIABLES] [TARGETS]
 
-SCons Error: option --experimental: invalid choice: 'warp_drive' (choose from 'all','none','legacysched','ninja','transporter','warp_speed')
+SCons Error: option --experimental: invalid choice: 'warp_drive' (choose from 'all','none','legacy_sched','ninja','transporter','warp_speed')
 """,
          status=2)
 

--- a/test/option/taskmastertrace.py
+++ b/test/option/taskmastertrace.py
@@ -52,7 +52,7 @@ Copy("Tfile.out", "Tfile.mid")
 """)
 
 # Test LegacyParallel Job implementation
-test.run(arguments='--experimental=legacysched --taskmastertrace=trace.out .', stdout=expect_stdout)
+test.run(arguments='--experimental=legacy_sched --taskmastertrace=trace.out .', stdout=expect_stdout)
 test.must_match_file('trace.out', 'taskmaster_expected_file_1.txt', mode='r')
 
 # Test NewParallel Job implementation

--- a/test/option/taskmastertrace.py
+++ b/test/option/taskmastertrace.py
@@ -51,11 +51,12 @@ Copy("Tfile.mid", "Tfile.in")
 Copy("Tfile.out", "Tfile.mid")
 """)
 
-test.run(arguments='--taskmastertrace=trace.out .', stdout=expect_stdout)
+# Test LegacyParallel Job implementation
+test.run(arguments='--experimental=legacysched --taskmastertrace=trace.out .', stdout=expect_stdout)
 test.must_match_file('trace.out', 'taskmaster_expected_file_1.txt', mode='r')
 
 # Test NewParallel Job implementation
-test.run(arguments='-j 2 --experimental=tm_v2 --taskmastertrace=new_parallel_trace.out .')
+test.run(arguments='-j 2 --taskmastertrace=new_parallel_trace.out .')
 
 new_trace = test.read('new_parallel_trace.out', mode='r')
 thread_id = re.compile(r'\[Thread:\d+\]')

--- a/test/option/taskmastertrace.py
+++ b/test/option/taskmastertrace.py
@@ -42,7 +42,7 @@ test.write('Tfile.in', "Tfile.in\n")
 
 expect_stdout = test.wrap_stdout(test.read('taskmaster_expected_stdout_1.txt', mode='r'))
 
-test.run(arguments='--taskmastertrace=- .', stdout=expect_stdout)
+test.run(arguments='--experimental=legacy_sched --taskmastertrace=- .', stdout=expect_stdout)
 
 test.run(arguments='-c .')
 


### PR DESCRIPTION
- Removes support for `--experimental=tm_v2` and makes it the default
- Adds `--experimental=legacy_sched` to opt-in to the old behavior
- Fixes a bug in `SConf.py` where the cached exception was not raised, and the code assumed the current thread had an 'active' exception.
- Uses `NewParallel` for `-j1` builds as well, but disables locking
- Changes `NewParallel` to use the main thread as a worker for `-j1` builds, bringing it more into alignment with the single threaded nature of `Serial`. Parallel builds still block the main thread and use only worker threads, so that all working threads are on the same footing w.r.t. any stack size settings.
- Fixes a broken f-string in `self.trace_message("Found {len(results_queue)} completed tasks to process")`
- Fixes *most* tests that I was able to run locally. The `test/Interactive/taskmastertrace.py` and `test/option/taskmastertrace.py` are still broken since the new scheduler has additional task master tracing output and breaks the comparisons, and I'm not quite sure how to fix it.

Note that I've only run the test suite on my mac and I don't have all the tools available (e.g. Java). It is possible that there are further regressions that I haven't seen, but hopefully the CI run here will reveal that. I'm making this PR draft until decisions are made about any failing tests.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
