### PR TITLE
Restore usage of "from SCons.Variables import *`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add a timeout to test/ninja/default_targets.py - it's gotten stuck on
       the GitHub Windows action and taken the run to the full six hour timeout.
       Usually runs in a few second, so set the timeout to 3min (120).
+    - SCons 4.8.0 added an `__all__`  specifier at the top of the Variables
+      module (`Variables/__init__.py`) to control what is made available in
+      a star import. However, there was existing usage of doing
+      `from SCons.Variables import *` which expected the variable *types*
+      to be avaiable. While we never advertised this usage, there's no
+      real reason it shouldn't keep working - add to `__all__`.
 
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -39,7 +39,13 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
-- List fixes of outright bugs
+- SCons 4.8.0 added an `__all__`  specifier at the top of the Variables
+  module (`Variables/__init__.py`) to control what is made available in
+  a star import. However, there was existing usage of doing
+  `from SCons.Variables import *` which expected the variable *types*
+  to be avaiable. `BoolVariable`, `EnumVariable`, `ListVariable`,
+  `PackageVariable` and `PathVariable` are added to `__all__`,
+  so this form of import should now work again.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -29,6 +29,7 @@ import SCons.Variables
 import SCons.Subst
 import SCons.Warnings
 from SCons.Util import cmp
+from SCons.Variables import *
 
 
 class Environment:
@@ -722,6 +723,27 @@ class UnknownVariablesTestCase(unittest.TestCase):
         r = opts.UnknownVariables()
         assert len(r) == 0, r
         assert env['ADDEDLATER'] == 'added', env['ADDEDLATER']
+
+    def test_VariableTypesImportVisibility(self) -> None:
+        """Test that 'from SCons.Variables import *' will import all types of SCons defined Variables
+            """
+
+        try:
+            x = BoolVariable('test', 'test option help', False)
+            y = EnumVariable('test', 'test option help', 0,
+                                          ['one', 'two', 'three'],
+                                          {})
+            z = ListVariable('test', 'test option help', 'all',
+                                          ['one', 'two', 'three'])
+            o = PackageVariable('test', 'test build variable help', '/default/path')
+            p = PathVariable('test',
+                                          'test build variable help',
+                                          '/default/path')
+        except Exception as e:
+            self.fail(f"Could not import all known Variable types: {e}")
+
+
+
 
 
 if __name__ == "__main__":

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -43,6 +43,11 @@ from .PathVariable import PathVariable
 __all__ = [
     "Variable",
     "Variables",
+    "BoolVariable",
+    "EnumVariable",
+    "ListVariable",
+    "PackageVariable",
+    "PathVariable",
 ]
 
 class Variable:


### PR DESCRIPTION
This (unadvertised) import turns out to have real-world usage, and there's no real reason to prohibit it, although we do suggest using `from SCons.Script import *` as a more complete version. SCons 4.8.0 introduced an `__all__` in the `Variables` module; add the five variables types to this so the listed import will work as expected.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
