### PR TITLE
Fix msvc `stdout` issues with `cl`/`link`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,10 @@ NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer suppo
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Thaddeus Crews:
+    - Fix msvc issue causing cl/link tools to clutter stdout with bloat &
+      incorrectly routed error messages.
+
   From Raymond Li:
     - Fix issue #3935: OSErrors are now no longer hidden during execution of
       Actions. All exceptions during the execution of an Action are now

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -48,9 +48,9 @@ FIXES
 IMPROVEMENTS
 ------------
 
-- List improvements that wouldn't be visible to the user in the
-  documentation:  performance improvements (describe the circumstances
-  under which they would be observed), or major code cleanups
+- Building with msvc will no longer cause the cl/link tools to flood the
+  command line with bloat. Any cl/link error messages erroneously filtered
+  to stdout will now be properly redirected to stderr.
 
 PACKAGING
 ---------


### PR DESCRIPTION
There's been a long-standing issue with msvc when using the `cl`/`link` tools: their `stdout` choices are abysmal. They will *always* have a line of bloat with absolutely no arguments to circumvent it & will frequently put error messages on `stdout` instead of `stderr`. This PR addresses both issues at once with a modified implementation of a `SPAWN` fix used in the Godot repo[^1]. The main change is this is directly built into the spawn function itself, branching off if `cl` or `link` is the leading argument.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation

[^1]: https://github.com/godotengine/godot/pull/90551