### PR TITLE
Fix bad typing in Action.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -74,6 +74,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Fixes #3529.
     - Clarify/fix documentation of Scanners in User Guide and Manpage.
       Fixes #4468.
+    - Fix bad typing in Action.py: process() and strfunction().
 
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700


### PR DESCRIPTION
Two methods had added type hints for the new override parameter, but not got them right: it's a dict if defined, else `None` - had been listed as a `bool`. Corrected this and made a few other minor tweaks.

There should be no functional changes.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
