### PR TITLE
Forward port benchmark for type checking

### DIFF
--- a/bench/is_types.py
+++ b/bench/is_types.py
@@ -5,23 +5,11 @@
 # src/engine/SCons/Util.py.
 
 import types
-try:
-    from collections import UserDict, UserList, UserString
-except ImportError:
-    # No 'collections' module or no UserFoo in collections
-    exec('from UserDict import UserDict')
-    exec('from UserList import UserList')
-    exec('from UserString import UserString')
+from collections import UserDict, UserList, UserString
 
-InstanceType = types.InstanceType
 DictType = dict
 ListType = list
 StringType = str
-try: unicode
-except NameError:
-    UnicodeType = None
-else:
-    UnicodeType = unicode
 
 
 # The original implementations, pretty straightforward checks for the
@@ -29,42 +17,29 @@ else:
 # User* type.
 
 def original_is_Dict(e):
-    return isinstance(e, (dict,UserDict))
+    return isinstance(e, (dict, UserDict))
 
 def original_is_List(e):
-    return isinstance(e, (list,UserList))
+    return isinstance(e, (list, UserList))
 
-if UnicodeType is not None:
-    def original_is_String(e):
-        return isinstance(e, (str,unicode,UserString))
-else:
-    def original_is_String(e):
-        return isinstance(e, (str,UserString))
-
+def original_is_String(e):
+    return isinstance(e, (str, UserString))
 
 
 # New candidates that explicitly check for whether the object is an
 # InstanceType before calling isinstance() on the corresponding User*
 # type.
+# InstanceType was only for old-style classes, so absent in Python 3
+# this this is no different than the previous
 
 def checkInstanceType_is_Dict(e):
-    return isinstance(e, dict) or \
-           (isinstance(e, types.InstanceType) and isinstance(e, UserDict))
+    return isinstance(e, (dict, UserDict))
 
 def checkInstanceType_is_List(e):
-    return isinstance(e, list) \
-        or (isinstance(e, types.InstanceType) and isinstance(e, UserList))
+    return isinstance(e, (list, UserList))
 
-if UnicodeType is not None:
-    def checkInstanceType_is_String(e):
-        return isinstance(e, str) \
-            or isinstance(e, unicode) \
-            or (isinstance(e, types.InstanceType) and isinstance(e, UserString))
-else:
-    def checkInstanceType_is_String(e):
-        return isinstance(e, str) \
-            or (isinstance(e, types.InstanceType) and isinstance(e, UserString))
-
+def checkInstanceType_is_String(e):
+    return isinstance(e, (str, UserString))
 
 
 # Improved candidates that cache the type(e) result in a variable
@@ -72,26 +47,15 @@ else:
 
 def cache_type_e_is_Dict(e):
     t = type(e)
-    return t is dict or \
-           (t is types.InstanceType and isinstance(e, UserDict))
+    return t is dict or isinstance(e, UserDict)
 
 def cache_type_e_is_List(e):
     t = type(e)
-    return t is list \
-        or (t is types.InstanceType and isinstance(e, UserList))
+    return t is list or isinstance(e, UserList)
 
-if UnicodeType is not None:
-    def cache_type_e_is_String(e):
-        t = type(e)
-        return t is str \
-            or t is unicode \
-            or (t is types.InstanceType and isinstance(e, UserString))
-else:
-    def cache_type_e_is_String(e):
-        t = type(e)
-        return t is str \
-            or (t is types.InstanceType and isinstance(e, UserString))
-
+def cache_type_e_is_String(e):
+    t = type(e)
+    return t is str or isinstance(e, UserString)
 
 
 # Improved candidates that cache the type(e) result in a variable
@@ -100,26 +64,15 @@ else:
 
 def global_cache_type_e_is_Dict(e):
     t = type(e)
-    return t is DictType or \
-           (t is InstanceType and isinstance(e, UserDict))
+    return t is DictType or isinstance(e, UserDict)
 
 def global_cache_type_e_is_List(e):
     t = type(e)
-    return t is ListType \
-        or (t is InstanceType and isinstance(e, UserList))
+    return t is ListType or isinstance(e, UserList)
 
