### PR TITLE
Adjust AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ image:
   # linux builds done in Travis CI for now
   - Visual Studio 2017
   - Visual Studio 2019
-  #- Visual Studio 2022  XXX Temporary disable while failing on .10 versions
+  #- Visual Studio 2022  # Temporary disable while failing on 14.40 build tools
 
 cache:
   - downloads -> appveyor.yml
@@ -37,38 +37,38 @@ environment:
     # Test oldest and newest supported Pythons, and a subset in between.
     # Skipping 3.7 and 3.9 at this time
     - WINPYTHON: "Python312"
-
     - WINPYTHON: "Python310"
-
     - WINPYTHON: "Python38"
-
     - WINPYTHON: "Python36"
 
 # remove sets of build jobs based on criteria below
 # to fine tune the number and platforms tested
 matrix:
   exclude:
-    # test python 3.6 on Visual Studio 2017 image
+    # XXX test python 3.6 on Visual Studio 2017 image
+    # test python 3.8 on Visual Studio 2017 image
     - image: Visual Studio 2017
       WINPYTHON: "Python312"
     - image: Visual Studio 2017
       WINPYTHON: "Python310"
     - image: Visual Studio 2017
-      WINPYTHON: "Python38"
+      WINPYTHON: "Python36"
 
-    # test python 3.8 on Visual Studio 2019 image
+    # test python 3.10 on Visual Studio 2019 image
     - image: Visual Studio 2019
       WINPYTHON: "Python312"
     - image: Visual Studio 2019
-      WINPYTHON: "Python310"
+      WINPYTHON: "Python38"
     - image: Visual Studio 2019
       WINPYTHON: "Python36"
 
-    # test python 3.10 and 3.11 on Visual Studio 2022 image
+    # test python 3.12 on Visual Studio 2022 image
     - image: Visual Studio 2022
-      WINPYTHON: "Python36"
+      WINPYTHON: "Python310"
     - image: Visual Studio 2022
       WINPYTHON: "Python38"
+    - image: Visual Studio 2022
+      WINPYTHON: "Python36"
 
 # Remove some binaries we don't want to be found
 # Note this is no longer needed, git-windows bin/ is quite minimal now.


### PR DESCRIPTION
The VS2017 x Python 3.6 combo is failing one test using xsltproc. We don't know why, but try moving the Python vesion in case it's involved (perhaps something in urllib and/or the certs/ssl that go with 3.6, since it seems to be failing to fetch a file).

This is CI-only, no changes to scons.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
