### PR TITLE
Handle permission errors while generating paths on Darwin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -50,6 +50,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Some manpage cleanup for the gettext and pdf/ps builders.
     - Some clarifications in the User Guide "Environments" chapter.
 
+  From Alex James:
+    - On Darwin, PermissionErrors are now handled while trying to access
+      /etc/paths.d. This may occur if SCons is invoked in a sandboxed
+      environment (such as Nix).
+
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -46,6 +46,10 @@ FIXES
 - Fix a problem with compilation_db component initialization - the
   entries for assembler files were not being set up correctly.
 
+- On Darwin, PermissionErrors are now handled while trying to access
+  /etc/paths.d. This may occur if SCons is invoked in a sandboxed environment
+  (such as Nix).
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Platform/darwin.py
+++ b/SCons/Platform/darwin.py
@@ -46,7 +46,7 @@ def generate(env) -> None:
     # make sure this works on Macs with Tiger or earlier
     try:
         dirlist = os.listdir('/etc/paths.d')
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         dirlist = []
 
     for file in dirlist:


### PR DESCRIPTION
On Darwin, Nix may invoke SCons in a sandbox which lacks access to /etc/paths.d. Handle PermissionError while iterating through /etc/paths.d to support sandboxed environments such as Nix.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
