### PR TITLE
Fix ListVariable with a space-containing value

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,9 +21,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - env.Dump() now considers the "key" positional argument to be a varargs
       type (zero, one or many). However called, it returns a serialized
-      result that looks like a dict. Previously, only one "key" was
-      accepted, and unlike the zero-args case, it was be serialized
-      to a string containing the value (without the key). For example, if
+      result that looks like a dict. Previously, only a single "key" was
+      accepted, and unlike the zero-args case, it was serialized to a
+      string containing just the value (without the key). For example, if
       "print(repr(env.Dump('CC'))" previously returned "'gcc'", it will now
       return "{'CC': 'gcc'}".
     - Add a timeout to test/ninja/default_targets.py - it's gotten stuck on

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,8 +22,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - env.Dump() now considers the "key" positional argument to be a varargs
       type (zero, one or many). However called, it returns a serialized
       result that looks like a dict. Previously, only one "key" was
-      accepted. and unlike the zero-args case, it was be serialized
-      to a string containing the value without the key. For example, if
+      accepted, and unlike the zero-args case, it was be serialized
+      to a string containing the value (without the key). For example, if
       "print(repr(env.Dump('CC'))" previously returned "'gcc'", it will now
       return "{'CC': 'gcc'}".
     - Add a timeout to test/ninja/default_targets.py - it's gotten stuck on
@@ -40,6 +40,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improve wording of manpage "Functions and Environment Methods" section.
       Make doc function signature style more consistent - tweaks to AddOption,
       DefaultEnvironment and Tool,.
