### PR TITLE
scons-time: add filter to tarfile extract call.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -61,6 +61,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       tweaks.  Update manpage and user guide for Variables usage.
     - Regularize internal usage of Python version strings and drop one
       old Python 2-only code block in a test.
+    - scons-time tests now supply a "filter" argument to tarfile.extract
+      to quiet a warning which was added in Python 3.13 beta 1.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/bin/scons-time.py
+++ b/bin/scons-time.py
@@ -223,23 +223,25 @@ class Gnuplotter(Plotter):
 
 def untar(fname):
     import tarfile
-    tar = tarfile.open(name=fname, mode='r')
-    for tarinfo in tar:
-        tar.extract(tarinfo)
-    tar.close()
+    with tarfile.open(name=fname, mode='r') as tar:
+        for tarinfo in tar:
+            try:
+                tar.extract(tarinfo, filter="tar")
+            except TypeError:
+                tar.extract(tarinfo)
 
 
 def unzip(fname):
     import zipfile
-    zf = zipfile.ZipFile(fname, 'r')
-    for name in zf.namelist():
-        dir = os.path.dirname(name)
-        try:
-            os.makedirs(dir)
-        except OSError:
-            pass
-        with open(name, 'wb') as f:
-            f.write(zf.read(name))
+    with zipfile.ZipFile(fname, 'r') as zf:
+        for name in zf.namelist():
+            dir = os.path.dirname(name)
+            try:
+                os.makedirs(dir)
+            except OSError:
+                pass
+            with open(name, 'wb') as f:
+                f.write(zf.read(name))
 
 
 def read_tree(dir):

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -103,7 +103,7 @@ Memory after reading SConscript files:  200%(index)s
 Memory before building targets:  300%(index)s
 Memory after building targets:  400%(index)s
 Object counts:
-       pre-   post-    pre-   post-   
+       pre-   post-    pre-   post-
        read    read   build   build   Class
        101%(index)s    102%(index)s    103%(index)s    104%(index)s   Action.CommandAction
        201%(index)s    202%(index)s    203%(index)s    204%(index)s   Action.CommandGeneratorAction
@@ -273,20 +273,16 @@ class TestSCons_time(TestCommon):
 
     def write_sample_tarfile(self, archive, dir, files):
         import shutil
-        try:
-            import tarfile
-        except ImportError:
-            self.skip_test('no tarfile module\n', from_framework=True)
-        else:
-            base, suffix = self.archive_split(archive)
+        import tarfile
+        base, suffix = self.archive_split(archive)
 
-            mode = {
-                '.tar'      : 'w',
-                '.tar.gz'   : 'w:gz',
-                '.tgz'      : 'w:gz',
-            }
+        mode = {
+            '.tar'      : 'w',
+            '.tar.gz'   : 'w:gz',
+            '.tgz'      : 'w:gz',
+        }
 
-            tar = tarfile.open(archive, mode[suffix])
+        with tarfile.open(archive, mode[suffix]) as tar:
             for name, content in files:
                 path = os.path.join(dir, name)
                 with open(path, 'wb') as f:
@@ -298,30 +294,20 @@ class TestSCons_time(TestCommon):
                 tarinfo.gname = 'fake_group'
                 with open(path, 'rb') as f:
                     tar.addfile(tarinfo, f)
-            tar.close()
-            shutil.rmtree(dir)
-            return self.workpath(archive)
+        shutil.rmtree(dir)
+        return self.workpath(archive)
 
     def write_sample_zipfile(self, archive, dir, files):
         import shutil
-        try:
-            import zipfile
-        except ImportError:
-
-            sys.stderr.write('no zipfile module\n')
-            self.no_result()
-
-        else:
-
-            zip = zipfile.ZipFile(archive, 'w')
+        import zipfile
+        with zipfile.ZipFile(archive, 'w') as zip:
             for name, content in files:
                 path = os.path.join(dir, name)
                 with open(path, 'w') as f:
                     f.write(content)
                 zip.write(path)
-            zip.close()
-            shutil.rmtree(dir)
-            return self.workpath(archive)
+        shutil.rmtree(dir)
+        return self.workpath(archive)
 
     sample_project_files = [
         ('SConstruct',  SConstruct),


### PR DESCRIPTION
Python 3.13.0b1 added a warning when the extraction filter is not specified.  The `filter` argument (to `extract()` and `extractall()`) was added in 3.12, but with no noise. Once the warning was added, the `scons-time` tests began to fail - this is a continuation of the work Red Hat did for RHEL 8 and RHEL 9 starting with Python 3.9.  Supplying the filter quiets the warning, which also worked for the RHEL case.

The `tarfile` and `zipfile` usage now uses a context manager (both objects can be used this way since Python 3.2 or so).

This has no visible effects - `scons-time` is only used during testing. Not added to release note as `bin/scons-time.py` is not part of the released SCons wheel.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
