### PR TITLE
Fix #3935 OSErrors being hidden

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,6 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Mats Wichmann:
-
     - Updated Value Node docs and tests.
     - Python 3.13 compat: re.sub deprecated count, flags as positional args,
       caused update-release-info test to fail.
@@ -19,6 +18,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       json output is also sorted, to match the default display.
     - Python 3.13 (alpha) changes the behavior of isabs() on Windows. Adjust
       SCons usage of in NodeInfo classes to match.  Fixes #4502, #4504.
+
+  From Raymond Li:
+    - Fix issue #3935: OSErrors are now no longer hidden during execution of
+      Actions. All exceptions during the execution of an Action are now
+      returned by value rather than by raising an exception, for more
+      consistent behavior.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,12 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Raymond Li:
+    - Fix issue #3935: OSErrors are now no longer hidden during execution of
+      Actions. All exceptions during the execution of an Action are now
+      returned by value rather than by raising an exception, for more
+      consistent behavior.
+
   From Mats Wichmann:
     - Updated Value Node docs and tests.
     - Python 3.13 compat: re.sub deprecated count, flags as positional args,
@@ -18,12 +24,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       json output is also sorted, to match the default display.
     - Python 3.13 (alpha) changes the behavior of isabs() on Windows. Adjust
       SCons usage of in NodeInfo classes to match.  Fixes #4502, #4504.
-
-  From Raymond Li:
-    - Fix issue #3935: OSErrors are now no longer hidden during execution of
-      Actions. All exceptions during the execution of an Action are now
-      returned by value rather than by raising an exception, for more
-      consistent behavior.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,9 +13,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix issue #3935: OSErrors are now no longer hidden during execution of
       Actions. All exceptions during the execution of an Action are now
       returned by value rather than by raising an exception, for more
-      consistent behavior. With this change, user created Actions should now
-      catch and handle expected exceptions (whereas previously many of these
-      were silently caught and suppressed by the SCons Action exection code).
+      consistent behavior.
+      NOTE: With this change, user created Actions should now catch and handle
+      expected exceptions (whereas previously many of these were silently
+      caught and suppressed by the SCons Action exection code).
 
   From Mats Wichmann:
     - Updated Value Node docs and tests.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix issue #3935: OSErrors are now no longer hidden during execution of
       Actions. All exceptions during the execution of an Action are now
       returned by value rather than by raising an exception, for more
-      consistent behavior.
+      consistent behavior. With this change, user created Actions should now
+      catch and handle expected exceptions (whereas previously many of these
+      were silently caught and suppressed by the SCons Action exection code).
 
   From Mats Wichmann:
     - Updated Value Node docs and tests.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -32,10 +32,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - Python 3.13 changes the behavior of isabs() on Windows. Adjust SCons
   usage of this in NodeInfo classes to avoid test problems.
 - All exceptions during the execution of an Action are now returned by value
-  rather than by raising an exception, for more consistent behavior. With this
-  change, user created Actions should now catch and handle expected exceptions
-  (whereas previously many of these were silently caught and suppressed by the
-  SCons Action exection code).
+  rather than by raising an exception, for more consistent behavior.
+  NOTE: With this change, user created Actions should now catch and handle
+  expected exceptions (whereas previously many of these were silently caught
+  and suppressed by the SCons Action exection code).
 
 FIXES
 -----

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -31,11 +31,13 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   json output is also sorted, to match the default display.
 - Python 3.13 changes the behavior of isabs() on Windows. Adjust SCons
   usage of this in NodeInfo classes to avoid test problems.
+- All exceptions during the execution of an Action are now returned by value
+  rather than by raising an exception, for more consistent behavior.
 
 FIXES
 -----
 
-- List fixes of outright bugs
+- OSErrors are now no longer hidden during the execution of Actions.
 
 IMPROVEMENTS
 ------------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -32,7 +32,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - Python 3.13 changes the behavior of isabs() on Windows. Adjust SCons
   usage of this in NodeInfo classes to avoid test problems.
 - All exceptions during the execution of an Action are now returned by value
-  rather than by raising an exception, for more consistent behavior.
+  rather than by raising an exception, for more consistent behavior. With this
+  change, user created Actions should now catch and handle expected exceptions
+  (whereas previously many of these were silently caught and suppressed by the
+  SCons Action exection code).
 
 FIXES
 -----

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -1461,7 +1461,7 @@ class FunctionAction(_ActionAction):
                 # some codes do not check the return value of Actions and I do
                 # not have the time to modify them at this point.
                 if (exc_info[1] and
-                    not isinstance(exc_info[1], EnvironmentError)):
+                    not isinstance(exc_info[1], SCons.Errors.SConsEnvironmentError)):
                     raise result
 
             return result

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -1454,16 +1454,6 @@ class FunctionAction(_ActionAction):
                 except TypeError:
                     result.command=self.strfunction(target, source, env)
 
-                # FIXME: This maintains backward compatibility with respect to
-                # which type of exceptions were returned by raising an
-                # exception and which ones were returned by value. It would
-                # probably be best to always return them by value here, but
-                # some codes do not check the return value of Actions and I do
-                # not have the time to modify them at this point.
-                if (exc_info[1] and
-                    not isinstance(exc_info[1], SCons.Errors.SConsEnvironmentError)):
-                    raise result
-
             return result
         finally:
             # Break the cycle between the traceback object and this

