### PR TITLE
Testing framework fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,7 +34,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       tweak for how it's handled (should be more accurate in a few situations).
     - Test framework now uses a subdirectory named "scons" below the base
       temporary directory. This gives something invariant to tell antivirus
-      software to ignore without having to exclude the tmpdir itself.
+      to ignore without having to exclude tmpdir itself. Fixes #4509.
     - MSVS "live" tests of project files adjusted to look for the generated
       executable with an exe sufffix
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,6 +32,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       ones in parent NodeInfoBase and can just be inherited.
     - Update manpage for Tools, and for TOOL, which also gets a minor
       tweak for how it's handled (should be more accurate in a few situations).
+    - Test framework now uses a subdirectory named "scons" below the base
+      temporary directory. This gives something invariant to tell antivirus
+      software to ignore without having to exclude the tmpdir itself.
+    - MSVS "live" tests of project files adjusted to look for the generated
+      executable with an exe sufffix
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -50,9 +50,7 @@ IMPROVEMENTS
 
 - Make the testing framework a little more resilient: the temporary
   directory for tests now includes a component named "scons" which can
-  be given to antivirus software to exclude; tests which are aborted
-  before startup by the operating system now generate a proper FAILED
-  message and are recorded in the fails list.
+  be given to antivirus software to exclude.
 
 PACKAGING
 ---------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -48,9 +48,11 @@ FIXES
 IMPROVEMENTS
 ------------
 
-- List improvements that wouldn't be visible to the user in the
-  documentation:  performance improvements (describe the circumstances
-  under which they would be observed), or major code cleanups
+- Make the testing framework a little more resilient: the temporary
+  directory for tests now includes a component named "scons" which can
+  be given to antivirus software to exclude; tests which are aborted
+  before startup by the operating system now generate a proper FAILED
+  message and are recorded in the fails list.
 
 PACKAGING
 ---------

--- a/test/MSVS/vs-14.0-exec.py
+++ b/test/MSVS/vs-14.0-exec.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that we can actually build a simple program using our generated
@@ -34,6 +33,7 @@ import os
 import sys
 
 import TestSConsMSVS
+from TestSConsMSVS import _obj, _exe
 
 test = TestSConsMSVS.TestSConsMSVS()
 
@@ -43,18 +43,16 @@ if sys.platform != 'win32':
 
 msvs_version = '14.0'
 
-if not msvs_version in test.msvs_versions():
+if msvs_version not in test.msvs_versions():
     msg = "Visual Studio %s not installed; skipping test.\n" % msvs_version
     test.skip_test(msg)
-
-
 
 # Let SCons figure out the Visual Studio environment variables for us and
 # print out a statement that we can exec to suck them into our external
 # environment so we can execute devenv and really try to build something.
 
