### PR TITLE
Bump SCons "added" version to 4.8

### DIFF
--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1423,6 +1423,10 @@ def _exec_main(parser, values) -> None:
                 sconscript files that don't have the suffix.
 
                 .. versionadded:: 4.6.0
+
+                .. versionchanged:: 4.8.0
+                   The additional name ``SCsub`` (with spelling variants)
+                   is also recognized - Godot uses this name.
                 """
                 if os.path.isabs(filename) and os.path.exists(filename):
                     return filename

--- a/SCons/Script/SConscript.xml
+++ b/SCons/Script/SConscript.xml
@@ -145,7 +145,7 @@ EnsureSConsVersion(0,96,90)
 <para>
 Returns the current SCons version in the form of a Tuple[int, int, int],
 representing the major, minor, and revision values respectively.
-<emphasis>Added in 4.7.1</emphasis>.
+<emphasis>Added in 4.8.0</emphasis>.
 </para>
 </summary>
 </scons_function>

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -1049,7 +1049,7 @@ recognized without requiring
 <filename>.py</filename> suffix.
 </para>
 <para>
-<emphasis>Changed in version 4.7.1</emphasis>:
+<emphasis>Changed in version 4.8.0</emphasis>:
 The name <filename>SCsub</filename> is now recognized
 without requiring <filename>.py</filename> suffix.
 </para>


### PR DESCRIPTION
Two additions in the cycle since 4.7.0 had documentation annotations that they were added in 4.7.1. Update to 4.8.0.  One of those changes didn't have an annotation in the code.

Doc-only change; no changelog since it's just fixing stuff already submitted.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
