### PR TITLE
Add `SCsub` to known SConscript names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -76,6 +76,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Migrate setup.cfg logic to pyproject.toml; remove setup.cfg.
     - Update .gitattributes to match .editorconfig; enforce eol settings.
     - Replace black/flake8 with ruff for more efficient formatting & linting.
+    - When debugging (--debug=pdb), the filename SCsub is now recognized when
+      manipulating breakpoints.
 
   From Raymond Li:
     - Fix issue #3935: OSErrors are now no longer hidden during execution of

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -74,6 +74,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   allow a developer to supply a custom validator, which previously
   could be inhibited by the converter failing before the validator
   is reached.
+- When debugging (--debug=pdb), the filename SCsub is now recognized when
+  manipulating breakpoints.
 
 FIXES
 -----

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -86,7 +86,11 @@ KNOWN_SCONSCRIPTS = [
     "Sconstruct",
     "sconstruct",
     "SConscript",
+    "Sconscript",
     "sconscript",
+    "SCsub",  # Uncommon alternative to SConscript
+    "Scsub",
+    "scsub",
 ]
 
 # Global variables

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1023,6 +1023,11 @@ The names &SConstruct; and &SConscript; are now
 recognized without requiring
 <filename>.py</filename> suffix.
 </para>
+<para>
+<emphasis>Changed in version 4.7.1</emphasis>:
+The name <filename>SCsub</filename> is now recognized
+without requiring <filename>.py</filename> suffix.
+</para>
 </note>
   </listitem>
   </varlistentry>


### PR DESCRIPTION
A very niche change, but the godot repo uses `SCsub` instead of `SConscript` & it'd be handy to utilize `--debug=pdb` breakpoints.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
