### PR TITLE
runtest.py now recognizes exit code 5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -85,6 +85,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Now matches the annotation and docstring (which were prematurely
       updated in 4.6). All SCons usage except unit test was already fully
       consistent with a bool.
+    - The test runner now recognizes the unittest module's return code of 5,
+      which means no tests were run. SCons/Script/MainTests.py currently
+      has no tests, so this particular error code is expected - should not
+      cause runtest to give up with an "unknown error code".
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -98,6 +98,10 @@ DEVELOPMENT
   The repo-wide line-ending is now `lf`, with the exception of a few
   Windows-only files using `crlf` instead. Any files not already fitting
   this format have been explicitly converted.
+- The test runner now recognizes the unittest module's return code of 5,
+  which means no tests were run. SCons/Script/MainTests.py currently
+  has no tests, so this particular error code is expected - should not
+  cause runtest to give up with an "unknown error code".
 
 
 Thanks to the following contributors listed below for their contributions to this release.

--- a/runtest.py
+++ b/runtest.py
@@ -417,7 +417,7 @@ class SystemExecutor(RuntestBase):
     def execute(self, env):
         self.stderr, self.stdout, s = spawn_it(self.command_args, env)
         self.status = s
-        if s < 0 or s > 2:
+        if s < 0 or s > 2 and s != 5:
             sys.stdout.write("Unexpected exit status %d\n" % s)
 
 


### PR DESCRIPTION
The unittest module's main() can exit with a code of 5, which means no tests were run. SCons/Script/MainTests.py currently has no tests, so this particular error code is expected - should not cause runtest to give up with an "unknown error code".

This is test runner only, no changes to SCons or to docs.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
