### PR TITLE
Add clang, clang++ to default tool search

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       methods don't have a problem if passed an OE instance.
     - Fix a problem with compilation_db component initialization - the
       entries for assembler files were not being set up correctly.
+    - Add clang and clang++ to the default tool search orders for POSIX
+      and Windows platforms. These will be searched for after gcc and g++,
+      respectively. Does not affect expliclity requested tool lists.
+      Note: on Windows, SCons currently only has builtin support for
+      clang, not for clang-cl, the version of the frontend that uses
+      cl.exe-compatible command line switches.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -58,6 +58,13 @@ IMPROVEMENTS
   Calling AddOption with the full set of arguments (option names and
   attributes) to set up the option is still the recommended approach.
 
+- Add clang and clang++ to the default tool search orders for POSIX
+  and Windows platforms. These will be searched for after gcc and g++,
+  respectively. Does not affect expliclity requested tool lists.  Note:
+  on Windows, SCons currently only has builtin support for clang, not
+  for clang-cl, the version of the frontend that uses cl.exe-compatible
+  command line switches.
+
 PACKAGING
 ---------
 

--- a/SCons/Tool/__init__.py
+++ b/SCons/Tool/__init__.py
@@ -691,8 +691,8 @@ def tool_list(platform, env):
     if str(platform) == 'win32':
         "prefer Microsoft tools on Windows"
         linkers = ['mslink', 'gnulink', 'ilink', 'linkloc', 'ilink32']
-        c_compilers = ['msvc', 'mingw', 'gcc', 'intelc', 'icl', 'icc', 'cc', 'bcc32']
-        cxx_compilers = ['msvc', 'intelc', 'icc', 'g++', 'cxx', 'bcc32']
+        c_compilers = ['msvc', 'mingw', 'gcc', 'clang', 'intelc', 'icl', 'icc', 'cc', 'bcc32']
+        cxx_compilers = ['msvc', 'intelc', 'icc', 'g++', 'clang++', 'cxx', 'bcc32']
         assemblers = ['masm', 'nasm', 'gas', '386asm']
         fortran_compilers = ['gfortran', 'g77', 'ifl', 'cvf', 'f95', 'f90', 'fortran']
         ars = ['mslib', 'ar', 'tlib']
@@ -757,8 +757,8 @@ def tool_list(platform, env):
     else:
         "prefer GNU tools on all other platforms"
         linkers = ['gnulink', 'ilink']
-        c_compilers = ['gcc', 'intelc', 'icc', 'cc']
-        cxx_compilers = ['g++', 'intelc', 'icc', 'cxx']
+        c_compilers = ['gcc', 'clang', 'intelc', 'icc', 'cc']
+        cxx_compilers = ['g++', 'clang++', 'intelc', 'icc', 'cxx']
         assemblers = ['gas', 'nasm', 'masm']
         fortran_compilers = ['gfortran', 'g77', 'ifort', 'ifl', 'f95', 'f90', 'f77']
         ars = ['ar', ]

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -451,6 +451,8 @@ searches in order for the
 &MSVC; tools,
 the MinGW tool chain,
 the Intel compiler tools,
+the GCC tools,
+the LLVM/clang tools,
 and the PharLap ETS compiler.
 On Windows system which identify as <emphasis>cygwin</emphasis>
 (that is, if &scons; is invoked from a cygwin shell),
@@ -472,6 +474,7 @@ including POSIX (Linux and UNIX) and macOS platforms,
 &scons;
 searches in order
 for the GCC tool chain,
+the LLVM/clang tools,
 and the Intel compiler tools.
 The defaul tool selection can be pre-empted
 through the use of the <parameter>tools</parameter>


### PR DESCRIPTION
SCons will now automatically find clang (clang++) on Linux and Windows, in each case looked for just after gcc (g++), if the default tool search is enabled (no `tools` argument, or `tools` contains `'default'`).

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
