### PR TITLE
Fix bad typing in Action.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -74,6 +74,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Fixes #3529.
     - Clarify/fix documentation of Scanners in User Guide and Manpage.
       Fixes #4468.
+    - Fix bad typing in Action.py: process() and strfunction().
 
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -1254,7 +1254,8 @@ class CommandGeneratorAction(ActionBase):
         try:
             env = self.presub_env
         except AttributeError:
-            import SCons.Defaults  # pylint: disable=import-outside-toplevel
+            env = None
+        if env is None:
             env = SCons.Defaults.DefaultEnvironment()
         act = self._generate([], [], env, 1)
         return str(act)

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -109,6 +109,7 @@ import sys
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from subprocess import DEVNULL, PIPE
+from typing import List, Optional, Tuple
 
 import SCons.Debug
 import SCons.Errors
@@ -117,7 +118,7 @@ import SCons.Util
 
 # we use these a lot, so try to optimize them
 from SCons.Debug import logInstanceCreation
-from SCons.Subst import SUBST_SIG, SUBST_RAW
+from SCons.Subst import SUBST_CMD, SUBST_RAW, SUBST_SIG
 from SCons.Util import is_String, is_List
 
 class _null:
@@ -127,13 +128,10 @@ print_actions = True
 execute_actions = True
 print_actions_presub = False
 
-# Use pickle protocol 1 when pickling functions for signature
-# otherwise python3 and python2 will yield different pickles
-# for the same object.
-# This is due to default being 1 for python 2.7, and 3 for 3.x
-# TODO: We can roll this forward to 2 (if it has value), but not
-# before a deprecation cycle as the sconsigns will change
-ACTION_SIGNATURE_PICKLE_PROTOCOL = 1
+# Use pickle protocol 4 when pickling functions for signature.
+# This is the common format since Python 3.4
+# TODO: use is commented out as not stable since 2017: e0bc3a04d5. Drop?
+# ACTION_SIGNATURE_PICKLE_PROTOCOL = 4
 
 
 def rfile(n):
@@ -448,7 +446,7 @@ def _do_create_action(act, kw):
         return act
 
     if is_String(act):
-        var=SCons.Util.get_environment_var(act)
+        var = SCons.Util.get_environment_var(act)
         if var:
             # This looks like a string that is purely an Environment
             # variable reference, like "$FOO" or "${FOO}".  We do
@@ -1010,18 +1008,18 @@ class CommandAction(_ActionAction):
             return ' '.join(map(str, self.cmd_list))
         return str(self.cmd_list)
 
-    def process(self, target, source, env, executor=None, overrides: bool=False):
+    def process(self, target, source, env, executor=None, overrides: Optional[dict] = None) -> Tuple[List, bool, bool]:
         if executor:
-            result = env.subst_list(self.cmd_list, 0, executor=executor, overrides=overrides)
+            result = env.subst_list(self.cmd_list, SUBST_CMD, executor=executor, overrides=overrides)
         else:
-            result = env.subst_list(self.cmd_list, 0, target, source, overrides=overrides)
-        silent = None
-        ignore = None
+            result = env.subst_list(self.cmd_list, SUBST_CMD, target, source, overrides=overrides)
+        silent = False
+        ignore = False
         while True:
             try: c = result[0][0][0]
             except IndexError: c = None
-            if c == '@': silent = 1
-            elif c == '-': ignore = 1
+            if c == '@': silent = True
+            elif c == '-': ignore = True
             else: break
             result[0][0] = result[0][0][1:]
         try:
@@ -1031,7 +1029,7 @@ class CommandAction(_ActionAction):
             pass
         return result, ignore, silent
 
-    def strfunction(self, target, source, env, executor=None, overrides: bool=False):
+    def strfunction(self, target, source, env, executor=None, overrides: Optional[dict] = None) -> str:
         if self.cmdstr is None:
             return None
         if self.cmdstr is not _null:
@@ -1256,8 +1254,7 @@ class CommandGeneratorAction(ActionBase):
         try:
             env = self.presub_env
         except AttributeError:
-            env = None
-        if env is None:
+            import SCons.Defaults  # pylint: disable=import-outside-toplevel
             env = SCons.Defaults.DefaultEnvironment()
         act = self._generate([], [], env, 1)
         return str(act)


### PR DESCRIPTION
Two methods had added type hints for the new override parameter, but not got them right: it's a dict if defined, else `None`; had been hinted as a `bool`. Corrected this and made a few other minor tweaks.

No test changes: existing tests should exercise the minor changes.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