-test.run(arguments = '-n -q -Q -f -', stdin = """\
-env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
+test.run(arguments='-n -q -Q -f -', stdin="""\
+env = Environment(tools=['msvc'], MSVS_VERSION='%(msvs_version)s')
 if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
@@ -65,18 +63,18 @@ if test.stdout() == "":
 
 exec(test.stdout())
 
-
-
 test.subdir('sub dir')
-
 test.write(['sub dir', 'SConstruct'], """\
-env=Environment(MSVS_VERSION = '%(msvs_version)s')
+DefaultEnvironment(tools=[])
+env = Environment(MSVS_VERSION='%(msvs_version)s')
 
-env.MSVSProject(target = 'foo.vcxproj',
-                srcs = ['foo.c'],
-                buildtarget = 'foo.exe',
-                variant = 'Release',
-                DebugSettings = {'LocalDebuggerCommandArguments':'echo "<foo.c>" > output.txt'})
+env.MSVSProject(
+    target='foo.vcxproj',
+    srcs=['foo.c'],
+    buildtarget='foo.exe',
+    variant='Release',
+    DebugSettings={'LocalDebuggerCommandArguments': 'echo "<foo.c>" > output.txt'},
+)
 env.Program('foo.c')
 """ % locals())
 
@@ -92,21 +90,22 @@ main(int argc, char *argv)
 
 test.run(chdir='sub dir', arguments='.')
 
-test.unlink_files('sub dir', ['foo.exe', 'foo.obj', '.sconsign.dblite'])
-
+test.unlink_files('sub dir', ['foo' + _exe, 'foo' + _obj, '.sconsign.dblite'])
 test.vcproj_sys_path(test.workpath('sub dir', 'foo.vcxproj'))
 
 import SCons.Platform.win32
-system_dll_path = os.path.join( SCons.Platform.win32.get_system_root(), 'System32' )
+
+system_dll_path = os.path.join(SCons.Platform.win32.get_system_root(), 'System32')
 os.environ['PATH'] = os.environ['PATH'] + os.pathsep + system_dll_path
 
-test.run(chdir='sub dir',
-         program=[test.get_msvs_executable(msvs_version)],
-         arguments=['foo.sln', '/build', 'Release'])
+test.run(
+    chdir='sub dir',
+    program=[test.get_msvs_executable(msvs_version)],
+    arguments=['foo.sln', '/build', 'Release'],
+)
 
-test.run(program=test.workpath('sub dir', 'foo'), stdout="foo.c\n")
+test.run(program=test.workpath('sub dir', 'foo' + _exe), stdout="foo.c\n")
 test.validate_msvs_file(test.workpath('sub dir', 'foo.vcxproj.user'))
-
 
 test.pass_test()
 

--- a/test/MSVS/vs-14.1-exec.py
+++ b/test/MSVS/vs-14.1-exec.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that we can actually build a simple program using our generated
-Visual Studio 14.1 project (.vcxproj) and solution (.sln) files
+Visual Studio 14.0 project (.vcxproj) and solution (.sln) files
 using Visual Studio 14.1 (Professional edition).
 """
 
@@ -34,6 +33,7 @@ import os
 import sys
 
 import TestSConsMSVS
+from TestSConsMSVS import _obj, _exe
 
 test = TestSConsMSVS.TestSConsMSVS()
 
@@ -47,14 +47,12 @@ if msvs_version not in test.msvs_versions():
     msg = "Visual Studio %s not installed; skipping test.\n" % msvs_version
     test.skip_test(msg)
 
-
-
 # Let SCons figure out the Visual Studio environment variables for us and
 # print out a statement that we can exec to suck them into our external
 # environment so we can execute devenv and really try to build something.
 
-test.run(arguments = '-n -q -Q -f -', stdin = """\
-env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
+test.run(arguments='-n -q -Q -f -', stdin="""\
+env = Environment(tools=['msvc'], MSVS_VERSION='%(msvs_version)s')
 if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
@@ -65,18 +63,18 @@ if test.stdout() == "":
 
 exec(test.stdout())
 
-
-
 test.subdir('sub dir')
-
 test.write(['sub dir', 'SConstruct'], """\
-env=Environment(MSVS_VERSION = '%(msvs_version)s')
+DefaultEnvironment(tools=[])
+env = Environment(MSVS_VERSION='%(msvs_version)s')
 
-env.MSVSProject(target = 'foo.vcxproj',
-                srcs = ['foo.c'],
-                buildtarget = 'foo.exe',
-                variant = 'Release',
-                DebugSettings = {'LocalDebuggerCommandArguments':'echo "<foo.c>" > output.txt'})
+env.MSVSProject(
+    target='foo.vcxproj',
+    srcs=['foo.c'],
+    buildtarget='foo.exe',
+    variant='Release',
+    DebugSettings={'LocalDebuggerCommandArguments': 'echo "<foo.c>" > output.txt'},
+)
 env.Program('foo.c')
 """ % locals())
 
@@ -92,19 +90,21 @@ main(int argc, char *argv)
 
 test.run(chdir='sub dir', arguments='.')
 
-test.unlink_files('sub dir', ['foo.exe', 'foo.obj', '.sconsign.dblite'])
-
+test.unlink_files('sub dir', ['foo' + _exe, 'foo' + _obj, '.sconsign.dblite'])
 test.vcproj_sys_path(test.workpath('sub dir', 'foo.vcxproj'))
 
 import SCons.Platform.win32
-system_dll_path = os.path.join( SCons.Platform.win32.get_system_root(), 'System32' )
+
+system_dll_path = os.path.join(SCons.Platform.win32.get_system_root(), 'System32')
 os.environ['PATH'] = os.environ['PATH'] + os.pathsep + system_dll_path
 
-test.run(chdir='sub dir',
-         program=[test.get_msvs_executable(msvs_version)],
-         arguments=['foo.sln', '/build', 'Release'])
+test.run(
+    chdir='sub dir',
+    program=[test.get_msvs_executable(msvs_version)],
+    arguments=['foo.sln', '/build', 'Release'],
+)
 
-test.run(program=test.workpath('sub dir', 'foo'), stdout="foo.c\n")
+test.run(program=test.workpath('sub dir', 'foo' + _exe), stdout="foo.c\n")
 test.validate_msvs_file(test.workpath('sub dir', 'foo.vcxproj.user'))
 
 test.pass_test()

--- a/test/MSVS/vs-14.2-exec.py
+++ b/test/MSVS/vs-14.2-exec.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that we can actually build a simple program using our generated
@@ -34,6 +33,7 @@ import os
 import sys
 
 import TestSConsMSVS
+from TestSConsMSVS import _obj, _exe
 
 test = TestSConsMSVS.TestSConsMSVS()
 
@@ -43,40 +43,38 @@ if sys.platform != 'win32':
 
 msvs_version = '14.2'
 
-if not msvs_version in test.msvs_versions():
+if msvs_version not in test.msvs_versions():
     msg = "Visual Studio %s not installed; skipping test.\n" % msvs_version
     test.skip_test(msg)
-
-
 
 # Let SCons figure out the Visual Studio environment variables for us and
 # print out a statement that we can exec to suck them into our external
 # environment so we can execute devenv and really try to build something.
 
-test.run(arguments = '-n -q -Q -f -', stdin = """\
-env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
+test.run(arguments='-n -q -Q -f -', stdin="""\
+env = Environment(tools=['msvc'], MSVS_VERSION='%(msvs_version)s')
 if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 
 exec(test.stdout())
 
-
-
 test.subdir('sub dir')
-
 test.write(['sub dir', 'SConstruct'], """\
-env=Environment(MSVS_VERSION = '%(msvs_version)s')
+DefaultEnvironment(tools=[])
+env = Environment(MSVS_VERSION='%(msvs_version)s')
 
-env.MSVSProject(target = 'foo.vcxproj',
-                srcs = ['foo.c'],
-                buildtarget = 'foo.exe',
-                variant = 'Release',
-                DebugSettings = {'LocalDebuggerCommandArguments':'echo "<foo.c>" > output.txt'})
+env.MSVSProject(
+    target='foo.vcxproj',
+    srcs=['foo.c'],
+    buildtarget='foo.exe',
+    variant='Release',
+    DebugSettings={'LocalDebuggerCommandArguments': 'echo "<foo.c>" > output.txt'},
+)
 env.Program('foo.c')
 """ % locals())
 
@@ -92,21 +90,22 @@ main(int argc, char *argv)
 
 test.run(chdir='sub dir', arguments='.')
 
-test.unlink_files('sub dir', ['foo.exe', 'foo.obj', '.sconsign.dblite'])
-
+test.unlink_files('sub dir', ['foo' + _exe, 'foo' + _obj, '.sconsign.dblite'])
 test.vcproj_sys_path(test.workpath('sub dir', 'foo.vcxproj'))
 
 import SCons.Platform.win32
-system_dll_path = os.path.join( SCons.Platform.win32.get_system_root(), 'System32' )
+
+system_dll_path = os.path.join(SCons.Platform.win32.get_system_root(), 'System32')
 os.environ['PATH'] = os.environ['PATH'] + os.pathsep + system_dll_path
 
-test.run(chdir='sub dir',
-         program=[test.get_msvs_executable(msvs_version)],
-         arguments=['foo.sln', '/build', 'Release'])
+test.run(
+    chdir='sub dir',
+    program=[test.get_msvs_executable(msvs_version)],
+    arguments=['foo.sln', '/build', 'Release'],
+)
 
-test.run(program=test.workpath('sub dir', 'foo'), stdout="foo.c\n")
+test.run(program=test.workpath('sub dir', 'foo' + _exe), stdout="foo.c\n")
 test.validate_msvs_file(test.workpath('sub dir', 'foo.vcxproj.user'))
-
 
 test.pass_test()
 

--- a/test/MSVS/vs-14.3-exec.py
+++ b/test/MSVS/vs-14.3-exec.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that we can actually build a simple program using our generated
@@ -34,6 +33,7 @@ import os
 import sys
 
 import TestSConsMSVS
+from TestSConsMSVS import _obj, _exe
 
 test = TestSConsMSVS.TestSConsMSVS()
 
@@ -47,36 +47,34 @@ if msvs_version not in test.msvs_versions():
     msg = "Visual Studio %s not installed; skipping test.\n" % msvs_version
     test.skip_test(msg)
 
-
-
 # Let SCons figure out the Visual Studio environment variables for us and
 # print out a statement that we can exec to suck them into our external
 # environment so we can execute devenv and really try to build something.
 
-test.run(arguments = '-n -q -Q -f -', stdin = """\
-env = Environment(tools = ['msvc'], MSVS_VERSION='%(msvs_version)s')
+test.run(arguments='-n -q -Q -f -', stdin="""\
+env = Environment(tools=['msvc'], MSVS_VERSION='%(msvs_version)s')
 if env.WhereIs('cl'):
     print("os.environ.update(%%s)" %% repr(env['ENV']))
 """ % locals())
 
-if(test.stdout() == ""):
+if test.stdout() == "":
     msg = "Visual Studio %s missing cl.exe; skipping test.\n" % msvs_version
     test.skip_test(msg)
 
 exec(test.stdout())
 
-
-
 test.subdir('sub dir')
-
 test.write(['sub dir', 'SConstruct'], """\
-env=Environment(MSVS_VERSION = '%(msvs_version)s')
+DefaultEnvironment(tools=[])
+env = Environment(MSVS_VERSION='%(msvs_version)s')
 
-env.MSVSProject(target = 'foo.vcxproj',
-                srcs = ['foo.c'],
-                buildtarget = 'foo.exe',
-                variant = 'Release',
-                DebugSettings = {'LocalDebuggerCommandArguments':'echo "<foo.c>" > output.txt'})
+env.MSVSProject(
+    target='foo.vcxproj',
+    srcs=['foo.c'],
+    buildtarget='foo.exe',
+    variant='Release',
+    DebugSettings={'LocalDebuggerCommandArguments': 'echo "<foo.c>" > output.txt'},
+)
 env.Program('foo.c')
 """ % locals())
 
@@ -92,21 +90,22 @@ main(int argc, char *argv)
 
 test.run(chdir='sub dir', arguments='.')
 
-test.unlink_files('sub dir', ['foo.exe', 'foo.obj', '.sconsign.dblite'])
-
+test.unlink_files('sub dir', ['foo' + _exe, 'foo' + _obj, '.sconsign.dblite'])
 test.vcproj_sys_path(test.workpath('sub dir', 'foo.vcxproj'))
 
 import SCons.Platform.win32
+
 system_dll_path = os.path.join(SCons.Platform.win32.get_system_root(), 'System32')
 os.environ['PATH'] = os.environ['PATH'] + os.pathsep + system_dll_path
 
-test.run(chdir='sub dir',
-         program=[test.get_msvs_executable(msvs_version)],
-         arguments=['foo.sln', '/build', 'Release'])
+test.run(
+    chdir='sub dir',
+    program=[test.get_msvs_executable(msvs_version)],
+    arguments=['foo.sln', '/build', 'Release'],
+)
 
-test.run(program=test.workpath('sub dir', 'foo'), stdout="foo.c\n")
+test.run(program=test.workpath('sub dir', 'foo' + _exe), stdout="foo.c\n")
 test.validate_msvs_file(test.workpath('sub dir', 'foo.vcxproj.user'))
-
 
 test.pass_test()
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1543,23 +1543,12 @@ class TestCmd:
         # It seems that all pythons up to py3.6 still set text mode if you set encoding.
         # TODO: File enhancement request on python to propagate universal_newlines even
         # if encoding is set.hg c
-        #
-        # Windows can fail the subprocess call itself (via exception), rather
-        # than having subprocess.Popen report failure - antivirus hit is an
-        # example.  Catch this and report it up as a test fail, as it gets
-        # missed easily otherwise. "Failed to run the test" should ostensibly
-        # be a No Result, but in this case, let's behave diffferently.
-        try:
-            p = Popen(
-                cmd,
-                stdin=stdin,
-                stdout=PIPE,
-                stderr=stderr_value,
-                env=os.environ,
-                universal_newlines=False,
-            )
-        except OSError as e:
-            self.fail_test(message=repr(e))
+        p = Popen(cmd,
+                  stdin=stdin,
+                  stdout=PIPE,
+                  stderr=stderr_value,
+                  env=os.environ,
+                  universal_newlines=False)
 
         self.process = p
         return p
@@ -1637,11 +1626,11 @@ class TestCmd:
         Output and error output are saved for future retrieval via
         the stdout() and stderr() methods.
 
-        The specified program will have the original directory
+        The specified *program* will have the original directory
         prepended unless it is enclosed in a [list].
 
-        arguments: if a dict() then will create arguments with KEY+VALUE for
-                   each entry in the dict.
+        If *arguments* is a dict then will create arguments with KEY+VALUE
+        for each entry in the dict.
         """
         if self.external:
             if not program:

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -2605,6 +2605,7 @@ script_recv:  STDERR:  input
             expect = f"script_recv:  {input}"
             assert result == expect, f"Result:[{result}] should match\nExpected:[{expect}]"
 
+            # TODO: Python 3.6+ ResourceWarning: unclosed file <_io.BufferedReader name=9>
             p = test.start(stdin=1)
             input = 'send() input to the receive script\n'
             p.send(input)

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1288,7 +1288,7 @@ SConscript(sconscript)
                     logfile.find("scons: warning: The stored build information has an unexpected class.") >= 0):
                 self.fail_test()
 
-            log = r'file\ \S*%s\,line \d+:' % re.escape(sconstruct) + ls
+            log = r'file \S*%s\,line \d+:' % re.escape(sconstruct) + ls
             if doCheckLog:
                 lastEnd = match_part_of_configlog(log, logfile, lastEnd)
 
@@ -1426,7 +1426,7 @@ SConscript(sconscript)
             sconf_dir = sconf_dir
             sconstruct = sconstruct
 
-            log = r'file\ \S*%s\,line \d+:' % re.escape(sconstruct) + ls
+            log = r'file \S*%s\,line \d+:' % re.escape(sconstruct) + ls
             if doCheckLog:
                 lastEnd = match_part_of_configlog(log, logfile, lastEnd)
 


### PR DESCRIPTION

- Test framework now uses a subdirectory named "scons" below the base temporary directory. This gives something invariant to tell antivirus software to ignore without having to exclude the tmpdir itself.

- MSVS "live" tests of project files (e.g. `test/MSVS/vs-14.3-exec.py`) adjusted to look for the generated executable with an `.exe` suffix. This had recently started failing on the line:

  `test.run(program=test.workpath('sub dir', 'foo'), stdout="foo.c\n")`

  as somehow `sub dir\foo` was created, and then `foo.exe` was not matched causing the binary not to execute and failing the test.


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
