### PR TITLE
NewParallel only adds worker threads as executable tasks are discovered

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -68,6 +68,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - CacheDir writes no longer happen within the taskmaster critical section,
       and therefore can run in parallel with both other CacheDir writes and the
       taskmaster DAG walk.
+    - The NewParallel scheduler now only adds threads as new work requiring execution
+      is discovered, up to the limit set by -j. This should reduce resource utilization
+      when the achievable parallelism in the DAG is less than the -j limit.
 
   From Mats Wichmann:
     - Add support for Python 3.13 (as of alpha 2). So far only affects

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -67,6 +67,9 @@ IMPROVEMENTS
         (Larger -j values)
 - CacheDir writes no longer happen within the taskmaster critical section, and therefore
   can run in parallel with both other CacheDir writes and the taskmaster DAG walk.
+- The NewParallel scheduler now only adds threads as new work requiring execution
+  is discovered, up to the limit set by -j. This should reduce resource utilization
+  when the achievable parallelism in the DAG is less than the -j limit.
 
 
 PACKAGING

--- a/SCons/Taskmaster/Job.py
+++ b/SCons/Taskmaster/Job.py
@@ -529,7 +529,8 @@ class NewParallel:
 
     def _maybe_start_worker(self) -> None:
         if self.max_workers > 1 and len(self.workers) < self.max_workers:
-            self._start_worker()
+            if self.jobs >= len(self.workers):
+                self._start_worker()
 
     def _start_worker(self) -> None:
         prev_size = self._adjust_stack_size()

--- a/test/option/fixture/taskmaster_expected_new_parallel.txt
+++ b/test/option/fixture/taskmaster_expected_new_parallel.txt
@@ -1,3 +1,4 @@
+Job.NewParallel._start_worker(): [Thread:XXXXX] Starting new worker thread
 Job.NewParallel._work(): [Thread:XXXXX] Gained exclusive access
 Job.NewParallel._work(): [Thread:XXXXX] Starting search
 Job.NewParallel._work(): [Thread:XXXXX] Found 0 completed tasks to process
@@ -84,7 +85,5 @@ Job.NewParallel._work(): [Thread:XXXXX] Searching for new tasks
 Taskmaster: Looking for a node to evaluate
 Taskmaster: No candidate anymore.
 Job.NewParallel._work(): [Thread:XXXXX] Found no task requiring execution, and have no jobs: marking complete
-Job.NewParallel._work(): [Thread:XXXXX] Gained exclusive access
-Job.NewParallel._work(): [Thread:XXXXX] Completion detected, breaking from main loop
 Job.NewParallel._work(): [Thread:XXXXX] Gained exclusive access
 Job.NewParallel._work(): [Thread:XXXXX] Completion detected, breaking from main loop

--- a/test/option/stack-size.py
+++ b/test/option/stack-size.py
@@ -89,14 +89,14 @@ File .*
 #
 # Test without any options
 #
