### PR TITLE
AddOption now recognizes "settable" option

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,9 +6,9 @@
 
 image:
   # linux builds done in Travis CI for now
-  # - Visual Studio 2017
+  - Visual Studio 2017
   - Visual Studio 2019
-  - Visual Studio 2022
+  #- Visual Studio 2022  XXX Temporary disable while failing on .10 versions
 
 cache:
   - downloads -> appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@
 
 image:
   # linux builds done in Travis CI for now
-  - Visual Studio 2017
+  # - Visual Studio 2017
   - Visual Studio 2019
   - Visual Studio 2022
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -102,9 +102,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - AddOption and the internal add_local_option which AddOption calls now
       recognize a "settable" keyword argument to indicate a project-added
       option can also be modified using SetOption. Fixes #3983.
-      SCons.Environment to SCons.Util to avoid the chance of import loops.
-      Variables and Environment both use the routine and Environment() uses
-      a Variables() object so better to move to a safer location.
     - ListVariable now has a separate validator, with the functionality
       that was previously part of the converter. The main effect is to
       allow a developer to supply a custom validator, which previously

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -102,6 +102,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - AddOption and the internal add_local_option which AddOption calls now
       recognize a "settable" keyword argument to indicate a project-added
       option can also be modified using SetOption. Fixes #3983.
+      NOTE: If you were using ninja and using SetOption() for ninja options
+      in your SConscripts prior to loading the ninja tool, you will now
+      see an error. The fix is to move the SetOption() to after you've loaded
+      the ninja tool.
     - ListVariable now has a separate validator, with the functionality
       that was previously part of the converter. The main effect is to
       allow a developer to supply a custom validator, which previously

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -99,6 +99,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       SCons.Environment to SCons.Util to avoid the chance of import loops. Variables
       and Environment both use the routine and Environment() uses a Variables()
       object so better to move to a safer location.
+    - AddOption and the internal add_local_option which AddOption calls now
+      recognize a "settable" keyword argument to indicate a project-added
+      option can also be modified using SetOption. Fixes #3983.
 
 
 RELEASE 4.7.0 -  Sun, 17 Mar 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -56,6 +56,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - AddOption and the internal add_local_option which AddOption calls now
   recognize a "settable" keyword argument to indicate a project-added
   option can also be modified using SetOption.
+  NOTE: If you were using ninja and using SetOption() for ninja options
+  in your SConscripts prior to loading the ninja tool, you will now
+  see an error. The fix is to move the SetOption() to after you've loaded
+  the ninja tool.
 - ListVariable now has a separate validator, with the functionality
   that was previously part of the converter. The main effect is to
   allow a developer to supply a custom validator, which previously

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,6 +53,9 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - The Variables object Add method now accepts a subst keyword argument
   (defaults to True) which can be set to inhibit substitution prior to
   calling the variable's converter and validator.
+- AddOption and the internal add_local_option which AddOption calls now
+  recognize a "settable" keyword argument to indicate a project-added
+  option can also be modified using SetOption.
 
 FIXES
 -----

--- a/SCons/Script/Main.xml
+++ b/SCons/Script/Main.xml
@@ -93,21 +93,25 @@ the option value may be accessed using
 &f-link-GetOption;
 or
 &f-link-env-GetOption;.
-&f-link-SetOption; is not currently supported for
-options added with &f-AddOption;.
-<!-- was:
-The value may also be set using
-&f-SetOption;
+If the <parameter>settable=True</parameter> argument
+was supplied in the &AddOption; call,
+the value may also be set later using
+&f-link-SetOption;
 or
-&f-env.SetOption;,
-if conditions in a
-&SConscript;
+&f-link-env-SetOption;,
+if conditions in an
+&SConscript; file
 require overriding any default value.
 Note however that a
 value specified on the command line will
 <emphasis>always</emphasis>
-override a value set by any SConscript file.
--->
+override a value set in an SConscript file.
+</para>
+
+<para>
+<emphasis>Changed in 4.8.0</emphasis>: added the
+<parameter>settable</parameter> keyword argument
+to enable an added option to be settable via &SetOption;.
 </para>
 
 <para>
@@ -196,6 +200,7 @@ Allows setting options for SCons debug options. Currently the only supported val
   <example_commands>
 DebugOptions(json='#/build/output/scons_stats.json')
 </example_commands>
+<para><emphasis>New in version 4.6.0.</emphasis></para>
 </summary>
 </scons_function>
 
@@ -334,9 +339,10 @@ atexit.register(print_build_failures)
 <summary>
 <para>
 Query the value of settable options which may have been set
-on the command line, or by using the &f-link-SetOption; function.
+on the command line, via option defaults,
+or by using the &f-link-SetOption; function.
 The value of the option is returned in a type matching how the
-option was declared - see the documentation for the
+option was declared - see the documentation of the
 corresponding command line option for information about each specific
 option.
 </para>
