### PR TITLE
Don't let deletions leak from OverrideEnvironment

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,9 +12,16 @@ NOTE: Python 3.6 support is deprecated and will be dropped in a future release.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
-
-        - Whatever John Doe did.
+  From Mats Wichmann:
+    - Override envirionments, created when giving construction environment
+      keyword arguments to Builder calls (or manually, through the undocumented
+      Override method), were modified not to "leak" on item deletion.  The item
+      will now not be deleted from the base environment.  Methods of regular
+      environments modified to (mostly) not directly access the _dict attribute
+      which stores the construction variables - in case they're called via
+      proxying from an OverrideEnv, which does not have such an attribute
+      (though for completeness, it now pretends to).  Let the dictionary-like
+      methods handle access/update instead.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,15 +13,6 @@ NOTE: Python 3.6 support is deprecated and will be dropped in a future release.
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Mats Wichmann:
-    - Override envirionments, created when giving construction environment
-      keyword arguments to Builder calls (or manually, through the undocumented
-      Override method), were modified not to "leak" on item deletion.  The item
-      will now not be deleted from the base environment.  Methods of regular
-      environments modified to (mostly) not directly access the _dict attribute
-      which stores the construction variables - in case they're called via
-      proxying from an OverrideEnv, which does not have such an attribute
-      (though for completeness, it now pretends to).  Let the dictionary-like
-      methods handle access/update instead.
     - PackageVariable now does what the documentation always said it does
       if the variable is used on the command line with one of the enabling
       string as the value: the variable's default value is produced (previously
@@ -32,6 +23,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       the test fails. The rest is cleanup and type annotations. Be more
       careful that the returns from stderr() and stdout(), which *can*
       return None, are not used without checking.
+    - Override envirionments, created when giving construction environment
+      keyword arguments to Builder calls (or manually, through the undocumented
+      Override method), were modified not to "leak" on item deletion.  The item
+      will now not be deleted from the base environment. Override Environments
+      now also pretend to have a _dict attribute so that regular environment
+      methods don't have a problem if passed an OE instance.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,11 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - List modifications to existing features, where the previous behavior
   wouldn't actually be considered a bug
 
+- Override envirionments, created when giving construction environment
+  keyword arguments to Builder calls (or manually, through the
+  undocumented Override method), were modified not to "leak" on item deletion.
+  The item will now not be deleted from the base environment.
+
 FIXES
 -----
 

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -2619,12 +2619,12 @@ class OverrideEnvironment(Base):
     # Methods that make this class act like a proxy.
 
     def __getattr__(self, name):
-        # Proxied environment methods don't know they could be called with
-        # us as 'self' and may access the _data consvar dict directly.
-        # And they shouldn't *have* to know, so we need to pretend to have one,
-        # and not serve up the one from the subject, or it will miss the
-        # overridden values (and possibly modify the base). Use ourselves
-        # and hope the dict-like methods below are sufficient.
+        # Proxied environment methods don't know (nor should they have to) that
+        # they could be called with an OverrideEnvironment as 'self' and may
+        # access the _dict construction variable dict directly, so we need to
+        # pretend to have one, and not serve up the one from the subject, or it
+        # will miss the overridden values (and possibly modify the base). Use
+        # ourselves and hope the dict-like methods below are sufficient.
         if name == '_dict':
             return self
 

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -1647,6 +1647,19 @@ Example:
 cvars = env.Dictionary()
 cc_values = env.Dictionary('CC', 'CCFLAGS', 'CCCOM')
 </example_commands>
+
+<note><para>
+The object returned by &f-link-env-Dictionary; should be treated
+as a read-only view into the &consvars;.
+Some &consvars; have special internal handling,
+and making changes through the &f-env-Dictionary; object can bypass
+that handling and cause data inconsistencies.
+The primary use of &f-env-Dictionary; is for diagnostic purposes -
+it is used widely by test cases specifically because
+it bypasses the special handling so that behavior
+can be verified.
+</para></note>
+
 </summary>
 </scons_function>
 

