### PR TITLE
Lock creation of CacheDir config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -104,6 +104,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       DeprecatedMissingSConscriptWarning) add two warnings to manpage
       (cache-cleanup-error, future-reserved-variable), improve unittest, tweak
       Sphinx build.
+    - Add locking around creation of CacheDir config file. Fixes #4489.
 
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -62,6 +62,7 @@ FIXES
   scanners - try harder to decode non-UTF-8 text.
 - PyPackageDir no longer fails if passed a module name which cannot be found,
   now returns None.
+- Add locking around creation of CacheDir config file. Fixes issue #4489.
 
 
 IMPROVEMENTS

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -173,7 +173,7 @@ def read_script_env_cache() -> dict:
     p = Path(CONFIG_CACHE)
     if not CONFIG_CACHE or not p.is_file():
         return envcache
-    with SCons.Util.FileLock(CONFIG_CACHE, timeout=5, writer=True), p.open('r') as f:
+    with SCons.Util.FileLock(CONFIG_CACHE, timeout=5, writer=False), p.open('r') as f:
         # Convert the list of cache entry dictionaries read from
         # json to the cache dictionary. Reconstruct the cache key
         # tuple from the key list written to json.

--- a/SCons/Util/filelock.py
+++ b/SCons/Util/filelock.py
@@ -42,7 +42,7 @@ class SConsLockFailure(Exception):
 class FileLock:
     """Lock a file using a lockfile.
 
-    Locking for the case where multiple processes try to hit an externally
+    Basic locking for when multiple processes may hit an externally
     shared resource that cannot depend on locking within a single SCons
     process. SCons does not have a lot of those, but caches come to mind.
 
@@ -51,8 +51,9 @@ class FileLock:
     and :meth:`release_lock`.
 
     Lock can be a write lock, which is held until released, or a read
-    lock, which releases immediately upon aquisition - the interesting
-    thing being to not read a file which somebody else may be writing,
+    lock, which releases immediately upon aquisition - we want to not
+    read a file which somebody else may be writing, but not create the
+    writers starvation problem of the classic readers/writers lock.
 
     TODO: Should default timeout be None (non-blocking), or 0 (block forever),
        or some arbitrary number?


### PR DESCRIPTION
When creating a new `CacheDir`, the config file is created in exclusive mode (that is, it fails if it exists), but there's a small timing window before the json dump to the file completes when another thread could read the config because it exists - but get a `JSONDecodeError` because it hasn't finished writing yet.  Add locking, so the readers will have to wait until the writer is done.

Don't really know how to test this, it's a race that should have a pretty hard time occurring.

Fixes #4489

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
