### PR TITLE
Maintenance: Python version usage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -58,6 +58,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Clean up Variables: more consistently call them variables (finish the
       old change from Options) in docstrings, etc.; some typing and other
       tweaks.  Update manpage and user guide for Variables usage.
+    - Regularize internal usage of Python version strings and drop one
+      old Python 2-only code block in a test.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -892,10 +892,10 @@ def scons_subproc_run(scons_env, *args, **kwargs) -> subprocess.CompletedProcess
     kwargs['check'] = check
 
     # TODO: Python version-compat stuff: remap/remove too-new args if needed
-    if 'text' in kwargs and sys.version_info[:3] < (3, 7):
+    if 'text' in kwargs and sys.version_info < (3, 7):
         kwargs['universal_newlines'] = kwargs.pop('text')
 
-    if 'capture_output' in kwargs and sys.version_info[:3] < (3, 7):
+    if 'capture_output' in kwargs and sys.version_info < (3, 7):
         capture_output = kwargs.pop('capture_output')
         if capture_output:
             kwargs['stdout'] = kwargs['stderr'] = PIPE

--- a/scripts/scons-configure-cache.py
+++ b/scripts/scons-configure-cache.py
@@ -51,7 +51,7 @@ import sys
 # python compatibility check
 if sys.version_info < (3, 6, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.5 is required.\n"
+Python >= 3.6.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/scripts/scons.py
+++ b/scripts/scons.py
@@ -44,7 +44,7 @@ import sys
 # Python compatibility check
 if sys.version_info < (3, 6, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.5 is required.\n"
+Python >= 3.6.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/scripts/sconsign.py
+++ b/scripts/sconsign.py
@@ -43,7 +43,7 @@ import sys
 # python compatibility check
 if sys.version_info < (3, 6, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.5 is required.\n"
+Python >= 3.6.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/test/Execute.py
+++ b/test/Execute.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,15 +22,13 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the Execute() function for executing actions directly.
 """
 import sys
 import TestSCons
+from TestCmd import IS_WINDOWS
 
 _python_ = TestSCons._python_
 
@@ -83,7 +83,7 @@ test.write('k.in', "k.in\n")
 test.write('l.in', "l.in\n")
 test.write('m.in', "m.in\n")
 
-if sys.platform == 'win32' and sys.version_info[0] == 3:
+if IS_WINDOWS:
     expect = r"""scons: \*\*\* Error 1
 scons: \*\*\* Error 2
 scons: \*\*\* nonexistent.in: (The system cannot find the path specified|Das System kann den angegebenen Pfad nicht finden)"""

--- a/test/option/option-j.py
+++ b/test/option/option-j.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,14 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
 """
 This tests the -j command line option, and the num_jobs
 SConscript settable option.
 """
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os.path
 import sys
@@ -121,43 +120,6 @@ test.fail_test(start2 < finish1)
 # Make sure that a parallel build using a list builder
 # succeeds.
 test.run(arguments='-j 2 out')
-
-if sys.platform != 'win32' and sys.version_info[0] == 2:
-    # Test breaks on win32 when using real subprocess is not the only
-    # package to import threading
-    #
-    # Test that we fall back and warn properly if there's no threading.py
-    # module (simulated), which is the case if this version of Python wasn't
-    # built with threading support.
-
-    test.subdir('pythonlib')
-
-    test.write(['pythonlib', 'threading.py'], "raise ImportError\n")
-
-    save_pythonpath = os.environ.get('PYTHONPATH', '')
-    os.environ['PYTHONPATH'] = test.workpath('pythonlib')
-
-    #start2, finish1 = RunTest('-j 2 f1, f2', "fifth")
-
-    test.write('f1.in', 'f1.in pythonlib\n')
-    test.write('f2.in', 'f2.in pythonlib\n')
-
-    test.run(arguments = "-j 2 f1 f2", stderr=None)
-
-    warn = """scons: warning: parallel builds are unsupported by this version of Python;
-\tignoring -j or num_jobs option."""
-    test.must_contain_all_lines(test.stderr(), [warn])
-
-    str = test.read("f1", mode='r')
-    start1,finish1 = list(map(float, str.split("\n")))
-
-    str = test.read("f2", mode='r')
-    start2,finish2 = list(map(float, str.split("\n")))
-
-    test.fail_test(start2 < finish1)
-
-    os.environ['PYTHONPATH'] = save_pythonpath
-
 
 # Test SetJobs() with no -j:
 test.write('SConstruct', """

--- a/testing/framework/TestRuntest.py
+++ b/testing/framework/TestRuntest.py
@@ -123,9 +123,6 @@ class TestRuntest(TestCommon):
             kw['program'] = 'runtest.py'
         if 'interpreter' not in kw:
             kw['interpreter'] = [python,]
-            if sys.version_info[0] < 3:
-                kw['interpreter'].append('-tt')
-
         if 'match' not in kw:
             kw['match'] = match_exact
         if 'workdir' not in kw:

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -752,17 +752,10 @@ class TestSCons(TestCommon):
     def unlink_sconsignfile(self, name: str='.sconsign.dblite') -> None:
         """Delete the sconsign file.
 
-        Note on python it seems to append .p3 to the file name so we take
-        care of that.
-
-        TODO the above seems to not be an issue any more.
-
         Args:
             name: expected name of sconsign file
         """
-        if sys.version_info[0] == 3:
-            name += '.p3'
-        self.unlink(name)
+        return self.unlink(name)
 
     def java_ENV(self, version=None):
         """ Initialize JAVA SDK environment.
@@ -1621,7 +1614,7 @@ else:
         if python_h == "False" and python_h_required:
             self.skip_test('Can not find required "Python.h", skipping test.\n', from_fw=True)
 
-        return (python, incpath, libpath, libname)
+        return (python, incpath, libpath, libname + _lib)
 
     def start(self, *args, **kw):
         """


### PR DESCRIPTION
Simplify/clarify some usage of Python version strings.  Dropped a couple which refer to unsupported versions.

While looking at version usage, it became clear one of the SWIG tests wasn't doing the right thing - it has a special case for Windows, where the way the path to the Python library is constructed would only work for the python.org release, not the Store version.  Since we compute this information correctly in the test framework, and the test already called that routine - before ignoring the results - just use that instead. Though it turns out the framework didn't quite do the right thing either, returning a bare lib name without the library suffix - that change was also added.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
