### PR TITLE
Explicitly wrap non-serializable values in json dump

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -43,6 +43,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       method so that the generated function argument list matches the function's
       prototype when including a header file.
 
+  From Thaddeus Crews:
+    - Explicitly wrap non-serializable values in json dump
+
   From William Deegan:
     - Fix sphinx config to handle SCons versions with post such as: 4.6.0.post1
 
@@ -1437,12 +1440,12 @@ RELEASE 3.1.0 - Mon, 20 Jul 2019 16:59:23 -0700
       scons: rebuilding `file3' because:
            the dependency order changed:
            ->Sources
-           Old:xxx	New:zzz
-           Old:yyy	New:yyy
-           Old:zzz	New:xxx
+           Old:xxx  New:zzz
+           Old:yyy  New:yyy
+           Old:zzz  New:xxx
            ->Depends
            ->Implicit
-           Old:/usr/bin/python	New:/usr/bin/python
+           Old:/usr/bin/python  New:/usr/bin/python
     - Fix Issue #3350 - SCons Exception EnvironmentError is conflicting with Python's EnvironmentError.
     - Fix spurious rebuilds on second build for cases where builder has > 1 target and the source file
       is generated. This was causing the > 1th target to not have it's implicit list cleared when the source

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -75,6 +75,8 @@ IMPROVEMENTS
 - The NewParallel scheduler now only adds threads as new work requiring execution
   is discovered, up to the limit set by -j. This should reduce resource utilization
   when the achievable parallelism in the DAG is less than the -j limit.
+- Dumping an environment with `json` formatting will now explicitly specify if a given
+  value cannot be serialized.
 
 
 PACKAGING

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1708,7 +1708,7 @@ class Base(SubstitutionEnvironment):
         elif fmt == 'json':
             import json
             def non_serializable(obj):
-                return str(type(obj).__qualname__)
+                return '<<non-serializable: %s>>' % type(obj).__qualname__
             return json.dumps(cvars, indent=4, default=non_serializable)
         else:
             raise ValueError("Unsupported serialization format: %s." % fmt)

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -3177,11 +3177,12 @@ def generate(env):
     def test_Dump(self) -> None:
         """Test the Dump() method"""
 
-        env = self.TestEnvironment(FOO = 'foo')
+        env = self.TestEnvironment(FOO='foo', FOOFLAGS=CLVar('--bar --baz'))
         assert env.Dump('FOO') == "'foo'", env.Dump('FOO')
         assert len(env.Dump()) > 200, env.Dump()    # no args version
 
         assert env.Dump('FOO', 'json') == '"foo"'    # JSON key version
+        self.assertEqual(env.Dump('FOOFLAGS', 'json'), '"<<non-serializable: CLVar>>"')
         import json
         env_dict = json.loads(env.Dump(format = 'json'))
         assert env_dict['FOO'] == 'foo'    # full JSON version


### PR DESCRIPTION
Minor adjustment to environment dumps in the `json` format style. The change now lets the dump specify if a given value cannot be serialized. On top of just looking cleaner imo, it also reduces the likelyhood of mistaking a non-serialized fallback value for a generic string. I don't *think* any existing unit tests need to be adjusted/added as a result of this, with the change being fairly self-contained & there not seeming to be anything testing this beforehand.

Before:
```json
{
    "ExampleKey": "ExampleValue",
    "SomeString": "SomeString"
}
```

After:
```json
{
    "ExampleKey": "<<non-serializable: ExampleValue>>",
    "SomeString": "SomeString"
}
```

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