+    - Fix handling of ListVariable when supplying a quoted choice containing
+      a space character (issue #4585).
 
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -46,6 +46,8 @@ FIXES
   to be avaiable. `BoolVariable`, `EnumVariable`, `ListVariable`,
   `PackageVariable` and `PathVariable` are added to `__all__`,
   so this form of import should now work again.
+- Fix handling of ListVariable when supplying a quoted choice containing
+  a space character (issue #4585).
 
 IMPROVEMENTS
 ------------

--- a/SCons/Variables/BoolVariable.py
+++ b/SCons/Variables/BoolVariable.py
@@ -32,7 +32,7 @@ Usage example::
         ...
 """
 
-from typing import Tuple, Callable
+from typing import Callable, Tuple, Union
 
 import SCons.Errors
 
@@ -42,7 +42,7 @@ TRUE_STRINGS = ('y', 'yes', 'true', 't', '1', 'on', 'all')
 FALSE_STRINGS = ('n', 'no', 'false', 'f', '0', 'off', 'none')
 
 
-def _text2bool(val: str) -> bool:
+def _text2bool(val: Union[str, bool]) -> bool:
     """Convert boolean-like string to boolean.
 
     If *val* looks like it expresses a bool-like value, based on
@@ -54,6 +54,9 @@ def _text2bool(val: str) -> bool:
     Raises:
         ValueError: if *val* cannot be converted to boolean.
     """
+    if isinstance(val, bool):
+        # mainly for the subst=False case: default might be a bool
+        return val
     lval = val.lower()
     if lval in TRUE_STRINGS:
         return True
@@ -63,7 +66,7 @@ def _text2bool(val: str) -> bool:
     raise ValueError(f"Invalid value for boolean variable: {val!r}")
 
 
-def _validator(key, val, env) -> None:
+def _validator(key: str, val, env) -> None:
     """Validate that the value of *key* in *env* is a boolean.
 
     Parameter *val* is not used in the check.

--- a/SCons/Variables/BoolVariableTests.py
+++ b/SCons/Variables/BoolVariableTests.py
@@ -43,7 +43,6 @@ class BoolVariableTestCase(unittest.TestCase):
         """Test the BoolVariable converter"""
         opts = SCons.Variables.Variables()
         opts.Add(SCons.Variables.BoolVariable('test', 'test option help', False))
-
         o = opts.options[0]
 
         true_values = [
@@ -75,6 +74,17 @@ class BoolVariableTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             o.converter('x')
+
+        # Synthesize the case where the variable is created with subst=False:
+        # Variables code won't subst before calling the converter,
+        # and we might have pulled a bool from the option default.
+        with self.subTest():
+            x = o.converter(True)
+            assert x, f"converter returned False for {t!r}"
+        with self.subTest():
+            x = o.converter(False)
+            assert not x, f"converter returned False for {t!r}"
+
 
     def test_validator(self) -> None:
         """Test the BoolVariable validator"""

--- a/SCons/Variables/EnumVariableTests.py
+++ b/SCons/Variables/EnumVariableTests.py
@@ -159,7 +159,7 @@ class EnumVariableTestCase(unittest.TestCase):
         def invalid(o, v) -> None:
             with self.assertRaises(
                 SCons.Errors.UserError,
-                msg=f"did not catch expected UserError for o = {o.key}, v = {v}",
+                msg=f"did not catch expected UserError for o = {o.key!r}, v = {v!r}",
             ):
                 o.validator('X', v, {})
         table = {
@@ -185,6 +185,22 @@ class EnumVariableTestCase(unittest.TestCase):
             expected[0](opt0, v)
             expected[1](opt1, v)
             expected[2](opt2, v)
+
+        # make sure there are no problems with space-containing entries
+        opts = SCons.Variables.Variables()
+        opts.Add(
+            SCons.Variables.EnumVariable(
+                'test0',
+                help='test option help',
+                default='nospace',
+                allowed_values=['nospace', 'with space'],
+                map={},
+                ignorecase=0,
+            )
+        )
+        opt = opts.options[0]
+        valid(opt, 'nospace')
+        valid(opt, 'with space')
 
 
 if __name__ == "__main__":

--- a/SCons/Variables/ListVariable.py
+++ b/SCons/Variables/ListVariable.py
@@ -81,6 +81,7 @@ class _ListVariable(collections.UserList):
         if allowedElems is None:
             allowedElems = []
         super().__init__([_f for _f in initlist if _f])
+        # TODO: why sorted? don't we want to display in the order user gave?
         self.allowedElems = sorted(allowedElems)
 
     def __cmp__(self, other):
@@ -118,7 +119,12 @@ def _converter(val, allowedElems, mapdict) -> _ListVariable:
     The arguments *allowedElems* and *mapdict* are non-standard
     for a :class:`Variables` converter: the lambda in the
     :func:`ListVariable` function arranges for us to be called correctly.
+
+    Incoming values ``all`` and ``none`` are recognized and converted
+    into their expanded form.
     """
+    val = val.replace('"', '')  # trim any wrapping quotes
+    val = val.replace("'", '')
     if val == 'none':
         val = []
     elif val == 'all':
@@ -155,7 +161,7 @@ def _validator(key, val, env) -> None:
     allowedElems = env[key].allowedElems
     if isinstance(val, _ListVariable):  # not substituted, use .data
         notAllowed = [v for v in val.data if v not in allowedElems]
-    else:  # val will be a string
+    else:  # presumably a string
         notAllowed = [v for v in val.split() if v not in allowedElems]
     if notAllowed:
         # Converter only synthesized 'all' and 'none', they are never

--- a/SCons/Variables/ListVariable.py
+++ b/SCons/Variables/ListVariable.py
@@ -123,8 +123,6 @@ def _converter(val, allowedElems, mapdict) -> _ListVariable:
     Incoming values ``all`` and ``none`` are recognized and converted
     into their expanded form.
     """
-    val = val.replace('"', '')  # trim any wrapping quotes
-    val = val.replace("'", '')
     if val == 'none':
         val = []
     elif val == 'all':

--- a/SCons/Variables/PackageVariable.py
+++ b/SCons/Variables/PackageVariable.py
@@ -51,7 +51,7 @@ Can be used as a replacement for autoconf's ``--with-xxx=yyy`` ::
 """
 
 import os
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Union
 
 import SCons.Errors
 
@@ -60,13 +60,16 @@ __all__ = ['PackageVariable',]
 ENABLE_STRINGS = ('1', 'yes', 'true',  'on', 'enable', 'search')
 DISABLE_STRINGS = ('0', 'no',  'false', 'off', 'disable')
 
-def _converter(val):
+def _converter(val: Union[str, bool]) -> Union[str, bool]:
     """Convert package variables.
 
     Returns True or False if one of the recognized truthy or falsy
     values is seen, else return the value unchanged (expected to
     be a path string).
     """
+    if isinstance(val, bool):
+        # mainly for the subst=False case: default might be a bool
+        return val
     lval = val.lower()
     if lval in ENABLE_STRINGS:
         return True
@@ -75,7 +78,7 @@ def _converter(val):
     return val
 
 
-def _validator(key, val, env, searchfunc) -> None:
+def _validator(key: str, val, env, searchfunc) -> None:
     """Validate package variable for valid path.
 
     Checks that if a path is given as the value, that pathname actually exists.

--- a/SCons/Variables/PackageVariableTests.py
+++ b/SCons/Variables/PackageVariableTests.py
@@ -82,6 +82,16 @@ class PackageVariableTestCase(unittest.TestCase):
         x = o.converter(str(False))
         assert not x, "converter returned a string when given str(False)"
 
+        # Synthesize the case where the variable is created with subst=False:
+        # Variables code won't subst before calling the converter,
+        # and we might have pulled a bool from the option default.
+        with self.subTest():
+            x = o.converter(True)
+            assert x, f"converter returned False for {t!r}"
+        with self.subTest():
+            x = o.converter(False)
+            assert not x, f"converter returned False for {t!r}"
+
     def test_validator(self) -> None:
         """Test the PackageVariable validator"""
         opts = SCons.Variables.Variables()

--- a/SCons/Variables/PathVariable.py
+++ b/SCons/Variables/PathVariable.py
@@ -93,12 +93,12 @@ class _PathVariableClass:
     """
 
     @staticmethod
-    def PathAccept(key, val, env) -> None:
+    def PathAccept(key: str, val, env) -> None:
         """Validate path with no checking."""
         return
 
     @staticmethod
-    def PathIsDir(key, val, env) -> None:
+    def PathIsDir(key: str, val, env) -> None:
         """Validate path is a directory."""
         if os.path.isdir(val):
             return
@@ -109,7 +109,7 @@ class _PathVariableClass:
         raise SCons.Errors.UserError(msg)
 
     @staticmethod
-    def PathIsDirCreate(key, val, env) -> None:
+    def PathIsDirCreate(key: str, val, env) -> None:
         """Validate path is a directory, creating if needed."""
         if os.path.isdir(val):
             return
@@ -123,7 +123,7 @@ class _PathVariableClass:
             raise SCons.Errors.UserError(msg) from exc
 
     @staticmethod
-    def PathIsFile(key, val, env) -> None:
+    def PathIsFile(key: str, val, env) -> None:
         """Validate path is a file."""
         if not os.path.isfile(val):
             if os.path.isdir(val):
@@ -133,7 +133,7 @@ class _PathVariableClass:
             raise SCons.Errors.UserError(msg)
 
     @staticmethod
-    def PathExists(key, val, env) -> None:
+    def PathExists(key: str, val, env) -> None:
         """Validate path exists."""
         if not os.path.exists(val):
             msg = f'Path for variable {key!r} does not exist: {val}'

--- a/SCons/Variables/__init__.py
+++ b/SCons/Variables/__init__.py
@@ -61,7 +61,10 @@ class Variable:
 
     def __str__(self) -> str:
         """Provide a way to "print" a Variable object."""
-        return f"({self.key!r}, {self.aliases}, {self.help!r}, {self.default!r}, {self.validator}, {self.converter})"
+        return (
+            f"({self.key!r}, {self.aliases}, {self.help!r}, {self.default!r}, "
+            f"validator={self.validator}, converter={self.converter})"
+        )
 
 
 class Variables:
@@ -287,7 +290,13 @@ class Variables:
         for option in self.options:
             if option.validator and option.key in values:
                 if option.do_subst:
-                    value = env.subst('${%s}' % option.key)
+                    val = env[option.key]
+                    if not SCons.Util.is_String(val):
+                        # issue #4585: a _ListVariable should not be further
+                        #    substituted, breaks on values with spaces.
+                        value = val
+                    else:
+                        value = env.subst('${%s}' % option.key)
                 else:
                     value = env[option.key]
                 option.validator(option.key, value, env)

--- a/test/Variables/EnumVariable.py
+++ b/test/Variables/EnumVariable.py
@@ -52,8 +52,8 @@ opts.AddVariables(
                allowed_values=('motif', 'gtk', 'kde'),
                map={}, ignorecase=1), # case insensitive
     EV('some', 'some option', 'xaver',
-       allowed_values=('xaver', 'eins'),
-       map={}, ignorecase=2), # make lowercase
+       allowed_values=('xaver', 'eins', 'zwei wörter'),
+       map={}, ignorecase=2), # case lowering
     )
 
 _ = DefaultEnvironment(tools=[])
@@ -89,10 +89,13 @@ scons: *** Invalid value for enum variable 'guilib': 'irgendwas'. Valid values a
 test.run(arguments='guilib=IrGeNdwas', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Invalid value for enum variable 'some': 'irgendwas'. Valid values are: ('xaver', 'eins')
+scons: *** Invalid value for enum variable 'some': 'irgendwas'. Valid values are: ('xaver', 'eins', 'zwei wörter')
 """ + test.python_file_line(SConstruct_path, 20)
 
 test.run(arguments='some=IrGeNdwas', stderr=expect_stderr, status=2)
+
+test.run(arguments=['some=zwei Wörter'])
+check(['no', 'gtk', 'zwei wörter'])  # case-lowering converter
 
 test.pass_test()
 

--- a/test/Variables/ListVariable.py
+++ b/test/Variables/ListVariable.py
@@ -37,7 +37,7 @@ SConstruct_path = test.workpath('SConstruct')
 
 def check(expected):
     result = test.stdout().split('\n')
-    r = result[1:len(expected)+1]
+    r = result[1 : len(expected) + 1]
     assert r == expected, (r, expected)
 
 
@@ -45,17 +45,24 @@ test.write(SConstruct_path, """\
 from SCons.Variables.ListVariable import ListVariable as LV
 from SCons.Variables import ListVariable
 
-list_of_libs = Split('x11 gl qt ical')
+list_of_libs = Split('x11 gl qt ical') + ["with space"]
 
 optsfile = 'scons.variables'
 opts = Variables(optsfile, args=ARGUMENTS)
 opts.AddVariables(
-    ListVariable('shared',
-               'libraries to build as shared libraries',
-               'all',
-               names = list_of_libs,
-               map = {'GL':'gl', 'QT':'qt'}),
-    LV('listvariable', 'listvariable help', 'all', names=['l1', 'l2', 'l3'])
+    ListVariable(
+        'shared',
+        'libraries to build as shared libraries',
+        default='all',
+        names=list_of_libs,
+        map={'GL': 'gl', 'QT': 'qt'},
+    ),
+    LV(
+        'listvariable',
+        'listvariable help',
+        default='all',
+        names=['l1', 'l2', 'l3'],
+    ),
 )
 
 _ = DefaultEnvironment(tools=[])  # test speedup
@@ -70,7 +77,7 @@ if 'ical' in env['shared']:
 else:
     print('0')
 
-print(" ".join(env['shared']))
+print(",".join(env['shared']))
 
 print(env.subst('$shared'))
 # Test subst_path() because it's used in $CPPDEFINES expansions.
@@ -79,14 +86,27 @@ Default(env.Alias('dummy', None))
 """)
 
 test.run()
-check(['all', '1', 'gl ical qt x11', 'gl ical qt x11',
-       "['gl ical qt x11']"])
+check(
+    [
+        'all',
+        '1',
+        'gl,ical,qt,with space,x11',
+        'gl ical qt with space x11',
+        "['gl ical qt with space x11']",
+    ]
+)
 
-expect = "shared = 'all'"+os.linesep+"listvariable = 'all'"+os.linesep
+expect = "shared = 'all'" + os.linesep + "listvariable = 'all'" + os.linesep
 test.must_match(test.workpath('scons.variables'), expect)
-
-check(['all', '1', 'gl ical qt x11', 'gl ical qt x11',
-       "['gl ical qt x11']"])
+check(
+    [
+        'all',
+        '1',
+        'gl,ical,qt,with space,x11',
+        'gl ical qt with space x11',
+        "['gl ical qt with space x11']",
+    ]
+)
 
 test.run(arguments='shared=none')
 check(['none', '0', '', '', "['']"])
@@ -95,74 +115,80 @@ test.run(arguments='shared=')
 check(['none', '0', '', '', "['']"])
 
 test.run(arguments='shared=x11,ical')
-check(['ical,x11', '1', 'ical x11', 'ical x11',
-       "['ical x11']"])
+check(['ical,x11', '1', 'ical,x11', 'ical x11', "['ical x11']"])
 
 test.run(arguments='shared=x11,,ical,,')
-check(['ical,x11', '1', 'ical x11', 'ical x11',
-       "['ical x11']"])
+check(['ical,x11', '1', 'ical,x11', 'ical x11', "['ical x11']"])
 
 test.run(arguments='shared=GL')
 check(['gl', '0', 'gl', 'gl'])
 
 test.run(arguments='shared=QT,GL')
-check(['gl,qt', '0', 'gl qt', 'gl qt', "['gl qt']"])
+check(['gl,qt', '0', 'gl,qt', 'gl qt', "['gl qt']"])
 
+#test.run(arguments='shared="with space"')
+#check(['with space', '0', 'with space', 'with space', "['with space']"])
 
 expect_stderr = """
-scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
-""" + test.python_file_line(SConstruct_path, 18)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,with space,x11,all,none
+""" + test.python_file_line(SConstruct_path, 25)
 
 test.run(arguments='shared=foo', stderr=expect_stderr, status=2)
 
 # be paranoid in testing some more combinations
 
 expect_stderr = """
-scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
-""" + test.python_file_line(SConstruct_path, 18)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,with space,x11,all,none
+""" + test.python_file_line(SConstruct_path, 25)
 
 test.run(arguments='shared=foo,ical', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
-""" + test.python_file_line(SConstruct_path, 18)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,with space,x11,all,none
+""" + test.python_file_line(SConstruct_path, 25)
 
 test.run(arguments='shared=ical,foo', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,x11,all,none
-""" + test.python_file_line(SConstruct_path, 18)
+scons: *** Invalid value(s) for variable 'shared': 'foo'. Valid values are: gl,ical,qt,with space,x11,all,none
+""" + test.python_file_line(SConstruct_path, 25)
 
 test.run(arguments='shared=ical,foo,x11', stderr=expect_stderr, status=2)
 
 expect_stderr = """
-scons: *** Invalid value(s) for variable 'shared': 'foo,bar'. Valid values are: gl,ical,qt,x11,all,none
-""" + test.python_file_line(SConstruct_path, 18)
+scons: *** Invalid value(s) for variable 'shared': 'foo,bar'. Valid values are: gl,ical,qt,with space,x11,all,none
+""" + test.python_file_line(SConstruct_path, 25)
 
 test.run(arguments='shared=foo,x11,,,bar', stderr=expect_stderr, status=2)
 
-test.write('SConstruct', """
+test.write('SConstruct2', """\
 from SCons.Variables import ListVariable
 
 opts = Variables(args=ARGUMENTS)
 opts.AddVariables(
-    ListVariable('gpib',
-               'comment',
-               ['ENET', 'GPIB'],
-               names = ['ENET', 'GPIB', 'LINUX_GPIB', 'NO_GPIB']),
-    )
+    ListVariable(
+        'gpib',
+        'comment',
+        default=['ENET', 'GPIB'],
+        names=['ENET', 'GPIB', 'LINUX_GPIB', 'NO_GPIB'],
+    ),
+)
 
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment(variables=opts)
+env = Environment(tools=[], variables=opts)
 Help(opts.GenerateHelpText(env))
 
 print(env['gpib'])
 Default(env.Alias('dummy', None))
 """)
 
-test.run(stdout=test.wrap_stdout(read_str="ENET,GPIB\n", build_str="""\
+test.run(
+    arguments="-f SConstruct2",
+    stdout=test.wrap_stdout(read_str="ENET,GPIB\n",
+    build_str="""\
 scons: Nothing to be done for `dummy'.
-"""))
+""")
+)
 
 test.pass_test()
 

--- a/test/Variables/PackageVariable.py
+++ b/test/Variables/PackageVariable.py
@@ -70,6 +70,11 @@ check([str(False)])
 test.run(arguments=['x11=%s' % test.workpath()])
 check([test.workpath()])
 
+space_subdir = test.workpath('space subdir')
+test.subdir(space_subdir)
+test.run(arguments=[f'x11={space_subdir}'])
+check([space_subdir])
+
 expect_stderr = """
 scons: *** Path does not exist for variable 'x11': '/non/existing/path/'
 """ + test.python_file_line(SConstruct_path, 13)

--- a/test/Variables/PathVariable.py
+++ b/test/Variables/PathVariable.py
@@ -106,11 +106,18 @@ test.run(arguments=['qt_libraries=%s' % qtpath], stderr=expect_stderr, status=2)
 
 default_file = test.workpath('default_file')
 default_subdir = test.workpath('default_subdir')
+
 existing_subdir = test.workpath('existing_subdir')
 test.subdir(existing_subdir)
 
 existing_file = test.workpath('existing_file')
 test.write(existing_file, "existing_file\n")
+
+space_subdir = test.workpath('space subdir')
+test.subdir(space_subdir)
+
+space_file = test.workpath('space file')
+test.write(space_file, "space_file\n")
 
 non_existing_subdir = test.workpath('non_existing_subdir')
 non_existing_file = test.workpath('non_existing_file')
@@ -135,17 +142,22 @@ check([default_subdir])
 test.run(arguments=['X=%s' % existing_file])
 check([existing_file])
 
-test.run(arguments=['X=%s' % non_existing_file])
-check([non_existing_file])
-
 test.run(arguments=['X=%s' % existing_subdir])
 check([existing_subdir])
 
+test.run(arguments=['X=%s' % space_file])
+check([space_file])
+
+test.run(arguments=['X=%s' % space_subdir])
+check([space_subdir])
+
 test.run(arguments=['X=%s' % non_existing_subdir])
 check([non_existing_subdir])
-
-test.must_not_exist(non_existing_file)
 test.must_not_exist(non_existing_subdir)
+
+test.run(arguments=['X=%s' % non_existing_file])
+check([non_existing_file])
+test.must_not_exist(non_existing_file)
 
 test.write(SConstruct_path, """\
 opts = Variables(args=ARGUMENTS)

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1178,7 +1178,10 @@ class TestCmd:
                 cmd.extend([f"{k}={v}" for k, v in arguments.items()])
                 return cmd
             if isinstance(arguments, str):
-                arguments = arguments.split()
+                # Split into a list for passing to SCons - don't lose
+                # quotes, and don't break apart quoted substring with space.
+                # str split() fails on the spaces, shlex.split() on the quotes.
+                arguments = re.findall(r"(?:\".*?\"|\S)+", arguments)
             cmd.extend(arguments)
         return cmd
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1023,7 +1023,7 @@ class TestCmd:
         interpreter=None,
         workdir=None,
         subdir=None,
-        verbose=None,
+        verbose: int = -1,
         match=None,
         match_stdout=None,
         match_stderr=None,
@@ -1039,7 +1039,7 @@ class TestCmd:
         self.description_set(description)
         self.program_set(program)
         self.interpreter_set(interpreter)
-        if verbose is None:
+        if verbose == -1:
             try:
                 verbose = max(0, int(os.environ.get('TESTCMD_VERBOSE', 0)))
             except ValueError:
@@ -1178,10 +1178,10 @@ class TestCmd:
                 cmd.extend([f"{k}={v}" for k, v in arguments.items()])
                 return cmd
             if isinstance(arguments, str):
-                # Split into a list for passing to SCons - don't lose
-                # quotes, and don't break apart quoted substring with space.
-                # str split() fails on the spaces, shlex.split() on the quotes.
-                arguments = re.findall(r"(?:\".*?\"|\S)+", arguments)
+                # Split into a list for passing to SCons. This *will*
+                # break if the string has embedded spaces as part of a substing -
+                # use a # list to pass those to avoid the problem.
+                arguments = arguments.split()
             cmd.extend(arguments)
         return cmd
 

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
-"""
-Unit tests for the TestCmd.py module.
-"""
-
+#
 # Copyright 2000-2010 Steven Knight
 # This module is free software, and you may redistribute it and/or modify
 # it under the same terms as Python itself, so long as this copyright message
@@ -19,6 +16,9 @@ Unit tests for the TestCmd.py module.
 # AND THERE IS NO OBLIGATION WHATSOEVER TO PROVIDE MAINTENANCE,
 # SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
+"""
+Unit tests for the TestCmd.py module.
+"""
 
 import os
 import shutil
@@ -2225,59 +2225,67 @@ class command_args_TestCase(TestCmdTestCase):
 
         r = test.command_args('prog')
         expect = [run_env.workpath('prog')]
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args(test.workpath('new_prog'))
         expect = [test.workpath('new_prog')]
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args('prog', 'python')
         expect = ['python', run_env.workpath('prog')]
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args('prog', 'python', 'arg1 arg2')
         expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2']
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
+
+        r = test.command_args('prog', 'python', 'arg1 arg2="quoted"')
+        expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2="quoted"']
+        with self.subTest():
+            self.assertEqual(expect, r)
+
+        r = test.command_args('prog', 'python', 'arg1 arg2="quoted with space"')
+        expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2="quoted with space"']
+        with self.subTest():
+            self.assertEqual(expect, r)
 
         test.program_set('default_prog')
         default_prog = run_env.workpath('default_prog')
 
         r = test.command_args()
         expect = [default_prog]
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args(interpreter='PYTHON')
         expect = ['PYTHON', default_prog]
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args(interpreter='PYTHON', arguments='arg3 arg4')
         expect = ['PYTHON', default_prog, 'arg3', 'arg4']
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         # Test arguments = dict
         r = test.command_args(interpreter='PYTHON', arguments={'VAR1':'1'})
         expect = ['PYTHON', default_prog, 'VAR1=1']
-        assert r == expect, (expect, r)
-
+        self.assertEqual(expect, r)
 
         test.interpreter_set('default_python')
 
         r = test.command_args()
         expect = ['default_python', default_prog]
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args(arguments='arg5 arg6')
         expect = ['default_python', default_prog, 'arg5', 'arg6']
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args('new_prog_1')
         expect = [run_env.workpath('new_prog_1')]
-        assert r == expect, (expect, r)
+        self.assertEqual(expect, r)
 
         r = test.command_args(program='new_prog_2')
         expect = [run_env.workpath('new_prog_2')]
-        assert r == expect, (expect, r)
-
+        self.assertEqual(expect, r)
 
 
 class start_TestCase(TestCmdTestCase):

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -2239,13 +2239,13 @@ class command_args_TestCase(TestCmdTestCase):
         expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2']
         self.assertEqual(expect, r)
 
-        r = test.command_args('prog', 'python', 'arg1 arg2="quoted"')
-        expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2="quoted"']
+        r = test.command_args('prog', 'python', 'arg1 arg2=value')
+        expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2=value']
         with self.subTest():
             self.assertEqual(expect, r)
 
-        r = test.command_args('prog', 'python', 'arg1 arg2="quoted with space"')
-        expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2="quoted with space"']
+        r = test.command_args('prog', 'python', ['arg1', 'arg2=with space'])
+        expect = ['python', run_env.workpath('prog'), 'arg1', 'arg2=with space']
         with self.subTest():
             self.assertEqual(expect, r)
 

--- a/testing/framework/test-framework.rst
+++ b/testing/framework/test-framework.rst
@@ -621,6 +621,18 @@ or::
 
    test.must_match(..., match=TestSCons.match_re, ...)
 
+Often you want to supply arguments to SCons when it is invoked
+to run a test, which you can do using an *arguments* parameter::
+
+   test.run(arguments="-O -v FOO=BAR")
+
+One caveat here: the way the parameter is processed is unavoidably
+different from typing on the command line - if you need it not to
+be split on spaces, pre-split it yourself, and pass the list, like::
+
+   test.run(arguments=["-f", "SConstruct2", "FOO=Two Words"])
+
+
 Avoiding tests based on tool existence
 ======================================
 


### PR DESCRIPTION
A call like: `scons SKIPUTILS="NSIS Menu"` for `ListVariable` `SKIPUTILS`, with a space embedded in the value and thus given quoted, did not work, as the splitting of `ListVariable` into separate converter / validator routines left `subst()` running twice.  The call before the converter is invoked was fine; but the converter turns the value into an instance of the internal list-variable class, which is then stored, and running `subst()` on *that* before the validator was invoked undid that work and turned it back into a string - which the validator then split incorrectly because of the lost context. There's no completely clean fix (perhaps other than going back to a combined converter/validator like before 4.8.0). The approach chosen was to not run the `subst` before the validator if the stored value doesn't look like a string - indicating it's probably already in the form we wanted.

(Edited) Testing this was complicated by the test framework it splits the `arguments=` parameter, and so breaks with embedded spaces like `test.run(arguments='TEST="a b"')`. Attempts to fix this up just created more problems, so the test additions now use a list to supply strings that should not be split, like `arguments=['TEST="a', 'b"']`. There's plenty of precedent for this, many tests are run this way without necessarily even needing to be. Added some doc notes on this. The various variables are now tested for space-included strings, which can be values in an Enum or List type, or path strings (think Windows paths...) in Path and Package types.

Although not directly related to the space problem, during the investigation it also became clear that the new option to avoid calling `subst()` before the converter (the earlier fix for #4241) could have side effects - it is now possible for a variable's converter to be called with a type that is not an expected user input type. This could happen with `BoolVariable` and `PathVariable`: here the inputs were all expected to be strings, but the default to use if the variable is not specified could be in a "final" type - a bool (for `PathVariable` it's bool-or-str).  If `subst` is used, those will arrive as stringified versions of the bool, but if `subst` is suppressed they will actually be bool, so those converters needed to check for a bool type before doing a ` string.lower()`.

Signed-off-by: Mats Wichmann <mats@linux.com>

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
