### PR TITLE
Fix isabs() check in NodeInfo for Py 3.13

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Dump() with json format selected now recognizes additional compound types
       (UserDict and UserList), which improves the detail of the display.
       json output is also sorted, to match the default display.
+    - Python 3.13 (alpha) changes the behavior of isabs() on Windows. Adjust
+      SCons usage of in NodeInfo classes to match.  Fixes #4502, #4504.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - Dump() with json format selected now recognizes additional compound types
   (UserDict and UserList), which improves the detail of the display.
   json output is also sorted, to match the default display.
+- Python 3.13 changes the behavior of isabs() on Windows. Adjust SCons
+  usage of this in NodeInfo classes to avoid test problems.
 
 FIXES
 -----


### PR DESCRIPTION
Python 3.13 (alpha) changes the behavior of `os.path.isabs` on Windows. SCons has places where it does `splitdrive` on an absolute path, then checks if the path part is absolute - this answer is now `False`, which caused some interesting test fails.  Do the check on the original path to get a more accurate answer.  There may be more subtle issues with the Python change, but first fix the ones we can see.

Simplify the setup of `_my_splitdrive` a bit: every caller is supposed to check `do_splitdrive` before calling, but a couple of locations did not. Remove the special check for UNC support, all Python versions SCons runs on do UNC handling, so just eliminate that bit.

Fixes #4502, #4504.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
