### PR TITLE
Resolve 4605: enhance SCONS_MSCOMMON_DEBUG handling of invalid input

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ NOTE: Python 3.6 support is deprecated and will be dropped in a future release.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Joseph Brill:
+    - Added error handling when creating MS VC detection debug log file specified by
+      SCONS_MSCOMMON_DEBUG
+
   From Dillan Mills:
     - Fix support for short options (`-x`).
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -50,10 +50,11 @@ FIXES
   following the option, with no spaces (e.g. -j5 and not -j 5).
 - Fix a problem with compilation_db component initialization - the
   entries for assembler files were not being set up correctly.
-
 - On Darwin, PermissionErrors are now handled while trying to access
   /etc/paths.d. This may occur if SCons is invoked in a sandboxed environment
   (such as Nix).
+- Added error handling when creating MS VC detection debug log file specified by
+  SCONS_MSCOMMON_DEBUG
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -45,15 +45,12 @@ class MSCommonLogFileWarning(SCons.Warnings.WarningOnByDefault):
     pass
 
 def _check_logfile(logfile):
-    if logfile and len(logfile) >= 2:
-        if logfile[0] == '"' and logfile[-1] == '"':
-            logfile = logfile[1:-1]
-            warn_msg = (
-                "SCONS_MSCOMMON_DEBUG value enclosed in double quotes, doubles quotes removed\n"
-                f'  original value="{logfile}"\n'
-                f"  modified value={logfile}"
-            )
-            SCons.Warnings.warn(MSCommonLogFileWarning, warn_msg)
+    if logfile and '"' in logfile:
+        err_msg = (
+            "SCONS_MSCOMMON_DEBUG value contains double quote character(s)\n"
+            f"  SCONS_MSCOMMON_DEBUG={logfile}"
+        )
+        raise SCons.Errors.UserError(err_msg)
     return logfile
 
 # SCONS_MSCOMMON_DEBUG is internal-use so undocumented:

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -41,9 +41,6 @@ import SCons.Warnings
 class MSVCCacheInvalidWarning(SCons.Warnings.WarningOnByDefault):
     pass
 
