### PR TITLE
Implement somewhat pythonic type hints in sctypes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,9 +12,11 @@ NOTE: Python 3.6 support is deprecated and will be dropped in a future release.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
-
-        - Whatever John Doe did.
+  From Thaddeus Crews:
+    - Add explicit return types to sctypes `is_*` functions. For Python <=3.9,
+      the return type is simply `bool`, same as before. Python 3.10 and later
+      will benefit from `TypeGuard`/`TypeIs`, to produce intellisense similar
+      to using `isinstance` directly.
 
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -56,7 +56,11 @@ DOCUMENTATION
 DEVELOPMENT
 -----------
 
-- List visible changes in the way SCons is developed
+- sctypes `is_*` functions given explicit return types. Python 3.13+ uses
+  `TypeIs` for a near-equivalent of `isinstance`. Python 3.10 through 3.12
+  uses `TypeGuard`, a less accurate implementation but still provides
+  usable type hinting. Python 3.9 and earlier simply returns `bool`, same
+  as before.
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/SCons/Util/sctypes.py
+++ b/SCons/Util/sctypes.py
@@ -11,7 +11,8 @@ import codecs
 import os
 import pprint
 import re
-from typing import Optional
+import sys
+from typing import Optional, Union
 
 from collections import UserDict, UserList, UserString, deque
 from collections.abc import MappingView, Iterable
@@ -50,38 +51,63 @@ StringTypes = (str, UserString)
 # Empirically, it is faster to check explicitly for str than for basestring.
 BaseStringTypes = str
 
+# Later Python versions allow us to explicitly apply type hints based off the
+# return value similar to isinstance(), albeit not as precise.
+if sys.version_info >= (3, 13):
+    from typing import TypeAlias, TypeIs
+
+    DictTypeRet: TypeAlias = TypeIs[Union[dict, UserDict]]
+    ListTypeRet: TypeAlias = TypeIs[Union[list, UserList, deque]]
+    SequenceTypeRet: TypeAlias = TypeIs[Union[list, tuple, deque, UserList, MappingView]]
+    TupleTypeRet: TypeAlias = TypeIs[tuple]
+    StringTypeRet: TypeAlias = TypeIs[Union[str, UserString]]
+elif sys.version_info >= (3, 10):
+    from typing import TypeAlias, TypeGuard
+
+    DictTypeRet: TypeAlias = TypeGuard[Union[dict, UserDict]]
+    ListTypeRet: TypeAlias = TypeGuard[Union[list, UserList, deque]]
+    SequenceTypeRet: TypeAlias = TypeGuard[Union[list, tuple, deque, UserList, MappingView]]
+    TupleTypeRet: TypeAlias = TypeGuard[tuple]
+    StringTypeRet: TypeAlias = TypeGuard[Union[str, UserString]]
+else:
+    DictTypeRet = Union[bool, bool]
+    ListTypeRet = Union[bool, bool]
+    SequenceTypeRet = Union[bool, bool]
+    TupleTypeRet = Union[bool, bool]
+    StringTypeRet = Union[bool, bool]
+
 
 def is_Dict(  # pylint: disable=redefined-outer-name,redefined-builtin
     obj, isinstance=isinstance, DictTypes=DictTypes
-) -> bool:
+) -> DictTypeRet:
     """Check if object is a dict."""
     return isinstance(obj, DictTypes)
 
 
 def is_List(  # pylint: disable=redefined-outer-name,redefined-builtin
     obj, isinstance=isinstance, ListTypes=ListTypes
-) -> bool:
+) -> ListTypeRet:
     """Check if object is a list."""
     return isinstance(obj, ListTypes)
 
 
 def is_Sequence(  # pylint: disable=redefined-outer-name,redefined-builtin
     obj, isinstance=isinstance, SequenceTypes=SequenceTypes
-) -> bool:
+) -> SequenceTypeRet:
     """Check if object is a sequence."""
     return isinstance(obj, SequenceTypes)
 
 
 def is_Tuple(  # pylint: disable=redefined-builtin
     obj, isinstance=isinstance, tuple=tuple
-) -> bool:
+) -> TupleTypeRet:
     """Check if object is a tuple."""
     return isinstance(obj, tuple)
 
 
 def is_String(  # pylint: disable=redefined-outer-name,redefined-builtin
     obj, isinstance=isinstance, StringTypes=StringTypes
-) -> bool:
+) -> StringTypeRet:
     """Check if object is a string."""
     return isinstance(obj, StringTypes)
 


### PR DESCRIPTION
Currently, the type-check functions provided by sctypes have no real way to pass the parsed logic to intellisense like `isinstance`; while I ultimately believe most/all of these functions should transition to `isinstance` eventually, that'd be a pretty radical overhaul to the repo. This PR is a stopgap solution, changing the return types of those functions to `TypeGuard` for Python 3.10 and later—while still returning bool, it'll make intellisense for the passed value similar to `isinstance`. 3.9 and earlier will see identical behavior to the existing implementation.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