--- a/SCons/Tool/packaging/__init__.py
+++ b/SCons/Tool/packaging/__init__.py
@@ -86,8 +86,7 @@ def Tag(env, target, source, *more_tags, **kw_tags):
             t.Tag(k, v)
 
 def Package(env, target=None, source=None, **kw):
-    """ Entry point for the package tool.
-    """
+    """Entry point for the package tool."""
     # check if we need to find the source files ourselves
     if not source:
         source = env.FindInstalledFiles()
@@ -96,17 +95,11 @@ def Package(env, target=None, source=None, **kw):
         raise UserError("No source for Package() given")
 
     # decide which types of packages shall be built. Can be defined through
-    # four mechanisms: command line argument, keyword argument,
-    # environment argument and default selection (zip or tar.gz) in that
-    # order.
-    try:
-        kw['PACKAGETYPE'] = env['PACKAGETYPE']
-    except KeyError:
-        pass
-
-    if not kw.get('PACKAGETYPE'):
+    # four mechanisms: command line argument, keyword argument, environment
+    # argument and default selection (zip or tar.gz) in that order.
+    kw.setdefault('PACKAGETYPE', env.get('PACKAGETYPE'))
+    if kw['PACKAGETYPE'] is None:
         kw['PACKAGETYPE'] = GetOption('package_type')
-
     if kw['PACKAGETYPE'] is None:
         if 'Tar' in env['BUILDERS']:
             kw['PACKAGETYPE'] = 'targz'

--- a/SCons/Tool/packaging/rpm.py
+++ b/SCons/Tool/packaging/rpm.py
@@ -25,7 +25,6 @@
 
 import SCons.Builder
 import SCons.Tool.rpmutils
-from SCons.Environment import OverrideEnvironment
 from SCons.Tool.packaging import stripinstallbuilder, src_targz
 from SCons.Errors import UserError
 
@@ -67,7 +66,7 @@ def package(env, target, source, PACKAGEROOT, NAME, VERSION,
         kw['SOURCE_URL']=(str(target[0])+".tar.gz").replace('.rpm', '')
 
     # mangle the source and target list for the rpmbuild
-    env = OverrideEnvironment(env, kw)
+    env = env.Override(kw)
     target, source = stripinstallbuilder(target, source, env)
     target, source = addspecfile(target, source, env)
     target, source = collectintargz(target, source, env)


### PR DESCRIPTION
**EDITED**

This PR changes two things about ``OverrideEnvirionment``:

1. The existing `__del__` method removed its argument from the override dict, and from the construction variable dict in the underlying environment ("subject"). There's "method to the madness": if the key is subsequently looked up, it would otherwise be supplied from the subject, leading to the weird outcome that you've deleted a variable, yet that variable is still in the environment you're looking at (which you don't know is a "special" ``OverrideEnvironment``).  Deleting from the subject makes that not happen, but has the side effect the variable is really deleted from the subject, which could lead to surprise elsewhere. The change is to track deletes from an OE, and use that information to make sure you don't supply a value from the subject in the OE context, but without actually modifying the subject.  

2. Many environment methods directly access/modify ``self._dict``, the dictionary of construction variables. Environments have special methods that make them "work like a dict", by accessing ``_dict``, but it's slightly faster to access ``__dict`` directly. In the existing code, if using an ``OverrideEnvironment`` instance, such a method will be supplied from the subject environment via proxying (``__getattr``) - as intended.  But now ``self`` is an OE, which doesn't have a ``_dict`` attribute, so that's revectored through ``__getattr__`` again, which supplies the attribute from the subject environment. Thus, these methods will end up taking the value from, or modifying the value in, the subject environment's ``_dict``, *even if there was already an entry in the override dict for it which should be used*. The change makes ``OverrideEnvironment`` pretend it has a ``_dict``, such that accesses go through OE's existing ``__getitem__`` and ``__setitem__`` methods and thus consider the override dict first.


Also in the rpm packaging tool: call `Override` factory method rather than directly instantiating `OverrideEnvironment` ("use best practices")

Fixes #4563

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