@@ -799,6 +805,16 @@ which evaluates to true (e.g. <constant>True</constant>,
 Options which affect the reading and processing of SConscript files
 are not settable using &f-SetOption; since those files must
 be read in order to find the &f-SetOption; call in the first place.
+</para>
+
+<para>
+For project-specific options (sometimes called
+<firstterm>local options</firstterm>)
+added via an &f-link-AddOption; call,
+&f-SetOption; is available only after the
+&f-AddOption; call has completed successfully,
+and only if that call included the
+<parameter>settable=True</parameter> argument.
 </para>
 
 <para>

--- a/SCons/Tool/ninja/Utils.py
+++ b/SCons/Tool/ninja/Utils.py
@@ -45,6 +45,7 @@ def ninja_add_command_line_options() -> None:
               metavar='BOOL',
               action="store_true",
               default=False,
+              settable=True,
               help='Disable automatically running ninja after scons')
 
     AddOption('--disable-ninja',
@@ -52,6 +53,7 @@ def ninja_add_command_line_options() -> None:
               metavar='BOOL',
               action="store_true",
               default=False,
+              settable=True,
               help='Disable ninja generation and build with scons even if tool is loaded. '+
                    'Also used by ninja to build targets which only scons can build.')
 
@@ -60,6 +62,7 @@ def ninja_add_command_line_options() -> None:
               metavar='BOOL',
               action="store_true",
               default=False,
+              settable=True,
               help='Allow scons to skip regeneration of the ninja file and restarting of the daemon. ' +
                     'Care should be taken in cases where Glob is in use or SCons generated files are used in ' +
                     'command lines.')

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -417,8 +417,10 @@ foo.in
 
       <para>
 
-      &SetOption; is not currently supported for
-      options added with &AddOption;.
+      &SetOption; works for options added with &AddOption;,
+      but only if they were created with
+      <parameter>settable=True</parameter> in the call to &AddOption;
+      (only available in SCons 4.8.0 and later).
 
       </para>
 
@@ -660,14 +662,12 @@ foo.in
       </para>
 
       <para>
-      &SetOption; is not currently supported for
-      options added with &AddOption;.
-      <!--
-      (The value can also be set using &SetOption;,
-      although that's not very useful in practice
-      because a default value can be specified in
-      directly in the &AddOption; call.)
-      -->
+
+      &f-link-SetOption; works for options added with &AddOption;,
+      but only if they were created with
+      <parameter>settable=True</parameter> in the call to &AddOption;
+      (only available in SCons 4.8.0 and later).
+
       </para>
 
       <para>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,4 @@ target-version = ['py36']
 skip-string-normalization = true
 
 [tool.mypy]
-python_version = "3.6"
+python_version = "3.8"

--- a/test/AddOption/help.py
+++ b/test/AddOption/help.py
@@ -23,6 +23,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Verify the help text when the AddOption() function is used (and when
+it's not).
+"""
+
 import TestSCons
 
 test = TestSCons.TestSCons()
@@ -30,16 +35,20 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 env = Environment(tools=[])
-AddOption('--force',
-          action="store_true",
-          help='force installation (overwrite existing files)')
-AddOption('--prefix',
-          nargs=1,
-          dest='prefix',
-          action='store',
-          type='string',
-          metavar='DIR',
-          help='installation prefix')
+AddOption(
+    '--force',
+    action="store_true",
+    help='force installation (overwrite existing files)',
+)
+AddOption(
+    '--prefix',
+    nargs=1,
+    dest='prefix',
+    action='store',
+    type='string',
+    metavar='DIR',
+    help='installation prefix',
+)
 """)
 
 expected_lines = [

--- a/test/GetOption/BadSetOption.py
+++ b/test/GetOption/BadSetOption.py
@@ -32,7 +32,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 badopts = (
-    ("no_such_var", True, "This option is not settable from a SConscript file: no_such_var"),
+    ("no_such_var", True, "This option is not settable from an SConscript file: 'no_such_var'"),
     ("num_jobs", -22, "A positive integer is required: -22"),
     ("max_drift", "'Foo'", "An integer is required: 'Foo'"),
     ("duplicate", "'cookie'", "Not a valid duplication style: cookie"),
@@ -45,11 +45,10 @@ for opt, value, expect in badopts:
     SConstruct = "SC-" + opt
     test.write(
         SConstruct,
-        """\
+        f"""\
 DefaultEnvironment(tools=[])
-SetOption("%(opt)s", %(value)s)
-"""
-        % locals(),
+SetOption("{opt}", {value})
+""",
     )
     expect = r"scons: *** %s" % expect
     test.run(arguments='-Q -f %s .' % SConstruct, stderr=None, status=2)

--- a/test/ninja/ninja_test_sconscripts/sconstruct_ninja_determinism
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_ninja_determinism
@@ -5,12 +5,10 @@
 import random
 
 SetOption('experimental', 'ninja')
-SetOption('skip_ninja_regen', True)
 DefaultEnvironment(tools=[])
-
 env = Environment(tools=[])
-
 env.Tool('ninja')
+SetOption('skip_ninja_regen', True)  # must wait until tool creates the option
 
 # make the dependency list vary in order. Ninja tool should sort them to be deterministic.
 for i in range(1, 10):


### PR DESCRIPTION
`AddOption` and the internal `add_local_option` (essentially the implementation of `AddOption`) now recognize a `settable` keyword argument to indicate a project-added option can also be modified using `SetOption`.

There was a TODO in `SCons/Script/SConsOptions.py` about removing three hard-coded ninja options in the `settable` list once this change was made. When that was done, it turned out one test failed, because it called the `SetOption` before the ninja tool was initialized. Logic reordered in the test, but this is a thing to watch out for (the manpage does mention it, we'll see if it's prominent enough).

There are doc and test suite tweaks. The modified test now checks that `SetOption` on an enabled option works, but if the same option is also set on the command line, the command line version wins.

**Note**: a difference from #3983 is that it proposes making the default `settable=True`, I left it as `False` for compatibility with released SCons.  That's easy to change if desired.

Closes #3983.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
