### PR TITLE
Updates on Value nodes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,7 @@ environment:
   matrix:
     # Test oldest and newest supported Pythons, and a subset in between.
     # Skipping 3.7 and 3.9 at this time
-    - WINPYTHON: "Python311"
+    - WINPYTHON: "Python312"
 
     - WINPYTHON: "Python310"
 
@@ -50,7 +50,7 @@ matrix:
   exclude:
     # test python 3.6 on Visual Studio 2017 image
     - image: Visual Studio 2017
-      WINPYTHON: "Python311"
+      WINPYTHON: "Python312"
     - image: Visual Studio 2017
       WINPYTHON: "Python310"
     - image: Visual Studio 2017
@@ -58,7 +58,7 @@ matrix:
 
     # test python 3.8 on Visual Studio 2019 image
     - image: Visual Studio 2019
-      WINPYTHON: "Python311"
+      WINPYTHON: "Python312"
     - image: Visual Studio 2019
       WINPYTHON: "Python310"
     - image: Visual Studio 2019

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -104,6 +104,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       DeprecatedMissingSConscriptWarning) add two warnings to manpage
       (cache-cleanup-error, future-reserved-variable), improve unittest, tweak
       Sphinx build.
+    - Updated Value Node docs and tests.
 
 
 RELEASE 4.6.0 -  Sun, 19 Nov 2023 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -96,6 +96,7 @@ DOCUMENTATION
 - The manpage entry for SharedLibrary was clarified.
 - Update API docs for Warnings framework; add two warns to manpage
   enable/disable control.
+- Updated Value Node docs.
 
 DEVELOPMENT
 -----------

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -3511,33 +3511,22 @@ gltool(env)  # adds 'opengl' to the TOOLS variable
 </arguments>
 <summary>
 <para>
-Returns a Node object representing the specified &Python; value.  Value
-Nodes can be used as dependencies of targets.  If the result of
-calling
-<function>str</function>(<parameter>value</parameter>)
-changes between SCons runs, any targets depending on
-<function>Value</function>(<parameter>value</parameter>)
-will be rebuilt.
-(This is true even when using timestamps to decide if
-files are up-to-date.)
-When using timestamp source signatures, Value Nodes'
-timestamps are equal to the system time when the Node is created.
+Returns a Node object representing the specified &Python;
+<parameter>value</parameter>.
+Value Nodes can be used as dependencies of targets.
+If the string representation of the Value Node
+changes between &SCons; runs, it is considered
+out of date and any targets depending it will be rebuilt.
+Since Value Nodes have no filesystem representation,
+timestamps are not used; the timestamp deciders
+perform the same content-based up to date check.
 </para>
-
 <para>
-The returned Value Node object has a
-<function>write</function>()
-method that can be used to "build" a Value Node
-by setting a new value.
 The optional
 <parameter>built_value</parameter>
 argument can be specified
 when the Value Node is created
-to indicate the Node should already be considered
-"built."
-There is a corresponding
-<function>read</function>()
-method that will return the built value of the Node.
+to indicate the Node should already be considered "built."
 </para>
 
 <para>
@@ -3545,6 +3534,16 @@ The optional <parameter>name</parameter> parameter can be provided as an
 alternative name for the resulting <literal>Value</literal> node;
 this is advised if the <parameter>value</parameter> parameter
 cannot be converted to a string.
+</para>
+
+<para>
+Value Nodes have a
+<methodname>write</methodname>
+method that can be used to "build" a Value Node
+by setting a new value.
+The corresponding
+<methodname>read</methodname>
+method returns the built value of the Node.
 </para>
 
 <para>
@@ -3556,36 +3555,39 @@ the <parameter>name</parameter> parameter was added.
 Examples:
 </para>
 
+<!-- TODO fix second example or replace - still doesn't work -->
 <example_commands>
 env = Environment()
 
 def create(target, source, env):
-    # A function that will write a 'prefix=$SOURCE'
-    # string into the file name specified as the
-    # $TARGET.
-    with open(str(target[0]), 'wb') as f:
-        f.write('prefix=' + source[0].get_contents())
+    """Action function to create a file from a Value.
 
-# Fetch the prefix= argument, if any, from the command
-# line, and use /usr/local as the default.
+    Writes 'prefix=$SOURCE' into the file name given as $TARGET.
+    """
+    with open(str(target[0]), 'wb') as f:
+        f.write(b'prefix=' + source[0].get_contents() + b'\n')
+
+# Fetch the prefix= argument, if any, from the command line.
+# Use /usr/local as the default.
 prefix = ARGUMENTS.get('prefix', '/usr/local')
 
-# Attach a .Config() builder for the above function action
-# to the construction environment.
+# Attach builder named Config to the construction environment
+# using the 'create' action function above.
 env['BUILDERS']['Config'] = Builder(action=create)
 env.Config(target='package-config', source=Value(prefix))
 
 def build_value(target, source, env):
-    # A function that "builds" a Python Value by updating
-    # the Python value with the contents of the file
-    # specified as the source of the Builder call ($SOURCE).
+    """Action function to "build" a Value.
+
+    Writes contents of $SOURCE into $TARGET, thus updating if it existed.
+    """
     target[0].write(source[0].get_contents())
 
 output = env.Value('before')
 input = env.Value('after')
 
