### PR TITLE
Update to current fastest env setitem

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -99,6 +99,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       SCons.Environment to SCons.Util to avoid the chance of import loops. Variables
       and Environment both use the routine and Environment() uses a Variables()
       object so better to move to a safer location.
+    - Performance tweak: the __setitem__ method of an Environment, used for
+      setting construction variables, now uses the string method isidentifier
+      to validate the name (updated from microbenchmark results).
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -69,6 +69,9 @@ IMPROVEMENTS
 - Make the testing framework a little more resilient: the temporary
   directory for tests now includes a component named "scons" which can
   be given to antivirus software to exclude.
+- Performance tweak: the __setitem__ method of an Environment, used for
+  setting construction variables, now uses the string method isidentifier
+  to validate the name (updated from microbenchmark results).
 
 PACKAGING
 ---------

--- a/SCons/Util/envs.py
+++ b/SCons/Util/envs.py
@@ -330,10 +330,13 @@ def AddMethod(obj, function: Callable, name: Optional[str] = None) -> None:
     setattr(obj, name, method)
 
 
+# This routine is used to validate that a construction var name can be used
+# as a Python identifier, which we require. However, Python 3 introduced an
+# isidentifier() string method so there's really not any need for it now.
 _is_valid_var_re = re.compile(r'[_a-zA-Z]\w*$')
 
 def is_valid_construction_var(varstr: str) -> bool:
-    """Return True if *varstr* is a legitimate construction variable."""
+    """Return True if *varstr* is a legitimate name of a construction variable."""
     return bool(_is_valid_var_re.match(varstr))
 
 # Local Variables:

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -131,7 +131,7 @@ class Variables:
             option.key = key
             # TODO: normalize to not include key in aliases. Currently breaks tests.
             option.aliases = [key,]
-        if not SCons.Util.is_valid_construction_var(option.key):
+        if not option.key.isidentifier():
             raise SCons.Errors.UserError(f"Illegal Variables key {option.key!r}")
         option.help = help
         option.default = default

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -62,10 +62,10 @@ Usage:  bench.py OPTIONS file.py
   -h, --help                    Display this help and exit
   -i ITER, --iterations ITER    Run each code snippet ITER times
   --time                        Use the time.time function
