### PR TITLE
Variables cleanup: core

### DIFF
--- a/test/Variables/BoolVariable.py
+++ b/test/Variables/BoolVariable.py
@@ -67,7 +67,7 @@ test.run(arguments='warnings=0 profile=no profile=true')
 check([str(False), str(True)])
 
 expect_stderr = """
-scons: *** Error converting option: warnings
+scons: *** Error converting option: 'warnings'
 Invalid value for boolean variable: 'irgendwas'
 """ + test.python_file_line(SConstruct_path, 13)
 

--- a/test/Variables/ListVariable.py
+++ b/test/Variables/ListVariable.py
@@ -113,7 +113,7 @@ check(['gl,qt', '0', 'gl qt', 'gl qt', "['gl qt']"])
 
 
 expect_stderr = """
-scons: *** Error converting option: shared
+scons: *** Error converting option: 'shared'
 Invalid value(s) for option: foo
 """ + test.python_file_line(SConstruct_path, 20)
 
@@ -122,28 +122,28 @@ test.run(arguments='shared=foo', stderr=expect_stderr, status=2)
 # be paranoid in testing some more combinations
 
 expect_stderr = """
-scons: *** Error converting option: shared
+scons: *** Error converting option: 'shared'
 Invalid value(s) for option: foo
 """ + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=foo,ical', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Error converting option: shared
+scons: *** Error converting option: 'shared'
 Invalid value(s) for option: foo
 """ + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=ical,foo', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Error converting option: shared
+scons: *** Error converting option: 'shared'
 Invalid value(s) for option: foo
 """ + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='shared=ical,foo,x11', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Error converting option: shared
+scons: *** Error converting option: 'shared'
 Invalid value(s) for option: foo,bar
 """ + test.python_file_line(SConstruct_path, 20)
 

--- a/test/Variables/Variables.py
+++ b/test/Variables/Variables.py
@@ -27,7 +27,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 print(env['CC'])
@@ -37,19 +37,17 @@ Default(env.Alias('dummy', None))
 test.run()
 cc, ccflags = test.stdout().split('\n')[1:3]
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 # test validator.  Change a key and add a new one to the environment
 def validator(key, value, environ):
     environ[key] = "v"
     environ["valid_key"] = "v"
 
-
-def old_converter (value):
+def old_converter(value):
     return "old_converter"
 
-def new_converter (value, env):
+def new_converter(value, env):
     return "new_converter"
-
 
 opts = Variables('custom.py')
 opts.Add('RELEASE_BUILD',
@@ -90,15 +88,17 @@ opts.Add('UNSPECIFIED',
 
 def test_tool(env):
     if env['RELEASE_BUILD']:
-        env.Append(CCFLAGS = '-O')
+        env.Append(CCFLAGS='-O')
     if env['DEBUG_BUILD']:
-        env.Append(CCFLAGS = '-g')
-
+        env.Append(CCFLAGS='-g')
 
 DefaultEnvironment(tools=[])  # test speedup
 env = Environment(variables=opts, tools=['default', test_tool])
 
-Help('Variables settable in custom.py or on the command line:\\n' + opts.GenerateHelpText(env))
+Help(
+    'Variables settable in custom.py or on the command line:\\n'
+    + opts.GenerateHelpText(env)
+)
 
 print(env['RELEASE_BUILD'])
 print(env['DEBUG_BUILD'])
@@ -121,7 +121,6 @@ opts.Update(env)
 assert env['RELEASE_BUILD'] == r
 
 Default(env.Alias('dummy', None))
-
 """)
 
 def check(expect):
@@ -146,7 +145,7 @@ check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v'])
 test.run(arguments='CCFLAGS=--taco')
 check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v'])
 
