### PR TITLE
Cleanup Warnings module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -99,6 +99,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       describe the Microsoft C++ compiler. Update the version table slightly.
       Amplified the usage of MSVC_VERSION.
     - Improve SharedLibrary docs a bit.
+    - Update warnings module: adds docstrings, drop three unused warnings
+      (DeprecatedSourceCodeWarning, TaskmasterNeedsExecuteWarning,
+      DeprecatedMissingSConscriptWarning) add two warnings to manpage
+      (cache-cleanup-error, future-reserved-variable), improve unittest, tweak
+      Sphinx build.
 
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -34,6 +34,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   prototype when including a header file. Fixes GH Issue #4320
 - Now supports pre-release Python 3.13
 - Support for Python versions without support for the `threading` package has been removed
+- Dropped three unused warning classes: DeprecatedSourceCodeWarning,
+  TaskmasterNeedsExecuteWarning, DeprecatedMissingSConscriptWarning.
+* Two warning classes that are actually used were added to manpage section on
+  enabling warnings (cache-cleanup-error, future-reserved-variable).
 
 FIXES
 -----
@@ -90,6 +94,8 @@ DOCUMENTATION
   the Scanner Objects section of the manpage.
 - The manpage entry for Pseudo was clarified.
 - The manpage entry for SharedLibrary was clarified.
+- Update API docs for Warnings framework; add two warns to manpage
+  enable/disable control.
 
 DEVELOPMENT
 -----------

--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -875,9 +875,9 @@ def Parser(version):
 
     def warn_md5_chunksize_deprecated(option, opt, value, parser) -> None:
         if opt == '--md5-chunksize':
-            SCons.Warnings.warn(SCons.Warnings.DeprecatedWarning,
-                                "Parameter %s is deprecated. Use "
-                                "--hash-chunksize instead." % opt)
+            SCons.Warnings.warn(SCons.Warnings.DeprecatedOptionsWarning,
+                                f"Option {opt} is deprecated. "
+                                "Use --hash-chunksize instead.")
 
         setattr(parser.values, option.dest, value)
 