-# Attach a .UpdateValue() builder for the above function
-# action to the construction environment.
+# Attach a builder named UpdateValue to the construction environment
+# using the 'build_value' action function above.
 env['BUILDERS']['UpdateValue'] = Builder(action=build_value)
 env.UpdateValue(target=Value(output), source=Value(input))
 </example_commands>
@@ -3600,7 +3602,7 @@ env.UpdateValue(target=Value(output), source=Value(input))
 <para>
 Sets up a mapping to define a variant build directory in
 <parameter>variant_dir</parameter>.
-<parameter>src_dir</parameter> may not be underneath
+<parameter>src_dir</parameter> must not be underneath
 <parameter>variant_dir</parameter>.
 A &f-VariantDir; mapping is global, even if called using the
 &f-env-VariantDir; form.

--- a/SCons/Taskmaster/Job.py
+++ b/SCons/Taskmaster/Job.py
@@ -278,9 +278,8 @@ class ThreadPool:
 
         try:
             prev_size = threading.stack_size(stack_size * 1024)
-        except AttributeError as e:
-            # Only print a warning if the stack size has been
-            # explicitly set.
+        except RuntimeError as e:
+            # Only print a warning if the stack size has been explicitly set.
             if explicit_stack_size is not None:
                 msg = "Setting stack size is unsupported by this version of Python:\n    " + \
                     e.args[0]

--- a/test/Actions/function.py
+++ b/test/Actions/function.py
@@ -39,9 +39,6 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', r"""
 import re
 
-import SCons.Action
-import SCons.Builder
-
 options = Variables()
 options.AddVariables(
     ('header', 'Header string (default cell argument)', 'Head:'),
@@ -91,8 +88,8 @@ def toto(header='%(header)s', trailer='%(trailer)s'):
 
 exec(withClosure % optEnv)
 
-genHeaderBld = SCons.Builder.Builder(
-    action=SCons.Action.Action(toto(), 'Generating $TARGET', varlist=['ENVDEPS']),
+genHeaderBld = Builder(
+    action=Action(toto(), 'Generating $TARGET', varlist=['ENVDEPS']),
     suffix='.gen.h',
 )
 

--- a/test/Value/GetContent.py
+++ b/test/Value/GetContent.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the Value node as a build target
@@ -33,18 +32,25 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
-import SCons.Script
+import SCons.Node
+
 def null_build(target, source, env):
     pass
+
 env = DefaultEnvironment()
-env['BUILDERS']['ValueBuilder'] =  SCons.Builder.Builder(
-    action=SCons.Action.Action(null_build),
-    target_factory=SCons.Node.Python.Value,    
-)    
-v = env.ValueBuilder("myvalue",env.Dir("#"))
-v[0].get_text_contents()
+env['BUILDERS']['ValueBuilder'] = Builder(
+    action=Action(null_build),
+    target_factory=SCons.Node.Python.Value,
+)
+v = env.ValueBuilder("myvalue", env.Dir("#"))
+_ = v[0].get_text_contents()  # only care it doesn't take exception
 """)
 
 test.run()
 test.pass_test()
 
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Value/Value.py
+++ b/test/Value/Value.py
@@ -23,6 +23,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""Test Value() with different deciders."""
+
 import re
 
 import TestSCons
@@ -34,12 +36,16 @@ test = TestSCons.TestSCons(match=TestCmd.match_re)
 
 python = TestSCons.python
 
+# do not f-string, "source_signature" substituted in a loop below
 SConstruct_content = """
 Decider(r'%(source_signature)s')
 
 class Custom:
-    def __init__(self, value):  self.value = value
-    def __str__(self):          return "C=" + str(self.value)
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return "C=" + str(self.value)
 
 P = ARGUMENTS.get('prefix', '/usr/local')
 L = len(P)
@@ -51,22 +57,22 @@ def create(target, source, env):
 
 DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
-env['BUILDERS']['B'] = Builder(action = create)
-env['BUILDERS']['S'] = Builder(action = r'%(_python_)s put.py $SOURCES into $TARGET')
+env['BUILDERS']['B'] = Builder(action=create)
+env['BUILDERS']['S'] = Builder(action=r'%(_python_)s put.py $SOURCES into $TARGET')
 env.B('f1.out', Value(P))
 env.B('f2.out', env.Value(L))
 env.B('f3.out', Value(C))
 env.S('f4.out', Value(L))
 
-def create_value (target, source, env):
+def create_value(target, source, env):
     target[0].write(source[0].get_contents())
 
-def create_value_file (target, source, env):
+def create_value_file(target, source, env):
     with open(str(target[0]), 'wb') as f:
         f.write(source[0].read())
 
-env['BUILDERS']['B2'] = Builder(action = create_value)
-env['BUILDERS']['B3'] = Builder(action = create_value_file)
+env['BUILDERS']['B2'] = Builder(action=create_value)
+env['BUILDERS']['B3'] = Builder(action=create_value_file)
 
 V = Value('my value')
 env.B2(V, 'f3.out')


### PR DESCRIPTION
Some doc changes.
E2E tests cleaned up a bit.

Before merge:
TODO: second half of manpage example doesn't work.

Also: should test give `SCons.Node.Value.Value` as factory, or just `Value`  (remove new import if the latter).  `SCons.Node.Value.Value` and  `SCons.Environment.Base.Value` are not the same thing.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