-  -r RUNS, --runs RUNS          Average times for RUNS invocations of 
+  -r RUNS, --runs RUNS          Average times for RUNS invocations of
 """
 
-# How many times each snippet of code will be (or should be) run by the 
+# How many times each snippet of code will be (or should be) run by the
 # functions under test to gather the time (the "inner loop").
 
 Iterations = 1000
@@ -191,19 +191,17 @@ py_ver_string = "%d.%d"%(sys.version_info.major, sys.version_info.minor)
 
 
 # pprint(results_dict)
-# breakpoint()
+
 tests = [label for label, args, kw in Data]
-columns = ['Python Version', 'Implementation', 'Test'] + tests
+columns = ['Python Version', 'Implementation'] + tests
 with open(results_filename, 'a') as r:
-    print("Python Version,%s" % ".".join(columns), file=r)
-    # print("Python Version,%s" % ".".join(columns))
+    print(",".join(columns), file=r)
 
-    for implementation in results_dict.keys():
+    for implementation in results_dict:
+        print(f'{py_ver_string},"{implementation}"', file=r, end='')
         for test in tests:
-            print(f'{py_ver_string},"{implementation}","{test}",%8.3f' % results_dict[implementation][test], file=r)
-            # print(f'{py_ver_string},"{implementation}","{test}",%8.3f' % results_dict[implementation][test])
-
-
+            print(',%8.3f' % results_dict[implementation][test], file=r, end='')
+        print(file=r)
 
 # Local Variables:
 # tab-width:4

--- a/bench/env.__setitem__.py
+++ b/bench/env.__setitem__.py
@@ -57,14 +57,14 @@ except AttributeError:
 script_dir = os.path.split(filename)[0]
 if script_dir:
     script_dir = script_dir + '/'
-sys.path = [os.path.abspath(script_dir + '../src/engine')] + sys.path
+sys.path = [os.path.abspath(script_dir + '..')] + sys.path
 
 import SCons.Errors
 import SCons.Environment
 import SCons.Util
 
 is_valid_construction_var = SCons.Util.is_valid_construction_var
-global_valid_var = re.compile(r'[_a-zA-Z]\w*$')
+global_valid_var = SCons.Util.envs._is_valid_var_re
 
 # The classes with different __setitem__() implementations that we're
 # going to horse-race.
@@ -105,7 +105,7 @@ class Environment:
         'SOURCES'  : None,
     }
     _special_set_keys = list(_special_set.keys())
-    _valid_var = re.compile(r'[_a-zA-Z]\w*$')
+    _valid_var = global_valid_var
     def __init__(self, **kw):
         self._dict = kw
 
@@ -247,8 +247,8 @@ class env_Best_attribute(Environment):
                     raise SCons.Errors.UserError("Illegal construction variable `%s'" % key)
             self._dict[key] = value
 
-class env_Best_has_key(Environment):
-    """Best __setitem__(), with has_key"""
+class env_Best_has_key_global_regex(Environment):
+    """Best __setitem__(), with membership test and global regex"""
     def __setitem__(self, key, value):
         if key in self._special_set:
             self._special_set[key](self, key, value)
@@ -257,6 +257,18 @@ class env_Best_has_key(Environment):
                and not global_valid_var.match(key):
                     raise SCons.Errors.UserError("Illegal construction variable `%s'" % key)
             self._dict[key] = value
+
+class env_Best_has_key_function(Environment):
+    """Best __setitem__(), with membership_test and validator function"""
+    def __setitem__(self, key, value):
+        if key in self._special_set:
+            self._special_set[key](self, key, value)
+        else:
+            if key not in self._dict \
+               and not is_valid_construction_var(key):
+                    raise SCons.Errors.UserError("Illegal construction variable `%s'" % key)
+            self._dict[key] = value
+
 
 class env_Best_list(Environment):
     """Best __setitem__(), with a list"""
@@ -283,6 +295,16 @@ else:
                 if not key.isalnum() and not global_valid_var.match(key):
                     raise SCons.Errors.UserError("Illegal construction variable `%s'" % key)
                 self._dict[key] = value
+
+class env_Best_isidentifier(Environment):
+    """Best __setitem__(), with membership test and isidentifier"""
+    def __setitem__(self, key, value):
+        if key in self._special_set:
+            self._special_set[key](self, key, value)
+        else:
+            if key not in self._dict and not key.isidentifier():
+                raise SCons.Errors.UserError("Illegal construction variable `%s'" % key)
+            self._dict[key] = value
 
 # We'll use the names of all the env_* classes we find later to build
 # the dictionary of statements to be timed, and the import statement

--- a/bench/is_types.py
+++ b/bench/is_types.py
@@ -53,7 +53,7 @@ def cache_type_e_is_Dict(e):
 
 def cache_type_e_is_List(e):
     t = type(e)
-    return t is list or isinstance(e, UserList or isinstance(e, deque))
+    return t is list or isinstance(e, (UserList, deque))
 
 def cache_type_e_is_String(e):
     t = type(e)

--- a/bench/is_types.py
+++ b/bench/is_types.py
@@ -2,10 +2,11 @@
 #
 # Benchmarks for testing various possible implementations
 # of the is_Dict(), is_List() and is_String() functions in
-# src/engine/SCons/Util.py.
+# SCons/Util.py.
 
 import types
-from collections import UserDict, UserList, UserString
+from collections import UserDict, UserList, UserString, deque
+from collections.abc import Iterable, MappingView, MutableMapping, MutableSequence
 
 DictType = dict
 ListType = list
@@ -28,19 +29,20 @@ def original_is_String(e):
 
 # New candidates that explicitly check for whether the object is an
 # InstanceType before calling isinstance() on the corresponding User*
-# type.
-# InstanceType was only for old-style classes, so absent in Python 3
-# this this is no different than the previous
+# type. Update: meaningless in Python 3, InstanceType was only for
+# old-style classes, so these are just removed.
+# XXX
 
-def checkInstanceType_is_Dict(e):
-    return isinstance(e, (dict, UserDict))
+# New candidates that try more generic names from collections:
 
-def checkInstanceType_is_List(e):
-    return isinstance(e, (list, UserList))
+def new_is_Dict(e):
+    return isinstance(e, MutableMapping)
 
-def checkInstanceType_is_String(e):
+def new_is_List(e):
+    return isinstance(e, MutableSequence)
+
+def new_is_String(e):
     return isinstance(e, (str, UserString))
-
 
 # Improved candidates that cache the type(e) result in a variable
 # before doing any checks.
@@ -51,7 +53,7 @@ def cache_type_e_is_Dict(e):
 
 def cache_type_e_is_List(e):
     t = type(e)
-    return t is list or isinstance(e, UserList)
+    return t is list or isinstance(e, UserList or isinstance(e, deque))
 
 def cache_type_e_is_String(e):
     t = type(e)
@@ -68,7 +70,7 @@ def global_cache_type_e_is_Dict(e):
 
 def global_cache_type_e_is_List(e):
     t = type(e)
-    return t is ListType or isinstance(e, UserList)
+    return t is ListType or isinstance(e, (UserList, deque))
 
 def global_cache_type_e_is_String(e):
     t = type(e)
@@ -77,30 +79,10 @@ def global_cache_type_e_is_String(e):
 
 # Alternative that uses a myType() function to map the User* objects
 # to their corresponding underlying types.
-
-instanceTypeMap = {
-    UserDict : dict,
-    UserList : list,
-    UserString : str,
-}
-
-def myType(obj):
-    t = type(obj)
-    if t is types.InstanceType:
-        t = instanceTypeMap.get(obj.__class__, t)
-    return t
-
-def myType_is_Dict(e):
-    return myType(e) is dict
-
-def myType_is_List(e):
-    return myType(e) is list
-
-def myType_is_String(e):
-    return myType(e) is str
+# Again, since this used InstanceType, it's not useful for Python 3.
 
 
-
+# These are the actual test entry points
 
 def Func01(obj):
     """original_is_String"""
@@ -118,19 +100,19 @@ def Func03(obj):
         original_is_Dict(obj)
 
 def Func04(obj):
-    """checkInstanceType_is_String"""
+    """new_is_String"""
     for i in IterationList:
-        checkInstanceType_is_String(obj)
+        new_is_String(obj)
 
 def Func05(obj):
-    """checkInstanceType_is_List"""
+    """new_is_List"""
     for i in IterationList:
-        checkInstanceType_is_List(obj)
+        new_is_List(obj)
 
 def Func06(obj):
-    """checkInstanceType_is_Dict"""
+    """new_is_Dict"""
     for i in IterationList:
-        checkInstanceType_is_Dict(obj)
+        new_is_Dict(obj)
 
 def Func07(obj):
     """cache_type_e_is_String"""
@@ -161,22 +143,6 @@ def Func12(obj):
     """global_cache_type_e_is_Dict"""
     for i in IterationList:
         global_cache_type_e_is_Dict(obj)
-
-#def Func13(obj):
-#    """myType_is_String"""
-#    for i in IterationList:
-#        myType_is_String(obj)
-#
-#def Func14(obj):
-#    """myType_is_List"""
-#    for i in IterationList:
-#        myType_is_List(obj)
-#
-#def Func15(obj):
-#    """myType_is_Dict"""
-#    for i in IterationList:
-#        myType_is_Dict(obj)
-
 
 
 # Data to pass to the functions on each run.  Each entry is a
@@ -215,6 +181,11 @@ Data = [
     (
         "UserList",
         (UserList([]),),
+        {},
+    ),
+    (
+        "deque",
+        (deque([]),),
         {},
     ),
     (

--- a/bench/lvars-gvars.py
+++ b/bench/lvars-gvars.py
@@ -23,9 +23,9 @@
 
 """
 Functions and data for timing different idioms for fetching a keyword
