### PR TITLE
Fix ParseFlags so -stdlib goes in CXXFLAGS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       expected exceptions (whereas previously many of these were silently
       caught and suppressed by the SCons Action exection code).
 
+  From Ryan Carsten Schmidt:
+    - Teach ParseFlags to put a --stdlib=libname argument into CXXFLAGS.
+      If placed in CCFLAGS (the default location), it could be fed to the
+      C compiler (gcc, clang) where it is not applicable and causes a
+      warning message.
+
   From Mats Wichmann:
     - Updated Value Node docs and tests.
     - Python 3.13 compat: re.sub deprecated count, flags as positional args,

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -39,6 +39,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   NOTE: With this change, user created Actions should now catch and handle
   expected exceptions (whereas previously many of these were silently caught
   and suppressed by the SCons Action exection code).
+- ParseFlags now sorts a --stdlib=libname argument into CXXFLAGS instead
+  of CCFLAGS; the latter variable could cause a compiler warning.
 
 FIXES
 -----

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -881,11 +881,11 @@ class SubstitutionEnvironment:
             'RPATH'         : [],
         }
 
-        def do_parse(arg) -> None:
-            # if arg is a sequence, recurse with each element
+        def do_parse(arg: Union[str, Sequence]) -> None:
             if not arg:
                 return
 
+            # if arg is a sequence, recurse with each element
             if not is_String(arg):
                 for t in arg: do_parse(t)
                 return
@@ -902,7 +902,7 @@ class SubstitutionEnvironment:
                 else:
                     mapping['CPPDEFINES'].append([t[0], '='.join(t[1:])])
 
-            # Loop through the flags and add them to the appropriate option.
+            # Loop through the flags and add them to the appropriate variable.
             # This tries to strike a balance between checking for all possible
             # flags and keeping the logic to a finite size, so it doesn't
             # check for some that don't occur often.  It particular, if the
@@ -926,6 +926,8 @@ class SubstitutionEnvironment:
             append_next_arg_to = None   # for multi-word args
             for arg in params:
                 if append_next_arg_to:
+                    # these are the second pass for options where the
+                    # option-argument follows as a second word.
                     if append_next_arg_to == 'CPPDEFINES':
                         append_define(arg)
                     elif append_next_arg_to == '-include':
@@ -1022,6 +1024,8 @@ class SubstitutionEnvironment:
                     else:
                         key = 'CFLAGS'
                     mapping[key].append(arg)
+                elif arg.startswith('-stdlib='):
+                    mapping['CXXFLAGS'].append(arg)
                 elif arg[0] == '+':
                     mapping['CCFLAGS'].append(arg)
                     mapping['LINKFLAGS'].append(arg)

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -2687,6 +2687,7 @@ and added to the following construction variables:
 -openmp                 CCFLAGS, LINKFLAGS
 -pthread                CCFLAGS, LINKFLAGS
 -std=                   CFLAGS
+-stdlib=                CXXFLAGS
 -Wa,                    ASFLAGS, CCFLAGS
 -Wl,-rpath=             RPATH
 -Wl,-R,                 RPATH

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -822,6 +822,7 @@ sys.exit(0)
             "-DFOO -DBAR=value -D BAZ "
             "-fsanitize=memory "
             "-fsanitize-address-use-after-return "
+            "-stdlib=libc++"
         )
 
         d = env.ParseFlags(s)
@@ -841,7 +842,7 @@ sys.exit(0)
                                 '+DD64',
                                 '-fsanitize=memory',
                                 '-fsanitize-address-use-after-return'], repr(d['CCFLAGS'])
-        assert d['CXXFLAGS'] == ['-std=c++0x'], repr(d['CXXFLAGS'])
+        assert d['CXXFLAGS'] == ['-std=c++0x', '-stdlib=libc++'], repr(d['CXXFLAGS'])
         assert d['CPPDEFINES'] == ['FOO', ['BAR', 'value'], 'BAZ'], d['CPPDEFINES']
         assert d['CPPFLAGS'] == ['-Wp,-cpp'], d['CPPFLAGS']
         assert d['CPPPATH'] == ['/usr/include/fum',


### PR DESCRIPTION
(from #4520 @ryandesign)

gpsd 3.25 failed to build with recent clang if -stdlib=libc++ was passed by the user in CXXFLAGS because gpsd used MergeFlags (which uses ParseFlags) to move the flags where SCons thinks they belong, and because SCons did not know where -stdlib goes it put it in CCFLAGS, which was then passed to the C compiler during a test, and clang emitted a warning that the -stdlib flag was unknown, and the test had requested that warnings be turned into errors with -Werror, which caused the test to get the wrong result which caused compilation to fail later.

See: https://gitlab.com/gpsd/gpsd/-/issues/279

It was easier to make a new PR with the additional files to update.  This obsoletes PR #4520

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
