### PR TITLE
Fix initialization of compilation_db emitters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       will now not be deleted from the base environment. Override Environments
       now also pretend to have a _dict attribute so that regular environment
       methods don't have a problem if passed an OE instance.
+    - Fix a problem with compilation_db component initialization - the
+      entries for assembler files were not being set up correctly.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -43,6 +43,8 @@ FIXES
   it always produced True in this case).
 - Temporary files created by TempFileMunge() are now cleaned up on
   scons exit, instead of at the time they're used.  Fixes #4595.
+- Fix a problem with compilation_db component initialization - the
+  entries for assembler files were not being set up correctly.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -43,6 +43,8 @@ from .cxx import CXXSuffixes
 from .cc import CSuffixes
 from .asm import ASSuffixes, ASPPSuffixes
 
+DEFAULT_DB_NAME = 'compile_commands.json'
+
 # TODO: Is there a better way to do this than this global? Right now this exists so that the
 # emitter we add can record all of the things it emits, so that the scanner for the top level
 # compilation database can access the complete list, and also so that the writer has easy
@@ -189,9 +191,8 @@ def compilation_db_emitter(target, source, env):
     if not target and len(source) == 1:
         target = source
 
-    # Default target name is compilation_db.json
     if not target:
-        target = ['compile_commands.json', ]
+        target = [DEFAULT_DB_NAME]
 
     # No source should have been passed. Drop it.
     if source:
@@ -224,13 +225,17 @@ def generate(env, **kwargs) -> None:
         ),
         itertools.product(
             ASSuffixes,
-            [(static_obj, SCons.Defaults.StaticObjectEmitter, "$ASCOM")],
-            [(shared_obj, SCons.Defaults.SharedObjectEmitter, "$ASCOM")],
+            [
+                (static_obj, SCons.Defaults.StaticObjectEmitter, "$ASCOM"),
+                (shared_obj, SCons.Defaults.SharedObjectEmitter, "$ASCOM")
+            ],
         ),
         itertools.product(
             ASPPSuffixes,
-            [(static_obj, SCons.Defaults.StaticObjectEmitter, "$ASPPCOM")],
-            [(shared_obj, SCons.Defaults.SharedObjectEmitter, "$ASPPCOM")],
+            [
+                (static_obj, SCons.Defaults.StaticObjectEmitter, "$ASPPCOM"),
+                (shared_obj, SCons.Defaults.SharedObjectEmitter, "$ASPPCOM")
+            ],
         ),
     )
 


### PR DESCRIPTION
As written, the entries using the `SharedObjectEmitter` aren't added for assembler files. This doesn't seem to be a problem in real life, as SCons doesn't distinguish between static/shared for objects created by the assemblers at the moment, but it's perhaps better to make this consistent, if only to keep people from copying bad code in making custom entries.  Can't really think of a testcase that would be useful.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
