### PR TITLE
Allow printing a Variables object

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       by adding SKIP_PDF=1.  This should help with distro packaging of SCons,
       which now does not need "fop" and other tools to be set up in order to
       build pdf versions which are then ignored.
+    - Add the ability to print a Variables object for debugging purposes
+      (provides a __str__ method in the class).
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -76,10 +76,21 @@ class Variables:
             if not Variables.instance:
                 Variables.instance=self
 
+    def __str__(self) -> str:
+        """Provide a way to "print" a Variables object."""
+        s = "Variables(\n  options=[\n"
+        for option in self.options:
+            s += f"    {str(option)},\n"
+        s += "  ],\n"
+        s += f"  args={self.args},\n  files={self.files},\n  unknown={self.unknown},\n)"
+        return s
+
     def _do_add(self, key, help: str="", default=None, validator=None, converter=None, **kwargs) -> None:
 
         class Variable:
-            pass
+            def __str__(self) -> str:
+                """Provide a way to "print" a Variable object."""
+                return f"({self.key!r}, {self.aliases}, {self.help!r}, {self.default!r}, {self.validator}, {self.converter})"
 
         option = Variable()
 


### PR DESCRIPTION
The `Variables` object has been somewhat opaque - kind of hard to tell what you got. This adds as `__str__` method which produces a formatted string showing the contents of the object, so debugging can do:
```py
var = Variables()
... bunch of setup stuff
print(var)
```
and get a reasonably readable representation.

This doesn't do anything visible to SCons behavior unless someone tries to print the object, so there are no doc impacts.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
