### PR TITLE
Fixed inconsistent usage of keep_local and local_only kwarg in Help() function, its implementation and docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -49,6 +49,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       cl.exe-compatible command line switches.
     - Some manpage cleanup for the gettext and pdf/ps builders.
     - Some clarifications in the User Guide "Environments" chapter.
+    - Fixed wrong naming in the documentation of "keep_local" parameter for 
+      the Help() method.
 
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -601,8 +601,8 @@ def ValidateOptions(throw_exception: bool = False) -> None:
     OptionsParser.preserve_unknown_options = False
     OptionsParser.parse_args(OptionsParser.largs, OptionsParser.values)
 
-def PrintHelp(file=None, local_only: bool = False) -> None:
-    if local_only:
+def PrintHelp(file=None, keep_local: bool = False) -> None:
+    if keep_local:
         OptionsParser.print_local_option_help(file=file)
     else:
         OptionsParser.print_help(file=file)

--- a/SCons/Script/SConscript.xml
+++ b/SCons/Script/SConscript.xml
@@ -272,7 +272,7 @@ file is found.
 
 <scons_function name="Help">
 <arguments>
-(text, append=False, local_only=False)
+(text, append=False, keep_local=False)
 </arguments>
 <summary>
 <para>
@@ -292,7 +292,7 @@ This is the help printed if &f-Help; has never been called.
 If <parameter>append</parameter> is <constant>True</constant>,
 <parameter>text</parameter> is appended to
 the existing help text.
-If <parameter>local_only</parameter> is also <constant>True</constant>
+If <parameter>keep_local</parameter> is also <constant>True</constant>
 (the default is <constant>False</constant>),
 the project-local help from &f-AddOption; calls is preserved
 in the help message but the &scons; command help is not.
@@ -301,11 +301,11 @@ in the help message but the &scons; command help is not.
 Subsequent calls to
 &f-Help; ignore the keyword arguments
 <parameter>append</parameter> and
-<parameter>local_only</parameter>
+<parameter>keep_local</parameter>
 and always append to the existing help text.
 </para>
 <para>
-<emphasis>Changed in 4.6.0</emphasis>: added <parameter>local_only</parameter>.
+<emphasis>Changed in 4.6.0</emphasis>: added <parameter>keep_local</parameter>.
 </para>
 
 </summary>

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -263,7 +263,7 @@ def HelpFunction(text, append: bool = False, keep_local: bool = False) -> None:
     if help_text is None:
         if append:
             with StringIO() as s:
-                PrintHelp(s, local_only=keep_local)
+                PrintHelp(s, keep_local=keep_local)
                 help_text = s.getvalue()
         else:
             help_text = ""


### PR DESCRIPTION

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
