### PR TITLE
ListVariable now has a separate validator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -96,9 +96,14 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Updated the notes about reproducible builds with SCons and the example.
     - The Clone() method now respects the variables argument (fixes #3590)
     - is_valid_construction_var() (not part of the public API) moved from
-      SCons.Environment to SCons.Util to avoid the chance of import loops. Variables
-      and Environment both use the routine and Environment() uses a Variables()
-      object so better to move to a safer location.
+      SCons.Environment to SCons.Util to avoid the chance of import loops.
+      Variables and Environment both use the routine and Environment() uses
+      a Variables() object so better to move to a safer location.
+    - ListVariable now has a separate validator, with the functionality
+      that was previously part of the converter. The main effect is to
+      allow a developer to supply a custom validator, which previously
+      could be inhibited by the converter failing before the validator
+      is reached.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,6 +53,11 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - The Variables object Add method now accepts a subst keyword argument
   (defaults to True) which can be set to inhibit substitution prior to
   calling the variable's converter and validator.
+- ListVariable now has a separate validator, with the functionality
+  that was previously part of the converter. The main effect is to
+  allow a developer to supply a custom validator, which previously
+  could be inhibited by the converter failing before the validator
+  is reached.
 
 FIXES
 -----

--- a/SCons/Variables/ListVariableTests.py
+++ b/SCons/Variables/ListVariableTests.py
@@ -38,7 +38,7 @@ class ListVariableTestCase(unittest.TestCase):
         assert o.key == 'test', o.key
         assert o.help == 'test option help\n    (all|none|comma-separated list of names)\n    allowed names: one two three', repr(o.help)
         assert o.default == 'all', o.default
-        assert o.validator is None, o.validator
+        assert o.validator is not None, o.validator
         assert o.converter is not None, o.converter
 
         opts = SCons.Variables.Variables()
@@ -52,9 +52,15 @@ class ListVariableTestCase(unittest.TestCase):
     def test_converter(self) -> None:
         """Test the ListVariable converter"""
         opts = SCons.Variables.Variables()
-        opts.Add(SCons.Variables.ListVariable('test', 'test option help', 'all',
-                                          ['one', 'two', 'three'],
-                                          {'ONE':'one', 'TWO':'two'}))
+        opts.Add(
+            SCons.Variables.ListVariable(
+                'test',
+                'test option help',
+                'all',
+                ['one', 'two', 'three'],
+                {'ONE': 'one', 'TWO': 'two'},
+            )
+        )
 
         o = opts.options[0]
 
@@ -101,8 +107,12 @@ class ListVariableTestCase(unittest.TestCase):
         x = o.converter('three,ONE,TWO')
         assert str(x) == 'all', x
 
-        with self.assertRaises(ValueError):
-            x = o.converter('no_match')
+        # invalid value should convert (no change) without error
+        x = o.converter('no_match')
+        assert str(x) == 'no_match', x
+        # ... and fail to validate
+        with self.assertRaises(SCons.Errors.UserError):
+            z = o.validator('test', 'no_match', {"test": x})
 
     def test_copy(self) -> None:
         """Test copying a ListVariable like an Environment would"""

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -5203,7 +5203,7 @@ converted to lower case.</para>
   </varlistentry>
 
   <varlistentry id="v-ListVariable">
-  <term><function>ListVariable</function>(<parameter>key, help, default, names, [map]</parameter>)</term>
+  <term><function>ListVariable</function>(<parameter>key, help, default, names, [map, validator]</parameter>)</term>
   <listitem>
 <para>
 Set up a variable
@@ -5225,6 +5225,8 @@ separated by commas.
 <parameter>default</parameter> may be specified
 either as a string of comma-separated value,
 or as a list of values.
+</para>
+<para>
 The optional
 <parameter>map</parameter>
 argument is a dictionary
@@ -5236,6 +5238,14 @@ list.
 (Note that the additional values accepted through
 the use of a <parameter>map</parameter> are not
 reflected in the generated help message).  </para>
+<para>
+The optional <parameter>validator</parameter> argument
+can be used to specify a custom validator callback function,
+as described for <link linkend='v-Add'><function>Add</function></link>.
+The default is to use an internal validator routine.
+</para>
+<para><emphasis>New in 4.8.0: <parameter>validator</parameter>.
+</emphasis></para>
   </listitem>
   </varlistentry>
 

--- a/test/Variables/BoolVariable.py
+++ b/test/Variables/BoolVariable.py
@@ -39,10 +39,7 @@ def check(expect):
 
 
 test.write(SConstruct_path, """\
-from SCons.Variables.BoolVariable import BoolVariable
-
-BV = BoolVariable
-
+from SCons.Variables.BoolVariable import BoolVariable as BV
 from SCons.Variables import BoolVariable
 
 opts = Variables(args=ARGUMENTS)
@@ -51,7 +48,8 @@ opts.AddVariables(
     BV('profile', 'create profiling informations', False),
 )
 
-env = Environment(variables=opts)
+_ = DefaultEnvironment(tools=[])
+env = Environment(variables=opts, tools=[])
 Help(opts.GenerateHelpText(env))
 
 print(env['warnings'])
@@ -69,7 +67,7 @@ check([str(False), str(True)])
 expect_stderr = """
 scons: *** Error converting option: 'warnings'
 Invalid value for boolean variable: 'irgendwas'
-""" + test.python_file_line(SConstruct_path, 13)
+""" + test.python_file_line(SConstruct_path, 11)
 
 test.run(arguments='warnings=irgendwas', stderr=expect_stderr, status=2)
 

--- a/test/Variables/EnumVariable.py
+++ b/test/Variables/EnumVariable.py
@@ -38,9 +38,7 @@ def check(expect):
     assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
 
 test.write(SConstruct_path, """\
-from SCons.Variables.EnumVariable import EnumVariable
-EV = EnumVariable
-
+from SCons.Variables.EnumVariable import EnumVariable as EV
 from SCons.Variables import EnumVariable
 
 list_of_libs = Split('x11 gl qt ical')
@@ -58,7 +56,8 @@ opts.AddVariables(
        map={}, ignorecase=2), # make lowercase
     )
 
-env = Environment(variables=opts)
+_ = DefaultEnvironment(tools=[])
+env = Environment(variables=opts, tools=[])
 Help(opts.GenerateHelpText(env))
 
 print(env['debug'])
@@ -78,19 +77,19 @@ check(['full', 'KdE', 'eins'])
 
 expect_stderr = """
 scons: *** Invalid value for enum variable 'debug': 'FULL'. Valid values are: ('yes', 'no', 'full')
-""" + test.python_file_line(SConstruct_path, 21)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='debug=FULL', stderr=expect_stderr, status=2)
 
 expect_stderr = """
 scons: *** Invalid value for enum variable 'guilib': 'irgendwas'. Valid values are: ('motif', 'gtk', 'kde')
-""" + test.python_file_line(SConstruct_path, 21)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='guilib=IrGeNdwas', stderr=expect_stderr, status=2)
 
 expect_stderr = """
 scons: *** Invalid value for enum variable 'some': 'irgendwas'. Valid values are: ('xaver', 'eins')
-""" + test.python_file_line(SConstruct_path, 21)
+""" + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='some=IrGeNdwas', stderr=expect_stderr, status=2)
 

--- a/test/Variables/ListVariable.py
+++ b/test/Variables/ListVariable.py
@@ -43,9 +43,7 @@ def check(expect):
 
 
 test.write(SConstruct_path, """\
-from SCons.Variables.ListVariable import ListVariable
-LV = ListVariable
-
+from SCons.Variables.ListVariable import ListVariable as LV
 from SCons.Variables import ListVariable
 
 list_of_libs = Split('x11 gl qt ical')
@@ -59,10 +57,10 @@ opts.AddVariables(
                names = list_of_libs,
                map = {'GL':'gl', 'QT':'qt'}),
     LV('listvariable', 'listvariable help', 'all', names=['l1', 'l2', 'l3'])
-    )
+)
 
-DefaultEnvironment(tools=[])  # test speedup
-env = Environment(variables=opts)
+_ = DefaultEnvironment(tools=[])  # test speedup
+env = Environment(variables=opts, tools=[])
 opts.Save(optsfile, env)
 Help(opts.GenerateHelpText(env))
 
@@ -113,39 +111,34 @@ check(['gl,qt', '0', 'gl qt', 'gl qt', "['gl qt']"])
 
 
 expect_stderr = """
-scons: *** Error converting option: 'shared'
-Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 20)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
+""" + test.python_file_line(SConstruct_path, 18)
 
 test.run(arguments='shared=foo', stderr=expect_stderr, status=2)
 
 # be paranoid in testing some more combinations
 
 expect_stderr = """
-scons: *** Error converting option: 'shared'
-Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 20)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
+""" + test.python_file_line(SConstruct_path, 18)
 
 test.run(arguments='shared=foo,ical', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Error converting option: 'shared'
-Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 20)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
+""" + test.python_file_line(SConstruct_path, 18)
 
 test.run(arguments='shared=ical,foo', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Error converting option: 'shared'
-Invalid value(s) for option: foo
-""" + test.python_file_line(SConstruct_path, 20)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
+""" + test.python_file_line(SConstruct_path, 18)
 
 test.run(arguments='shared=ical,foo,x11', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Error converting option: 'shared'
-Invalid value(s) for option: foo,bar
-""" + test.python_file_line(SConstruct_path, 20)
+scons: *** Invalid value(s) for variable 'shared': 'foo,bar'. Valid values are: gl,ical,qt,x11,all,none
+""" + test.python_file_line(SConstruct_path, 18)
 
 test.run(arguments='shared=foo,x11,,,bar', stderr=expect_stderr, status=2)
 

--- a/test/Variables/PackageVariable.py
+++ b/test/Variables/PackageVariable.py
@@ -39,9 +39,7 @@ def check(expect):
     assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
 
 test.write(SConstruct_path, """\
-from SCons.Variables.PackageVariable import PackageVariable
-PV = PackageVariable
-
+from SCons.Variables.PackageVariable import PackageVariable as PV
 from SCons.Variables import PackageVariable
 
 opts = Variables(args=ARGUMENTS)
@@ -52,7 +50,8 @@ opts.AddVariables(
     PV('package', 'help for package', 'yes'),
     )
 
-env = Environment(variables=opts)
+_ = DefaultEnvironment(tools=[])
+env = Environment(variables=opts, tools=[])
 Help(opts.GenerateHelpText(env))
 
 print(env['x11'])
@@ -73,7 +72,7 @@ check([test.workpath()])
 
 expect_stderr = """
 scons: *** Path does not exist for variable 'x11': '/non/existing/path/'
-""" + test.python_file_line(SConstruct_path, 14)
+""" + test.python_file_line(SConstruct_path, 13)
 
 test.run(arguments='x11=/non/existing/path/', stderr=expect_stderr, status=2)
 

--- a/test/Variables/PathVariable.py
+++ b/test/Variables/PathVariable.py
@@ -47,9 +47,7 @@ workpath = test.workpath()
 libpath = os.path.join(workpath, 'lib')
 
 test.write(SConstruct_path, """\
-from SCons.Variables.PathVariable import PathVariable
-PV = PathVariable
-
+from SCons.Variables.PathVariable import PathVariable as PV
 from SCons.Variables import PathVariable
 
 qtdir = r'%s'
@@ -60,8 +58,8 @@ opts.AddVariables(
     PV('qt_libraries', 'where the Qt library is installed', r'%s'),
 )
 
-DefaultEnvironment(tools=[])  # test speedup
-env = Environment(variables=opts)
+_ = DefaultEnvironment(tools=[])  # test speedup
+env = Environment(variables=opts, tools=[])
 Help(opts.GenerateHelpText(env))
 
 print(env['qtdir'])
@@ -92,7 +90,7 @@ test.run(arguments=['qtdir=%s' % qtpath, 'qt_libraries=%s' % libpath])
 check([qtpath, libpath, libpath])
 
 qtpath = os.path.join(workpath, 'non', 'existing', 'path')
-SConstruct_file_line = test.python_file_line(test.workpath('SConstruct'), 15)[:-1]
+SConstruct_file_line = test.python_file_line(test.workpath('SConstruct'), 13)[:-1]
 
 expect_stderr = """
 scons: *** Path for variable 'qtdir' does not exist: %(qtpath)s

--- a/test/Variables/Variables.py
+++ b/test/Variables/Variables.py
@@ -23,12 +23,21 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test general behavior of Variables including save files.
+
+Note this test is coded to expect a compiler tool to have run
+so that CC and CCFLAGS are set. The first test "run" collects
+those values and uses them as a baseline for the actual tests.
+We should be able to mock that in some way.
+"""
+
 import TestSCons
 
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-DefaultEnvironment(tools=[])  # test speedup
+_ = DefaultEnvironment(tools=[])  # test speedup
 env = Environment()
 print(env['CC'])
 print(" ".join(env['CCFLAGS']))
@@ -277,7 +286,7 @@ opts.Add('LISTOPTION_TEST',
          names = ['a','b','c',])
 
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment(variables=opts)
+env = Environment(variables=opts, tools=[])
 
 print(env['RELEASE_BUILD'])
 print(env['DEBUG_BUILD'])

--- a/test/Variables/chdir.py
+++ b/test/Variables/chdir.py
@@ -43,7 +43,8 @@ SConscript('subdir/SConscript')
 
 SConscript_contents = """\
 Import("opts")
-env = Environment()
+_ = DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 opts.Update(env)
 print("VARIABLE = "+repr(env['VARIABLE']))
 """

--- a/test/Variables/help.py
+++ b/test/Variables/help.py
@@ -92,7 +92,8 @@ opts.AddVariables(
     PathVariable('qt_libraries', 'where the Qt library is installed', r'%(libdirvar)s'),
 )
 
-env = Environment(variables=opts)
+_ = DefaultEnvironment(tools=[])
+env = Environment(variables=opts, tools=[])
 Help(opts.GenerateHelpText(env))
 
 print(env['warnings'])

--- a/test/Variables/import.py
+++ b/test/Variables/import.py
@@ -45,7 +45,8 @@ SConscript('subdir/SConscript')
 
 SConscript_contents = """\
 Import("opts")
-env = Environment()
+_ = DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 opts.Update(env)
 print("VARIABLE = %s"%env.get('VARIABLE'))
 """


### PR DESCRIPTION
Previously, the converter did both conversion and validation, making it difficult to write a custom validator.

`ListVariable` now takes a `validator` kwarg to supply a custom validator.

This should address the issues of #3882, although it doesn't directly fix it, because SCons still doesn't officially supply a must-specify type of `ListVariable`. Will close that issue with a comment if this is merged.

Includes "test suite speedup" changes for `test/Variables` along the lines of #4544.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
