### PR TITLE
Allow a Variable to not be substituted

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -86,8 +86,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       updated in 4.6). All SCons usage except unit test was already fully
       consistent with a bool.
     - When a variable is added to a Variables object, it can now be flagged
-      as "don't perform substitution". This allows variables to contain
-      characters which would otherwise cause expansion. Fixes #4241.
+      as "don't perform substitution" by setting the argument subst. 
+      This allows variables to contain characters which would otherwise 
+      cause expansion. Fixes #4241.
     - The test runner now recognizes the unittest module's return code of 5,
       which means no tests were run. SCons/Script/MainTests.py currently
       has no tests, so this particular error code is expected - should not

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -85,6 +85,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Now matches the annotation and docstring (which were prematurely
       updated in 4.6). All SCons usage except unit test was already fully
       consistent with a bool.
+    - When a variable is added to a Variables object, it can now be flagged
+      as "don't perform substitution". This allows variables to contain
+      characters which would otherwise cause expansion. Fixes #4241.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -50,7 +50,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   Now matches the annotation and docstring (which were prematurely
   updated in 4.6). All SCons usage except unit test was already fully
   consistent with a bool.
-- The Variables object Add method now accepts a do_subst keyword argument
+- The Variables object Add method now accepts a subst keyword argument
   (defaults to True) which can be set to inhibit substitution prior to
   calling the variable's converter and validator.
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -50,6 +50,9 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   Now matches the annotation and docstring (which were prematurely
   updated in 4.6). All SCons usage except unit test was already fully
   consistent with a bool.
+- The Variables object Add method now accepts a do_subst keyword argument
+  (defaults to True) which can be set to inhibit substitution prior to
+  calling the variable's converter and validator.
 
 FIXES
 -----

--- a/SCons/Tool/yacc.xml
+++ b/SCons/Tool/yacc.xml
@@ -236,7 +236,7 @@ The value is used only if &cv-YACC_GRAPH_FILE_SUFFIX; is not set.
 The default value is <filename>.gv</filename>.
 </para>
 <para>
-<emphasis>Changed in version 4.X.Y</emphasis>: deprecated. The default value
+<emphasis>Changed in version 4.6.0</emphasis>: deprecated. The default value
 changed from <filename>.vcg</filename> (&bison; stopped generating
 <filename>.vcg</filename> output with version 2.4, in 2006).
 </para>
@@ -261,7 +261,7 @@ Various yacc tools have emitted various formats
 at different times.
 Set this to match what your parser generator produces.
 </para>
-<para><emphasis>New in version 4.X.Y</emphasis>. </para>
+<para><emphasis>New in version 4.6.0</emphasis>. </para>
 </summary>
 </cvar>
 

--- a/SCons/Variables/PathVariable.py
+++ b/SCons/Variables/PathVariable.py
@@ -141,7 +141,7 @@ class _PathVariableClass:
 
     # lint: W0622: Redefining built-in 'help' (redefined-builtin)
     def __call__(
-        self, key, help: str, default, validator: Optional[Callable] = None
+        self, key: str, help: str, default, validator: Optional[Callable] = None
     ) -> Tuple[str, str, str, Callable, None]:
         """Return a tuple describing a path list SCons Variable.
 

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -150,6 +150,28 @@ class VariablesTestCase(unittest.TestCase):
         opts.Update(env, {})
         assert env['ANSWER'] == 54
 
+        # Test that the value is not substituted if 'subst' is False
+        def check_subst(key, value, env) -> None:
+            """Check that variable was not substituted before we get called."""
+            assert value == "$ORIGIN", \
+                f"Validator: '$ORIGIN' was substituted to {value!r}"
+
+        def conv_subst(value) -> None:
+            """Check that variable was not substituted before we get called."""
+            assert value == "$ORIGIN", \
+                f"Converter: '$ORIGIN' was substituted to {value!r}"
+            return value
+
+        opts.Add('NOSUB',
+                 help='Variable whose value will not be substituted',
+                 default='$ORIGIN',
+                 validator=check_subst,
+                 converter=conv_subst,
+                 subst=False)
+        env = Environment()
+        opts.Update(env)
+        assert env['NOSUB'] == "$ORIGIN"
+
         # Test that a bad value from the file is used and
         # validation fails correctly.
         test = TestSCons.TestSCons()

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -113,7 +113,8 @@ class Variables:
     ) -> None:
         """Create a Variable and add it to the list.
 