-class MSCommonLogFileWarning(SCons.Warnings.WarningOnByDefault):
-    pass
-
 def _check_logfile(logfile):
     if logfile and '"' in logfile:
         err_msg = (

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -33,6 +33,7 @@ import sys
 from contextlib import suppress
 from subprocess import DEVNULL, PIPE
 from pathlib import Path
+from typing import Optional, Tuple
 
 import SCons.Util
 import SCons.Warnings
@@ -40,9 +41,175 @@ import SCons.Warnings
 class MSVCCacheInvalidWarning(SCons.Warnings.WarningOnByDefault):
     pass
 
+class WindowsFileNameWarning(SCons.Warnings.WarningOnByDefault):
+    pass
+
+class _WindowsFileName:
+
+    # Known Issues:
+    # * NTFS filenames with a colon are reported as invalid (false positive)
+    #   given a file named "colonbeg:colonend.txt":
+    #     * file "colonbeg" is created and appears empty
+    #     * hidden alternate data stream file "colonbeg:colonend.txt:$DATA" is created
+    #     * use "dir /R colonbeg" to display alternate data streams of files
+
+    drive_prefix = r"([a-zA-Z][:])[\\]?(?P<suffix>.*)$"
+    re_drive_spec = re.compile(drive_prefix)
+
+    unc_prefix = r"(\\\\[^\\]+)[\\](?P<suffix>.*)$"
+    re_unc_spec = re.compile(unc_prefix)
+
+    re_illegal_chars = re.compile(
+        r'[<>:"/\\|?*\r\t\n]',
+        re.IGNORECASE
+    )
+
+    re_reserved_names = re.compile(
+        r"^(?P<reserved>CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])(\.|$)",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def is_filename_invalid(cls, fileorig: str) -> Tuple[str, str]:
+
+        filename = fileorig
+        if not filename:
+            reason = "file name is empty"
+            return reason, filename
+
+        filename = os.fspath(filename)
+        filename = os.path.abspath(filename)
+
+        pathspec, filespec = os.path.split(filename)
+
+        if filespec and not filespec.strip():
+            reason = f"file name is whitespace only: {filespec!r}"
+            return reason, filename
+
+        suffix = ""
+
+        do_once = True
+        while do_once:
+            do_once = False
+
+            m = cls.re_drive_spec.match(filename)
+            if m:
+                # filename: r"c:\dir\filename.txt"
+                #   prefix: r"c:"
+                #   suffix: r"dir\filename.txt"
+                suffix = m.group("suffix")
+                break
+
+            m = cls.re_unc_spec.match(filename)
+            if m:
+                # filename: r"\\server\share\filename.txt"
+                #   prefix: r"\\server"
+                #   suffix: r"share\filename.txt"
+                suffix = m.group("suffix")
+                break
+
+            reason = "unrecognized path prefix"
+            return reason, filename
+
+        if suffix:
+
+            comps = suffix.split(os.path.sep)
+            for name in comps:
+
+                if not name:
+                    reason = "file name component is empty"
+                    return reason, filename
+
+                if name and not name.strip():
+                    reason = f"file name component is whitespace-only ({name!r})"
+                    return reason, filename
+
+                illegal_chars = cls.re_illegal_chars.findall(name)
+                if illegal_chars:
+                    seen_chars = ', '.join(list(
+                        {repr(s): s for s in illegal_chars}.keys()
+                    ))
+                    reason = f"file name contains illegal characters ({seen_chars})"
+                    return reason, filename
+
+                match = cls.re_reserved_names.match(name)
+                if match:
+                    reserved = match.group("reserved")
+                    reason = f"file name contains a reserved name ({reserved!r})"
+                    return reason, filename
+
+        if not os.path.exists(pathspec):
+            reason = "path to file name does not exist"
+            return reason, filename
+
+        if os.path.exists(filename) and os.path.isdir(filename):
+            reason = "file name is a directory"
+            return reason, filename
+
+        return "", filename
+
+    @classmethod
+    def check_filename_invalid(
+        cls,
+        filename: str,
+        description: Optional[str] = None
+    ) -> bool:
+        reason, abspath = cls.is_filename_invalid(filename)
+        if reason:
+            if description:
+                msg_description = description + " "
+            else:
+                msg_description = ""
+            msg = (
+                f"{msg_description}file name is invalid:\n"
+                f"  filename: {filename!r}\n"
+                f"   abspath: {abspath!r}\n"
+                f"    reason: {reason}"
+            )
+            SCons.Warnings.warn(WindowsFileNameWarning, msg)
+        return bool(reason)
+
+    @classmethod
+    def process_filename(
+        cls,
+        filename: Optional[str],
+        description: Optional[str] = None
+    ) -> Optional[str]:
+        if filename is None:
+            return filename
+        if len(filename) < 2:
+            return filename
+        if filename[0] == '"' and filename[-1] == '"':
+            fileorig = filename
+            filename = filename[1:-1]
+            if description:
+                msg_description = description + " "
+            else:
+                msg_description = ""
+            msg = (
+                f"{msg_description}file name is invalid:\n"
+                f"  filename: {fileorig!r}\n"
+                f"  modified: {filename!r}\n"
+                f"    action: leading and trailing double quotes removed"
+            )
+            SCons.Warnings.warn(WindowsFileNameWarning, msg)
+        return filename
+
+    @classmethod
+    def get_filename_environ(
+        cls,
+        evar: str,
+    ) -> Optional[str]:
+        filename = cls.process_filename(os.environ.get(evar), description=evar)
+        return filename
+
+check_filename_invalid = _WindowsFileName.check_filename_invalid
+get_filename_environ = _WindowsFileName.get_filename_environ
+
+_LOGFILE_EVAR = "SCONS_MSCOMMON_DEBUG"
 # SCONS_MSCOMMON_DEBUG is internal-use so undocumented:
 # set to '-' to print to console, else set to filename to log to
-LOGFILE = os.environ.get('SCONS_MSCOMMON_DEBUG')
+LOGFILE = get_filename_environ(_LOGFILE_EVAR)
 if LOGFILE:
     import logging
 
@@ -128,8 +295,14 @@ if LOGFILE:
         log_prefix = 'debug: '
         log_handler = logging.StreamHandler(sys.stdout)
     else:
+        isinvalid = check_filename_invalid(LOGFILE, description=_LOGFILE_EVAR)
         log_prefix = ''
-        log_handler = logging.FileHandler(filename=LOGFILE)
+        try:
+            log_handler = logging.FileHandler(filename=LOGFILE)
+        except Exception as e:
+            if isinvalid:
+                raise e.with_traceback(None)
+            raise
     log_formatter = _CustomFormatter(log_prefix)
     log_handler.setFormatter(log_formatter)
     logger = logging.getLogger(name=__name__)

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -149,7 +149,7 @@ if LOGFILE:
             log_handler = logging.FileHandler(filename=LOGFILE)
         except (OSError, FileNotFoundError) as e:
             err_msg = (
-                f"Could not create logfile, check SCONS_MSCOMMON_DEBUG\n"
+                "Could not create logfile, check SCONS_MSCOMMON_DEBUG\n"
                 f"  SCONS_MSCOMMON_DEBUG={LOGFILE}\n"
                 f"  {e.__class__.__name__}: {str(e)}"
             )


### PR DESCRIPTION
Enhancements:
* Detect double quote character(s) in SCONS_MSCOMMON_DEBUG value and raise a UserError immediately. 
* Catch logging module OSError and FileNotFoundError and wrap in SCons UserError.

Resolves #4605

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