--- a/SCons/Warnings.py
+++ b/SCons/Warnings.py
@@ -21,159 +21,211 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""The SCons warnings framework."""
+"""The SCons Warnings framework.
+
+Enables issuing warnings in situations where it is useful to alert
+the user of a condition that does not warrant raising an exception
+that could terminate the program.
+
+A new warning class should inherit (perhaps indirectly) from one of
+two base classes: :exc:`SConsWarning` or :exc:`WarningOnByDefault`,
+which are the same except warnings derived from the latter will start
+out in an enabled state. Enabled warnings cause a message to be
+printed when called, disabled warnings are silent.
+
+There is also a hierarchy for indicating deprecations and future
+changes: for these, derive from :exc:`DeprecatedWarning`,
+:exc:`MandatoryDeprecatedWarning`, :exc:`FutureDeprecatedWarning`
+or :exc:`FutureReservedVariableWarning`.
+
+Whether or not to display warnings, beyond those that are on by
+default, is controlled through the command line (``--warn``) or
+through ``SetOption('warn')``.  The names used there use a different
+naming style than the warning class names. :func:`process_warn_strings`
+converts the names before enabling/disabling.
+
+The behavior of issuing only a message (for "enabled" warnings) can
+be toggled to raising an exception instead by calling the
+:func:`warningAsException` function.
+
+For new/removed warnings, the manpage needs to be kept in sync.
+Any warning class defined here is accepted, but we don't want to make
+people have to dig around to find the names.  Warnings do not have to
+be defined in this file, though it is preferred: those defined elsewhere
+cannot use the enable/disable functionality unless they monkeypatch the
+warning into this module's namespace.
+
+You issue a warning, either in SCons code or in a build project's
+SConscripts, by calling the :func:`warn` function defined in this module.
+Raising directly with an instance of a warning class bypasses the
+framework and it will behave like an ordinary exception.
+"""
 
 import sys
+from typing import Callable, Sequence, Optional
 
 import SCons.Errors
 
+# _enabled is a list of 2-tuples with a warning class object and a
+# boolean (True if that warning is enabled). Initialized in SCons/Main.py.
+_enabled = []
+
+# If False, just emit the msg for an enabled warning; else raise exception
+_warningAsException: bool = False
+
+# Function to emit the warning. Initialized by SCons/Main.py for regular use;
+# the unit test will set to a capturing version for testing.
+_warningOut: Optional[Callable] = None
+
+
 class SConsWarning(SCons.Errors.UserError):
-    pass
+    """Base class for all SCons warnings."""
 
 class WarningOnByDefault(SConsWarning):
-    pass
+    """Base class for SCons warnings that are enabled by default."""
 
+SConsWarningOnByDefault = WarningOnByDefault  # transition to new name
 
-# NOTE:  If you add a new warning class, add it to the man page, too!
-# Not all warnings are defined here, some are defined in the location of use
-
-class TargetNotBuiltWarning(SConsWarning): # Should go to OnByDefault
-    pass
-
-class CacheVersionWarning(WarningOnByDefault):
-    pass
-
-class CacheWriteErrorWarning(SConsWarning):
-    pass
-
-class CacheCleanupErrorWarning(SConsWarning):
-    pass
-
-class CorruptSConsignWarning(WarningOnByDefault):
-    pass
-
-class DependencyWarning(SConsWarning):
-    pass
-
-class DevelopmentVersionWarning(WarningOnByDefault):
-    pass
-
-class DuplicateEnvironmentWarning(WarningOnByDefault):
-    pass
-
-class FutureReservedVariableWarning(WarningOnByDefault):
-    pass
 
 class LinkWarning(WarningOnByDefault):
-    pass
+    """Base class for linker warnings."""
 
-class MisleadingKeywordsWarning(WarningOnByDefault):
-    pass
+# NOTE:  If you add a new warning class here, add it to the man page, too!
 
-# TODO: no longer needed, now an error instead of warning. Leave for a bit.
-class MissingSConscriptWarning(WarningOnByDefault):
-    pass
+# General warnings
 
-class NoObjectCountWarning(WarningOnByDefault):
-    pass
+class CacheVersionWarning(WarningOnByDefault):
+    """The derived-file cache directory has an out of date config."""
 
-class NoParallelSupportWarning(WarningOnByDefault):
-    pass
+class CacheWriteErrorWarning(SConsWarning):
+    """Problems writing a derived file to the cache."""
 
-class ReservedVariableWarning(WarningOnByDefault):
-    pass
+class CacheCleanupErrorWarning(SConsWarning):
+    """Problems removing retrieved target prior to rebuilding."""
 
-class StackSizeWarning(WarningOnByDefault):
-    pass
+class CorruptSConsignWarning(WarningOnByDefault):
+    """Problems decoding the contents of the sconsign database."""
 
-class VisualCMissingWarning(WarningOnByDefault):
-    pass
+class DependencyWarning(SConsWarning):
+    """A scanner identified a dependency but did not add it."""
 
-# Used when MSVC_VERSION and MSVS_VERSION do not point to the
-# same version (MSVS_VERSION is deprecated)
-class VisualVersionMismatch(WarningOnByDefault):
-    pass
+class DevelopmentVersionWarning(WarningOnByDefault):
+    """Use of a deprecated feature."""
 
-class VisualStudioMissingWarning(SConsWarning):
-    pass
+class DuplicateEnvironmentWarning(WarningOnByDefault):
+    """A target appears in more than one consenv with identical actions.
+
+    A duplicate target with different rules cannot be built;
+    with the same rule it can, but this could indicate a problem in
+    the build configuration.
+    """
 
 class FortranCxxMixWarning(LinkWarning):
+    """Fortran and C++ objects appear together in a link line.
+
+    Some compilers support this, others do not.
+    """
+
+class FutureReservedVariableWarning(WarningOnByDefault):
+    """Setting a variable marked to become reserved in a future release."""
+
+class MisleadingKeywordsWarning(WarningOnByDefault):
+    """Use of possibly misspelled kwargs in Builder calls."""
+
+class MissingSConscriptWarning(WarningOnByDefault):
+    """The script specified in an SConscript() call was not found.
+
+    TODO: this is now an error, so no need for a warning. Left in for
+    a while in case anyone is using, remove eventually.
+
+    Manpage entry removed in 4.6.0.
+    """
+
+class NoObjectCountWarning(WarningOnByDefault):
+    """Object counting (debug mode) could not be enabled."""
+
+class NoParallelSupportWarning(WarningOnByDefault):
+    """Fell back to single-threaded build, as no thread support found."""
+
+class ReservedVariableWarning(WarningOnByDefault):
+    """Attempt to set reserved construction variable names."""
+
+class StackSizeWarning(WarningOnByDefault):
+    """Requested thread stack size could not be set."""
+
+class TargetNotBuiltWarning(SConsWarning): # TODO: should go to OnByDefault
+    """A target build indicated success but the file is not found."""
+
+class VisualCMissingWarning(WarningOnByDefault):
+    """Requested MSVC version not found and policy is to not fail."""
+
+class VisualVersionMismatch(WarningOnByDefault):
+    """``MSVC_VERSION`` and ``MSVS_VERSION`` do not match.
+
+    Note ``MSVS_VERSION`` is deprecated, use ``MSVC_VERSION``.
+    """
+
+class VisualStudioMissingWarning(SConsWarning):  # TODO: unused
     pass
 
 
 # Deprecation warnings
 
 class FutureDeprecatedWarning(SConsWarning):
-    pass
+    """Base class for features that will become deprecated in a future release."""
 
 class DeprecatedWarning(SConsWarning):
-    pass
+    """Base class for deprecated features, will be removed in future."""
 
 class MandatoryDeprecatedWarning(DeprecatedWarning):
-    pass
+    """Base class for deprecated features where warning cannot be disabled."""
 
 
 # Special case; base always stays DeprecatedWarning
 class PythonVersionWarning(DeprecatedWarning):
-    pass
-
-class DeprecatedSourceCodeWarning(FutureDeprecatedWarning):
-    pass
-
-class TaskmasterNeedsExecuteWarning(DeprecatedWarning):
-    pass
+    """SCons was run with a deprecated Python version."""
 
 class DeprecatedOptionsWarning(MandatoryDeprecatedWarning):
-    pass
+    """Options that are deprecated."""
 
 class DeprecatedDebugOptionsWarning(MandatoryDeprecatedWarning):
+    """Option-arguments to --debug that are deprecated."""
+
+class ToolQtDeprecatedWarning(DeprecatedWarning):  # TODO: unused
     pass
 
-class DeprecatedMissingSConscriptWarning(DeprecatedWarning):
-    pass
-
-class ToolQtDeprecatedWarning(DeprecatedWarning):
-    pass
-
-# The below is a list of 2-tuples.  The first element is a class object.
-# The second element is true if that class is enabled, false if it is disabled.
-_enabled = []
-
-# If set, raise the warning as an exception
-_warningAsException = False
-
-# If not None, a function to call with the warning
-_warningOut = None
 
 def suppressWarningClass(clazz) -> None:
-    """Suppresses all warnings of type clazz or derived from clazz."""
+    """Suppresses all warnings of type *clazz* or derived from *clazz*."""
     _enabled.insert(0, (clazz, False))
 
 def enableWarningClass(clazz) -> None:
-    """Enables all warnings of type clazz or derived from clazz."""
+    """Enables all warnings of type *clazz* or derived from *clazz*."""
     _enabled.insert(0, (clazz, True))
 
-def warningAsException(flag: bool=True):
-    """Set global _warningAsExeption flag.
+def warningAsException(flag: bool = True) -> bool:
+    """Sets global :data:`_warningAsExeption` flag.
+
+    If true, any enabled warning will cause an exception to be raised.
 
     Args:
-        flag: value to set warnings-as-exceptions to [default: True]
+        flag: new value for warnings-as-exceptions.
 
     Returns:
         The previous value.
     """
