### PR TITLE
Add Pseudo() to global functions, had been omitted.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -74,6 +74,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Fixes #3529.
     - Clarify/fix documentation of Scanners in User Guide and Manpage.
       Fixes #4468.
+    - Add Pseudo() to global functions, had been omitted. Fixes #4474.
 
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -52,6 +52,8 @@ FIXES
   build of the project file fails.
 - On Windows platform, when collecting command output (Configure checks),
   make sure decoding of bytes doesn't fail.
+- Documentation indicated that both Pseudo() and env.Pseudo() were usable,
+  but Pseudo() did not work; is now enabled.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -343,6 +343,7 @@ GlobalDefaultEnvironmentFunctions = [
     'Local',
     'ParseDepends',
     'Precious',
+    'Pseudo',
     'PyPackageDir',
     'Repository',
     'Requires',


### PR DESCRIPTION
When `Pseudo` was added in SCons 2.3.1, it was not added to the `GlobalDefaultEnvironmentFunctions` table which makes environment methods available in the default environment.

Reworked the test so it does not rewrite the test `SConstruct` repeatedly, and added steps to test the global function version as well.

No doc impacts - this brings behavior in line with existing documentation.

Fixes #4474.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