-value from a pair of dictionaries for localand global values.  This was
+value from a pair of dictionaries for local and global values.  This was
 used to select how to most efficiently expand single $KEYWORD strings
-in src/engine/SCons/Subst.py.
+in SCons/Subst.py (StringSubber and ListSubber).
 """
 
 def Func1(var, gvars, lvars):
@@ -40,7 +40,7 @@ def Func1(var, gvars, lvars):
                 x = ''
 
 def Func2(var, gvars, lvars):
-    """lvars has_key(), gvars try:-except:"""
+    """lvars membership test, gvars try:-except:"""
     for i in IterationList:
         if var in lvars:
             x = lvars[var]
@@ -51,7 +51,7 @@ def Func2(var, gvars, lvars):
                 x = ''
 
 def Func3(var, gvars, lvars):
-    """lvars has_key(), gvars has_key()"""
+    """lvars membership test, gvars membership test)"""
     for i in IterationList:
         if var in lvars:
             x = lvars[var]
@@ -71,7 +71,7 @@ def Func4(var, gvars, lvars):
 def Func5(var, gvars, lvars):
     """Chained get with default values"""
     for i in IterationList:
-        x = lvars.get(var,gvars.get(var,''))
+        x = lvars.get(var, gvars.get(var, ''))
 
 
 # Data to pass to the functions on each run.  Each entry is a

--- a/test/bad-variables.py
+++ b/test/bad-variables.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Test that setting illegal construction variables fails in ways that are
@@ -37,13 +36,14 @@ SConstruct_path = test.workpath('SConstruct')
 SConscript_path = test.workpath('SConscript')
 
 test.write(SConstruct_path, """\
-env = Environment()
+_ = DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env['foo-bar'] = 1
 """)
 
 expect_stderr = """
-scons: *** Illegal construction variable `foo-bar'
-""" + test.python_file_line(SConstruct_path, 2)
+scons: *** Illegal construction variable 'foo-bar'
+""" + test.python_file_line(SConstruct_path, 3)
 
 test.run(arguments='.', status=2, stderr=expect_stderr)
 
@@ -54,14 +54,15 @@ SConscript('SConscript')
 """)
 
 test.write('SConscript', """\
-env = Environment()
+_ = DefaultEnvironment(tools=[])
+env = Environment(tools=[])
 env['foo(bar)'] = 1
 """)
 
 
 expect_stderr = """
-scons: *** Illegal construction variable `foo(bar)'
-""" + test.python_file_line(SConscript_path, 2)
+scons: *** Illegal construction variable 'foo(bar)'
+""" + test.python_file_line(SConscript_path, 3)
 
 test.run(arguments='.', status=2, stderr=expect_stderr)
 


### PR DESCRIPTION
Updated and re-ran benchmark tests for `SubstitutionEnvironment.__setitem__`. Added test for new (Python 3.0) string.`isidentifier()` method. That's actually exactly what we want, and it times out as the fastest method when combined with a membership test if the variable is already defined.

Tweaked some comments about this performance consideration, and did other updates in `bench/`.

No doc impacts as there are no behavioral changes.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