-test.write('custom.py', """
+test.write('custom.py', """\
 DEBUG_BUILD=0
 RELEASE_BUILD=1
 """)
@@ -157,8 +156,7 @@ check(['1', '0', cc, (ccflags + ' -O').strip(), 'v', 'v'])
 test.run(arguments='DEBUG_BUILD=1')
 check(['1', '1', cc, (ccflags + ' -O -g').strip(), 'v', 'v'])
 
-test.run(arguments='-h',
-         stdout = """\
+test.run(arguments='-h', stdout = """\
 scons: Reading SConscript files ...
 1
 0
@@ -220,7 +218,7 @@ opts.Add('UNSPECIFIED',
          'An option with no value')
 
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment(variables = opts)
+env = Environment(variables=opts)
 
 print(env['RELEASE_BUILD'])
 print(env['DEBUG_BUILD'])
@@ -241,18 +239,18 @@ def checkSave(file, expected):
 # First test with no command line variables
 # This should just leave the custom.py settings
 test.run()
-check(['1','0'])
-checkSave('variables.saved', { 'RELEASE_BUILD':1, 'DEBUG_BUILD':0})
+check(['1', '0'])
+checkSave('variables.saved', {'RELEASE_BUILD': 1, 'DEBUG_BUILD': 0})
 
 # Override with command line arguments
 test.run(arguments='DEBUG_BUILD=3')
-check(['1','3'])
-checkSave('variables.saved', {'RELEASE_BUILD':1, 'DEBUG_BUILD':3})
+check(['1', '3'])
+checkSave('variables.saved', {'RELEASE_BUILD': 1, 'DEBUG_BUILD': 3})
 
 # Now make sure that saved variables are overridding the custom.py
 test.run()
-check(['1','3'])
-checkSave('variables.saved', {'DEBUG_BUILD':3, 'RELEASE_BUILD':1})
+check(['1', '3'])
+checkSave('variables.saved', {'DEBUG_BUILD': 3, 'RELEASE_BUILD': 1})
 
 # Load no variables from file(s)
 # Used to test for correct output in save option file
@@ -279,7 +277,7 @@ opts.Add('LISTOPTION_TEST',
          names = ['a','b','c',])
 
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment(variables = opts)
+env = Environment(variables=opts)
 
 print(env['RELEASE_BUILD'])
 print(env['DEBUG_BUILD'])
@@ -329,12 +327,13 @@ env = Environment(variables=opts)
 def compare(a, b):
     return (a > b) - (a < b)
 
-Help('Variables settable in custom.py or on the command line:\\n' + opts.GenerateHelpText(env,sort=compare))
-
+Help(
+    'Variables settable in custom.py or on the command line:\\n'
+    + opts.GenerateHelpText(env, sort=compare)
+)
 """)
 
-test.run(arguments='-h',
-         stdout = """\
+test.run(arguments='-h', stdout = """\
 scons: Reading SConscript files ...
 scons: done reading SConscript files.
 Variables settable in custom.py or on the command line:
@@ -360,9 +359,10 @@ Use scons -H for help about SCons built-in command-line options.
 
 test.write('SConstruct', """
 import SCons.Variables
+
 DefaultEnvironment(tools=[])  # test speedup
-env1 = Environment(variables = Variables())
-env2 = Environment(variables = SCons.Variables.Variables())
+env1 = Environment(variables=Variables())
+env2 = Environment(variables=SCons.Variables.Variables())
 """)
 
 test.run()

--- a/test/Variables/chdir.py
+++ b/test/Variables/chdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can chdir() to the directory in which an Variables

--- a/test/Variables/help.py
+++ b/test/Variables/help.py
@@ -101,7 +101,6 @@ print(env['profile'])
 Default(env.Alias('dummy', None))
 """ % locals())
 
-
 test.run(arguments='-h',
          stdout = """\
 scons: Reading SConscript files ...
@@ -150,8 +149,6 @@ qt_libraries: where the Qt library is installed ( /path/to/qt_libraries )
 
 Use scons -H for help about SCons built-in command-line options.
 """ % locals())
-
-
 
 test.pass_test()
 

--- a/test/Variables/import.py
+++ b/test/Variables/import.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that an Variables file in a different directory can import


### PR DESCRIPTION
Part 6 of a series, updating the core of the Variables implementation (__init__.py), tests and docstrings.

There are more lines of change in this one, but not much more in the way of substantive changes - turning Variable into a more visible class and docstring and typing changes make up the most of it.

The attempt to treat `Variables` as a singleton, which was incorrectly implemented, has been dropped from the code (fixes #2446)

Changelog note was merged in Part 1.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
