### PR TITLE
Remove redundant node-info code

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       json output is also sorted, to match the default display.
     - Python 3.13 (alpha) changes the behavior of isabs() on Windows. Adjust
       SCons usage of in NodeInfo classes to match.  Fixes #4502, #4504.
+    - Drop duplicated __getstate__ and __setstate__ methods in AliasNodeInfo,
+      FileNodeInfo and ValueNodeInfo classes, as they are identical to the
+      ones in parent NodeInfoBase and can just be inherited.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -31,6 +31,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   json output is also sorted, to match the default display.
 - Python 3.13 changes the behavior of isabs() on Windows. Adjust SCons
   usage of this in NodeInfo classes to avoid test problems.
+- Drop duplicated __getstate__ and __setstate__ methods in AliasNodeInfo,
+  FileNodeInfo and ValueNodeInfo classes, as they are identical to the
+  ones in parent NodeInfoBase and can just be inherited.
+
 
 FIXES
 -----

--- a/SCons/Node/Alias.py
+++ b/SCons/Node/Alias.py
@@ -57,38 +57,6 @@ class AliasNodeInfo(SCons.Node.NodeInfoBase):
     def str_to_node(self, s):
         return default_ans.Alias(s)
 
-    def __getstate__(self):
-        """
-        Return all fields that shall be pickled. Walk the slots in the class
-        hierarchy and add those to the state dictionary. If a '__dict__' slot is
-        available, copy all entries to the dictionary. Also include the version
-        id, which is fixed for all instances of a class.
-        """
-        state = getattr(self, '__dict__', {}).copy()
-        for obj in type(self).mro():
-            for name in getattr(obj,'__slots__',()):
-                if hasattr(self, name):
-                    state[name] = getattr(self, name)
-
-        state['_version_id'] = self.current_version_id
-        try:
-            del state['__weakref__']
-        except KeyError:
-            pass
-
-        return state
-
-    def __setstate__(self, state) -> None:
-        """
-        Restore the attributes from a pickled state.
-        """
-        # TODO check or discard version
-        del state['_version_id']
-        for key, value in state.items():
-            if key not in ('__weakref__',):
-                setattr(self, key, value)
-
-
 class AliasBuildInfo(SCons.Node.BuildInfoBase):
     __slots__ = ()
     current_version_id = 2

--- a/SCons/Node/FS.py
+++ b/SCons/Node/FS.py
@@ -2528,37 +2528,6 @@ class FileNodeInfo(SCons.Node.NodeInfoBase):
             s = top.get_labspath() + '/' + s
         return root._lookup_abs(s, Entry)
 
-    def __getstate__(self):
-        """
-        Return all fields that shall be pickled. Walk the slots in the class
-        hierarchy and add those to the state dictionary. If a '__dict__' slot is
-        available, copy all entries to the dictionary. Also include the version
-        id, which is fixed for all instances of a class.
-        """
-        state = getattr(self, '__dict__', {}).copy()
-        for obj in type(self).mro():
-            for name in getattr(obj, '__slots__', ()):
-                if hasattr(self, name):
-                    state[name] = getattr(self, name)
-
-        state['_version_id'] = self.current_version_id
-        try:
-            del state['__weakref__']
-        except KeyError:
-            pass
-
-        return state
-
-    def __setstate__(self, state) -> None:
-        """
-        Restore the attributes from a pickled state.
-        """
-        # TODO check or discard version
-        del state['_version_id']
-        for key, value in state.items():
-            if key not in ('__weakref__',):
-                setattr(self, key, value)
-
     def __eq__(self, other):
         return self.csig == other.csig and self.timestamp == other.timestamp and self.size == other.size
 

--- a/SCons/Node/Python.py
+++ b/SCons/Node/Python.py
@@ -37,37 +37,6 @@ class ValueNodeInfo(SCons.Node.NodeInfoBase):
     def str_to_node(self, s):
         return ValueWithMemo(s)
 
-    def __getstate__(self):
-        """
-        Return all fields that shall be pickled. Walk the slots in the class
-        hierarchy and add those to the state dictionary. If a '__dict__' slot
-        is available, copy all entries to the dictionary. Also include the
-        version id, which is fixed for all instances of a class.
-        """
-        state = getattr(self, '__dict__', {}).copy()
-        for obj in type(self).mro():
-            for name in getattr(obj, '__slots__', ()):
-                if hasattr(self, name):
-                    state[name] = getattr(self, name)
-
-        state['_version_id'] = self.current_version_id
-        try:
-            del state['__weakref__']
-        except KeyError:
-            pass
-
-        return state
-
-    def __setstate__(self, state) -> None:
-        """
-        Restore the attributes from a pickled state.
-        """
-        # TODO check or discard version
-        del state['_version_id']
-        for key, value in state.items():
-            if key not in ('__weakref__',):
-                setattr(self, key, value)
-
 
 class ValueBuildInfo(SCons.Node.BuildInfoBase):
     __slots__ = ()


### PR DESCRIPTION
Three classes that inherit from `NodeInfoBase` - `FileNodeInfo`, `AliasNodeInfo` and `ValueNodeInfo` - have "specializations" of `__getstate__` and `__setstate__` from the parent, but they're identical to the parent's and thus not needed.  Always easy to add back if a different implementation is ever needed for any of them.

This is not user-visible, and no behavioral change so there are no doc or test impacts (other than making sure the existing test suite runs, of course).

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