-if UnicodeType is not None:
-    def global_cache_type_e_is_String(e):
-        t = type(e)
-        return t is StringType \
-            or t is UnicodeType \
-            or (t is InstanceType and isinstance(e, UserString))
-else:
-    def global_cache_type_e_is_String(e):
-        t = type(e)
-        return t is StringType \
-            or (t is InstanceType and isinstance(e, UserString))
-
+def global_cache_type_e_is_String(e):
+    t = type(e)
+    return t is StringType or isinstance(e, UserString)
 
 
 # Alternative that uses a myType() function to map the User* objects
@@ -131,20 +84,11 @@ instanceTypeMap = {
     UserString : str,
 }
 
-if UnicodeType is not None:
-    def myType(obj):
-        t = type(obj)
-        if t is types.InstanceType:
-            t = instanceTypeMap.get(obj.__class__, t)
-        elif t is unicode:
-            t = str
-        return t
-else:
-    def myType(obj):
-        t = type(obj)
-        if t is types.InstanceType:
-            t = instanceTypeMap.get(obj.__class__, t)
-        return t
+def myType(obj):
+    t = type(obj)
+    if t is types.InstanceType:
+        t = instanceTypeMap.get(obj.__class__, t)
+    return t
 
 def myType_is_Dict(e):
     return myType(e) is dict


### PR DESCRIPTION
`is_types.py` had not been modernized.  Remove any reference to the `unicode` builtin, which will never be present on Py3; stop using `types.InstanceType` which was only for old-style classes and never exists on Py3. It is now possible to:
```
$ python bench.py is_types.py
```
to get an up to date timing run of the type checking functions.  Note it's probably a good idea to up the counts in `bench.py`, this completes pretty quickly.

This is internal-use stuff only, not part of the release or docs. 

Here's a run with the repeat counts upped (Note: the `checkInstanceType_is*` functions no longer differ from the `original_is*` functions with the dropping of the `InstanceType` checks. Next round, we should just get rid of these).

```
Bench: is_types : is_types.py
Func01 (original_is_String):
       0.088 : String
       0.403 : List
       0.436 : Dict
       0.121 : UserString
       0.373 : UserList
       0.415 : UserDict
       0.360 : Object
Func02 (original_is_List):
       0.406 : String
       0.086 : List
       0.415 : Dict
       0.378 : UserString
       0.118 : UserList
       0.371 : UserDict
       0.375 : Object
Func03 (original_is_Dict):
       0.377 : String
       0.415 : List
       0.085 : Dict
       0.433 : UserString
       0.375 : UserList
       0.126 : UserDict
       0.372 : Object
Func04 (checkInstanceType_is_String):
       0.086 : String
       0.409 : List
       0.387 : Dict
       0.188 : UserString
       0.378 : UserList
       0.368 : UserDict
       0.358 : Object
Func05 (checkInstanceType_is_List):
       0.410 : String
       0.087 : List
       0.403 : Dict
       0.369 : UserString
       0.122 : UserList
       0.366 : UserDict
       0.384 : Object
Func06 (checkInstanceType_is_Dict):
       0.389 : String
       0.407 : List
       0.084 : Dict
       0.368 : UserString
       0.377 : UserList
       0.120 : UserDict
       0.416 : Object
Func07 (cache_type_e_is_String):
       0.053 : String
       0.348 : List
       0.340 : Dict
       0.080 : UserString
       0.341 : UserList
       0.357 : UserDict
       0.371 : Object
Func08 (cache_type_e_is_List):
       0.341 : String
       0.056 : List
       0.335 : Dict
       0.338 : UserString
       0.082 : UserList
       0.357 : UserDict
       0.333 : Object
Func09 (cache_type_e_is_Dict):
       0.394 : String
       0.340 : List
       0.086 : Dict
       0.386 : UserString
       0.338 : UserList
       0.080 : UserDict
       0.330 : Object
Func10 (global_cache_type_e_is_String):
       0.059 : String
       0.371 : List
       0.332 : Dict
       0.076 : UserString
       0.381 : UserList
       0.344 : UserDict
       0.388 : Object
Func11 (global_cache_type_e_is_List):
       0.389 : String
       0.061 : List
       0.326 : Dict
       0.337 : UserString
       0.077 : UserList
       0.334 : UserDict
       0.348 : Object
Func12 (global_cache_type_e_is_Dict):
       0.379 : String
       0.348 : List
       0.055 : Dict
       0.338 : UserString
       0.332 : UserList
       0.077 : UserDict
       0.330 : Object
```
