### PR TITLE
Fix a Python 3.13 problem in re.sub usage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
 
     - Updated Value Node docs and tests.
+    - Python 3.13 compat: re.sub deprecated count, flags as positional args,
+      caused update-release-info test to fail.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/bin/update-release-info.py
+++ b/bin/update-release-info.py
@@ -218,7 +218,7 @@ class UpdateFile:
 
     def sub(self, pattern, replacement, count=1):
         """ XXX """
-        self.content = re.sub(pattern, replacement, self.content, count)
+        self.content = re.sub(pattern, replacement, self.content, count=count)
 
     def replace_assign(self, name, replacement, count=1):
         """ XXX """
@@ -226,11 +226,11 @@ class UpdateFile:
 
     def replace_version(self, count=1):
         """ XXX """
-        self.content = self.match_rel.sub(rel_info.version_string, self.content, count)
+        self.content = self.match_rel.sub(rel_info.version_string, self.content, count=count)
 
     def replace_date(self, count=1):
         """ XXX """
-        self.content = self.match_date.sub(rel_info.new_date, self.content, count)
+        self.content = self.match_date.sub(rel_info.new_date, self.content, count=count)
 
     def __del__(self):
         """ XXX """

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -668,14 +668,14 @@ class TestSCons(TestCommon):
         return s
 
     @staticmethod
-    def to_bytes_re_sub(pattern, repl, str, count: int=0, flags: int=0):
+    def to_bytes_re_sub(pattern, repl, string, count: int=0, flags: int=0):
         """
         Wrapper around re.sub to change pattern and repl to bytes to work with
         both python 2 & 3
         """
         pattern = to_bytes(pattern)
         repl = to_bytes(repl)
-        return re.sub(pattern, repl, str, count, flags)
+        return re.sub(pattern, repl, string, count=count, flags=flags)
 
     def normalize_pdf(self, s):
         s = self.to_bytes_re_sub(r'/(Creation|Mod)Date \(D:[^)]*\)',


### PR DESCRIPTION
`re.sub`'s `count` and `flags` arguments are transitioning to keyword-only. With 3.13a5, usage as positional args issues a `DeprecationWarning`, which caused one SCons test to fail.  Updated in test framework and in `bin/update-release-info.py`.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
