### PR TITLE
Tweak User Guide environment descriptions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Note: on Windows, SCons currently only has builtin support for
       clang, not for clang-cl, the version of the frontend that uses
       cl.exe-compatible command line switches.
+    - Some clarifications in the User Guide "Environments" chapter.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,7 +29,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - List modifications to existing features, where the previous behavior
   wouldn't actually be considered a bug
 
-- Override envirionments, created when giving construction environment
+- Override environments, created when giving construction environment
   keyword arguments to Builder calls (or manually, through the
   undocumented Override method), were modified not to "leak" on item deletion.
   The item will now not be deleted from the base environment.
@@ -77,7 +77,7 @@ DOCUMENTATION
   typo fixes, even if they're mentioned in src/CHANGES.txt to give
   the contributor credit)
 
-- Some manpage cleanup for the gettext and pdf/ps builders.
+- Some clarifications in the User Guide "Environments" chapter.
 
 DEVELOPMENT
 -----------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -77,6 +77,8 @@ DOCUMENTATION
   typo fixes, even if they're mentioned in src/CHANGES.txt to give
   the contributor credit)
 
+- Some manpage cleanup for the gettext and pdf/ps builders.
+
 DEVELOPMENT
 -----------
 

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -1037,7 +1037,8 @@ class BaseTestCase(unittest.TestCase,TestEnvironmentFixture):
     # underlying method it tests (Environment.BuilderWrapper.execute())
     # is necessary, but we're leaving the code here for now in case
     # that's mistaken.
