### PR TITLE
Switch scons build to use setuptools version hook

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add a timeout to test/ninja/default_targets.py - it's gotten stuck on
       the GitHub Windows action and taken the run to the full six hour timeout.
       Usually runs in a few second, so set the timeout to 3min (120).
+    - Switch SCons build to use setuptools' supported version fetcher from
+      the old homegrown one.
 
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ zip-safe = false
 include-package-data = true
 license-files = ["LICENSE"]
 
+[tool.setuptools.dynamic]
+version = {attr = "SCons.__version__"}
+
 [tool.setuptools.packages.find]
 exclude = ["template"]
 namespaces = false

--- a/setup.py
+++ b/setup.py
@@ -14,24 +14,16 @@ def read(rel_path):
         return fp.read()
 
 
-def get_version(rel_path):
-    for line in read(rel_path).splitlines():
-        if line.startswith('__version__'):
-            delim = '"' if '"' in line else "'"
-            return line.split(delim)[1]
-    else:
-        raise RuntimeError("Unable to find version string.")
-
-
 exclude = ['*Tests']
 
 
 class build_py(build_py_orig):
 
     def find_package_modules(self, package, package_dir):
-        """
-        Custom module to find package modules.
-        It will strip out any modules which match the glob patters in exclude above
+        """Custom module to find package modules.
+
+        Will strip out any modules which match the glob patters in
+        *exclude* above
         """
         modules = super().find_package_modules(package, package_dir)
         return [(pkg, mod, file, ) for (pkg, mod, file, ) in modules
@@ -42,5 +34,4 @@ setup(
     cmdclass={
         'build_py': build_py,
     },
-    version=get_version('SCons/__init__.py'),
 )


### PR DESCRIPTION
The stanza we used, still published in the Python packaging docs, is now considered the least desirable of the alternatives for keeping a "single package version", so update to a better one.

Note there's what's considered a "better" one than this, but it requires Python 3.8 ("provisional" until 3.10) or a backport of `importlib.metadata`.

This is a packaging-only change, no change to SCons itself or docs.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
