### PR TITLE
[Platform win32] Fix crash when pipe encoding is set to None

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Make doc function signature style more consistent - tweaks to AddOption,
       DefaultEnvironment and Tool,.
 
+  From Anthony Siegrist;
+    - On win32 platform, handle piped process output more robustly. Output encoding
+      fallback to UTF8 if it is defined at None by the output stream object.
+
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,7 +20,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Anthony Siegrist;
     - On win32 platform, handle piped process output more robustly. Output encoding
-      fallback to UTF8 if it is defined at None by the output stream object.
+      now uses 'oem' which should be the systems default encoding for the shell where
+      the process is being spawned.
 
   From Mats Wichmann:
     - env.Dump() now considers the "key" positional argument to be a varargs

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       will benefit from `TypeGuard`/`TypeIs`, to produce intellisense similar
       to using `isinstance` directly.
 
+  From Anthony Siegrist;
+    - On win32 platform, handle piped process output more robustly. Output encoding
+      fallback to UTF8 if it is defined at None by the output stream object.
+
   From Mats Wichmann:
     - env.Dump() now considers the "key" positional argument to be a varargs
       type (zero, one or many). However called, it returns a serialized
@@ -41,9 +45,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Make doc function signature style more consistent - tweaks to AddOption,
       DefaultEnvironment and Tool,.
 
-  From Anthony Siegrist;
-    - On win32 platform, handle piped process output more robustly. Output encoding
-      fallback to UTF8 if it is defined at None by the output stream object.
+
 
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -47,6 +47,14 @@ FIXES
   `PackageVariable` and `PathVariable` are added to `__all__`,
   so this form of import should now work again.
 
+- On win32 platform, SCons 4.7.0 modified the determination
+  of the output encoding of piped processes. Instead of using the default
+  encoding, it relied on the encoding attribute of the output stream.
+  If the encoding attribute of the output stream was set to None,
+  it was triggering an invalid argument exeption. This was the case with
+  streams of type io.StringIO for example.
+  From now, if the encoding is set to None, UTF8 is used.
+
 IMPROVEMENTS
 ------------
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -51,9 +51,10 @@ FIXES
   of the output encoding of piped processes. Instead of using the default
   encoding, it relied on the encoding attribute of the output stream.
   If the encoding attribute of the output stream was set to None,
-  it was triggering an invalid argument exeption. This was the case with
+  it was triggering an invalid argument exception. This was the case with
   streams of type io.StringIO for example.
-  From now, if the encoding is set to None, UTF8 is used.
+  This has been changed to always use the `oem` encoding which should be the
+  encoding in the shell where the command was spawned.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -149,10 +149,12 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         args.append("2>" + tmpFileStderrName)
 
     # Sanitize encoding. None is not a valid encoding.
+    # Since we're handling a redirected shell command use
+    # the shells default encoding.
     if stdout.encoding is None:
-        stdout.encoding = 'utf-8'
+        stdout.encoding = 'oem'
     if stderr.encoding is None:
-        stderr.encoding = 'utf-8'
+        stderr.encoding = 'oem'
 
     # actually do the spawn
     try:

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -148,6 +148,12 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
     if not stderrRedirected:
         args.append("2>" + tmpFileStderrName)
 
+    # Sanitize encoding. None is not a valid encoding.
+    if stdout.encoding is None:
+        stdout.encoding = 'utf-8'
+    if stderr.encoding is None:
+        stderr.encoding = 'utf-8'
+
     # actually do the spawn
     try:
         args = [sh, '/C', escape(' '.join(args))]
@@ -167,7 +173,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStdoutName, "rb") as tmpFileStdout:
                 output = tmpFileStdout.read()
-                stdout.write(output.decode(stdout.encoding if stdout.encoding is not None else 'utf-8', "replace"))
+                stdout.write(output.decode(stdout.encoding, "replace"))
             os.remove(tmpFileStdoutName)
         except OSError:
             pass
@@ -176,7 +182,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStderrName, "rb") as tmpFileStderr:
                 errors = tmpFileStderr.read()
-                stderr.write(errors.decode(stderr.encoding if stderr.encoding is not None else 'utf-8', "replace"))
+                stderr.write(errors.decode(stderr.encoding, "replace"))
             os.remove(tmpFileStderrName)
         except OSError:
             pass

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -167,7 +167,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStdoutName, "rb") as tmpFileStdout:
                 output = tmpFileStdout.read()
-                stdout.write(output.decode(stdout.encoding, "replace"))
+                stdout.write(output.decode(stdout.encoding if stdout.encoding is not None else 'utf-8', "replace"))
             os.remove(tmpFileStdoutName)
         except OSError:
             pass
@@ -176,7 +176,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStderrName, "rb") as tmpFileStderr:
                 errors = tmpFileStderr.read()
-                stderr.write(errors.decode(stderr.encoding, "replace"))
+                stderr.write(errors.decode(stderr.encoding if stderr.encoding is not None else 'utf-8', "replace"))
             os.remove(tmpFileStderrName)
         except OSError:
             pass

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -148,14 +148,6 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
     if not stderrRedirected:
         args.append("2>" + tmpFileStderrName)
 
-    # Sanitize encoding. None is not a valid encoding.
-    # Since we're handling a redirected shell command use
-    # the shells default encoding.
-    if stdout.encoding is None:
-        stdout.encoding = 'oem'
-    if stderr.encoding is None:
-        stderr.encoding = 'oem'
-
     # actually do the spawn
     try:
         args = [sh, '/C', escape(' '.join(args))]
@@ -175,7 +167,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStdoutName, "rb") as tmpFileStdout:
                 output = tmpFileStdout.read()
-                stdout.write(output.decode(stdout.encoding, "replace").replace("\r\n", "\n"))
+                stdout.write(output.decode('oem', "replace").replace("\r\n", "\n"))
             os.remove(tmpFileStdoutName)
         except OSError:
             pass
@@ -184,7 +176,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStderrName, "rb") as tmpFileStderr:
                 errors = tmpFileStderr.read()
-                stderr.write(errors.decode(stderr.encoding, "replace").replace("\r\n", "\n"))
+                stderr.write(errors.decode('oem', "replace").replace("\r\n", "\n"))
             os.remove(tmpFileStderrName)
         except OSError:
             pass

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -175,7 +175,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStdoutName, "rb") as tmpFileStdout:
                 output = tmpFileStdout.read()
-                stdout.write(output.decode(stdout.encoding, "replace"))
+                stdout.write(output.decode(stdout.encoding, "replace").replace("\r\n", "\n"))
             os.remove(tmpFileStdoutName)
         except OSError:
             pass
@@ -184,7 +184,7 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         try:
             with open(tmpFileStderrName, "rb") as tmpFileStderr:
                 errors = tmpFileStderr.read()
-                stderr.write(errors.decode(stderr.encoding, "replace"))
+                stderr.write(errors.decode(stderr.encoding, "replace").replace("\r\n", "\n"))
             os.remove(tmpFileStderrName)
         except OSError:
             pass


### PR DESCRIPTION
If stdout or stderr argument is of type io.stringIO, the function crash because stringIO has it's encoding property set to None.
This issue has been introduced by this [commit](https://github.com/SCons/scons/commit/a74ae6a35613b372a53b7dcc206d5cbdf709c465) in version 4.7.0

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x ] I have updated the appropriate documentation