-        Internal routine, not public API.
+        This is the internal implementation for :meth:`Add` and
+        :meth:`AddVariables`. Not part of the public API.
 
         .. versionadded:: 4.8.0
               *subst* keyword argument is now recognized.
@@ -157,15 +158,16 @@ class Variables:
         """Add a Build Variable.
 
         Arguments:
-          key: the name of the variable, or a 5-tuple (or list).
-            If *key* is a tuple, and there are no additional positional
-            arguments, it is unpacked into the variable name plus the
-            *help*, *default*, *validator* and *converter keyword args.
-            If *key* is a tuple and there are additional positional arguments,
-            the first word of the tuple is taken as the variable name,
-            and the remainder as aliases.
+          key: the name of the variable, or a 5-tuple (or other sequence).
+            If *key* is a tuple, and there are no additional arguments
+            except the *help*, *default*, *validator* and *converter*
+            keyword arguments, *key* is unpacked into the variable name
+            plus the *help*, *default*, *validator* and *converter*
+            arguments; if there are additional arguments, the first
+            elements of *key* is taken as the variable name, and the
+            remainder as aliases.
           args: optional positional arguments, corresponding to the
-            *help*, *default*, *validator* and *converter keyword args.
+            *help*, *default*, *validator* and *converter* keyword args.
           kwargs: arbitrary keyword arguments used by the variable itself.
 
         Keyword Args:
@@ -174,7 +176,7 @@ class Variables:
           validator: function called to validate the value (default: ``None``)
           converter: function to be called to convert the variable's
             value before putting it in the environment. (default: ``None``)
-          subst: if true perform substitution on the value before the converter
+          subst: perform substitution on the value before the converter
             and validator functions (if any) are called (default: ``True``)
 
         .. versionadded:: 4.8.0

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -135,7 +135,8 @@ class Variables:
         option.default = default
         option.validator = validator
         option.converter = converter
-        option.do_subst = kwargs.get("subst", True)
+        option.do_subst = kwargs.pop("subst", True)
+        # TODO should any remaining kwargs be saved in the Variable?
 
         self.options.append(option)
 
@@ -158,21 +159,26 @@ class Variables:
         Arguments:
           key: the name of the variable, or a 5-tuple (or list).
             If *key* is a tuple, and there are no additional positional
-            arguments, it is unpacked into the variable name plus the four
-            listed keyword arguments from below.
+            arguments, it is unpacked into the variable name plus the
+            *help*, *default*, *validator* and *converter keyword args.
             If *key* is a tuple and there are additional positional arguments,
             the first word of the tuple is taken as the variable name,
             and the remainder as aliases.
-          args: optional positional arguments, corresponding to the four
-            listed keyword arguments.
+          args: optional positional arguments, corresponding to the
+            *help*, *default*, *validator* and *converter keyword args.
           kwargs: arbitrary keyword arguments used by the variable itself.
 
         Keyword Args:
-          help: help text for the variable (default: ``""``)
+          help: help text for the variable (default: empty string)
           default: default value for variable (default: ``None``)
           validator: function called to validate the value (default: ``None``)
           converter: function to be called to convert the variable's
             value before putting it in the environment. (default: ``None``)
+          subst: if true perform substitution on the value before the converter
+            and validator functions (if any) are called (default: ``True``)
+
+        .. versionadded:: 4.8.0
+              The *subst* keyword argument is now specially recognized.
         """
         if SCons.Util.is_Sequence(key):
             # If no other positional args (and no fundamental kwargs),

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -114,6 +114,9 @@ class Variables:
         """Create a Variable and add it to the list.
 
         Internal routine, not public API.
+
+        .. versionadded:: 4.8.0
+              *subst* keyword argument is now recognized.
         """
         option = Variable()
 
@@ -252,7 +255,7 @@ class Variables:
         for option in self.options:
             if option.converter and option.key in values:
                 if option.do_subst:
-                    value = env.subst(f'${option.key}')
+                    value = env.subst('${%s}' % option.key)
                 else:
                     value = env[option.key]
                 try:
@@ -270,7 +273,7 @@ class Variables:
         for option in self.options:
             if option.validator and option.key in values:
                 if option.do_subst:
-                    value = env.subst('${%s}'%option.key)
+                    value = env.subst('${%s}' % option.key)
                 else:
                     value = env[option.key]
                 option.validator(option.key, value, env)

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -10668,7 +10668,7 @@ Various yacc tools have emitted various formats
 at different times.
 Set this to match what your parser generator produces.
 </para>