-test.run(chdir='work1', 
+test.run(chdir='work1',
          arguments = '.',
          stdout=expected_stdout,
          stderr='')
 test.must_exist(['work1', 'f1.out'])
 test.must_exist(['work1', 'f2.out'])
 
-test.run(chdir='work1', 
+test.run(chdir='work1',
          arguments = '-c .')
 test.must_not_exist(['work1', 'f1.out'])
 test.must_not_exist(['work1', 'f2.out'])
@@ -104,14 +104,14 @@ test.must_not_exist(['work1', 'f2.out'])
 #
 # Test with -j2
 #
-test.run(chdir='work1', 
+test.run(chdir='work1',
          arguments = '-j2 .',
          stdout=expected_stdout,
          stderr='')
 test.must_exist(['work1', 'f1.out'])
 test.must_exist(['work1', 'f2.out'])
 
-test.run(chdir='work1', 
+test.run(chdir='work1',
          arguments = '-j2 -c .')
 test.must_not_exist(['work1', 'f1.out'])
 test.must_not_exist(['work1', 'f2.out'])
@@ -120,14 +120,14 @@ test.must_not_exist(['work1', 'f2.out'])
 #
 # Test with --stack-size
 #
-test.run(chdir='work1', 
+test.run(chdir='work1',
          arguments = '--stack-size=128 .',
          stdout=expected_stdout,
          stderr='')
 test.must_exist(['work1', 'f1.out'])
 test.must_exist(['work1', 'f2.out'])
 
-test.run(chdir='work1', 
+test.run(chdir='work1',
          arguments = '--stack-size=128 -c .')
 test.must_not_exist(['work1', 'f1.out'])
 test.must_not_exist(['work1', 'f2.out'])
@@ -135,14 +135,14 @@ test.must_not_exist(['work1', 'f2.out'])
 #
 # Test with SetOption('stack_size', 128)
 #
-test.run(chdir='work2', 
+test.run(chdir='work2',
          arguments = '.',
          stdout=expected_stdout,
          stderr='')
 test.must_exist(['work2', 'f1.out'])
 test.must_exist(['work2', 'f2.out'])
 
-test.run(chdir='work2', 
+test.run(chdir='work2',
          arguments = '--stack-size=128 -c .')
 test.must_not_exist(['work2', 'f1.out'])
 test.must_not_exist(['work2', 'f2.out'])
@@ -151,14 +151,14 @@ if isStackSizeAvailable:
     #
     # Test with -j2 --stack-size=128
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128 .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128 -c .')
     test.must_not_exist(['work1', 'f1.out'])
     test.must_not_exist(['work1', 'f2.out'])
@@ -166,7 +166,7 @@ if isStackSizeAvailable:
     #
     # Test with -j2 --stack-size=16
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 .',
              match=TestSCons.match_re,
              stdout=re_expected_stdout,
@@ -174,14 +174,22 @@ if isStackSizeAvailable:
 scons: warning: Setting stack size failed:
     size not valid: 16384 bytes
 File .*
+
+scons: warning: Setting stack size failed:
+    size not valid: 16384 bytes
+File .*
 """)
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 -c .',
              match=TestSCons.match_re,
              stderr="""
+scons: warning: Setting stack size failed:
+    size not valid: 16384 bytes
+File .*
+
 scons: warning: Setting stack size failed:
     size not valid: 16384 bytes
 File .*
@@ -192,14 +200,14 @@ File .*
     #
     # Test with -j2 SetOption('stack_size', 128)
     #
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2 .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work2', 'f1.out'])
     test.must_exist(['work2', 'f2.out'])
 
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2  -c .')
     test.must_not_exist(['work2', 'f1.out'])
     test.must_not_exist(['work2', 'f2.out'])
@@ -207,14 +215,14 @@ File .*
     #
     # Test with -j2 --stack-size=128 --warn=no-stack-size
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128 --warn=no-stack-size .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128  --warn=no-stack-size -c .')
     test.must_not_exist(['work1', 'f1.out'])
     test.must_not_exist(['work1', 'f2.out'])
@@ -222,29 +230,29 @@ File .*
     #
     # Test with -j2 --stack-size=16 --warn=no-stack-size
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 --warn=no-stack-size .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 --warn=no-stack-size -c .')
     test.must_not_exist(['work1', 'f1.out'])
     test.must_not_exist(['work1', 'f2.out'])
 
     #
-    # Test with -j2  --warn=no-stack-size SetOption('stack_size', 128) 
+    # Test with -j2  --warn=no-stack-size SetOption('stack_size', 128)
     #
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2  --warn=no-stack-size .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work2', 'f1.out'])
     test.must_exist(['work2', 'f2.out'])
 
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2   --warn=no-stack-size -c .')
     test.must_not_exist(['work2', 'f1.out'])
     test.must_not_exist(['work2', 'f2.out'])
@@ -254,7 +262,7 @@ else:
     #
     # Test with -j2 --stack-size=128
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128 .',
              match=TestSCons.match_re,
              stdout=re_expected_stdout,
@@ -262,7 +270,7 @@ else:
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128 -c .',
              match=TestSCons.match_re,
              stderr=expect_unsupported)
@@ -272,7 +280,7 @@ else:
     #
     # Test with -j2 --stack-size=16
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 .',
              match=TestSCons.match_re,
              stdout=re_expected_stdout,
@@ -280,7 +288,7 @@ else:
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 -c .',
              match=TestSCons.match_re,
              stderr=expect_unsupported)
@@ -290,7 +298,7 @@ else:
     #
     # Test with -j2 SetOption('stack_size', 128)
     #
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2 .',
              match=TestSCons.match_re,
              stdout=re_expected_stdout,
@@ -298,7 +306,7 @@ else:
     test.must_exist(['work2', 'f1.out'])
     test.must_exist(['work2', 'f2.out'])
 
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2  -c .',
              match=TestSCons.match_re,
              stderr=expect_unsupported)
@@ -308,14 +316,14 @@ else:
     #
     # Test with -j2 --stack-size=128 --warn=no-stack-size
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128 --warn=no-stack-size .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=128  --warn=no-stack-size -c .')
     test.must_not_exist(['work1', 'f1.out'])
     test.must_not_exist(['work1', 'f2.out'])
@@ -323,29 +331,29 @@ else:
     #
     # Test with -j2 --stack-size=16 --warn=no-stack-size
     #
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 --warn=no-stack-size .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work1', 'f1.out'])
     test.must_exist(['work1', 'f2.out'])
 
-    test.run(chdir='work1', 
+    test.run(chdir='work1',
              arguments = '-j2 --stack-size=16 --warn=no-stack-size -c .')
     test.must_not_exist(['work1', 'f1.out'])
     test.must_not_exist(['work1', 'f2.out'])
 
     #
-    # Test with -j2  --warn=no-stack-size SetOption('stack_size', 128) 
+    # Test with -j2  --warn=no-stack-size SetOption('stack_size', 128)
     #
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2  --warn=no-stack-size .',
              stdout=expected_stdout,
              stderr='')
     test.must_exist(['work2', 'f1.out'])
     test.must_exist(['work2', 'f2.out'])
 
-    test.run(chdir='work2', 
+    test.run(chdir='work2',
              arguments = '-j2   --warn=no-stack-size -c .')
     test.must_not_exist(['work2', 'f1.out'])
     test.must_not_exist(['work2', 'f2.out'])


### PR DESCRIPTION
The status quo with NewParallel is that if you build with -j100 it will create 100 threads immediately. That's sort of unnecessary if the DAG doesn't admit that sort of parallelism. Instead, once a "leader" thread finds work that `needs_execute`, it will spawn a new thread before executing it, unless the -j limit has already been reached.

## Contributor Checklist:

* [Y] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [Y] I have updated `CHANGES.txt` (and read the `README.rst`)
* [N/A?] I have updated the appropriate documentation