-    global _warningAsException
+    global _warningAsException  # pylint: disable=global-statement
     old = _warningAsException
     _warningAsException = flag
     return old
 
-def warn(clazz, *args):
+def warn(clazz, *args) -> None:
     """Issue a warning, accounting for SCons rules.
 
-    Check if warnings for this class are enabled.
-    If warnings are treated as exceptions, raise exception.
-    Use the global warning-emitter _warningOut, which allows selecting
-    different ways of presenting a traceback (see Script/Main.py)
+    Check if warnings for this class are enabled.  If warnings are treated
+    as exceptions, raise exception.  Use the global warning emitter
+    :data:`_warningOut`, which allows selecting different ways of
+    presenting a traceback (see Script/Main.py).
     """
     warning = clazz(args)
     for cls, flag in _enabled:
@@ -182,30 +234,32 @@ def warn(clazz, *args):
                 if _warningAsException:
                     raise warning
 
-                if _warningOut:
+                if _warningOut is not None:
                     _warningOut(warning)
             break
 
-def process_warn_strings(arguments) -> None:
+def process_warn_strings(arguments: Sequence[str]) -> None:
     """Process requests to enable/disable warnings.
 
-    The requests are strings passed to the --warn option or the
-    SetOption('warn') function.
+    The requests come from the option-argument string passed to the
+    ``--warn`` command line option or as the value passed to the
+    ``SetOption`` function with a first argument of ``warn``;
 
-    An argument to this option should be of the form "warning-class"
-    or "no-warning-class".  The warning class is munged and has
-    the suffix "Warning" added in order to get an actual class name
-    from the classes above, which we need to pass to the
-    {enable,disable}WarningClass() functions.
 
-    For example, "deprecated" will enable the DeprecatedWarning class.
-    "no-dependency" will disable the DependencyWarning class.
+    The arguments are expected to be as documented in the SCons manual
+    page for the ``--warn`` option, in the style ``some-type``,
+    which is converted here to a camel-case name like ``SomeTypeWarning``,
+    to try to match the warning classes defined here, which are then
+    passed to :func:`enableWarningClass` or :func:`suppressWarningClass`.
 
-    As a special case, --warn=all and --warn=no-all will enable or
-    disable (respectively) the base class of all SCons warnings.
+    For example, a string``"deprecated"`` enables the
+    :exc:`DeprecatedWarning` class, while a string``"no-dependency"``
+    disables the :exc:`DependencyWarning` class.
+
+    As a special case, the string ``"all"`` disables all warnings and
+    a the string ``"no-all"`` disables all warnings.
     """
