### PR TITLE
Win32 test speedup - Part 1

### DIFF
--- a/test/AR/AR.py
+++ b/test/AR/AR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 
 import TestSCons
@@ -35,6 +34,7 @@ test = TestSCons.TestSCons()
 test.file_fixture('wrapper.py')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 foo = Environment(LIBS = ['foo'], LIBPATH = ['.'])
 ar = foo.Dictionary('AR')
 bar = Environment(LIBS = ['bar'], LIBPATH = ['.'], AR = r'%(_python_)s wrapper.py ' + ar)

--- a/test/AR/ARCOM.py
+++ b/test/AR/ARCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $ARCOM construction variable.
@@ -38,6 +37,7 @@ test.file_fixture('mycompile.py')
 test.file_fixture('myrewrite.py')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(tools=['default', 'ar'],
                   ARCOM = r'%(_python_)s mycompile.py ar $TARGET $SOURCES',
                   RANLIB = True,

--- a/test/AR/ARCOMSTR.py
+++ b/test/AR/ARCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $ARCOMSTR construction variable allows you to customize
@@ -39,6 +38,7 @@ test.file_fixture('mycompile.py')
 test.file_fixture('myrewrite.py')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(tools=['default', 'ar'],
                   ARCOM = r'%(_python_)s mycompile.py ar $TARGET $SOURCES',
                   ARCOMSTR = 'Archiving $TARGET from $SOURCES',

--- a/test/AR/ARFLAGS.py
+++ b/test/AR/ARFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 
 import TestSCons
@@ -35,6 +34,7 @@ test = TestSCons.TestSCons()
 test.file_fixture('wrapper.py')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 foo = Environment(LIBS = ['foo'], LIBPATH = ['.'])
 bar = Environment(LIBS = ['bar'], LIBPATH = ['.'],
                   AR = '', ARFLAGS = foo.subst(r'%(_python_)s wrapper.py $AR $ARFLAGS'))

--- a/test/AS/AS.py
+++ b/test/AS/AS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the ability to set the $AS construction variable to a different
@@ -41,7 +40,9 @@ test.file_fixture('mylink.py')
 test.file_fixture(['fixture', 'myas.py'])
 
 test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['link','as','gcc'],
+                  LINK = r'%(_python_)s mylink.py',
                   AS = r'%(_python_)s myas.py',
                   CC = r'%(_python_)s myas.py')
 env.Program(target = 'test1', source = 'test1.s')

--- a/test/AS/ASCOM.py
+++ b/test/AS/ASCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $ASCOM construction variable.
@@ -46,7 +45,9 @@ else:
     alt_asm_suffix = '.asm'
 
 test.write('SConstruct', """
-env = Environment(ASCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['as'],
+                  ASCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
                   OBJSUFFIX = '.obj',
                   SHOBJPREFIX = '',
                   SHOBJSUFFIX = '.shobj')

--- a/test/AS/ASCOMSTR.py
+++ b/test/AS/ASCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $ASCOMSTR construction variable allows you to configure
@@ -47,7 +46,9 @@ else:
     alt_asm_suffix = '.asm'
 
 test.write('SConstruct', """
-env = Environment(ASCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['as'],
+                  ASCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
                   ASCOMSTR = 'Assembling $TARGET from $SOURCE',
                   OBJSUFFIX = '.obj')
 env.Object(target = 'test1', source = 'test1.s')

--- a/test/AS/ASFLAGS.py
+++ b/test/AS/ASFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 
@@ -38,14 +37,11 @@ test.file_fixture(['fixture', 'myas_args.py'])
 
 o = ' -x'
 o_c = ' -x -c'
-if sys.platform == 'win32':
-    import SCons.Tool.MSCommon as msc
-    
-    if msc.msvc_exists():
-        o_c = ' -x'
 
 test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['link','as'],
+                  LINK = r'%(_python_)s mylink.py',
                   LINKFLAGS = [],
                   AS = r'%(_python_)s myas_args.py', ASFLAGS = '-x',
                   CC = r'%(_python_)s myas_args.py')

--- a/test/AS/ASPP.py
+++ b/test/AS/ASPP.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,10 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 
 import TestSCons
 
@@ -36,7 +34,9 @@ test.file_fixture('mylink.py')
 test.file_fixture(['fixture', 'myas.py'])
 
 test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['link','cc','as'],
+                  LINK = r'%(_python_)s mylink.py',
                   LINKFLAGS = [],
                   ASPP = r'%(_python_)s myas.py',
                   CC = r'%(_python_)s myas.py')

--- a/test/AS/ASPPCOM.py
+++ b/test/AS/ASPPCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $ASPPCOM construction variable.
@@ -37,7 +36,9 @@ test = TestSCons.TestSCons()
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(ASPPCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['as'],
+                  ASPPCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
                   OBJSUFFIX = '.obj',
                   SHOBJPREFIX = '',
                   SHOBJSUFFIX = '.shobj')

