### PR TITLE
Fix some more regex strings

### DIFF
--- a/bin/SConsExamples.py
+++ b/bin/SConsExamples.py
@@ -554,7 +554,7 @@ def CCCom(target, source, env):
             process(src, fp)
             fp.write('debug = ' + ARGUMENTS.get('debug', '0') + '\\n')
 
-public_class_re = re.compile('^public class (\S+)', re.MULTILINE)
+public_class_re = re.compile(r'^public class (\S+)', re.MULTILINE)
 
 def JavaCCom(target, source, env):
     # This is a fake Java compiler that just looks for

--- a/bin/scons-diff.py
+++ b/bin/scons-diff.py
@@ -115,11 +115,11 @@ diff_map = {
 
 diff_function = diff_map.get(diff_type, simple_diff)
 
-baseline_re = re.compile('(# |@REM )/home/\S+/baseline/')
-comment_rev_re = re.compile('(# |@REM )(\S+) 0.96.[CD]\d+ \S+ \S+( knight)')
-revision_re = re.compile('__revision__ = "[^"]*"')
-build_re = re.compile('__build__ = "[^"]*"')
-date_re = re.compile('__date__ = "[^"]*"')
+baseline_re = re.compile(r'(# |@REM )/home/\S+/baseline/')
+comment_rev_re = re.compile(r'(# |@REM )(\S+) 0.96.[CD]\d+ \S+ \S+( knight)')
+revision_re = re.compile(r'__revision__ = "[^"]*"')
+build_re = re.compile(r'__build__ = "[^"]*"')
+date_re = re.compile(r'__date__ = "[^"]*"')
 
 def lines_read(file):
     return open(file).readlines()

--- a/bin/scons-time.py
+++ b/bin/scons-time.py
@@ -552,7 +552,7 @@ class SConsTimer:
         specified prefix, extracts the run numbers from each file name,
         and returns the next run number after the largest it finds.
         """
-        x = re.compile(re.escape(prefix) + '-([0-9]+).*')
+        x = re.compile(re.escape(prefix) + r'-([0-9]+).*')
         matches = [x.match(e) for e in os.listdir(dir)]
         matches = [_f for _f in matches if _f]
         if not matches:


### PR DESCRIPTION
Building the userguide examples with Python 3.12 led to `SyntaxWarning` lines appearing in the output. The reason was a regex string that contained an escape sequence that is not one of the Python escapes, and the string wasn't entered in raw-string format - 3.12 compains about this. This sort of problem has been fixed elsewhere, but missed some cases in the tools. Continuing on with the rule "if it's a regex, use raw string format".

Three auxiliary scripts in `bin/` are affected, only one of which (`SConsExamples.py`) is even in regular use.  This has no effect on the operation of SCons, or on documentation, or on tests, so no release note created.