-
-    def _classmunge(s):
+    def _classmunge(s: str) -> str:
         """Convert a warning argument to SConsCase.
 
         The result is CamelCase, except "Scons" is changed to "SCons"
@@ -215,7 +269,10 @@ def process_warn_strings(arguments) -> None:
 
     for arg in arguments:
         enable = True
-        if arg.startswith("no-"):
+        if arg.startswith("no-") and arg not in (
+            "no-object-count",
+            "no-parallel-support",
+        ):
             enable = False
             arg = arg[len("no-") :]
         if arg == 'all':
@@ -225,13 +282,12 @@ def process_warn_strings(arguments) -> None:
         try:
             clazz = globals()[class_name]
         except KeyError:
-            sys.stderr.write("No warning type: '%s'\n" % arg)
+            sys.stderr.write(f"No warning type: {arg!r}\n")
         else:
             if enable:
                 enableWarningClass(clazz)
             elif issubclass(clazz, MandatoryDeprecatedWarning):
-                fmt = "Can not disable mandataory warning: '%s'\n"
-                sys.stderr.write(fmt % arg)
+                sys.stderr.write(f"Can not disable mandataory warning: {arg!r}\n")
             else:
                 suppressWarningClass(clazz)
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2174,6 +2174,15 @@ These warnings are disabled by default.</para>
   </varlistentry>
 
   <varlistentry>
+  <term><emphasis role="bold">cache-cleanup-error</emphasis></term>
+  <listitem>
+<para>Warnings about errors when a file retrieved
+from the derived-file cache could not be removed.
+</para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><emphasis role="bold">corrupt-sconsign</emphasis></term>
   <listitem>
 <para>Warnings about unfamiliar signature data in
@@ -2224,6 +2233,16 @@ These warnings are enabled by default.</para>
 <para>Warnings about linking
 Fortran and C++ object files in a single executable,
 which can yield unpredictable behavior with some compilers.</para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
+  <term><emphasis role="bold">future-reserved-variable</emphasis></term>
+  <listitem>
+<para>Warnings about construction variables which
+are currently allowed,
+but will become reserved variables in a future release.
+</para>
   </listitem>
   </varlistentry>
 
@@ -2296,6 +2315,10 @@ feature not working when
 is run with the &Python;
 <option>-O</option>
 option or from optimized &Python; (<filename>.pyo</filename>) modules.</para>
+<para>
+Note the "no-" prefix is part of the name of this warning.
+Add an additional "-no" to disable.
+</para>
   </listitem>
   </varlistentry>
 
@@ -2307,6 +2330,10 @@ not being able to support parallel builds when the
 <option>-j</option>
 option is used.
 These warnings are enabled by default.</para>
+<para>
+Note the "no-" prefix is part of the name of this warning.
+Add an additional "-no" to disable.
+</para>
   </listitem>
   </varlistentry>
 

--- a/doc/sphinx/SCons.rst
+++ b/doc/sphinx/SCons.rst
@@ -143,11 +143,13 @@ SCons.Subst module
 
 SCons.Warnings module
 ---------------------
+.. Turn off inherited members to quiet fluff from the Python base Exception
 
 .. automodule:: SCons.Warnings
     :members:
     :undoc-members:
     :show-inheritance:
+    :no-inherited-members:
 
 SCons.cpp module
 ----------------

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -10,15 +10,17 @@ SCons API Documentation
    This is the **internal** API Documentation for SCons.
    The documentation is automatically generated for each release
    from the source code using the
-   `Sphinx <https://www.sphinx-doc.org>`_ tool.
+   `Sphinx <https://www.sphinx-doc.org>`_ documentation generator.
    Missing information is due to shortcomings in the docstrings in the code,
-   which are by no means complete (contributions welcomed!).
+   which admittedly could use a lot more work (contributions welcomed!).
 
-   The target audience is developers working on SCons itself:
-   what is "Public API" is not clearly deliniated here.
-   The interfaces available for use in SCons configuration scripts,
-   which have a consistency guarantee, are those documented in the
-   `SCons Reference Manual
+   The target audience is both developers working on SCons itself,
+   and those writing external Tools, Builders, etc. and other
+   related functionality, who need to reach beyond the Public API.
+   Note that what is Public API is not clearly deliniated in the API Docs.
+   The interfaces available for use in SCons configuration scripts
+   ("SConscript files"), which have a consistency guarantee,
+   are those documented in the `SCons Reference Manual
    <https://scons.org/doc/production/HTML/scons-man.html>`_.
 
 .. toctree::


### PR DESCRIPTION
* Added docstrings on warning classes and module docstring.
* Move globals to top of file.
* Typing.
* Dropped `DeprecatedSourceCodeWarning`, last use was removed, with the feature, for SCons 3.1.2.
* Dropped `TaskmasterNeedsExecuteWarning`, now enforced by Python via an abstract base class (unused/unneeded since 4.0.0).
* Dropped `DeprecatedMissingSConscriptWarning`. This was a transitional warning, no longer needed; can use `MissingSConscriptWarning`, which also is no longer used but is left in in case it might be useful.
* Two in-use warnings added to manpage section on enabling warnings.
* Improve unit test a bit.
* Sphinx build set not to show inherited member for Warnings - got ugly exception stuff otherwise.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