--- a/test/AS/ASPPCOMSTR.py
+++ b/test/AS/ASPPCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $ASPPCOMSTR construction variable allows you to customize
@@ -38,7 +37,9 @@ test = TestSCons.TestSCons()
 test.file_fixture('mycompile.py')
 
 test.write('SConstruct', """
-env = Environment(ASPPCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['as'],
+                  ASPPCOM = r'%(_python_)s mycompile.py as $TARGET $SOURCE',
                   ASPPCOMSTR = 'Assembling $TARGET from $SOURCE',
                   OBJSUFFIX = '.obj')
 env.Object(target = 'test1', source = 'test1.spp')

--- a/test/AS/ASPPFLAGS.py
+++ b/test/AS/ASPPFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 
@@ -38,14 +37,11 @@ test.file_fixture(['fixture', 'myas_args.py'])
 
 o = ' -x'
 o_c = ' -x -c'
-if sys.platform == 'win32':
-    import SCons.Tool.MSCommon as msc
-
-    if msc.msvc_exists():
-        o_c = ' -x'
 
 test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['link','as','cc'],
+                  LINK = r'%(_python_)s mylink.py',
                   LINKFLAGS = [],
                   ASPP = r'%(_python_)s myas_args.py', ASPPFLAGS = '-x',
                   CC = r'%(_python_)s myas_args.py')

--- a/test/AS/ml.py
+++ b/test/AS/ml.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify correct use of the live 'ml' assembler.

--- a/test/Actions/addpost-link.py
+++ b/test/Actions/addpost-link.py
@@ -41,6 +41,7 @@ test = TestSCons.TestSCons()
 test.dir_fixture('addpost-link-fixture')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 
 mylib = env.StaticLibrary('mytest', 'test_lib.c')

--- a/test/Actions/append.py
+++ b/test/Actions/append.py
@@ -41,7 +41,7 @@ test = TestSCons.TestSCons()
 test.dir_fixture('append-fixture')
 
 test.write('SConstruct', """
-
+DefaultEnvironment(tools=[])
 env=Environment()
 
 def before(env, target, source):

--- a/test/Actions/exitstatfunc.py
+++ b/test/Actions/exitstatfunc.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that setting exitstatfunc on an Action works as advertised.
@@ -33,6 +32,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 def always_succeed(s):
     # Always return 0, which indicates success.
     return 0

--- a/test/AddOption/args-and-targets.py
+++ b/test/AddOption/args-and-targets.py
@@ -35,7 +35,8 @@ test = TestSCons.TestSCons()
 test.write(
     'SConstruct',
     """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 AddOption(
     '--extra',
     nargs=1,

--- a/test/AddOption/basic.py
+++ b/test/AddOption/basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the help text when the AddOption() function is used (and when
@@ -34,7 +33,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment()
+    DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 AddOption('--force',
           action="store_true",
           help='force installation (overwrite any existing files)')

--- a/test/AddOption/basic.py
+++ b/test/AddOption/basic.py
@@ -33,7 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-    DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 AddOption('--force',
           action="store_true",

--- a/test/AddOption/help.py
+++ b/test/AddOption/help.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,19 +23,13 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""
-Verify the help text when the AddOption() function is used (and when
-it's not).
-"""
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
-
 import TestSCons
 
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 AddOption('--force',
           action="store_true",
           help='force installation (overwrite existing files)')

--- a/test/AddOption/longopts.py
+++ b/test/AddOption/longopts.py
@@ -35,6 +35,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 AddOption('--myargument', dest='myargument', type='string', default='gully')
 AddOption('--myarg', dest='myarg', type='string', default='balla')
 print("myargument: " + str(GetOption('myargument')))

--- a/test/AddOption/multi-arg.py
+++ b/test/AddOption/multi-arg.py
@@ -37,7 +37,6 @@ test.write(
     'SConstruct',
     """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=[])
 AddOption('--extras',
           nargs=2,
           dest='extras',
@@ -73,7 +72,6 @@ test.write(
     'SConstruct',
     """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=[])
 AddOption(
     '--prefix',
     nargs=1,
@@ -103,7 +101,7 @@ test.run('-Q -q .', stdout="None\n()\n")
 # one single-arg option
 test.run('-Q -q . --prefix=/home/foo', stdout="/home/foo\n()\n")
 # one two-arg option
-test.run('-Q -q . --extras A B', status=1, stdout="None\n('A', 'B')\n")
+test.run('-Q -q . --extras A B', status=2, stdout="None\n('A', 'B')\n")
 # single-arg option followed by two-arg option
 test.run(
     '-Q -q . --prefix=/home/foo --extras A B',

--- a/test/AddOption/multi-arg.py
+++ b/test/AddOption/multi-arg.py
@@ -36,7 +36,8 @@ test = TestSCons.TestSCons()
 test.write(
     'SConstruct',
     """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 AddOption('--extras',
           nargs=2,
           dest='extras',
@@ -71,7 +72,8 @@ test.run('-Q -q . -- --extras A B', status=1, stdout="()\n")
 test.write(
     'SConstruct',
     """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 AddOption(
     '--prefix',
     nargs=1,

--- a/test/AddOption/optional-arg.py
+++ b/test/AddOption/optional-arg.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of the nargs='?' keyword argument to specify a long
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 AddOption('--install',
           nargs='?',
           dest='install',
@@ -85,6 +85,7 @@ test.run('-Q -q . first-arg --install=/command/line/directory next-arg',
 
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 AddOption('-X', nargs='?')
 """)
 

--- a/test/Alias/Alias.py
+++ b/test/Alias/Alias.py
@@ -44,7 +44,7 @@ sys.exit(0)
 test.write('SConstruct', """
 B = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment()
+env = Environment(tools=[])
 env['BUILDERS']['B'] = B
 env.B(target = 'f1.out', source = 'f1.in')
 env.B(target = 'f2.out', source = 'f2.in')
@@ -137,7 +137,7 @@ test.write('SConstruct', """
 Decider('content')
 B = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment()
+env = Environment(tools=[])
 env['BUILDERS']['B'] = B
 env.B(target = 'f1.out', source = 'f1.in')
 env.B(target = 'f2.out', source = 'f2.in')

--- a/test/Alias/Depends.py
+++ b/test/Alias/Depends.py
@@ -44,7 +44,7 @@ sys.exit(0)
 test.write('SConstruct', """
 B = Builder(action = r'%(_python_)s build.py $TARGET $SOURCES')
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment()
+env = Environment(tools=[])
 env['BUILDERS']['B'] = B
 env.B(target = 'f1.out', source = 'f1.in')
 env.B(target = 'f2.out', source = 'f2.in')

--- a/test/Alias/Dir-order.py
+++ b/test/Alias/Dir-order.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Validate that calling Dir() for a string after we've used it as an
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 Alias('afoo', 'foo')
 f = Dir('foo')
 """)

--- a/test/Alias/action.py
+++ b/test/Alias/action.py
@@ -52,7 +52,7 @@ def bar(target, source, env):
         f.write(bytearray("bar(%s, %s)\\n" % (target, source),'utf-8'))
 
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment(BUILDERS = {'Cat':Builder(action=cat)})
+env = Environment(tools=[], BUILDERS = {'Cat':Builder(action=cat)})
 env.Alias(target = ['build-f1'], source = 'f1.out', action = foo)
 f1 = env.Cat('f1.out', 'f1.in')
 f2 = env.Cat('f2.out', 'f2.in')

--- a/test/Alias/errors.py
+++ b/test/Alias/errors.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,16 +22,14 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
-env=Environment()
+DefaultEnvironment(tools=[])
+env=Environment(tools=[])
 Decider('content')
 env.Alias('C', 'D')
 env.Alias('B', 'C')

--- a/test/Alias/scanner.py
+++ b/test/Alias/scanner.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,19 +22,18 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
 """
 Test that an Alias of a node with a Scanner works.
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     with open(target, "wb") as f:
@@ -41,7 +42,7 @@ def cat(env, source, target):
                 f.write(ifp.read())
 
 XBuilder = Builder(action = cat, src_suffix = '.x', suffix = '.c')
-env = Environment()
+env = Environment(tools=[])
 env.Append(BUILDERS = { 'XBuilder': XBuilder })
 f = env.XBuilder(source = ['file.x'], target = ['file.c'])
 env.Alias(target = ['cfiles'], source = f)

--- a/test/Alias/srcdir.py
+++ b/test/Alias/srcdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that an Alias for a VariantDir()'s source directory works as
@@ -62,8 +61,8 @@ test.subdir('python')
 
 test.write('SConstruct', """\
 import os.path
-
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 
 def at_copy_ext(target, source, env):
     n = str(source[0])

--- a/test/Batch/Boolean.py
+++ b/test/Batch/Boolean.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify basic use of batch_key to write a batch builder that handles
@@ -34,11 +33,13 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
+
 def batch_build(target, source, env):
     for t, s in zip(target, source):
         with open(str(t), 'wb') as f, open(str(s), 'rb') as infp:
             f.write(infp.read())
-env = Environment()
+env = Environment(tools=[])
 bb = Action(batch_build, batch_key=True)
 env['BUILDERS']['Batch'] = Builder(action=bb)
 env1 = env.Clone()

--- a/test/Batch/CHANGED_SOURCES.py
+++ b/test/Batch/CHANGED_SOURCES.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of $CHANGED_SOURCES with batch builders correctly decides
@@ -49,7 +48,8 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env['BATCH_BUILD'] = 'batch_build.py'
 env['BATCHCOM'] = r'%(_python_)s $BATCH_BUILD ${TARGET.dir} $CHANGED_SOURCES'
 bb = Action('$BATCHCOM', batch_key=True, targets='CHANGED_TARGETS')

--- a/test/Batch/SOURCES.py
+++ b/test/Batch/SOURCES.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of $SOURCES with batch builders correctly decides to
@@ -49,7 +48,8 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env['BATCH_BUILD'] = 'batch_build.py'
 env['BATCHCOM'] = r'%(_python_)s $BATCH_BUILD ${TARGET.dir} $SOURCES'
 bb = Action('$BATCHCOM', batch_key=True)

--- a/test/Batch/action-changed.py
+++ b/test/Batch/action-changed.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that targets in a batch builder are rebuilt when the
@@ -62,7 +61,9 @@ build_py_workpath = test.workpath('build.py')
 # Provide IMPLICIT_COMMAND_DEPENDENCIES=2 so we take a dependency on build.py.
 # Without that, we only scan the first entry in the action string.
 test.write('SConstruct', """
-env = Environment(IMPLICIT_COMMAND_DEPENDENCIES=2)
+DefaultEnvironment(tools=[])
+env = Environment(tools=[],
+                  IMPLICIT_COMMAND_DEPENDENCIES=2)
 env.PrependENVPath('PATHEXT', '.PY')
 bb = Action(r'%(_python_)s "%(build_py_workpath)s" $CHANGED_TARGETS -- $CHANGED_SOURCES',
             batch_key=True,

--- a/test/Batch/callable.py
+++ b/test/Batch/callable.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify passing in a batch_key callable for more control over how
@@ -38,6 +37,7 @@ test = TestSCons.TestSCons()
 test.subdir('sub1', 'sub2')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 def batch_build(target, source, env):
     for t, s in zip(target, source):
         with open(str(t), 'wb') as f, open(str(s), 'rb') as infp:
@@ -47,7 +47,7 @@ if ARGUMENTS.get('BATCH_CALLABLE'):
         return (id(action), id(env), target[0].dir)
 else:
     batch_key=True
-env = Environment()
+env = Environment(tools=[])
 bb = Action(batch_build, batch_key=batch_key)
 env['BUILDERS']['Batch'] = Builder(action=bb)
 env1 = env.Clone()

--- a/test/Batch/changed_sources_alwaysbuild.py
+++ b/test/Batch/changed_sources_alwaysbuild.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that files marked AlwaysBuild also get put into CHANGED_SOURCES.

--- a/test/Batch/generated.py
+++ b/test/Batch/generated.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of a batch builder when one of the later targets in the
@@ -34,6 +33,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
+
 def batch_build(target, source, env):
     for t, s in zip(target, source):
         with open(str(t), 'wb') as fp:
@@ -42,7 +43,7 @@ def batch_build(target, source, env):
                     fp.write(f.read())
             with open(str(s), 'rb') as f:
                 fp.write(f.read())
-env = Environment()
+env = Environment(tools=[])
 bb = Action(batch_build, batch_key=True)
 env['BUILDERS']['Batch'] = Builder(action=bb)
 env1 = env.Clone()

--- a/test/Batch/removed.py
+++ b/test/Batch/removed.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify correct batch builder $CHANGED_SOURCES behavior when some of
@@ -48,7 +47,8 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env['BATCH_BUILD'] = 'batch_build.py'
 env['BATCHCOM'] = r'%(_python_)s $BATCH_BUILD ${TARGET.dir} $CHANGED_SOURCES'
 bb = Action('$BATCHCOM', batch_key=True, targets='CHANGED_TARGETS')

--- a/test/Batch/up_to_date.py
+++ b/test/Batch/up_to_date.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify simple use of $SOURCES with batch builders correctly decide
@@ -48,7 +47,8 @@ sys.exit(0)
 """)
 
 test.write('SConstruct', """
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env['BATCH_BUILD'] = 'batch_build.py'
 env['BATCHCOM'] = r'%(_python_)s $BATCH_BUILD ${TARGET.dir} $SOURCES'
 bb = Action('$BATCHCOM', batch_key=True)

--- a/test/Builder/TargetSubst.py
+++ b/test/Builder/TargetSubst.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the ensure_suffix argument to causes us to add the suffix

--- a/test/Builder/add_src_builder.py
+++ b/test/Builder/add_src_builder.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can call add_src_builder() to add a builder to

--- a/test/Builder/different-actions.py
+++ b/test/Builder/different-actions.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that two builders in two environments with different 

--- a/test/Builder/ensure_suffix.py
+++ b/test/Builder/ensure_suffix.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the ensure_suffix argument to causes us to add the suffix

--- a/test/Builder/errors.py
+++ b/test/Builder/errors.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to catch Builder creation with poorly specified Actions.
@@ -36,6 +35,8 @@ test = TestSCons.TestSCons()
 SConstruct_path = test.workpath('SConstruct')
 
 sconstruct = """
+DefaultEnvironment(tools=[])
+
 def buildop(env, source, target):
     with open(str(target[0]), 'wb') as outf, open(str(source[0]), 'r') as infp:
         for line in inpf.readlines():
@@ -54,7 +55,7 @@ foo.b
 built
 """)
 
-python_file_line = test.python_file_line(SConstruct_path, 11)
+python_file_line = test.python_file_line(SConstruct_path, 13)
 
 ### Gross mistake in Builder spec
 

--- a/test/Builder/non-multi.py
+++ b/test/Builder/non-multi.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that a builder without "multi" set can still be called multiple

--- a/test/Builder/not-a-Builder.py
+++ b/test/Builder/not-a-Builder.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the error when trying to configure a Builder with a non-Builder object.

--- a/test/Builder/same-actions-diff-envs.py
+++ b/test/Builder/same-actions-diff-envs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that two builders in two environments with the same actions generate

--- a/test/Builder/same-actions-diff-overrides.py
+++ b/test/Builder/same-actions-diff-overrides.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that two calls to a builder with different overrides, but the same

--- a/test/Builder/srcdir.py
+++ b/test/Builder/srcdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 
 """
 Verify that specifying a srcdir when calling a Builder correctly

--- a/test/Builder/wrapper.py
+++ b/test/Builder/wrapper.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to use a direct Python function to wrap

--- a/test/CC/CC.py
+++ b/test/CC/CC.py
@@ -36,13 +36,12 @@ test.dir_fixture('CC-fixture')
 test.file_fixture('mylink.py')
 
 test.write('SConstruct', """
-cc = Environment().Dictionary('CC')
+DefaultEnvironment(tools=[])
 env = Environment(
+    tools=['link','cc'],
     LINK=r'%(_python_)s mylink.py',
     LINKFLAGS=[],
     CC=r'%(_python_)s mycc.py',
-    CXX=cc,
-    CXXFLAGS=[],
 )
 env.Program(target='test1', source='test1.c')
 """ % locals())
@@ -54,11 +53,12 @@ test.must_match('test1' + _exe, "This is a .c file.\n", mode='r')
 if os.path.normcase('.c') == os.path.normcase('.C'):
 
     test.write('SConstruct', """
-cc = Environment().Dictionary('CC')
+DefaultEnvironment(tools=[])
+
 env = Environment(
+    tools=['link','cc'],
     LINK=r'%(_python_)s mylink.py',
     CC=r'%(_python_)s mycc.py',
-    CXX=cc,
 )
 env.Program(target='test2', source='test2.C')
 """ % locals())
@@ -69,9 +69,11 @@ env.Program(target='test2', source='test2.C')
 test.file_fixture('wrapper.py')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
+
 foo = Environment()
-cc = foo.Dictionary('CC')
-bar = Environment(CC=r'%(_python_)s wrapper.py ' + cc)
+bar = Environment()
+bar['CC'] = r'%(_python_)s wrapper.py ' + foo['CC']
 foo.Program(target='foo', source='foo.c')
 bar.Program(target='bar', source='bar.c')
 """ % locals())

--- a/test/CC/CCCOM.py
+++ b/test/CC/CCCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the ability to configure the $CCCOM construction variable.
@@ -44,7 +43,9 @@ else:
     alt_c_suffix = '.c'
 
 test.write('SConstruct', """
-env = Environment(CCCOM = r'%(_python_)s mycompile.py cc $TARGET $SOURCE',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['cc'],
+                  CCCOM = r'%(_python_)s mycompile.py cc $TARGET $SOURCE',
                   OBJSUFFIX='.obj')
 env.Object(target = 'test1', source = 'test1.c')
 env.Object(target = 'test2', source = 'test2%(alt_c_suffix)s')

--- a/test/CC/CCCOMSTR.py
+++ b/test/CC/CCCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $CCCOMSTR construction variable allows you to configure
@@ -45,7 +44,9 @@ else:
     alt_c_suffix = '.c'
 
 test.write('SConstruct', """
-env = Environment(CCCOM = r'%(_python_)s mycompile.py cc $TARGET $SOURCE',
+DefaultEnvironment(tools=[])
+env = Environment(tools=['cc'],
+                  CCCOM = r'%(_python_)s mycompile.py cc $TARGET $SOURCE',
                   CCCOMSTR = 'Building $TARGET from $SOURCE',
                   OBJSUFFIX='.obj')
 env.Object(target = 'test1', source = 'test1.c')

--- a/test/CC/CCFLAGS.py
+++ b/test/CC/CCFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 import TestSCons
@@ -45,6 +44,7 @@ else:
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tool=[])
 foo = Environment(CCFLAGS = '%s')
 bar = Environment(CCFLAGS = '%s')
 foo.Object(target = 'foo%s', source = 'prog.c')
@@ -88,6 +88,8 @@ prog.c:  BAZ
 """)
 
 test.write('SConstruct', """
+DefaultEnvironment(tool=[])
+
 bar = Environment(CCFLAGS = '%s')
 bar.Object(target = 'foo%s', source = 'prog.c')
 bar.Object(target = 'bar%s', source = 'prog.c')

--- a/test/CC/CCVERSION.py
+++ b/test/CC/CCVERSION.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 import TestSCons

--- a/test/CC/CFLAGS.py
+++ b/test/CC/CFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 import TestSCons
@@ -31,6 +30,7 @@ test = TestSCons.TestSCons()
 
 # Make sure CFLAGS is not passed to CXX by just expanding CXXCOM
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(CFLAGS='-xyz', CCFLAGS='-abc')
 print(env.subst('$CXXCOM'))
 print(env.subst('$CXXCOMSTR'))

--- a/test/CC/SHCC.py
+++ b/test/CC/SHCC.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 
 import TestSCons
@@ -34,8 +33,9 @@ test = TestSCons.TestSCons()
 test.file_fixture('wrapper.py')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 foo = Environment()
-shcc = foo.Dictionary('SHCC')
+shcc = foo['SHCC']
 bar = Environment(SHCC = r'%(_python_)s wrapper.py ' + shcc)
 foo.SharedObject(target = 'foo/foo', source = 'foo.c')
 bar.SharedObject(target = 'bar/bar', source = 'bar.c')

--- a/test/CC/SHCCCOM.py
+++ b/test/CC/SHCCCOM.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import os
 
@@ -44,6 +43,7 @@ else:
     alt_c_suffix = '.c'
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(SHCCCOM = r'%(_python_)s mycompile.py cc $TARGET $SOURCE',
                   SHOBJPREFIX='',
                   SHOBJSUFFIX='.obj')

--- a/test/CC/SHCCCOMSTR.py
+++ b/test/CC/SHCCCOMSTR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the $SHCCCOMSTR construction variable allows you to customize
@@ -45,6 +44,7 @@ else:
     alt_c_suffix = '.c'
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(SHCCCOM = r'%(_python_)s mycompile.py cc $TARGET $SOURCE',
                   SHCCCOMSTR = 'Building $TARGET from $SOURCE',
                   SHOBJPREFIX='',

--- a/test/CC/SHCCFLAGS.py
+++ b/test/CC/SHCCFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 import TestSCons

--- a/test/CC/SHCFLAGS.py
+++ b/test/CC/SHCFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
 __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
@@ -39,9 +39,10 @@ if os.name == 'posix':
 if sys.platform.find('irix') > -1:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
-test.write('SConstruct', """
-foo = Environment(SHCFLAGS = '%s', WINDOWS_INSERT_DEF=1)
-bar = Environment(SHCFLAGS = '%s', WINDOWS_INSERT_DEF=1)
+test.write('SConstruct', f"""
+DefaultEnvironment(tools=[])
+foo = Environment(SHCFLAGS = '{fooflags}', WINDOWS_INSERT_DEF=1)
+bar = Environment(SHCFLAGS = '{barflags}', WINDOWS_INSERT_DEF=1)
 
 foo_obj = foo.SharedObject(target = 'foo', source = 'prog.c')
 foo.SharedLibrary(target = 'foo', source = foo_obj)
@@ -56,7 +57,7 @@ fooMain.Program(target='fooprog', source=foomain_obj)
 barMain = bar.Clone(LIBS='bar', LIBPATH='.')
 barmain_obj = barMain.Object(target='barmain', source='main.c')
 barMain.Program(target='barprog', source=barmain_obj)
-""" % (fooflags, barflags))
+""")
 
 test.write('foo.def', r"""
 LIBRARY        "foo"
@@ -106,8 +107,9 @@ test.run(arguments = '.')
 test.run(program = test.workpath('fooprog'), stdout = "prog.c:  FOO\n")
 test.run(program = test.workpath('barprog'), stdout = "prog.c:  BAR\n")
 
-test.write('SConstruct', """
-bar = Environment(SHCFLAGS = '%s', WINDOWS_INSERT_DEF=1)
+test.write('SConstruct', f"""
+DefaultEnvironment(tools=[])
+bar = Environment(SHCFLAGS = '{barflags}', WINDOWS_INSERT_DEF=1)
 
 foo_obj = bar.SharedObject(target = 'foo', source = 'prog.c')
 bar.SharedLibrary(target = 'foo', source = foo_obj)
@@ -120,7 +122,7 @@ foomain_obj = barMain.Object(target='foomain', source='main.c')
 barmain_obj = barMain.Object(target='barmain', source='main.c')
 barMain.Program(target='barprog', source=foomain_obj)
 barMain.Program(target='fooprog', source=barmain_obj)
-""" % barflags)
+""")
 
 test.run(arguments = '.')
 

--- a/test/CPPDEFINES/basic.py
+++ b/test/CPPDEFINES/basic.py
@@ -32,6 +32,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 test_list = [
     'xyz',
     ['x', 'y', 'z'],
@@ -47,7 +48,7 @@ def generator(target, source, env, for_signature):
     return 'TARGET_AND_SOURCE_ARE_MISSING'
 
 for i in test_list:
-    env = Environment(
+    env = Environment(tools=['cc'],
         CPPDEFPREFIX='-D',
         CPPDEFSUFFIX='',
         INTEGER=0,
@@ -65,7 +66,7 @@ for i in test_list:
     )
 
 for i in test_list:
-    env = Environment(
+    env = Environment(tools=['cc'],
         CPPDEFPREFIX='|',
         CPPDEFSUFFIX='|',
         INTEGER=1,

--- a/test/CPPDEFINES/fixture/SConstruct-Append
+++ b/test/CPPDEFINES/fixture/SConstruct-Append
@@ -8,38 +8,38 @@ DefaultEnvironment(tools=[])
 
 # Special cases:
 # https://github.com/SCons/scons/issues/1738
-env_1738_2 = Environment(CPPDEFPREFIX='-D')
+env_1738_2 = Environment(tools=['gcc'],CPPDEFPREFIX='-D')
 env_1738_2['CPPDEFINES'] = ['FOO']
 env_1738_2.Append(CPPDEFINES={'value': '1'})
 print(env_1738_2.subst('$_CPPDEFFLAGS'))
 # env_1738_2.Object('test_1738_2', 'main.c')
 
 # https://github.com/SCons/scons/issues/2300
-env_2300_1 = Environment(CPPDEFINES='foo', CPPDEFPREFIX='-D')
+env_2300_1 = Environment(tools=['gcc'],CPPDEFINES='foo', CPPDEFPREFIX='-D')
 env_2300_1.Append(CPPDEFINES='bar')
 print(env_2300_1.subst('$_CPPDEFFLAGS'))
 
-env_2300_2 = Environment(CPPDEFINES=['foo'], CPPDEFPREFIX='-D')  # note the list
+env_2300_2 = Environment(tools=['gcc'],CPPDEFINES=['foo'], CPPDEFPREFIX='-D')  # note the list
 env_2300_2.Append(CPPDEFINES='bar')
 print(env_2300_2.subst('$_CPPDEFFLAGS'))
 
 # An initial space-separated string will be split, but not a string in a list.
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['gcc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = "foo bar"
 env_multi.Append(CPPDEFINES="baz")
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['gcc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = ["foo bar"]
 env_multi.Append(CPPDEFINES="baz")
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['gcc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = "foo"
 env_multi.Append(CPPDEFINES=["bar baz"])
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['gcc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = "foo"
 env_multi.Append(CPPDEFINES="bar baz")
 print(env_multi.subst('$_CPPDEFFLAGS'))
@@ -47,7 +47,7 @@ print(env_multi.subst('$_CPPDEFFLAGS'))
 # Check that AppendUnique(..., delete_existing=True) works as expected.
 # Each addition is in different but matching form, and different order
 # so we expect a reordered list, but with the same macro defines.
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['gcc'],CPPDEFPREFIX='-D')
 env_multi.Append(CPPDEFINES=["Macro1=Value1", ("Macro2", "Value2"), {"Macro3": "Value3"}, "Macro4"])
 try:
     env_multi.AppendUnique(CPPDEFINES="Macro2=Value2", delete_existing=True)
@@ -60,9 +60,9 @@ else:
     print(env_multi.subst('$_CPPDEFFLAGS'))
 
 # A lone tuple handled differently than a lone list.
-env_multi = Environment(CPPDEFPREFIX='-D', CPPDEFINES=("Macro1", "Value1"))
+env_multi = Environment(tools=['gcc'],CPPDEFPREFIX='-D', CPPDEFINES=("Macro1", "Value1"))
 print(env_multi.subst('$_CPPDEFFLAGS'))
-env_multi = Environment(CPPDEFPREFIX='-D', CPPDEFINES=["Macro1", "Value1"])
+env_multi = Environment(tools=['gcc'],CPPDEFPREFIX='-D', CPPDEFINES=["Macro1", "Value1"])
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
 # https://github.com/SCons/scons/issues/1152
@@ -114,7 +114,7 @@ for (t1, c1) in cases:
         orig = f"{c1!r}" if isinstance(c1, str) else c1
         app = f"{c2!r}" if isinstance(c2, str) else c2
         print(f"   orig = {orig}, append = {app}")
-        env = Environment(CPPDEFINES=c1, CPPDEFPREFIX='-D')
+        env = Environment(tools=['gcc'],CPPDEFINES=c1, CPPDEFPREFIX='-D')
         try:
             env.Append(CPPDEFINES=c2)
             final = env.subst('$_CPPDEFFLAGS', source="src", target="tgt")
@@ -122,7 +122,7 @@ for (t1, c1) in cases:
         except Exception as t:
             print(f"Append:\n    FAILED: {t}")
 
-        env = Environment(CPPDEFINES=c1, CPPDEFPREFIX='-D')
+        env = Environment(tools=['gcc'],CPPDEFINES=c1, CPPDEFPREFIX='-D')
         try:
             env.AppendUnique(CPPDEFINES=c2)
             final = env.subst('$_CPPDEFFLAGS', source="src", target="tgt")

--- a/test/CPPDEFINES/fixture/SConstruct-Prepend
+++ b/test/CPPDEFINES/fixture/SConstruct-Prepend
@@ -8,38 +8,38 @@ DefaultEnvironment(tools=[])
 
 # Special cases:
 # https://github.com/SCons/scons/issues/1738
-env_1738_2 = Environment(CPPDEFPREFIX='-D')
+env_1738_2 = Environment(tools=['cc'],CPPDEFPREFIX='-D')
 env_1738_2['CPPDEFINES'] = ['FOO']
 env_1738_2.Prepend(CPPDEFINES={'value': '1'})
 print(env_1738_2.subst('$_CPPDEFFLAGS'))
 # env_1738_2.Object('test_1738_2', 'main.c')
 
 # https://github.com/SCons/scons/issues/2300
-env_2300_1 = Environment(CPPDEFINES='foo', CPPDEFPREFIX='-D')
+env_2300_1 = Environment(tools=['cc'],CPPDEFINES='foo', CPPDEFPREFIX='-D')
 env_2300_1.Prepend(CPPDEFINES='bar')
 print(env_2300_1.subst('$_CPPDEFFLAGS'))
 
-env_2300_2 = Environment(CPPDEFINES=['foo'], CPPDEFPREFIX='-D')  # note the list
+env_2300_2 = Environment(tools=['cc'],CPPDEFINES=['foo'], CPPDEFPREFIX='-D')  # note the list
 env_2300_2.Prepend(CPPDEFINES='bar')
 print(env_2300_2.subst('$_CPPDEFFLAGS'))
 
 # An initial space-separated string will be split, but not a string in a list.
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['cc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = "foo bar"
 env_multi.Prepend(CPPDEFINES="baz")
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['cc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = ["foo bar"]
 env_multi.Prepend(CPPDEFINES="baz")
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['cc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = "foo"
 env_multi.Prepend(CPPDEFINES=["bar baz"])
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['cc'],CPPDEFPREFIX='-D')
 env_multi['CPPDEFINES'] = "foo"
 env_multi.Prepend(CPPDEFINES="bar baz")
 print(env_multi.subst('$_CPPDEFFLAGS'))
@@ -47,7 +47,7 @@ print(env_multi.subst('$_CPPDEFFLAGS'))
 # Check that PrependUnique(..., delete_existing=True) works as expected.
 # Each addition is in different but matching form, and different order
 # so we expect a reordered list, but with the same macro defines.
-env_multi = Environment(CPPDEFPREFIX='-D')
+env_multi = Environment(tools=['cc'],CPPDEFPREFIX='-D')
 env_multi.Prepend(CPPDEFINES=["Macro1=Value1", ("Macro2", "Value2"), {"Macro3": "Value3"}])
 try:
     env_multi.PrependUnique(CPPDEFINES="Macro2=Value2", delete_existing=True)
@@ -60,9 +60,9 @@ else:
     print(env_multi.subst('$_CPPDEFFLAGS'))
 
 # A lone tuple handled differently than a lone list.
-env_tuple = Environment(CPPDEFPREFIX='-D', CPPDEFINES=("Macro1", "Value1"))
+env_tuple = Environment(tools=['cc'],CPPDEFPREFIX='-D', CPPDEFINES=("Macro1", "Value1"))
 print(env_tuple.subst('$_CPPDEFFLAGS'))
-env_multi = Environment(CPPDEFPREFIX='-D', CPPDEFINES=["Macro1", "Value1"])
+env_multi = Environment(tools=['cc'],CPPDEFPREFIX='-D', CPPDEFINES=["Macro1", "Value1"])
 print(env_multi.subst('$_CPPDEFFLAGS'))
 
 # https://github.com/SCons/scons/issues/1152
@@ -115,7 +115,7 @@ for (t1, c1) in cases:
         orig = f"{c1!r}" if isinstance(c1, str) else c1
         pre = f"{c2!r}" if isinstance(c2, str) else c2
         print(f"   orig = {orig}, prepend = {pre}")
-        env = Environment(CPPDEFINES=c1, CPPDEFPREFIX='-D')
+        env = Environment(tools=['cc'],CPPDEFINES=c1, CPPDEFPREFIX='-D')
         try:
             env.Prepend(CPPDEFINES=c2)
             final = env.subst('$_CPPDEFFLAGS', source="src", target="tgt")
@@ -123,7 +123,7 @@ for (t1, c1) in cases:
         except Exception as t:
             print(f"Prepend:\n    FAILED: {t}")
 
-        env = Environment(CPPDEFINES=c1, CPPDEFPREFIX='-D')
+        env = Environment(tools=['cc'],CPPDEFINES=c1, CPPDEFPREFIX='-D')
         try:
             env.PrependUnique(CPPDEFINES=c2)
             final = env.subst('$_CPPDEFFLAGS', source="src", target="tgt")

--- a/test/CPPDEFINES/live.py
+++ b/test/CPPDEFINES/live.py
@@ -32,6 +32,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 foo = Environment(CPPDEFINES=['FOO', ('VAL', '$VALUE')], VALUE=7)
 bar = Environment(CPPDEFINES={'BAR': None, 'VAL': 8})
 baz = Environment(CPPDEFINES=['BAZ', ('VAL', 9)])

--- a/test/CPPDEFINES/undefined.py
+++ b/test/CPPDEFINES/undefined.py
@@ -32,7 +32,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=['cc'])
 print(env.subst('$_CPPDEFFLAGS'))
 """)
 

--- a/test/CPPPATH/Dir.py
+++ b/test/CPPPATH/Dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that CPPPATH values with Dir nodes work correctly.
@@ -37,6 +36,7 @@ test = TestSCons.TestSCons()
 test.subdir('inc1', 'inc2', 'inc3', ['inc3', 'subdir'])
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(CPPPATH = [Dir('inc1'), '$INC2', '$INC3/subdir'],
                   INC2 = Dir('inc2'),
                   INC3 = Dir('inc3'))

--- a/test/CPPPATH/absolute-path.py
+++ b/test/CPPPATH/absolute-path.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify the ability to #include a file with an absolute path name.  (Which

--- a/test/CPPPATH/expand-object.py
+++ b/test/CPPPATH/expand-object.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Make sure that $CPPPATH expands correctly if one of the subsidiary
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 class XXX:
     def __init__(self, value):
         self.value = value

--- a/test/CPPPATH/function-expansion.py
+++ b/test/CPPPATH/function-expansion.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that expansion of construction variables whose values are functions
@@ -47,7 +46,7 @@ test.subdir('list_inc1',
             ['inc3', 'subdir'])
 
 test.write('SConstruct', """\
-env = Environment()
+DefaultEnvironment(tools=[])
 def my_cpppaths( target, source, env, for_signature ):
     return [ Dir('list_inc1'), Dir('list_inc2') ]
 

--- a/test/CPPPATH/list-expansion.py
+++ b/test/CPPPATH/list-expansion.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that expansion of construction variables whose values are
@@ -42,6 +41,7 @@ test = TestSCons.TestSCons()
 test.subdir('sub1', 'sub2', 'sub3', 'sub4')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 class _inc_test:
     def __init__(self, name):
         self.name = name

--- a/test/CPPPATH/match-dir.py
+++ b/test/CPPPATH/match-dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that we don't blow up if there's a directory name within
@@ -45,6 +44,7 @@ test.subdir(['src'],
             ['src', 'inc', 'inc2'])
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 SConscript('src/SConscript', variant_dir = 'build', duplicate = 0)
 """)
 

--- a/test/CPPPATH/nested-lists.py
+++ b/test/CPPPATH/nested-lists.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that CPPPATH values consisting of nested lists work correctly.
@@ -37,6 +36,7 @@ test = TestSCons.TestSCons()
 test.subdir('inc1', 'inc2', 'inc3')
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(CPPPATH = ['inc1', ['inc2', ['inc3']]])
 env.Program('prog.c')
 """)

--- a/test/CPPPATH/null.py
+++ b/test/CPPPATH/null.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWAR
 
 """
 Verify that neither a null-string CPPPATH nor a
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(CPPPATH = '')
 env.Library('one', source = 'empty1.c')
 env = Environment(CPPPATH = [None])

--- a/test/CPPPATH/subdir-as-include.py
+++ b/test/CPPPATH/subdir-as-include.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWAR
 
 """
 This is an obscure test case. When a file without a suffix is included in 
@@ -42,6 +41,7 @@ test = TestSCons.TestSCons()
 test.subdir('inc1', ['inc1', 'iterator'])
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(CPPPATH = [Dir('inc1')])
 env.Program('prog.cpp')
 

--- a/test/CacheDir/CacheDir.py
+++ b/test/CacheDir/CacheDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test retrieving derived files from a CacheDir.

--- a/test/CacheDir/CacheDir_TryCompile.py
+++ b/test/CacheDir/CacheDir_TryCompile.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that CacheDir functions with TryCompile.

--- a/test/CacheDir/NoCache.py
+++ b/test/CacheDir/NoCache.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the NoCache environment method works.

--- a/test/CacheDir/SideEffect.py
+++ b/test/CacheDir/SideEffect.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"_"
 
 """
 Test that use of SideEffect() doesn't interfere with CacheDir.

--- a/test/CacheDir/VariantDir.py
+++ b/test/CacheDir/VariantDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"
 
 """
 Test retrieving derived files from a CacheDir when a VariantDir is used.
@@ -40,6 +39,8 @@ cache = test.workpath('cache')
 cat_out = test.workpath('cat.out')
 
 test.write(['src', 'SConscript'], """\
+DefaultEnvironment(tools=[])
+
 def cat(env, source, target):
     target = str(target[0])
     with open('cat.out', 'a') as f:

--- a/test/CacheDir/debug.py
+++ b/test/CacheDir/debug.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the --cache-debug option to see if it prints the expected messages.

--- a/test/CacheDir/environment.py
+++ b/test/CacheDir/environment.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that whether or not a target gets retrieved from a CacheDir

--- a/test/CacheDir/multi-targets.py
+++ b/test/CacheDir/multi-targets.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that multiple target files get retrieved from a CacheDir correctly.

--- a/test/CacheDir/multiple-targets.py
+++ b/test/CacheDir/multiple-targets.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that multiple target files get retrieved from a CacheDir correctly.

--- a/test/CacheDir/option--cd.py
+++ b/test/CacheDir/option--cd.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the --cache-disable option when retrieving derived files from a

--- a/test/CacheDir/option--cf.py
+++ b/test/CacheDir/option--cf.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 
 """
 Test populating a CacheDir with the --cache-force option.

--- a/test/CacheDir/option--cr.py
+++ b/test/CacheDir/option--cr.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test the --cache-readonly option when retrieving derived files from a

--- a/test/CacheDir/option--cs.py
+++ b/test/CacheDir/option--cs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"
 
 """
 Test printing build actions when using the --cache-show option and

--- a/test/CacheDir/readonly-cache.py
+++ b/test/CacheDir/readonly-cache.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"
 
 """
 Verify accessing cache works even if it's read-only.

--- a/test/CacheDir/scanner-target.py
+++ b/test/CacheDir/scanner-target.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"
 
 """
 Test the case (reported by Jeff Petkau, bug #694744) where a target

--- a/test/CacheDir/source-scanner.py
+++ b/test/CacheDir/source-scanner.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._""
 
 """
 Test retrieving derived files from a CacheDir.

--- a/test/CacheDir/symlink.py
+++ b/test/CacheDir/symlink.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,14 +21,11 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"
 import os
 import sys
 
 import TestSCons
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we push and retrieve a built symlink to/from a CacheDir()

--- a/test/CacheDir/up-to-date-q.py
+++ b/test/CacheDir/up-to-date-q.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"
 
 """
 Verify that targets retrieved from CacheDir() are reported as

--- a/test/CacheDir/value_dependencies.py
+++ b/test/CacheDir/value_dependencies.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._"
 
 """
 Verify that bwuilds with caching work for an action with a Value as a child

--- a/test/CacheDir/value_dependencies/SConstruct
+++ b/test/CacheDir/value_dependencies/SConstruct
@@ -20,7 +20,7 @@ scanner = Scanner(function=scan, node_class=SCons.Node.Node)
 builder = Builder(action=b, source_scanner=scanner)
 
 DefaultEnvironment(tools=[])
-env = Environment()
+env = Environment(tools=[])
 env.Append(BUILDERS={'B': builder})
 
 # Create a node and a directory that each depend on an instance of

--- a/test/Clang/clang_default_environment.py
+++ b/test/Clang/clang_default_environment.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Clang/clang_specific_environment.py
+++ b/test/Clang/clang_specific_environment.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Clang/clang_static_library.py
+++ b/test/Clang/clang_static_library.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 from TestCmd import IS_WINDOWS

--- a/test/Clang/clangxx_default_environment.py
+++ b/test/Clang/clangxx_default_environment.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Clang/clangxx_shared_library.py
+++ b/test/Clang/clangxx_shared_library.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Clang/clangxx_specific_environment.py
+++ b/test/Clang/clangxx_specific_environment.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Clang/clangxx_static_library.py
+++ b/test/Clang/clangxx_static_library.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 from TestCmd import IS_WINDOWS

--- a/test/Clean/Option.py
+++ b/test/Clean/Option.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that {Set,Get}Option('clean') works correctly to control

--- a/test/Clean/basic.py
+++ b/test/Clean/basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test various basic uses of the -c (clean) option.

--- a/test/Clean/function.py
+++ b/test/Clean/function.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of the Clean() function.

--- a/test/Clean/mkfifo.py
+++ b/test/Clean/mkfifo.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that SCons reports an error when cleaning up a target directory

--- a/test/Clean/symlinks.py
+++ b/test/Clean/symlinks.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify correct deletion of broken symlinks.

--- a/test/Climb/U-Default-dir.py
+++ b/test/Climb/U-Default-dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Make sure that a Default() directory doesn't cause an exception
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 Default('.')
 """)
 

--- a/test/Climb/U-Default-no-target.py
+++ b/test/Climb/U-Default-no-target.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Make sure a Default() target that doesn't exist is handled with
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 Default('not_a_target.in')
 """)
 

--- a/test/Climb/U-no-Default.py
+++ b/test/Climb/U-no-Default.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Make sure no Default() targets in the SConstruct doesn't cause an

--- a/test/Climb/explicit-parent--D.py
+++ b/test/Climb/explicit-parent--D.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Make sure explicit targets beginning with ../ get built correctly

--- a/test/Climb/explicit-parent--U.py
+++ b/test/Climb/explicit-parent--U.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Make sure explicit targets beginning with ../ get built correctly.
@@ -36,13 +35,15 @@ test = TestSCons.TestSCons()
 test.subdir('subdir')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     with open(target, 'wb') as ofp:
         for src in source:
             with open(str(src), 'rb') as ifp:
                 ofp.write(ifp.read())
-env = Environment(BUILDERS={'Cat':Builder(action=cat)})
+env = Environment(tools=[],
+                  BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('foo.out', 'foo.in')
 SConscript('subdir/SConscript', "env")
 """)

--- a/test/Climb/explicit-parent-u.py
+++ b/test/Climb/explicit-parent-u.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the -u option only builds targets at or below
@@ -37,13 +36,15 @@ test = TestSCons.TestSCons()
 test.subdir('subdir')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 def cat(env, source, target):
     target = str(target[0])
     with open(target, 'wb') as ofp:
         for src in source:
             with open(str(src), 'rb') as ifp:
                 ofp.write(ifp.read())
-env = Environment(BUILDERS={'Cat':Builder(action=cat)})
+env = Environment(tools=[],
+                  BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('f1.out', 'f1.in')
 env.Cat('f2.out', 'f2.in')
 SConscript('subdir/SConscript', "env")

--- a/test/Climb/filename--D.py
+++ b/test/Climb/filename--D.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the ability to use the -D option with the -f option to

--- a/test/Climb/filename--U.py
+++ b/test/Climb/filename--U.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the ability to use the -U option with the -f option to

--- a/test/Climb/filename-u.py
+++ b/test/Climb/filename-u.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the ability to use the -u option with the -f option to

--- a/test/Climb/option--D.py
+++ b/test/Climb/option--D.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Climb/option--U.py
+++ b/test/Climb/option--U.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 

--- a/test/Climb/option-u.py
+++ b/test/Climb/option-u.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that the -u option only builds targets at or below

--- a/test/Configure/Action-error.py
+++ b/test/Configure/Action-error.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that calling Configure from an Action results in a readable error.
@@ -33,10 +32,12 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 def ConfigureAction(target, source, env):
     env.Configure()
     return 0
-env = Environment(BUILDERS = {'MyAction' :
+env = Environment(tools=[],
+                  BUILDERS = {'MyAction' :
                           Builder(action=Action(ConfigureAction))})
 env.MyAction('target', [])
 """)

--- a/test/Configure/Builder-call.py
+++ b/test/Configure/Builder-call.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that calling normal Builders from an actual Configure
@@ -44,7 +43,8 @@ with open(sys.argv[1], 'w') as f:
 """)
 
 test.write('SConstruct', """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 def CustomTest(*args):
     return 0
 conf = env.Configure(custom_tests = {'MyTest' : CustomTest})

--- a/test/Configure/CONFIGUREDIR.py
+++ b/test/Configure/CONFIGUREDIR.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Test that the configure context directory can be specified by
@@ -34,11 +33,12 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write("SConstruct", """\
+DefaultEnvironment(tools=[])
 def CustomTest(context):
   context.Message('Executing Custom Test ... ')
   context.Result(1)
 
-env = Environment(CONFIGUREDIR = 'custom_config_dir')
+env = Environment(tools=[], CONFIGUREDIR = 'custom_config_dir')
 conf = Configure(env, custom_tests = {'CustomTest' : CustomTest})
 conf.CustomTest();
 env = conf.Finish()

--- a/test/Configure/CONFIGURELOG.py
+++ b/test/Configure/CONFIGURELOG.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Test that the configure context log file name can be specified by
@@ -36,11 +35,12 @@ test = TestSCons.TestSCons()
 SConstruct_path = test.workpath('SConstruct')
 
 test.write(SConstruct_path, """\
+DefaultEnvironment(tools=[])
 def CustomTest(context):
   context.Message('Executing Custom Test ...')
   context.Result(1)
 
-env = Environment(CONFIGURELOG = 'custom.logfile')
+env = Environment(tools=[], CONFIGURELOG = 'custom.logfile')
 conf = Configure(env, custom_tests = {'CustomTest' : CustomTest})
 conf.CustomTest();
 env = conf.Finish()
@@ -49,7 +49,7 @@ env = conf.Finish()
 test.run()
 
 expect = """\
-file %(SConstruct_path)s,line 6:
+file %(SConstruct_path)s,line 7:
 \tConfigure(confdir = .sconf_temp)
 scons: Configure: Executing Custom Test ...
 scons: Configure: (cached) yes

--- a/test/Configure/SConscript.py
+++ b/test/Configure/SConscript.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that Configure contexts from multiple subsidiary SConscript
@@ -39,7 +38,8 @@ test.subdir(['dir1'],
             ['dir2', 'sub1', 'sub2'])
 
 test.write('SConstruct', """\
-env = Environment()
+DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 SConscript(dirs=['dir1', 'dir2'], exports="env")
 """)
 

--- a/test/Configure/Streamer1.py
+++ b/test/Configure/Streamer1.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Test for BitBucket PR 126:
@@ -37,6 +36,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 # SConstruct
 #
 # The CheckHello should return 'yes' if everything works fine. Otherwise it
@@ -63,7 +63,7 @@ def CheckHello(context):
     context.Result('failed')
   return out
 
-env = Environment()
+env = Environment(tools=[])
 cfg = Configure(env)
 
 cfg.AddTest('CheckHello', CheckHello)

--- a/test/Configure/VariantDir-SConscript.py
+++ b/test/Configure/VariantDir-SConscript.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that Configure calls in SConscript files work when used
@@ -45,6 +44,7 @@ NCF = test.NCF  # non-cached build failure
 CF  = test.CF   # cached build failure
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 opts = Variables()
 opts.Add('chdir')
 env = Environment(options=opts)

--- a/test/Configure/VariantDir.py
+++ b/test/Configure/VariantDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that Configure contexts work with basic use of VariantDir.
@@ -42,6 +41,8 @@ NCF = test.NCF  # non-cached build failure
 CF  = test.CF   # cached build failure
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+
 env = Environment(LOGFILE='build/config.log')
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])

--- a/test/Configure/VariantDir2.py
+++ b/test/Configure/VariantDir2.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that Configure contexts work with SConstruct/SConscript structure
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 SConscript('SConscript', variant_dir='build', src='.')
 """)
 

--- a/test/Configure/basic.py
+++ b/test/Configure/basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that basic builds work with Configure contexts.

--- a/test/Configure/basic.py
+++ b/test/Configure/basic.py
@@ -39,6 +39,7 @@ NCF = test.NCF  # non-cached build failure
 CF  = test.CF   # cached build failure
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])

--- a/test/Configure/build-fail.py
+++ b/test/Configure/build-fail.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that Configure tests work even after an earlier test fails.
@@ -51,6 +50,7 @@ a_boost_hpp = os.path.join('..', 'a', 'boost.hpp')
 b_boost_hpp = os.path.join('..', 'b', 'boost.hpp')
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 import os
 def _check(context):
     for dir in ['a', 'b']:

--- a/test/Configure/cache-not-ok.py
+++ b/test/Configure/cache-not-ok.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that the cache mechanism works when checks are not ok.
@@ -43,6 +42,7 @@ NCF = test.NCF  # non-cached build failure
 CF  = test.CF   # cached build failure
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 if not int(ARGUMENTS.get('target_signatures_content', 0)):
     Decider('timestamp-newer')
 env = Environment()

--- a/test/Configure/cache-ok.py
+++ b/test/Configure/cache-ok.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that the cache mechanism works when checks are ok.
@@ -43,6 +42,7 @@ NCF = test.NCF  # non-cached build failure
 CF  = test.CF   # cached build failure
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 if not int(ARGUMENTS.get('target_signatures_content', 0)):
     Decider('timestamp-newer')
 env = Environment()

--- a/test/Configure/clean.py
+++ b/test/Configure/clean.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that we don't perform Configure context actions when the
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])

--- a/test/Configure/config-h.py
+++ b/test/Configure/config-h.py
@@ -37,6 +37,7 @@ lib = test.Configure_lib
 LIB = "LIB" + lib.upper()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])

--- a/test/Configure/custom-tests.py
+++ b/test/Configure/custom-tests.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,13 +21,12 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify execution of custom test cases.
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -54,6 +55,7 @@ sys.exit(int(sys.argv[1]))
 """)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])    
 def CheckCustom(test):
     test.Message( 'Executing MyTest ... ' )
     retCompileOK                = test.TryCompile( '%(compileOK)s', '.c' )

--- a/test/Configure/from-SConscripts.py
+++ b/test/Configure/from-SConscripts.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Make sure we can call Configure() from subsidiary SConscript calls.
@@ -37,6 +36,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = SConscript('x.scons')
 """)
 
@@ -48,7 +48,7 @@ Return('env')
 """)
 
 test.write('y.scons', """\
-env = Environment()
+env = Environment(tools=[])
 Return('env')
 """)
 

--- a/test/Configure/help.py
+++ b/test/Configure/help.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that we don't perform Configure context actions when the
@@ -34,6 +33,7 @@ import TestSCons
 test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])

--- a/test/Configure/implicit-cache.py
+++ b/test/Configure/implicit-cache.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,7 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that use of --implicit-cache with the Python Value Nodes
@@ -52,7 +54,6 @@ something else changed in the .sconf_temp directory), the string would
 get longer and longer until it blew out the users's memory.
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSConsign
 from SCons.Util import get_hash_format, get_current_hash_algorithm_used
@@ -60,6 +61,7 @@ from SCons.Util import get_hash_format, get_current_hash_algorithm_used
 test = TestSConsign.TestSConsign()
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(CPPPATH=['.'])
 conf = Configure(env)
 conf.CheckHeader( 'math.h' )

--- a/test/Configure/option--Q.py
+++ b/test/Configure/option--Q.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify that the -Q option suppresses Configure context output.
@@ -33,6 +32,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment()
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])

--- a/test/Configure/option--config.py
+++ b/test/Configure/option--config.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -19,10 +21,7 @@
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 """
 Verify use of the --config=<auto|force|cache> option.
@@ -51,6 +50,7 @@ if get_current_hash_algorithm_used() != 'md5':
 SConstruct_path = test.workpath('SConstruct')
 
 test.write(SConstruct_path, """
+DefaultEnvironment(tools=[])
 env = Environment(CPPPATH='#/include')
 import os
 env.AppendENVPath('PATH', os.environ['PATH'])
@@ -78,7 +78,7 @@ conftest_0_base = os.path.join(".sconf_temp", "conftest_%s_0%%s"%conftest_0_c_ha
 conftest_0_c = conftest_0_base%'.c'
 conftest_1_base = os.path.join(".sconf_temp", "conftest_%s_0%%s"%conftest_1_c_hash)
 
-SConstruct_file_line = test.python_file_line(SConstruct_path, 6)[:-1]
+SConstruct_file_line = test.python_file_line(SConstruct_path, 7)[:-1]
 
 expect = """
 scons: *** "%(conftest_0_c)s" is not yet built and cache is forced.
@@ -191,6 +191,7 @@ test.file_fixture('test_main.c')
 # Check the combination of --config=force and Decider('MD5-timestamp')
 SConstruct_path = test.workpath('SConstruct')
 test.write(SConstruct_path, """
+DefaultEnvironment(tools=[])
 env = Environment()
 env.Decider('MD5-timestamp')
 conf = Configure(env)


### PR DESCRIPTION
Disabling tool initialization in tests where those tools aren't needed.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
