### PR TITLE
Fix two scons-time tests on GH Windows runner

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -71,6 +71,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       tweaked the Util package doc build so it's structured more like the
       other packages (a missed part of the transition when it was split).
     - Updated manpage description of Command "builder" and function.
+    - Framework for scons-time tests adjusted so a path with a long username
+      Windows has squashed doesn't get re-expanded. Fixes a problem seen
+      on GitHub Windows runner which uses a name "runneradmin".
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/testing/framework/TestSCons_time.py
+++ b/testing/framework/TestSCons_time.py
@@ -40,6 +40,7 @@ import sys
 
 from TestCommon import *
 from TestCommon import __all__
+from TestCmd import IS_WINDOWS
 # some of the scons_time tests may need regex-based matching:
 from TestSCons import search_re, search_re_in_list
 
@@ -236,7 +237,11 @@ class TestSCons_time(TestCommon):
         except AttributeError:
             pass
         else:
-            tempdir = realpath(tempdir)
+            # Don't realpath on Windows, tempdir could contain 8+3 path
+            # E.g. username on GitHub runner is "runneradmin" -> "RUNNER~1"
+            # We don't want to convert that back!
+            if not IS_WINDOWS:
+                tempdir = realpath(tempdir)
 
         args = (tempdir, 'scons-time-',) + args
         x = os.path.join(*args)

--- a/windows_ci_skip.txt
+++ b/windows_ci_skip.txt
@@ -33,8 +33,6 @@ test/packaging/msi/package.py
 test/packaging/tar/xz_packaging.py
 test/scons-time/run/config/python.py
 test/scons-time/run/option/python.py
-test/scons-time/run/option/quiet.py
-test/scons-time/run/option/verbose.py
 test/sconsign/script/no-SConsignFile.py
 test/sconsign/script/SConsignFile.py
 test/sconsign/script/Signatures.py


### PR DESCRIPTION
## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
