### PR TITLE
Fix an outdated test path in `CONTRIBUTING.rst`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -297,13 +297,13 @@ You may specifically list one or more tests to be run::
 
         $ python runtest.py SCons/BuilderTests.py
 
-        $ python runtest.py test/option-j.py test/Program.py
+        $ python runtest.py test/option/option-j.py test/Program.py
 
 You also use the ``-f`` option to execute just the tests listed in a specified
 text file::
 
         $ cat testlist.txt
-        test/option-j.py
+        test/option/option-j.py
         test/Program.py
         $ python runtest.py -f testlist.txt
 


### PR DESCRIPTION
I wanted to modify option `-j` to have an easy way to set `os.cpu_count()` as number of jobs but I've got utterly lost in the code of the option parser and gave up on this. :'-(
Instead, my humble contribution is to fix an incorrect path in an example in `CONTRIBUTING.rst`. (It looks like the files were grouped into sub-directories since the guide was written.)

I did not modified `CHANGES.txt` because I don't know if such a change qualifies.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
