### PR TITLE
Deprecate Python 3.6 support.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       build pdf versions which are then ignored.
     - Add the ability to print a Variables object for debugging purposes
       (provides a __str__ method in the class).
+    - Mark Python 3.6 support as deprecated.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -21,7 +21,8 @@ NEW FUNCTIONALITY
 DEPRECATED FUNCTIONALITY
 ------------------------
 
-- List anything that's been deprecated since the last release
+- Mark Python 3.6 support as deprecated. Use --warn=no-python-version
+  to quiet the warning.
 
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -65,7 +65,7 @@ from SCons import __version__ as SConsVersion
 
 # these define the range of versions SCons supports
 minimum_python_version = (3, 6, 0)
-deprecated_python_version = (3, 6, 0)
+deprecated_python_version = (3, 7, 0)  # the first non-deprecated version
 
 # ordered list of SConsctruct names to look for if there is no -f flag
 KNOWN_SCONSTRUCT_NAMES = [
@@ -1104,11 +1104,13 @@ def _main(parser):
     # warning about deprecated Python versions--delayed until here
     # in case they disabled the warning in the SConscript files.
     if python_version_deprecated():
-        msg = "Support for pre-%s Python version (%s) is deprecated.\n" + \
-              "    If this will cause hardship, contact scons-dev@scons.org"
         deprecated_version_string = ".".join(map(str, deprecated_python_version))
-        SCons.Warnings.warn(SCons.Warnings.PythonVersionWarning,
-                            msg % (deprecated_version_string, python_version_string()))
+        msg = (
+            f"Support for Python older than {deprecated_version_string}"
+            f" is deprecated ({python_version_string()} detected).\n"
+            "    If this will cause hardship, contact scons-dev@scons.org"
+        )
+        SCons.Warnings.warn(SCons.Warnings.PythonVersionWarning, msg)
 
     if not options.help:
         # [ ] Clarify why we need to create Builder here at all, and

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -112,9 +112,16 @@ unless the experimental Ninja tool is used.
 </para>
 <para>
 <emphasis>Changed in version 4.3.0:</emphasis>
-support for &Python; 3.5 is removed;
-the CPython project has retired 3.5:
-<ulink url="https://www.python.org/dev/peps/pep-0478"/>.
+support for &Python; 3.5 is removed.
+The CPython project retired 3.5 in Sept 2020:
+<ulink url="https://peps.python.org/pep-0478"/>.
+</para>
+<para>
+<emphasis>Changed in version 4.8.0:</emphasis>
+support for &Python; 3.6 is deprecated and will be removed
+in a future &SCons; release.
+The CPython project retired 3.6 in Sept 2021:
+<ulink url="https://peps.python.org/pep-0494"/>.
 </para>
 
 <para>You set up an &SCons;

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -59,8 +59,8 @@ default_version = '4.7.1ayyyymmdd'
 
 # TODO: these need to be hand-edited when there are changes
 python_version_unsupported = (3, 6, 0)
-python_version_deprecated = (3, 6, 0)
-python_version_supported_str = "3.6.0"  # str of lowest non-deprecated version
+python_version_deprecated = (3, 7, 0)  # lowest non-deprecated Python
+python_version_supported_str = "3.7.0"  # str of lowest non-deprecated Python
 
 SConsVersion = default_version
 
@@ -173,7 +173,7 @@ def deprecated_python_version(version=sys.version_info):
 
 if deprecated_python_version():
     msg = r"""
-scons: warning: Support for pre-%s Python version (%s) is deprecated.
+scons: warning: Support for Python older than %s is deprecated (%s detected).
     If this will cause hardship, contact scons-dev@scons.org
 """
     deprecated_python_expr = (


### PR DESCRIPTION
No claim is made about when it will actually be dropped, but some notice seems polite. Reworded the text of the version warning.

RELEASE contains a note on how to shut up the warning if people don't want to see it.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
