### PR TITLE
Improve conversion to BuildError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       old Python 2-only code block in a test.
     - scons-time tests now supply a "filter" argument to tarfile.extract
       to quiet a warning which was added in Python 3.13 beta 1.
+    - Improved the conversion of a "foreign" exception from an action
+      into BuildError by making sure our defaults get applied even in
+      corner cases. Fixes #4530.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -51,7 +51,7 @@ FIXES
 - OSErrors are now no longer hidden during the execution of Actions.
 - Improved the conversion of a "foreign" exception from an action
   into BuildError by making sure our defaults get applied even in
-  corner cases.
+  corner cases. Fixes Issue #4530
 
 IMPROVEMENTS
 ------------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -49,6 +49,9 @@ FIXES
 -----
 
 - OSErrors are now no longer hidden during the execution of Actions.
+- Improved the conversion of a "foreign" exception from an action
+  into BuildError by making sure our defaults get applied even in
+  corner cases.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Errors.py
+++ b/SCons/Errors.py
@@ -177,8 +177,12 @@ def convert_to_BuildError(status, exc_info=None):
         # (for example, failure to create the directory in which the
         # target file will appear).
         filename = getattr(status, 'filename', None)
-        strerror = getattr(status, 'strerror', str(status))
-        errno = getattr(status, 'errno', 2)
+        strerror = getattr(status, 'strerror', None)
+        if strerror is None:
+            strerror = str(status)
+        errno = getattr(status, 'errno', None)
+        if errno is None:
+            errno = 2
 
         buildError = BuildError(
             errstr=strerror,

--- a/SCons/ErrorsTests.py
+++ b/SCons/ErrorsTests.py
@@ -46,7 +46,7 @@ class ErrorsTestCase(unittest.TestCase):
             assert e.command == "c"
 
         try:
-            raise SCons.Errors.BuildError("n", "foo", 57, 3, "file", 
+            raise SCons.Errors.BuildError("n", "foo", 57, 3, "file",
                                           "e", "a", "c", (1,2,3))
         except SCons.Errors.BuildError as e:
             assert e.errstr == "foo", e.errstr
@@ -96,26 +96,48 @@ class ErrorsTestCase(unittest.TestCase):
             assert e.node == "node"
 
     def test_convert_EnvironmentError_to_BuildError(self) -> None:
-        """Test the convert_to_BuildError function on SConsEnvironmentError
-        exceptions.
-        """
+        """Test convert_to_BuildError on SConsEnvironmentError."""
         ee = SCons.Errors.SConsEnvironmentError("test env error")
         be = SCons.Errors.convert_to_BuildError(ee)
-        assert be.errstr == "test env error"
-        assert be.status == 2
-        assert be.exitstatus == 2
-        assert be.filename is None
+        with self.subTest():
+            self.assertEqual(be.errstr, "test env error")
+        with self.subTest():
+            self.assertEqual(be.status, 2)
+        with self.subTest():
+            self.assertEqual(be.exitstatus, 2)
+        with self.subTest():
+            self.assertIsNone(be.filename)
 
     def test_convert_OSError_to_BuildError(self) -> None:
-        """Test the convert_to_BuildError function on OSError
-        exceptions.
-        """
+        """Test convert_to_BuildError on OSError."""
         ose = OSError(7, 'test oserror')
         be = SCons.Errors.convert_to_BuildError(ose)
-        assert be.errstr == 'test oserror'
-        assert be.status == 7
-        assert be.exitstatus == 2
-        assert be.filename is None
+        with self.subTest():
+            self.assertEqual(be.errstr, 'test oserror')
+        with self.subTest():
+            self.assertEqual(be.status, 7)
+        with self.subTest():
+            self.assertEqual(be.exitstatus, 2)
+        with self.subTest():
+            self.assertIsNone(be.filename)
+
+    def test_convert_phony_OSError_to_BuildError(self) -> None:
+        """Test convert_to_BuildError on OSError with defaults."""
+        class PhonyException(OSError):
+            def __init__(self, name):
+                OSError.__init__(self, name)  # most fields will default to None
+                self.name = name
+
+        ose = PhonyException("test oserror")
+        be = SCons.Errors.convert_to_BuildError(ose)
+        with self.subTest():
+            self.assertEqual(be.errstr, 'test oserror')
+        with self.subTest():
+            self.assertEqual(be.status, 2)
+        with self.subTest():
+            self.assertEqual(be.exitstatus, 2)
+        with self.subTest():
+            self.assertIsNone(be.filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In some cases, the conversion of another exception to a `BuildError` could yield undesired results: if the exception was a `OSError`/`IOError`, and some fields were initially set to `None`, then the return code and error string were set to `None`, rather than the SCons defaults (which are return code 2, and the string set originally in the exception).

A unit test is added which attempts to build an `OSError` in the way that the case "in the wild" does - confirmed failing to pick up defaults without the change.

Fixes #4530

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