--- a/SCons/CacheDirTests.py
+++ b/SCons/CacheDirTests.py
@@ -164,7 +164,7 @@ class ExceptionTestCase(unittest.TestCase):
         # so that _readconfig* will try to rewrite it
         old_config = os.path.join(self._CacheDir.path, "config")
         os.remove(old_config)
-        
+
         try:
             self._CacheDir._readconfig(self._CacheDir.path)
             assert False, "Should have raised exception and did not"
@@ -315,23 +315,17 @@ class FileTestCase(BaseTestCase):
         old_warn_exceptions = SCons.Warnings.warningAsException(1)
         SCons.Warnings.enableWarningClass(SCons.Warnings.CacheWriteErrorWarning)
 
-        try:
-            cd_f7 = self.test.workpath("cd.f7")
-            self.test.write(cd_f7, "cd.f7\n")
-            f7 = self.File(cd_f7, 'f7_bsig')
+        cd_f7 = self.test.workpath("cd.f7")
+        self.test.write(cd_f7, "cd.f7\n")
+        f7 = self.File(cd_f7, 'f7_bsig')
 
-            warn_caught = 0
-            try:
-                f7.push_to_cache()
-            except SCons.Errors.BuildError as e:
-                assert e.exc_info[0] == SCons.Warnings.CacheWriteErrorWarning
-                warn_caught = 1
-            assert warn_caught
-        finally:
-            shutil.copy2 = save_copy2
-            os.mkdir = save_mkdir
-            SCons.Warnings.warningAsException(old_warn_exceptions)
-            SCons.Warnings.suppressWarningClass(SCons.Warnings.CacheWriteErrorWarning)
+        warn_caught = 0
+        r = f7.push_to_cache()
+        assert r.exc_info[0] == SCons.Warnings.CacheWriteErrorWarning
+        shutil.copy2 = save_copy2
+        os.mkdir = save_mkdir
+        SCons.Warnings.warningAsException(old_warn_exceptions)
+        SCons.Warnings.suppressWarningClass(SCons.Warnings.CacheWriteErrorWarning)
 
     def test_no_strfunction(self) -> None:
         """Test handling no strfunction() for an action."""

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -291,7 +291,15 @@ def copy_func(dest, src, symlinks: bool=True) -> int:
 
     elif os.path.islink(src):
         if symlinks:
-            os.symlink(os.readlink(src), dest)
+            try:
+                os.symlink(os.readlink(src), dest)
+            except FileExistsError:
+                raise SCons.Errors.BuildError(
+                    errstr=(
+                        f'Error: Copy() called to create symlink at "{dest}",'
+                        ' but a file already exists at that location.'
+                    )
+                )
             return 0
 
         return copy_func(dest, os.path.realpath(src))

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -2999,7 +2999,7 @@ class File(Base):
         # created.
         self.dir._create()
 
-    def push_to_cache(self) -> None:
+    def push_to_cache(self) -> bool:
         """Try to push the node into a cache
         """
         # This should get called before the Nodes' .built() method is
@@ -3010,10 +3010,10 @@ class File(Base):
         # the node to cache so that the memoization of the self.exists()
         # return value doesn't interfere.
         if self.nocache:
-            return
+            return None
         self.clear_memoized_values()
         if self.exists():
-            self.get_build_env().get_CacheDir().push(self)
+            return self.get_build_env().get_CacheDir().push(self)
 
     def retrieve_from_cache(self) -> bool:
         """Try to retrieve the node's content from a cache

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -678,7 +678,7 @@ class Node(metaclass=NoSlotsPyPy):
         except AttributeError:
             pass
 
-    def push_to_cache(self) -> None:
+    def push_to_cache(self) -> bool:
         """Try to push a node into a cache
         """
         pass

--- a/SCons/SConfTests.py
+++ b/SCons/SConfTests.py
@@ -207,7 +207,7 @@ class SConfTestCase(unittest.TestCase):
                         return False
                     def prepare(self) -> None:
                         pass
-                    def push_to_cache(self) -> None:
+                    def push_to_cache(self) -> bool:
                         pass
                     def retrieve_from_cache(self) -> bool:
                         return False

--- a/SCons/Taskmaster/TaskmasterTests.py
+++ b/SCons/Taskmaster/TaskmasterTests.py
@@ -72,7 +72,7 @@ class Node:
     def disambiguate(self):
         return self
 
-    def push_to_cache(self) -> None:
+    def push_to_cache(self) -> bool:
         pass
 
     def retrieve_from_cache(self) -> bool:

--- a/SCons/Variables/PathVariable.py
+++ b/SCons/Variables/PathVariable.py
@@ -109,6 +109,9 @@ class _PathVariableClass:
         except PermissionError:
             m = 'Path for option %s could not be created: %s'
             raise SCons.Errors.UserError(m % (key, val))
+        except OSError:
+            m = 'Path for option %s could not be created: %s'
+            raise SCons.Errors.UserError(m % (key, val))
 
     @staticmethod
     def PathIsFile(key, val, env) -> None:


### PR DESCRIPTION
Fixes #3935

## Explanations
- `FSTests:test_srcdir_duplicate` -> `FS.Dir:bld1.srcdir_duplicate('exists')` -> `FS.File:node.do_duplicate(srcnode)` -> `FS:Unlink(self, None, None)` -> `FS:UnlinkFunc` -> `t.fs.unlink(file)` -> throws `FileNotFoundError` when file does not exist, wrap in try-except
- The new fix means `e = Link(self, src, None)` in `FS.File:node.do_duplicate()` raises `SCons.Errors.BuildError` instead of returning them, so we catch it and raise (along with raising when an error is returned)

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
