### PR TITLE
Fix short-option processing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@ NOTE: Python 3.6 support is deprecated and will be dropped in a future release.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Dillan Mills:
+    - Fix support for short options (`-x`).
+
   From Mats Wichmann:
     - PackageVariable now does what the documentation always said it does
       if the variable is used on the command line with one of the enabling

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -43,6 +43,11 @@ FIXES
   it always produced True in this case).
 - Temporary files created by TempFileMunge() are now cleaned up on
   scons exit, instead of at the time they're used.  Fixes #4595.
+- AddOption now correctly adds short (single-character) options.
+  Previously an added short option would always report as unknown,
+  while long option names for the same option worked. Short options
+  that take a value require the user to specify the value immediately
+  following the option, with no spaces (e.g. -j5 and not -j 5).
 
 IMPROVEMENTS
 ------------

--- a/test/AddOption/basic.py
+++ b/test/AddOption/basic.py
@@ -38,7 +38,7 @@ from SCons.Script.SConsOptions import SConsOption
 DefaultEnvironment(tools=[])
 env = Environment(tools=[])
 AddOption(
-    '--force',
+    '-F', '--force',
     action="store_true",
     help='force installation (overwrite any existing files)',
 )
@@ -74,6 +74,7 @@ if GetOption('zcount'):
 
 test.run('-Q -q .', stdout="None\nNone\n")
 test.run('-Q -q . --force', stdout="True\nNone\n")
+test.run('-Q -q . -F', stdout="True\nNone\n")
 test.run('-Q -q . --prefix=/home/foo', stdout="None\n/home/foo\n")
 test.run('-Q -q . -- --prefix=/home/foo --force', status=1, stdout="None\nNone\n")
 # check that SetOption works on prefix...

--- a/test/SCONSFLAGS.py
+++ b/test/SCONSFLAGS.py
@@ -62,15 +62,15 @@ test.run(arguments = "-H")
 test.must_not_contain_any_line(test.stdout(), ['Help text.'])
 test.must_contain_all_lines(test.stdout(), ['-H, --help-options'])
 
-os.environ['SCONSFLAGS'] = '-Z'
-
 expect = r"""usage: scons [OPTIONS] [VARIABLES] [TARGETS]
 
 SCons Error: no such option: -Z
 """
 
-test.run(arguments = "-H", status = 2,
-         stderr = expect, match=TestSCons.match_exact)
+test.run(arguments="-Z", status=2, stderr=expect, match=TestSCons.match_exact)
+
+os.environ['SCONSFLAGS'] = '-Z'
+test.run(status=2, stderr=expect, match=TestSCons.match_exact)
 
 test.pass_test()
 


### PR DESCRIPTION
Provide an override the `_process_short_opts` method from `optparse` so it behaves better.  This fix is lifted directly from #3799 (other parts of that PR will be picked later).

Fixes #3798

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
