### PR TITLE
Fix some AddOption issues

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,14 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       the test fails. The rest is cleanup and type annotations. Be more
       careful that the returns from stderr() and stdout(), which *can*
       return None, are not used without checking.
+    - The optparse add_option method supports an additional calling style
+      that is not directly described in SCons docs, but is included
+      by reference ("see the optparse documentation for details"):
+      a single arg consisting of a premade option object. Because optparse
+      detects that case based on seeing zero kwargs and we always
+      added at least one (default=) that would fail for AddOption. Fix
+      for consistency, but don't advertise it further - not addewd to
+      manpage synoposis/description.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,6 +44,11 @@ IMPROVEMENTS
   documentation:  performance improvements (describe the circumstances
   under which they would be observed), or major code cleanups
 
+- For consistency with the optparse "add_option" method, AddOption accepts
+  an SConsOption object as a single argument (this failed previouly).
+  Calling AddOption with the full set of arguments (option names and
+  attributes) to set up the option is still the recommended approach.
+
 PACKAGING
 ---------
 

--- a/test/AddOption/basic.py
+++ b/test/AddOption/basic.py
@@ -33,6 +33,8 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
+from SCons.Script.SConsOptions import SConsOption
+
 DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 AddOption(
@@ -55,6 +57,9 @@ AddOption(
     action="store_true",
     help="try SetOption of 'prefix' to '/opt/share'"
 )
+z_opt = SConsOption("--zcount", type="int", nargs=1, settable=True)
+AddOption(z_opt)
+
 f = GetOption('force')
 if f:
     f = "True"
@@ -63,6 +68,8 @@ print(GetOption('prefix'))
 if GetOption('set'):
     SetOption('prefix', '/opt/share')
     print(GetOption('prefix'))
+if GetOption('zcount'):
+    print(GetOption('zcount'))
 """)
 
 test.run('-Q -q .', stdout="None\nNone\n")
@@ -73,6 +80,8 @@ test.run('-Q -q . -- --prefix=/home/foo --force', status=1, stdout="None\nNone\n
 test.run('-Q -q . --set', stdout="None\nNone\n/opt/share\n")
 # but the "command line wins" rule is not violated
 test.run('-Q -q . --set --prefix=/home/foo', stdout="None\n/home/foo\n/home/foo\n")
+# also try in case we pass a premade option object to AddOption
+test.run('-Q -q . --zcount=22', stdout="None\nNone\n22\n")
 
 test.pass_test()
 


### PR DESCRIPTION
The `optparse.add_option` method supports an additional calling style that is not directly described in SCons docs, but is included by reference ("see the `optparse` documentation for details"): it takes a single argument consisting of a premade option object. Because the `optparse` code detects that case based on seeing zero kwargs, and we always add at least one (`default=`) that would fail for `AddOption`. Fix for consistency, but don't advertise it further: not added to manpage synoposis/description.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
