### PR TITLE
Fix bug with unique adds and delete_existing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Improve wording of manpage "Functions and Environment Methods" section.
       Make doc function signature style more consistent - tweaks to AddOption,
       DefaultEnvironment and Tool,.
+    - Fix a problem with AppendUnique and PrependUnique where a value could
+      be erroneously removed due to a substring match.
 
 
 RELEASE 4.8.0 -  Sun, 07 Jul 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -46,6 +46,8 @@ FIXES
   to be avaiable. `BoolVariable`, `EnumVariable`, `ListVariable`,
   `PackageVariable` and `PathVariable` are added to `__all__`,
   so this form of import should now work again.
+- Fix a problem with AppendUnique and PrependUnique where a value could
+  be erroneously removed due to a substring match.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1512,11 +1512,17 @@ class Base(SubstitutionEnvironment):
 
         self._dict[envname][name] = nv
 
-    def AppendUnique(self, delete_existing: bool=False, **kw) -> None:
-        """Append values to existing construction variables
-        in an Environment, if they're not already there.
-        If delete_existing is True, removes existing values first, so
-        values move to end.
+    def AppendUnique(self, delete_existing: bool = False, **kw) -> None:
+        """Append values uniquely to existing construction variables.
+
+        Similar to :meth:`Append`, but the result may not contain duplicates
+        of any values passed for each given key (construction variable),
+        so an existing list may need to be pruned first, however it may still
+        contain other duplicates.
+
+        If *delete_existing* is true, removes existing values first, so values
+        move to the end; otherwise (the default) values are skipped if
+        already present.
         """
         kw = copy_non_reserved_keywords(kw)
         for key, val in kw.items():
@@ -1539,12 +1545,11 @@ class Base(SubstitutionEnvironment):
                     val = [x for x in val if x not in dk]
                 self._dict[key] = dk + val
             else:
+                # val is not a list, so presumably a scalar (likely str).
                 dk = self._dict[key]
                 if is_List(dk):
-                    # By elimination, val is not a list.  Since dk is a
-                    # list, wrap val in a list first.
                     if delete_existing:
-                        dk = list(filter(lambda x, val=val: x not in val, dk))
+                        dk = [x for x in dk if x != val]
                         self._dict[key] = dk + [val]
                     else:
                         if val not in dk:
@@ -1939,11 +1944,17 @@ class Base(SubstitutionEnvironment):
 
         self._dict[envname][name] = nv
 
-    def PrependUnique(self, delete_existing: bool=False, **kw) -> None:
-        """Prepend values to existing construction variables
-        in an Environment, if they're not already there.
-        If delete_existing is True, removes existing values first, so
-        values move to front.
+    def PrependUnique(self, delete_existing: bool = False, **kw) -> None:
+        """Prepend values uniquely to existing construction variables.
+
+        Similar to :meth:`Prepend`, but the result may not contain duplicates
+        of any values passed for each given key (construction variable),
+        so an existing list may need to be pruned first, however it may still
+        contain other duplicates.
+
+        If *delete_existing* is true, removes existing values first, so values
+        move to the front; otherwise (the default) values are skipped if
+        already present.
         """
         kw = copy_non_reserved_keywords(kw)
         for key, val in kw.items():
@@ -1966,12 +1977,11 @@ class Base(SubstitutionEnvironment):
                     val = [x for x in val if x not in dk]
                 self._dict[key] = val + dk
             else:
+                # val is not a list, so presumably a scalar (likely str).
                 dk = self._dict[key]
                 if is_List(dk):
-                    # By elimination, val is not a list.  Since dk is a
-                    # list, wrap val in a list first.
                     if delete_existing:
-                        dk = [x for x in dk if x not in val]
+                        dk = [x for x in dk if x != val]
                         self._dict[key] = [val] + dk
                     else:
                         if val not in dk:


### PR DESCRIPTION
`AppendUnique` and `PrependUnique`, when called with `delete_existing` true, had a small logic flaw: it might remove an existing value if the value to be added is a scalar (string, most likely) and there was a substring match. The code needs to do an equality test, not a membership test.

Docstrings and unit tests updated, plus dropped a duplicate definition of `reserved_variables` in the test.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