-<para><emphasis>New in version 4.X.Y</emphasis>. </para>
+<para><emphasis>New in version 4.6.0</emphasis>. </para>
 </listitem>
   </varlistentry>
   <varlistentry id="cv-YACC_HEADER_FILE">
@@ -10826,7 +10826,7 @@ The value is used only if &cv-YACC_GRAPH_FILE_SUFFIX; is not set.
 The default value is <filename>.gv</filename>.
 </para>
 <para>
-<emphasis>Changed in version 4.X.Y</emphasis>: deprecated. The default value
+<emphasis>Changed in version 4.6.0</emphasis>: deprecated. The default value
 changed from <filename>.vcg</filename> (&bison; stopped generating
 <filename>.vcg</filename> output with version 2.4, in 2006).
 </para>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -4835,7 +4835,7 @@ not to any stored-values files.
 
 <variablelist>
   <varlistentry id="v-Add">
-  <term><replaceable>vars</replaceable>.<function>Add</function>(<parameter>key, [help, default, validator, converter]</parameter>)</term>
+  <term><replaceable>vars</replaceable>.<function>Add</function>(<parameter>key, [help, default, validator, converter, do_subst]</parameter>)</term>
   <listitem>
 <para>Add a customizable &consvar; to the &Variables; object.
 <parameter>key</parameter>
@@ -4888,6 +4888,16 @@ it can raise a <exceptionname>ValueError</exceptionname>.
 </para>
 
 <para>
+Substitution will be performed on the variable value
+as it is added, before the converter and validator are called,
+unless the optional <parameter>do_subst</parameter> parameter
+is false (default <literal>True</literal>).
+Suppressing substitution may be useful if the variable value
+looks like a &consvar; reference (<literal>$VAR</literal>)
+to be expanded later.
+</para>
+
+<para>
 As a special case, if <parameter>key</parameter>
 is a sequence and is the <emphasis>only</emphasis>
 argument to &Add;, it is unpacked into the five parameters
@@ -4919,6 +4929,11 @@ def valid_color(key, val, env):
 
 vars.Add('COLOR', validator=valid_color)
 </programlisting>
+
+<para>
+<emphasis>Changed in version 4.8.0:</emphasis>
+added the <parameter>do_subst</parameter> parameter.
+</para>
   </listitem>
   </varlistentry>
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -4835,7 +4835,7 @@ not to any stored-values files.
 
 <variablelist>
   <varlistentry id="v-Add">
-  <term><replaceable>vars</replaceable>.<function>Add</function>(<parameter>key, [help, default, validator, converter, do_subst]</parameter>)</term>
+  <term><replaceable>vars</replaceable>.<function>Add</function>(<parameter>key, [help, default, validator, converter, subst]</parameter>)</term>
   <listitem>
 <para>Add a customizable &consvar; to the &Variables; object.
 <parameter>key</parameter>
@@ -4889,12 +4889,12 @@ it can raise a <exceptionname>ValueError</exceptionname>.
 
 <para>
 Substitution will be performed on the variable value
-as it is added, before the converter and validator are called,
-unless the optional <parameter>do_subst</parameter> parameter
+before the converter and validator are called,
+unless the optional <parameter>subst</parameter> parameter
 is false (default <literal>True</literal>).
 Suppressing substitution may be useful if the variable value
-looks like a &consvar; reference (<literal>$VAR</literal>)
-to be expanded later.
+looks like a &consvar; reference (e.g. <literal>$VAR</literal>)
+and the validator and/or converter should see it unexpanded.
 </para>
 
 <para>
@@ -4932,7 +4932,7 @@ vars.Add('COLOR', validator=valid_color)
 
 <para>
 <emphasis>Changed in version 4.8.0:</emphasis>
-added the <parameter>do_subst</parameter> parameter.
+added the <parameter>subst</parameter> parameter.
 </para>
   </listitem>
   </varlistentry>


### PR DESCRIPTION
New parameter `do_subst` added to the variables `Add` method, if false, indicates the variable value should not be substituted by the Variables logic. The default is `True`.

Snuck in a side change: a yacc change had been flagged with 4.X.Y and then the actual value never substituted (perhaps we need to call `subst` on documentation? :-) ). Now marked as 4.6.0.

Fixes #4241.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
