### PR TITLE
Add timeout to test/ninja/default_targets.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       to a string containing the value without the key. For example, if
       "print(repr(env.Dump('CC'))" previously returned "'gcc'", it will now
       return "{'CC': 'gcc'}".
+    - Add a timeout to test/ninja/default_targets.py - it's gotten stuck on
+      the GitHub Windows action and taken the run to the full six hour timeout.
+      Usually runs in a few second, so set the timeout to 3min (120).
 
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700

--- a/test/ninja/default_targets.py
+++ b/test/ninja/default_targets.py
@@ -20,7 +20,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
 import os
 
@@ -32,45 +31,42 @@ test = TestSCons.TestSCons()
 try:
     import ninja
 except ImportError:
-    test.skip_test("Could not find module in python")
+    test.skip_test("Could not find 'ninja'; skipping test.\n")
 
 _python_ = TestSCons._python_
 _exe = TestSCons._exe
 
-ninja_bin = os.path.abspath(os.path.join(
-    ninja.__file__,
-    os.pardir,
-    'data',
-    'bin',
-    'ninja' + _exe))
+ninja_bin = os.path.abspath(
+    os.path.join(ninja.__file__, os.pardir, 'data', 'bin', 'ninja' + _exe)
+)
 
 test.dir_fixture('ninja-fixture')
 
 test.file_fixture('ninja_test_sconscripts/sconstruct_default_targets', 'SConstruct')
 
+# this test has had some hangs on the GitHut Windows runner, add timeout.
+
 # generate simple build
-test.run(stdout=None)
+test.run(stdout=None, timeout=120)
 test.must_contain_all_lines(test.stdout(), ['Generating: build.ninja'])
 test.must_contain_all(test.stdout(), 'Executing:')
-test.must_contain_all(test.stdout(), 'ninja%(_exe)s -f' % locals())
+test.must_contain_all(test.stdout(), f'ninja{_exe} -f')
 test.must_not_exist([test.workpath('out1.txt')])
 test.must_exist([test.workpath('out2.txt')])
 
 # clean build and ninja files
-test.run(arguments='-c', stdout=None)
-test.must_contain_all_lines(test.stdout(), [
-    'Removed out2.txt',
-    'Removed build.ninja'])
+test.run(arguments='-c', stdout=None, timeout=120)
+test.must_contain_all_lines(test.stdout(), ['Removed out2.txt', 'Removed build.ninja'])
 
 # only generate the ninja file
-test.run(arguments='--disable-execute-ninja', stdout=None)
+test.run(arguments='--disable-execute-ninja', stdout=None, timeout=120)
 test.must_contain_all_lines(test.stdout(), ['Generating: build.ninja'])
 test.must_not_exist(test.workpath('out1.txt'))
 test.must_not_exist(test.workpath('out2.txt'))
 
 # run ninja independently
 program = test.workpath('run_ninja_env.bat') if IS_WINDOWS else ninja_bin
-test.run(program=program, stdout=None)
+test.run(program=program, stdout=None, timeout=120)
 test.must_not_exist([test.workpath('out1.txt')])
 test.must_exist(test.workpath('out2.txt'))
 

--- a/test/ninja/ninja_test_sconscripts/sconstruct_default_targets
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_default_targets
@@ -4,13 +4,14 @@
 
 import SCons
 
-SetOption('experimental','ninja')
+SetOption('experimental', 'ninja')
 DefaultEnvironment(tools=[])
-
 env = Environment(tools=[])
 env.Tool('ninja')
-env.Command('out1.txt', 'foo.c', 'echo test > $TARGET' )
-out2_node = env.Command('out2.txt', 'foo.c', 'echo test > $TARGET', NINJA_FORCE_SCONS_BUILD=True)
+env.Command('out1.txt', 'foo.c', 'echo test > $TARGET')
+out2_node = env.Command(
+    'out2.txt', 'foo.c', 'echo test > $TARGET', NINJA_FORCE_SCONS_BUILD=True
+)
 alias = env.Alias('def', out2_node)
 
 env.Default(alias)


### PR DESCRIPTION
Has timed out not completing in the CI.

Test-only change - not sure if this will help, we'll keep an eye on other timeouts. Note that a pass result does not prove this tendency is squashed, since it's intermittent and fairly infrequent.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
