### PR TITLE
Make is_valid_construction_var really be a bool function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -79,8 +79,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Framework for scons-time tests adjusted so a path with a long username
       Windows has squashed doesn't get re-expanded. Fixes a problem seen
       on GitHub Windows runner which uses a name "runneradmin".
-    - SCons.Environment.is_valid_construction_var now returns a boolean to
-      match the convention that functions beginnig with "is" have yes/no
+    - SCons.Environment.is_valid_construction_var() now returns a boolean to
+      match the convention that functions beginning with "is" have yes/no
       answers (previously returned either None or an re.match object).
       Now matches the annotation and docstring (which were prematurely
       updated in 4.6). All SCons usage except unit test was already fully

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,11 @@
 
                             Change Log
 
-NOTE: The 4.0.0 Release of SCons dropped Python 2.7 Support
-NOTE: 4.3.0 now requires Python 3.6.0 and above. Python 3.5.x is no longer supported
+NOTE: The 4.0.0 release of SCons dropped Python 2.7 support. Use 3.1.2 if
+  Python 2.7 support is required (but note old SCons releases are unsupported).
+NOTE: Since SCons 4.3.0, Python 3.6.0 or above is required.
+NOTE: Python 3.6 support is deprecated and will be dropped in a future reease.
+  python.org no longer supports 3.6 or 3.7, and will drop 3.8 in Oct. 2024.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
@@ -76,6 +79,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Framework for scons-time tests adjusted so a path with a long username
       Windows has squashed doesn't get re-expanded. Fixes a problem seen
       on GitHub Windows runner which uses a name "runneradmin".
+    - SCons.Environment.is_valid_construction_var now returns a boolean to
+      match the convention that functions beginnig with "is" have yes/no
+      answers (previously returned either None or an re.match object).
+      Now matches the annotation and docstring (which were prematurely
+      updated in 4.6). All SCons usage except unit test was already fully
+      consistent with a bool.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,6 +44,12 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   of CCFLAGS; the latter variable could cause a compiler warning.
 - The implementation of Variables was slightly refactored, there should
   not be user-visible changes.
+- SCons.Environment.is_valid_construction_var() now returns a boolean to
+  match the convention that functions beginning with "is" have yes/no
+  answers (previously returned either None or an re.match object).
+  Now matches the annotation and docstring (which were prematurely
+  updated in 4.6). All SCons usage except unit test was already fully
+  consistent with a bool.
 
 FIXES
 -----

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -512,9 +512,9 @@ class BuilderDict(UserDict):
 
 _is_valid_var = re.compile(r'[_a-zA-Z]\w*$')
 
-def is_valid_construction_var(varstr) -> bool:
+def is_valid_construction_var(varstr: str) -> bool:
     """Return True if *varstr* is a legitimate construction variable."""
-    return _is_valid_var.match(varstr)
+    return bool(_is_valid_var.match(varstr))
 
 
 class SubstitutionEnvironment:

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -2306,7 +2306,7 @@ f5: \
 
         exc_caught = None
         try:
-            env.ParseDepends(test.workpath('does_not_exist'), must_exist=1)
+            env.ParseDepends(test.workpath('does_not_exist'), must_exist=True)
         except IOError:
             exc_caught = 1
         assert exc_caught, "did not catch expected IOError"
@@ -2314,7 +2314,7 @@ f5: \
         del tlist[:]
         del dlist[:]
 
-        env.ParseDepends('$SINGLE', only_one=1)
+        env.ParseDepends('$SINGLE', only_one=True)
         t = list(map(str, tlist))
         d = list(map(str, dlist))
         assert t == ['f0'], t
@@ -2331,7 +2331,7 @@ f5: \
 
         exc_caught = None
         try:
-            env.ParseDepends(test.workpath('multiple'), only_one=1)
+            env.ParseDepends(test.workpath('multiple'), only_one=True)
         except SCons.Errors.UserError:
             exc_caught = 1
         assert exc_caught, "did not catch expected UserError"
@@ -4147,33 +4147,33 @@ class EnvironmentVariableTestCase(unittest.TestCase):
     def test_is_valid_construction_var(self) -> None:
         """Testing is_valid_construction_var()"""
         r = is_valid_construction_var("_a")
-        assert r is not None, r
+        assert r, r
         r = is_valid_construction_var("z_")
-        assert r is not None, r
+        assert r, r
         r = is_valid_construction_var("X_")
-        assert r is not None, r
+        assert r, r
         r = is_valid_construction_var("2a")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("a2_")
-        assert r is not None, r
+        assert r, r
         r = is_valid_construction_var("/")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("_/")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("a/")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var(".b")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("_.b")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("b1._")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("-b")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("_-b")
-        assert r is None, r
+        assert not r, r
         r = is_valid_construction_var("b1-_")
-        assert r is None, r
+        assert not r, r
 
 
 


### PR DESCRIPTION
This does not change any user-visible behavior (not a public api), it is only a "consistency" change.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