-    def _DO_NOT_test_Builder_execs(self) -> None:
+    @unittest.skip("BuilderWrapper.execute method not needed")
+    def test_Builder_execs(self) -> None:
         """Test Builder execution through different environments
 
         One environment is initialized with a single
@@ -1291,10 +1292,14 @@ env4.builder1.env, env3)
         ]
         assert flags == expect, flags
 
-        env.Replace(F77PATH = [ 'foo', '$FOO/bar', blat ],
-                    INCPREFIX = 'foo ',
-                    INCSUFFIX = 'bar',
-                    FOO = 'baz')
+        # do a Replace using the dict form
+        newvalues = {
+            "F77PATH": ['foo', '$FOO/bar', blat],
+            "INCPREFIX": 'foo ',
+            "INCSUFFIX": 'bar',
+            "FOO": 'baz',
+        }
+        env.Replace(**newvalues)
         flags = env.subst_list('$_F77INCFLAGS', 1)[0]
         expect = [ '$(',
                    normalize_path('foo'),

--- a/SCons/Subst.xml
+++ b/SCons/Subst.xml
@@ -31,16 +31,16 @@ This file is processed by the bin/SConsDoc.py module.
 </arguments>
 <summary>
 <para>
-Specifies the exceptions that will be allowed
-when expanding construction variables.
+Specifies the exceptions that will be ignored
+when expanding &consvars;.
 By default,
-any construction variable expansions that generate a
-<literal>NameError</literal>
+any &consvar; expansions that generate a
+&NameError;
 or
-<literal>IndexError</literal>
+&IndexError;
 exception will expand to a
 <literal>''</literal>
-(an empty string) and not cause scons to fail.
+(an empty string) and not cause &scons; to fail.
 All exceptions not in the specified list
 will generate an error message
 and terminate processing.
@@ -51,7 +51,8 @@ If
 &f-AllowSubstExceptions;
 is called multiple times,
 each call completely overwrites the previous list
-of allowed exceptions.
+of ignored exceptions.
+Calling it with no arguments means no exceptions will be ignored.
 </para>
 
 <para>

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -405,16 +405,16 @@ env.Alias('update', ['file1', 'file2'], "update_database $SOURCES")
   <varlistentry id="f-AllowSubstExceptions">
     <term><function>AllowSubstExceptions</function>(<parameter>[exception, ...]</parameter>)</term>
     <listitem><para>
-Specifies the exceptions that will be allowed
-when expanding construction variables.
+Specifies the exceptions that will be ignored
+when expanding &consvars;.
 By default,
-any construction variable expansions that generate a
-<literal>NameError</literal>
+any &consvar; expansions that generate a
+&NameError;
 or
-<literal>IndexError</literal>
+&IndexError;
 exception will expand to a
 <literal>''</literal>
-(an empty string) and not cause scons to fail.
+(an empty string) and not cause &scons; to fail.
 All exceptions not in the specified list
 will generate an error message
 and terminate processing.
@@ -425,7 +425,8 @@ If
 &f-AllowSubstExceptions;
 is called multiple times,
 each call completely overwrites the previous list
-of allowed exceptions.
+of ignored exceptions.
+Calling it with no arguments means no exceptions will be ignored.
 </para>
 
 <para>
@@ -1634,6 +1635,19 @@ Example:
 cvars = env.Dictionary()
 cc_values = env.Dictionary('CC', 'CCFLAGS', 'CCCOM')
 </example_commands>
+
+<note><para>
+The object returned by &f-link-env-Dictionary; should be treated
+as a read-only view into the &consvars;.
+Some &consvars; have special internal handling,
+and making changes through the &f-env-Dictionary; object can bypass
+that handling and cause data inconsistencies.
+The primary use of &f-env-Dictionary; is for diagnostic purposes -
+it is used widely by test cases specifically because
+it bypasses the special handling so that behavior
+can be verified.
+</para></note>
+
 </listitem>
   </varlistentry>
   <varlistentry id="f-Dir">

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -9651,16 +9651,41 @@ The suffix used for tar file names.
       <envar>TEMPFILE</envar>
     </term>
     <listitem><para>
-A callable object used to handle overly long command line strings,
-since operations which call out to a shell will fail
-if the line is longer than the shell can accept.
-This tends to particularly impact linking.
-The tempfile object stores the command line in a temporary
-file in the appropriate format, and returns
-an alternate command line so the invoked tool will make
-use of the contents of the temporary file.
-If you need to replace the default tempfile object,
-the callable should take into account the settings of
+Holds a callable object which will be invoked to transform long
+command lines (string or list) into an alternate form.
+Length limits on various operating systems
+may cause long command lines to fail when calling out to
+a shell to run the command.
+Most often affects linking, when there are many object files and/or
+libraries to be linked, but may also affect other
+compilation steps which have many arguments.
+&cv-TEMPFILE; is not called directly,
+but rather is typically embedded in another
+&consvar;, to be expanded when used. Example:
+</para>
+
+<example_commands>
+env["TEMPFILE"] = TempFileMunge
+env["LINKCOM"] = "${TEMPFILE('$LINK $TARGET $SOURCES', '$LINKCOMSTR')}"
+</example_commands>
+
+<para>
+The SCons default value for &cv-TEMPFILE;,
+<classname>TempFileMunge</classname>,
+performs command substitution on the passed command line,
+calculates whether modification is needed,
+then puts all but the first word (assumed to be the command name)
+of the resulting list into a temporary file
+(sometimes called a response file or command file),
+and returns a new command line consisting of the
+the command name and an appropriately formatted reference
+to the temporary file.
+</para>
+
+<para>
+A replacement for the default tempfile object would need
+to do fundamentally the same thing, including taking into account
+the values of
 &cv-link-MAXLINELENGTH;,
 &cv-link-TEMPFILEPREFIX;,
 &cv-link-TEMPFILESUFFIX;,
@@ -9668,6 +9693,11 @@ the callable should take into account the settings of
 &cv-link-TEMPFILEDIR;
 and
 &cv-link-TEMPFILEARGESCFUNC;.
+If a particular use case requires a different transformation
+than the default, it is recommended to copy the mechanism and
+define a new &consvar; and rewrite the relevant <literal>*COM</literal>
+variable(s) to use it, to avoid possibly disrupting existing uses
+of &cv-TEMPFILE;.
 </para>
 </listitem>
   </varlistentry>
@@ -9726,6 +9756,9 @@ Note this value is used literally and not expanded by the subst logic.
     </term>
     <listitem><para>
 The directory to create the long-lines temporary file in.
+If unset, some suitable default should be chosen.
+The default tempfile object lets the &Python;
+<systemitem>tempfile</systemitem> module choose.
 </para>
 </listitem>
   </varlistentry>
@@ -9736,6 +9769,8 @@ The directory to create the long-lines temporary file in.
     <listitem><para>
 The prefix for the name of the temporary file used
 to store command lines exceeding &cv-link-MAXLINELENGTH;.
+The prefix must include the compiler syntax to actually
+include and process the file.
 The default prefix is <literal>'@'</literal>, which works for the &MSVC;
 and GNU toolchains on Windows.
 Set this appropriately for other toolchains,
@@ -9751,7 +9786,7 @@ or <literal>'-via'</literal> for ARM toolchain.
     <listitem><para>
 The suffix for the name of the temporary file used
 to store command lines exceeding &cv-link-MAXLINELENGTH;.
-The suffix should include the dot ('.') if one is wanted as
+The suffix should include the dot ('.') if one is needed as
 it will not be added automatically.
 The default is <filename>.lnk</filename>.
 </para>

--- a/doc/scons.mod
+++ b/doc/scons.mod
@@ -308,8 +308,10 @@ This file is processed by the bin/SConsDoc.py module.
 
 <!-- Python functions and classes -->
 
-<!ENTITY IndexError "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>IndexError</classname>">
-<!ENTITY NameError "<classname xmlns='http://www.scons.org/dbxsd/v1.0'>NameError</classname>">
+<!ENTITY AttributeError "<exceptionname xmlns='http://www.scons.org/dbxsd/v1.0'>AttributeError</exceptionname>">
+<!ENTITY IndexError "<exceptionname xmlns='http://www.scons.org/dbxsd/v1.0'>IndexError</exceptionname>">
+<!ENTITY KeyError "<exceptionname xmlns='http://www.scons.org/dbxsd/v1.0'>KeyError</exceptionname>">
+<!ENTITY NameError "<exceptionname xmlns='http://www.scons.org/dbxsd/v1.0'>NameError</exceptionname>">
 <!ENTITY str "<function xmlns='http://www.scons.org/dbxsd/v1.0'>str</function>">
 <!ENTITY zipfile "<function xmlns='http://www.scons.org/dbxsd/v1.0'>zipfile</function>">
 

--- a/doc/user/command-line.xml
+++ b/doc/user/command-line.xml
@@ -874,7 +874,7 @@ prog.c
           <methodname>get</methodname> method,
           so you can supply a default value if the variable is
           not given on the command line. Otherwise, the build
-          will fail with a <exceptionname>KeyError</exceptionname>
+          will fail with a &KeyError;
           if the variable is not set.
         </para>
       </listitem>

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -593,7 +593,7 @@ void main() { }
       &consvars;, each with a name and a value, just like a dictionary.
       (A &consenv; also has an attached
       set of &Builder; methods,
-      which you'll learn more abour later.)
+      which you'll learn more about later.)
 
     </para>
 

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -410,7 +410,7 @@ environment, of directory names, suffixes, etc.
 
   <para>
 
-  Unlike &Make;,  &SCons; does not automatically
+  Unlike &Make;, &SCons; does not automatically
   copy or import values between different environments
   (with the exception of explicit clones of &consenvs;,
   which inherit the values from their parent).
@@ -458,26 +458,39 @@ environment, of directory names, suffixes, etc.
     <para>
 
     If you're not familiar with the &Python; programming language,
-    we need to talk a little bit about the &Python; dictionary data type.
-    A dictionary (also known by terms such as mapping, associative array
-    and key-value store) associates keys with values, such
-    that asking the dict about a key gives you back the associated value
-    and assigning to a key creates the association - either a new
-    setting if the key was unknown, or replacing the
-    previous association if the key was already in the dictionary.
-    Values can be retrieved using <firstterm>item access</firstterm>
-    (the key name in square brackets (<literal>[]</literal>)),
-    and dictionaries also provide a
-    method named <methodname>get</methodname> which responds
-    with a default value, either <constant>None</constant> or a value
-    you supply as the second argument, if the key is not in the dictionary,
-    which avoids failing in that case.  The syntax
-    for initializing a dictionary uses curly braces (<literal>{}</literal>).
-    Here are some simple examples (inspired by those in the official
-    Python tutorial) using syntax that indicates
-    interacting with the &Python; interpreter
-    (<prompt>&gt;&gt;&gt;</prompt> is the interpreter prompt) -
-    you can try these out:
+    here is a short summary of the &Python; dictionary data type,
+    or "dict". You may also see the terms mapping, associative array
+    or key-value store used for this type of data structure,
+    which appears in many programming languages.
+
+    </para>
+
+    <para>
+
+    A dictionary associates keys with values,
+    so asking the dict about a key gives you back the associated value.
+    Values can be retrieved using <firstterm>item access</firstterm>:
+    the key name string in square brackets (<literal>mydict["keyname"]</literal>).
+    If the key is not present, you get a &KeyError; exception.
+    Dicts also provide a <methodname>get()</methodname> method
+    which returns a default value if the key is not present,
+    so it does not fail in that case.
+    You can specity the default as a second argument to the
+    <methodname>get</methodname> call, otherwise it defaults to
+    <constant>None</constant>.
+
+    </para>
+
+    <para>
+
+    Assigning to a key creates the association - either a new
+    key/value pair if the key was unknown, or replacing the
+    previous value if the key was already in the dictionary.
+    Initializing a dictionary uses curly braces (<literal>{}</literal>).
+    Here are some simple examples inspired by those in the official
+    &Python; tutorial, as you would see them if you typed these to
+    the interactive &Python; interpreter
+    (<prompt>&gt;&gt;&gt;</prompt> is the interpreter prompt):
 
     </para>
 
@@ -503,7 +516,7 @@ None
     <para>
 
     &Consenvs; are written to behave like a &Python;
-    dictionary, and the &cv-ENV; construction variable in
+    dictionary, and the &cv-ENV; &consvar; in
     a &consenv; <emphasis>is</emphasis> a &Python; dictionary.
     The <varname>os.environ</varname> value that &Python; uses
     to make available the external environment is also a
@@ -527,7 +540,7 @@ None
   <varname>os.environ</varname> dictionary.
   That syntax means the <varname>environ</varname>
   attribute of the <systemitem>os</systemitem> module.
-  In Python, to access the contents of a module you must first
+  In &Python;, to access the contents of a module you must first
   <literal>import</literal> it - so you would include the
   <literal>import os</literal> statement
   to any &SConscript; file
@@ -578,18 +591,18 @@ void main() { }
       A &consenv; is an object
       that has a number of associated
       &consvars;, each with a name and a value, just like a dictionary.
-      (A construction environment also has an attached
+      (A &consenv; also has an attached
       set of &Builder; methods,
-      about which we'll learn more later.)
+      which you'll learn more abour later.)
 
     </para>
 
-    <section>
-    <title>Creating a &ConsEnv;:  the &Environment; Function</title>
+    <section id="sec-creating-consenv">
+    <title>Creating a &ConsEnv;: the &Environment; Function</title>
 
       <para>
 
-        A &consenv; is created by the &Environment; method:
+        A &consenv; is created by the &f-link-Environment; function:
 
       </para>
 
@@ -599,13 +612,12 @@ env = Environment()
 
       <para>
 
-        By default, &SCons; initializes every
-        new construction environment
+        &SCons; initializes every new &consenv;
         with a set of &consvars;
         based on the tools that it finds on your system,
         plus the default set of builder methods
         necessary for using those tools.
-        The construction variables
+        The &consvars;
         are initialized with values describing
         the C compiler,
         the Fortran compiler,
@@ -617,7 +629,7 @@ env = Environment()
 
       <para>
 
-        When you initialize a construction environment
+        When you initialize a &consenv;
         you can set the values of the
         environment's &consvars;
         to control how a program is built.
@@ -637,18 +649,18 @@ int main() { }
 
       <para>
 
-        The construction environment in this example
+        The &consenv; in this example
         is still initialized with the same default
-        construction variable values,
+        &consvar; values,
         except that the user has explicitly specified use of the
         GNU C compiler &gcc;,
         and that the <option>-O2</option>
         (optimization level two)
         flag should be used when compiling the object file.
-        In other words, the explicit initializations of
+        In other words, the explicit initialization of
         &cv-link-CC; and &cv-link-CCFLAGS;
-        override the default values in the newly-created
-        construction environment.
+        overrides the default values in the newly-created
+        &consenv;.
         So a run from this example would look like:
 
       </para>
@@ -659,13 +671,13 @@ int main() { }
 
     </section>
 
-    <section>
+    <section id="sect-fetching-consvars">
     <title>Fetching Values From a &ConsEnv;</title>
 
       <para>
 
       You can fetch individual values, known as
-      <firstterm>Construction Variables</firstterm>,
+      <firstterm>&ConsVars;</firstterm>,
       using the same syntax used
       for accessing individual named items in a &Python; dictionary:
 
@@ -685,8 +697,9 @@ print("LATEX is: %s" % env.get('LATEX', None))
       for building any targets, but because it's still a valid
       &SConstruct; it will be evaluated and the &Python;
       <function>print</function> calls will output the values
-      of &cv-link-CC; and &cv-link-LATEX; for us (remember using the
-      <methodname>.get()</methodname> method for fetching means
+      of &cv-link-CC; and &cv-link-LATEX; for us (remember
+      from the sidebar that using the
+      <methodname>get()</methodname> method for access means
       we get a default value back, rather than a failure,
       if the variable is not set):
 
@@ -764,7 +777,7 @@ print(env.Dump())
 
     </section>
 
-    <section>
+    <section id="sect-subst-consvars">
     <title>Expanding Values From a &ConsEnv;:  the &subst; Method</title>
 
       <para>
@@ -802,7 +815,7 @@ print("CC is: %s" % env.subst('$CC'))
 
       <sconstruct>
 env = Environment(CCFLAGS='-DFOO')
-print("CCCOM is: %s" % env['CCCOM'])
+print("CCCOM is:", env['CCCOM'])
       </sconstruct>
 
       <para>
@@ -828,13 +841,13 @@ scons: `.' is up to date.
 
       <sconstruct>
 env = Environment(CCFLAGS='-DFOO')
-print("CCCOM is: %s" % env.subst('$CCCOM'))
+print("CCCOM is:", env.subst('$CCCOM'))
       </sconstruct>
 
       <para>
 
       Will recursively expand all of
-      the construction variables prefixed
+      the &consvars; prefixed
       with <literal>$</literal> (dollar signs),
       showing us the final output:
 
@@ -857,20 +870,20 @@ scons: `.' is up to date.
 
     </section>
 
-    <section>
-    <title>Handling Problems With Value Expansion</title>
+    <section id="sect-allowsubstexpressions">
+    <title>Handling Problems With Value Expansion (advanced topic)</title>
 
       <para>
-
-      If a problem occurs when expanding a construction variable,
-      by default it is expanded to <literal>''</literal>
-      (an empty string), and will not cause &scons; to fail.
+      If a problem occurs when expanding a &consvar;,
+      by default it is expanded to an empty string,
+      that is, "replaced with nothing" -
+      &scons; will not fail for unknown variables.
       </para>
 
        <scons_example name="environments_missing1">
          <file name="SConstruct" printme="1">
 env = Environment()
-print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
+print("value is:", env.subst('-&gt;$MISSING&lt;-'))
         </file>
       </scons_example>
 
@@ -879,26 +892,33 @@ print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
        </scons_output>
 
       <para>
-      This default behaviour can be changed using the &AllowSubstExceptions;
-      function.
-      When a problem occurs with a variable expansion it generates
-      an exception, and the &AllowSubstExceptions; function controls
-      which of these exceptions are actually fatal and which are
-      allowed to occur safely.   By default, &NameError; and &IndexError;
-      are the two exceptions that are allowed to occur: so instead of
-      causing &scons; to fail, these are caught, the variable expanded to
-      <literal>''</literal>
-      and &scons; execution continues.
-      To require that all construction variable names exist, and that
-      indexes out of range are not allowed, call &AllowSubstExceptions;
-      with no extra arguments.
+      Sometimes this behavior leads to surprises while the build
+      configuration is being developed,
+      for example a typo in a variable name isn't reported,
+      and the variable expression is just dropped (empty string).
+      &SCons; provides a &f-link-AllowSubstExceptions; function
+      to allow the behavior to be tuned.
+      Internally, when a problem occurs with a variable expansion,
+      it generates an exception,
+      but before letting that exception kill the build,
+      &scons; checks a list of exceptions to ignore - by default
+      &NameError; and &IndexError;.
+      You can call &AllowSubstExceptions; to set the list of ignored
+      exceptions to anything you wish, including none at all.
+      That way, when a variable fails to expand that you thought
+      should be expanding to something, the build will stop and
+      you'll get an error message that should help diagnose the problem.
+      You give &AllowSubstExceptions; as many exception name arguments
+      as you wish it to ignore,
+      or call it with no arguments to have all expansion exceptions
+      propagate and stop &scons;.
       </para>
 
        <scons_example name="environments_missing2">
          <file name="SConstruct" printme="1">
 AllowSubstExceptions()
 env = Environment()
-print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
+print("value is:", env.subst('-&gt;$MISSING&lt;-'))
         </file>
       </scons_example>
 
@@ -908,8 +928,8 @@ print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
 
       <para>
       This can also be used to allow other exceptions that might occur,
-      most usefully with the <literal>${...}</literal> construction
-      variable syntax.  For example, this would allow zero-division to
+      most usefully with the <literal>${...}</literal> &consvar;
+      syntax.  For example, this would allow zero-division to
       occur in a variable expansion in addition to the default exceptions
       allowed
       </para>
@@ -918,7 +938,7 @@ print("value is: %s"%env.subst( '-&gt;$MISSING&lt;-' ))
          <file name="SConstruct" printme="1">
 AllowSubstExceptions(IndexError, NameError, ZeroDivisionError)
 env = Environment()
-print("value is: %s"%env.subst( '-&gt;${1 / 0}&lt;-' ))
+print("value is:",  env.subst('-&gt;${1 / 0}&lt;-'))
         </file>
       </scons_example>
 
@@ -933,7 +953,7 @@ print("value is: %s"%env.subst( '-&gt;${1 / 0}&lt;-' ))
 
     </section>
 
-    <section>
+    <section id="sect-default-environment">
     <title>Controlling the Default &ConsEnv;:  the &DefaultEnvironment; Function</title>
 
       <para>
@@ -989,7 +1009,7 @@ DefaultEnvironment(CC='/usr/local/bin/gcc')
       previous example, setting the &cv-CC;
       variable to <filename>/usr/local/bin/gcc</filename>
       but as a separate step after
-      the default construction environment has been initialized:
+      the default &consenv; has been initialized:
 
       </para>
 
@@ -1016,7 +1036,7 @@ def_env['CC'] = '/usr/local/bin/gcc'
       that &SCons; performs
       by specifying some specific
       tool modules with which to
-      initialize the default construction environment:
+      initialize the default &consenv;:
 
       </para>
 
@@ -1168,29 +1188,29 @@ int main() { }
 
     </section>
 
-    <section>
+    <section id="sect-clone">
     <title>Making Copies of &ConsEnvs;:  the &Clone; Method</title>
 
       <para>
 
-      Sometimes you want more than one construction environment
+      Sometimes you want more than one &consenv;
       to share the same values for one or more variables.
       Rather than always having to repeat all of the common
-      variables when you create each construction environment,
+      variables when you create each &consenv;,
       you can use the &f-link-env-Clone; method
-      to create a copy of a construction environment.
+      to create a copy of a &consenv;.
 
       </para>
 
       <para>
 
-      Like the &f-link-Environment; call that creates a construction environment,
+      Like the &f-link-Environment; call that creates a &consenv;,
       the &Clone; method takes &consvar; assignments,
-      which will override the values in the copied construction environment.
+      which will override the values in the copied &consenv;.
       For example, suppose we want to use &gcc;
       to create three versions of a program,
       one optimized, one debug, and one with neither.
-      We could do this by creating a "base" construction environment
+      We could do this by creating a "base" &consenv;
       that sets &cv-link-CC; to &gcc;,
       and then creating two copies,
       one which sets &cv-link-CCFLAGS; for optimization
@@ -1229,12 +1249,12 @@ int main() { }
 
     </section>
 
-    <section>
+    <section id="sect-replace">
     <title>Replacing Values:  the &Replace; Method</title>
 
       <para>
 
-      You can replace existing construction variable values
+      You can replace existing &consvar; values
       using the &f-link-env-Replace; method:
 
       </para>
@@ -1252,10 +1272,10 @@ int main() { }
 
       <para>
 
-      The replacing value
+      The new value
       (<literal>-DDEFINE2</literal> in the above example)
-      completely replaces the value in the
-      construction environment:
+      replaces the value in the &consenv; - it's
+      like a &Python; assignment statement for &consvars;.
 
       </para>
 
@@ -1265,9 +1285,8 @@ int main() { }
 
       <para>
 
-      You can safely call &Replace;
-      for construction variables that
-      don't exist in the construction environment:
+      You can safely call &Replace; for &consvars; that
+      don't exist in the &consenv;
 
       </para>
 
@@ -1281,9 +1300,7 @@ print("NEW_VARIABLE = %s" % env['NEW_VARIABLE'])
 
       <para>
 
-      In this case,
-      the construction variable simply
-      gets added to the construction environment:
+      In this case, the &consvar; simply gets added to the &consenv;.
 
       </para>
 
@@ -1293,8 +1310,26 @@ print("NEW_VARIABLE = %s" % env['NEW_VARIABLE'])
 
       <para>
 
+      If you have a lot of variables to replace, it may be more
+      convenient to put them in a dictionary and pass that to the
+      &Replace; method. That might look like:
+
+      <screen>
+newvalues = {
+    "F77PATH": ['foo', '$FOO/bar', blat],
+    "INCPREFIX": 'foo ',
+    "INCSUFFIX": 'bar',
+    "FOO": 'baz',
+}
+env.Replace(**newvalues)
+      </screen>
+
+      </para>
+
+      <para>
+
       Because the variables
-      aren't expanded until the construction environment
+      aren't expanded until the &consenv;
       is actually used to build the targets,
       and because &SCons; function and method calls
       are order-independent,
@@ -1356,14 +1391,14 @@ int main() { }
 
     </section>
 
-    <section>
+    <section id="sect-setdefault">
     <title>Setting Values Only If They're Not Already Defined:  the &SetDefault; Method</title>
 
       <para>
 
       Sometimes it's useful to be able to specify
-      that a construction variable should be
-      set to a value only if the construction environment
+      that a &consvar; should be
+      set to a value only if the &consenv;
       does not already have that variable defined
       You can do this with the &f-link-env-SetDefault; method,
       which behaves similarly to the <function>setdefault</function>
@@ -1379,7 +1414,7 @@ env.SetDefault(SPECIAL_FLAG='-extra-option')
 
       This is especially useful
       when writing your own <literal>Tool</literal> modules
-      to apply variables to construction environments.
+      to apply variables to &consenvs;.
       <!--
       See <xref linkend="chap-tool-modules"></xref>
       for more information about writing
@@ -1390,13 +1425,13 @@ env.SetDefault(SPECIAL_FLAG='-extra-option')
 
     </section>
 
-    <section>
+    <section id="sect-append">
     <title>Appending to the End of Values:  the &Append; Method</title>
 
       <para>
 
       You can append a value to
-      an existing construction variable
+      an existing &consvar;
       using the &f-link-env-Append; method:
 
       </para>
@@ -1428,7 +1463,7 @@ int main() { }
 
       <para>
 
-      If the construction variable doesn't already exist,
+      If the &consvar; doesn't already exist,
       the &Append; method will create it:
 
       </para>
@@ -1466,13 +1501,13 @@ print("NEW_VARIABLE = %s"%env['NEW_VARIABLE'])
 
     </section>
 
-    <section>
+    <section id="sect-append-unique">
     <title>Appending Unique Values:  the &AppendUnique; Method</title>
 
       <para>
 
       Sometimes it's useful to add a new value
-      only if the existing construction variable
+      only if the existing &consvar;
       doesn't already contain the value.
       This can be done using the &f-link-env-AppendUnique; method:
 
@@ -1493,13 +1528,13 @@ env.AppendUnique(CCFLAGS=['-g'])
 
     </section>
 
-    <section>
+    <section id="sect-prepend">
     <title>Prepending to the Beginning of Values:  the &Prepend; Method</title>
 
       <para>
 
       You can prepend a value to the beginning of
-      an existing construction variable
+      an existing &consvar;
       using the &f-link-env-Prepend; method:
 
       </para>
@@ -1530,7 +1565,7 @@ int main() { }
 
       <para>
 
-      If the construction variable doesn't already exist,
+      If the &consvar; doesn't already exist,
       the &Prepend; method will create it:
 
       </para>
@@ -1569,13 +1604,13 @@ print("NEW_VARIABLE = %s" % env['NEW_VARIABLE'])
 
     </section>
 
-    <section>
+    <section id="sect-prepend-unique">
     <title>Prepending Unique Values:  the &PrependUnique; Method</title>
 
       <para>
 
       Some times it's useful to add a new value
-      to the beginning of a construction variable
+      to the beginning of a &consvar;
       only if the existing value
       doesn't already contain the to-be-added value.
       This can be done using the &f-link-env-PrependUnique; method:
@@ -1598,12 +1633,12 @@ env.PrependUnique(CCFLAGS=['-g'])
       </section>
 
       <section id="builder_overrides">
-      <title>Overriding Construction Variable Settings</title>
+      <title>Overriding &ConsVar; Settings</title>
 
       <para>
 
       Rather than creating a cloned &consenv; for specific tasks,
-      you can <firstterm>override</firstterm> or add construction variables
+      you can <firstterm>override</firstterm> or add &consvars;
       when calling a builder method by passing them as keyword arguments.
       The values of these overridden or added variables will only be in
       effect when building that target, and will not affect other parts
@@ -1709,7 +1744,7 @@ void main() {
       <para>
 
       Using temporary overrides this way is lighter weight than making
-      a full construction environment, so it can help performance in
+      a full &consenv;, so it can help performance in
       large projects which have lots of special case values to set.
       However, keep in mind that this only works well when the
       targets are unique.  Using builder overrides to try to build
@@ -1767,14 +1802,14 @@ void main() {
       are not in these default locations,
       you need to set the &PATH; value
       in the &cv-ENV; dictionary
-      in your construction environment.
+      in your &consenv;.
 
     </para>
 
     <para>
 
       The simplest way to do this is to initialize explicitly
-      the value when you create the construction environment;
+      the value when you create the &consenv;;
       this is one way to do that:
 
     </para>
@@ -1787,7 +1822,7 @@ env = Environment(ENV={'PATH': path})
     <para>
 
     Assigning a dictionary to the &cv-ENV;
-    construction variable in this way
+    &consvar; in this way
     completely resets the execution environment,
     so that the only variable that will be
     set when external commands are executed
@@ -1863,7 +1898,7 @@ for key in keys:
 
     -->
 
-    <section>
+    <section id="sect-propagating-path">
     <title>Propagating &PATH; From the External Environment</title>
 
       <para>
@@ -1919,7 +1954,7 @@ env = Environment(ENV=os.environ.copy())
 
     </section>
 
-    <section>
+    <section id="sect-adding-path">
     <title>Adding to <varname>PATH</varname> Values in the Execution Environment</title>
 
       <para>
@@ -1970,11 +2005,11 @@ env.AppendENVPath('LIB', '/usr/local/lib')
   <section id="sect-environment-toolpath">
   <title>Using the toolpath for external Tools</title>
 
-    <section>
+    <section id="sect-default-toolpath">
     <title>The default tool search path</title>
 
       <para>
-      Normally when using a tool from the construction environment,
+      Normally when using a tool from the &consenv;,
       several different search locations are checked by default.
       This includes the <filename>SCons/Tools/</filename> directory
       that is part of the &scons; distribution
@@ -1996,7 +2031,7 @@ SCons/Tool/SomeTool/__init__.py
 
     </section>
 
-	<section>
+	<section id="sect-toolpath-extradir">
     <title>Providing an external directory to toolpath</title>
 
       <para>
@@ -2027,8 +2062,8 @@ SCons/Tool/SomeTool/__init__.py
 
     </section>
 
-    <section>
-    <title>Nested Tools within a toolpath</title>
+    <section id="sect-toolpath-nested-tools">
+    <title>Nested Tools within a toolpath (advanced topic)</title>
 
       <para>
 
@@ -2060,8 +2095,8 @@ SCons/Tool/SubDir1/SubDir2/SomeTool/__init__.py
 
     </section>
 
-    <section>
-    <title>Using sys.path within the toolpath</title>
+    <section id="sect-toolpath-syspath">
+    <title>Using <literal>sys.path</literal> within the toolpath</title>
 
       <para>
       If we want to access tools external to &scons; which are findable
@@ -2109,7 +2144,7 @@ C:\Python35\Lib\site-packages\someinstalledpackage\SomeTool\__init__.py
 
     </section>
 
-	<section>
+	<section id="sect-pypackagedir">
     <title>Using the &PyPackageDir; function to add to the toolpath</title>
 
       <para>

--- a/doc/user/parseconfig.xml
+++ b/doc/user/parseconfig.xml
@@ -55,7 +55,7 @@ This file is processed by the bin/SConsDoc.py module.
 
  <para>
 
- &SCons; &consvars; have a &f-link-ParseConfig;
+ &SCons; &consenvs; have a &f-link-ParseConfig;
  method that asks the host system to execute a command
  and then configures the appropriate &consvars; based on
  the output of that command.
@@ -102,7 +102,7 @@ scons: `.' is up to date.
 
  In the example above, &SCons; has added the include directory to
  &cv-link-CPPPATH;
- (Depending upon what other flags are emitted by the
+ (depending on what other flags are emitted by the
  <filename>pkg-config</filename> command,
  other variables may have been extended as well.)
 

--- a/doc/user/preface.xml
+++ b/doc/user/preface.xml
@@ -102,7 +102,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   -->
 
-  <section>
+  <section id="sect-principles">
   <title>&SCons; Principles</title>
 
     <para>
@@ -193,7 +193,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   -->
 
-  <section>
+  <section id="sect-using-guide">
   <title>How to Use this Guide</title>
 
     <para>
@@ -223,19 +223,23 @@ This file is processed by the bin/SConsDoc.py module.
 
     <para>
 
-    It is often useful to keep &SCons; man page open in a separate
+    If you are viewing an html version of this Guide, there are many
+    hyperlinks present that you can follow to get more details
+    if you want them, as the User Guide intentionally does not attempt
+    to provide every detail, to allow smoother study of the basics.
+    It may also be useful to keep the &SCons; man page open in a separate
     browser tab or window to refer to as a complement to this Guide,
-    as the User Guide does not attempt to provide every detail.
-    While this Guide's Appendices A-D do duplicate information that appears
-    in the man page (this is to allow intra-document links to
-    definitions of &consvars;, builders, tools and environment methods
-    to work), the rest of the man page is unique content.
+    which can avoid some jumping back and forth.
+    The four important manpage sections describiing the
+    of &consvars;, builders, tools and environment methods
+    are actually duplicated as appendices in the User Guide,
+    to avoid inter-document links.
 
     </para>
 
   </section>
 
-  <section>
+  <section id="sect-completeness">
   <title>A Caveat About This Guide's Completeness</title>
 
   <para>
@@ -272,7 +276,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </section>
 
-  <section>
+  <section id="sect-acknowledgements">
   <title>Acknowledgements</title>
 
     <para>
@@ -395,7 +399,7 @@ This file is processed by the bin/SConsDoc.py module.
     <para>
 
     And last, thanks to Guido van Rossum
-    for his elegant scripting language,
+    for his elegant scripting language &Python;,
     which is the basis not only for the &SCons; implementation,
     but for the interface itself.
 
@@ -403,7 +407,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </section>
 
-  <section>
+  <section id="sect-contact">
   <title>Contact</title>
 
     <para>


### PR DESCRIPTION
Reword/clarify the section on `AllowSubstExceptions` and the sidebar on Python dictionaries.  Add an additonal piece to `env.Replace`.

Also, some entity replacements, and more explicit `id` tags added to `section` elements.

One unittest change to make sure passing a dict to `env.Replace` works.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` (and read the `README.rst`)
* [X] I have updated the appropriate documentation
