### PR TITLE
Fix ParseFlags so -stdlib flag goes in CXXFLAGS

### DIFF
--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1022,6 +1022,8 @@ class SubstitutionEnvironment:
                     else:
                         key = 'CFLAGS'
                     mapping[key].append(arg)
+                elif arg[:8] == '-stdlib=':
+                    mapping['CXXFLAGS'].append(arg)
                 elif arg[0] == '+':
                     mapping['CCFLAGS'].append(arg)
                     mapping['LINKFLAGS'].append(arg)


### PR DESCRIPTION
gpsd 3.25 failed to build with recent clang if `-stdlib=libc++` was passed by the user in `CXXFLAGS` because gpsd used `MergeFlags` (which uses `ParseFlags`) to move the flags where SCons thinks they belong, and because SCons did not know where `-stdlib` goes it put it in `CCFLAGS`, which was then passed to the C compiler during a test, and clang emitted a warning that the `-stdlib` flag was unknown, and the test had requested that warnings be turned into errors with `-Werror`, which caused the test to get the wrong result which caused compilation to fail later.

See: https://gitlab.com/gpsd/gpsd/-/issues/279

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
