### PR TITLE
Adjust tests in case running as root

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Change long-standing irritant in Environment tests - instead of using
       a while loop to pull test info from a list of tests and then delete
       the test, structure the test data as a list of tuples and iterate it.
+    - Skip running a few validation tests if the user is root and the test is
+      not designed to work for the root user.
 
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -37,9 +37,6 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 
 FIXES
 -----
-
-- List fixes of outright bugs
-
 - PackageVariable now does what the documentation always said it does
   if the variable is used on the command line with one of the enabling
   string as the value: the variable's default value is produced (previously
@@ -75,13 +72,13 @@ IMPROVEMENTS
   under which they would be observed), or major code cleanups
 
 - For consistency with the optparse "add_option" method, AddOption accepts
-  an SConsOption object as a single argument (this failed previouly).
+  an SConsOption object as a single argument (this failed previously).
   Calling AddOption with the full set of arguments (option names and
   attributes) to set up the option is still the recommended approach.
 
 - Add clang and clang++ to the default tool search orders for POSIX
   and Windows platforms. These will be searched for after gcc and g++,
-  respectively. Does not affect expliclity requested tool lists.  Note:
+  respectively. Does not affect explicitly requested tool lists.  Note:
   on Windows, SCons currently only has builtin support for clang, not
   for clang-cl, the version of the frontend that uses cl.exe-compatible
   command line switches.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -37,17 +37,22 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
+- List fixes of outright bugs
+
 - PackageVariable now does what the documentation always said it does
   if the variable is used on the command line with one of the enabling
   string as the value: the variable's default value is produced (previously
   it always produced True in this case).
+
 - Temporary files created by TempFileMunge() are now cleaned up on
   scons exit, instead of at the time they're used.  Fixes #4595.
+
 - AddOption now correctly adds short (single-character) options.
   Previously an added short option would always report as unknown,
   while long option names for the same option worked. Short options
   that take a value require the user to specify the value immediately
   following the option, with no spaces (e.g. -j5 and not -j 5).
+
 - Fix a problem with compilation_db component initialization - the
   entries for assembler files were not being set up correctly.
 - On Darwin, PermissionErrors are now handled while trying to access
@@ -57,6 +62,9 @@ FIXES
   SCONS_MSCOMMON_DEBUG
 
 - Fix nasm test for missing include file, cleanup.
+
+- Skip running a few validation tests if the user is root and the test is
+  not designed to work for the root user.
 
 IMPROVEMENTS
 ------------

--- a/SCons/CacheDirTests.py
+++ b/SCons/CacheDirTests.py
@@ -28,17 +28,11 @@ import unittest
 import tempfile
 import stat
 
-from TestCmd import TestCmd, IS_WINDOWS
+from TestCmd import TestCmd, IS_WINDOWS, IS_ROOT
 
 import SCons.CacheDir
 
 built_it = None
-
-try:
-    IS_ROOT = os.geteuid() == 0
-except AttributeError:
-    IS_ROOT = False
-
 
 class Action:
     def __call__(self, targets, sources, env, **kw) -> int:

--- a/SCons/CacheDirTests.py
+++ b/SCons/CacheDirTests.py
@@ -34,6 +34,13 @@ import SCons.CacheDir
 
 built_it = None
 
+IS_WINDOWS = sys.platform == 'win32'
+try:
+    IS_ROOT = os.geteuid() == 0
+except AttributeError:
+    IS_ROOT = False
+
+
 class Action:
     def __call__(self, targets, sources, env, **kw) -> int:
         global built_it
@@ -85,7 +92,6 @@ class BaseTestCase(unittest.TestCase):
     def tearDown(self) -> None:
         os.remove(os.path.join(self._CacheDir.path, 'config'))
         os.rmdir(self._CacheDir.path)
-        # Should that be shutil.rmtree?
 
 class CacheDirTestCase(BaseTestCase):
     """
@@ -124,20 +130,29 @@ class ExceptionTestCase(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.tmpdir)
 
-    @unittest.skipIf(sys.platform.startswith("win"), "This fixture will not trigger an OSError on Windows")
+    @unittest.skipIf(
+        IS_WINDOWS,
+        "Skip privileged CacheDir test on Windows, cannot change directory rights",
+    )
+    @unittest.skipIf(
+        IS_ROOT,
+        "Skip privileged CacheDir test if running as root.",
+    )
     def test_throws_correct_on_OSError(self) -> None:
-        """Test that the correct error is thrown when cache directory cannot be created."""
+        """Test for correct error when cache directory cannot be created."""
+        test = TestCmd()
         privileged_dir = os.path.join(self.tmpdir, "privileged")
-        try:
-            os.mkdir(privileged_dir)
-            os.chmod(privileged_dir, stat.S_IREAD)
-            cd = SCons.CacheDir.CacheDir(os.path.join(privileged_dir, "cache"))
-            assert False, "Should have raised exception and did not"
-        except SCons.Errors.SConsEnvironmentError as e:
-            assert str(e) == "Failed to create cache directory {}".format(os.path.join(privileged_dir, "cache"))
-        finally:
-            os.chmod(privileged_dir, stat.S_IWRITE | stat.S_IEXEC | stat.S_IREAD)
-            shutil.rmtree(privileged_dir)
+        cachedir_path = os.path.join(privileged_dir, "cache")
+        os.makedirs(privileged_dir, exist_ok=True)
+        test.writable(privileged_dir, False)
+        with self.assertRaises(SCons.Errors.SConsEnvironmentError) as cm:
+            cd = SCons.CacheDir.CacheDir(cachedir_path)
+        self.assertEqual(
+            str(cm.exception),
+            "Failed to create cache directory " + cachedir_path
+        )
+        test.writable(privileged_dir, True)
+        shutil.rmtree(privileged_dir)
 
 
     def test_throws_correct_when_failed_to_write_configfile(self) -> None:

--- a/SCons/CacheDirTests.py
+++ b/SCons/CacheDirTests.py
@@ -28,13 +28,12 @@ import unittest
 import tempfile
 import stat
 
-from TestCmd import TestCmd
+from TestCmd import TestCmd, IS_WINDOWS
 
 import SCons.CacheDir
 
 built_it = None
 
-IS_WINDOWS = sys.platform == 'win32'
 try:
     IS_ROOT = os.geteuid() == 0
 except AttributeError:

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -31,7 +31,7 @@ import shutil
 import stat
 from typing import Optional
 
-from TestCmd import TestCmd, IS_WINDOWS
+from TestCmd import TestCmd, IS_WINDOWS, IS_ROOT
 
 import SCons.Errors
 import SCons.Node.FS
@@ -43,12 +43,6 @@ from SCons.Util.sctyping import ExecutorType
 built_it = None
 
 scanner_count = 0
-
-try:
-    IS_ROOT = os.geteuid() == 0
-except AttributeError:
-    IS_ROOT = False
-
 
 class Scanner:
     def __init__(self, node=None) -> None:

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -518,7 +518,7 @@ class VariantDirTestCase(unittest.TestCase):
             # Disable symlink and link for now in win32.
             # We don't have a consistant plan to make these work as yet
             # They are only supported with PY3
-            if sys.platform == 'win32':
+            if IS_WINDOWS:
                 real_symlink = None
                 real_link = None
 
@@ -711,7 +711,7 @@ class BaseTestCase(_tempdirTestCase):
         nonexistent = fs.Entry('nonexistent')
         assert not nonexistent.isfile()
 
-    @unittest.skipUnless(sys.platform != 'win32' and hasattr(os, 'symlink'),
+    @unittest.skipIf(IS_WINDOWS or not hasattr(os, 'symlink'),
                          "symlink is not used on Windows")
     def test_islink(self) -> None:
         """Test the Base.islink() method"""
@@ -1456,7 +1456,7 @@ class FSTestCase(_tempdirTestCase):
         except SyntaxError:
             assert c == ""
 
-        if sys.platform != 'win32' and hasattr(os, 'symlink'):
+        if not IS_WINDOWS and hasattr(os, 'symlink'):
             os.symlink('nonexistent', test.workpath('dangling_symlink'))
             e = fs.Entry('dangling_symlink')
             c = e.get_contents()
@@ -1548,7 +1548,7 @@ class FSTestCase(_tempdirTestCase):
         assert r, r
         assert not os.path.exists(test.workpath('exists')), "exists was not removed"
 
-        if sys.platform != 'win32' and hasattr(os, 'symlink'):
+        if not IS_WINDOWS and hasattr(os, 'symlink'):
             symlink = test.workpath('symlink')
             os.symlink(test.workpath('does_not_exist'), symlink)
             assert os.path.islink(symlink)
@@ -1857,7 +1857,7 @@ class FSTestCase(_tempdirTestCase):
         d = root._lookup_abs('/tmp/foo-nonexistent/nonexistent-dir', SCons.Node.FS.Dir)
         assert d.__class__ == SCons.Node.FS.Dir, str(d.__class__)
 
-    @unittest.skipUnless(sys.platform == "win32", "requires Windows")
+    @unittest.skipUnless(IS_WINDOWS, "requires Windows")
     def test_lookup_uncpath(self) -> None:
         """Testing looking up a UNC path on Windows"""
         test = self.test
@@ -1869,13 +1869,13 @@ class FSTestCase(_tempdirTestCase):
         assert str(f) == r'\\servername\C$\foo', \
             'UNC path %s got looked up as %s' % (path, f)
 
-    @unittest.skipUnless(sys.platform.startswith == "win32", "requires Windows")
+    @unittest.skipUnless(IS_WINDOWS, "requires Windows")
     def test_unc_drive_letter(self) -> None:
         """Test drive-letter lookup for windows UNC-style directories"""
         share = self.fs.Dir(r'\\SERVER\SHARE\Directory')
         assert str(share) == r'\\SERVER\SHARE\Directory', str(share)
 
-    @unittest.skipUnless(sys.platform == "win32", "requires Windows")
+    @unittest.skipUnless(IS_WINDOWS, "requires Windows")
     def test_UNC_dirs_2689(self) -> None:
         """Test some UNC dirs that printed incorrectly and/or caused
         infinite recursion errors prior to r5180 (SCons 2.1)."""
@@ -1938,7 +1938,7 @@ class FSTestCase(_tempdirTestCase):
             d1_d2_f, d3_d4_f, '../../d3/d4/f',
         ]
 
-        if sys.platform in ('win32',):
+        if IS_WINDOWS:
             x_d1 = fs.Dir(r'X:\d1')
             x_d1_d2 = x_d1.Dir('d2')
             y_d1 = fs.Dir(r'Y:\d1')

--- a/SCons/Variables/PathVariableTests.py
+++ b/SCons/Variables/PathVariableTests.py
@@ -28,13 +28,7 @@ import SCons.Errors
 import SCons.Variables
 
 import TestCmd
-from TestCmd import IS_WINDOWS
-
-try:
-    IS_ROOT = os.geteuid() == 0
-except AttributeError:
-    IS_ROOT = False
-
+from TestCmd import IS_WINDOWS, IS_ROOT
 
 class PathVariableTestCase(unittest.TestCase):
     def test_PathVariable(self) -> None:

--- a/SCons/Variables/PathVariableTests.py
+++ b/SCons/Variables/PathVariableTests.py
@@ -30,6 +30,12 @@ import SCons.Variables
 import TestCmd
 from TestCmd import IS_WINDOWS
 
+try:
+    IS_ROOT = os.geteuid() == 0
+except AttributeError:
+    IS_ROOT = False
+
+
 class PathVariableTestCase(unittest.TestCase):
     def test_PathVariable(self) -> None:
         """Test PathVariable creation"""
@@ -93,7 +99,7 @@ class PathVariableTestCase(unittest.TestCase):
         self.assertEqual(str(e), f"Directory path for variable 'X' does not exist: {dne}")
 
     def test_PathIsDirCreate(self):
-        """Test the PathIsDirCreate validator"""
+        """Test the PathIsDirCreate validator."""
         opts = SCons.Variables.Variables()
         opts.Add(SCons.Variables.PathVariable('test',
                                           'test build variable help',
@@ -115,6 +121,27 @@ class PathVariableTestCase(unittest.TestCase):
         e = cm.exception
         self.assertEqual(str(e), f"Path for variable 'X' is a file, not a directory: {f}")
 
+
+    @unittest.skipIf(IS_ROOT, "Skip creating bad directory if running as root.")
+    def test_PathIsDirCreate_bad_dir(self):
+        """Test the PathIsDirCreate validator with an uncreatable dir.
+
+        Split from :meth:`test_PathIsDirCreate` to be able to skip on root.
+        We want to be able to skip only this one testcase and run the rest.
+        """
+        opts = SCons.Variables.Variables()
+        opts.Add(
+            SCons.Variables.PathVariable(
+                'test',
+                'test build variable help',
+                '/default/path',
+                SCons.Variables.PathVariable.PathIsDirCreate,
+            )
+        )
+
+        test = TestCmd.TestCmd(workdir='')
+        o = opts.options[0]
+
         # pick a directory path that can't be mkdir'd
         if IS_WINDOWS:
             f = r'\\noserver\noshare\yyy\zzz'
@@ -125,8 +152,9 @@ class PathVariableTestCase(unittest.TestCase):
         e = cm.exception
         self.assertEqual(str(e), f"Path for variable 'X' could not be created: {f}")
 
+
     def test_PathIsFile(self):
-        """Test the PathIsFile validator"""
+        """Test the PathIsFile validator."""
         opts = SCons.Variables.Variables()
         opts.Add(SCons.Variables.PathVariable('test',
                                           'test build variable help',

--- a/template/RELEASE.txt
+++ b/template/RELEASE.txt
@@ -6,7 +6,7 @@ Past official release announcements appear at:
 
 ==================================================================
 
-A new SCons release, 4.4.1, is now available on the SCons download page:
+A new SCons release, NEXT_RELEASE, is now available on the SCons download page:
 
     https://scons.org/pages/download.html
 

--- a/test/Install/Install.py
+++ b/test/Install/Install.py
@@ -31,6 +31,7 @@ import os.path
 import time
 
 import TestSCons
+from TestCmd import IS_ROOT
 
 test = TestSCons.TestSCons()
 
@@ -132,10 +133,6 @@ test.must_match(['work', 'f2.out'], "f2.in\n", mode='r')
 test.write(['work', 'f1.in'], "f1.in again again\n")
 
 # This test is not designed to work if running as root
-try:
-    IS_ROOT = os.geteuid() == 0
-except AttributeError:
-    IS_ROOT = False
 if not IS_ROOT:
     os.chmod(test.workpath('work', 'export'), 0o555)
     with open(f1_out, 'rb'):

--- a/test/Install/Install.py
+++ b/test/Install/Install.py
@@ -144,9 +144,8 @@ if not IS_ROOT:
             "The process cannot access the file because it is being used by another process",
             "Der Prozess kann nicht auf die Datei zugreifen, da sie von einem anderen Prozess verwendet wird",
         ]
-
-    test.run(chdir='work', arguments=f1_out, stderr=None, status=2)
-    test.must_contain_any_line(test.stderr(), expect)
+        test.run(chdir='work', arguments=f1_out, stderr=None, status=2)
+        test.must_contain_any_line(test.stderr(), expect)
 
 test.pass_test()
 

--- a/test/Install/Install.py
+++ b/test/Install/Install.py
@@ -131,16 +131,21 @@ test.must_match(['work', 'f2.out'], "f2.in\n", mode='r')
 # if a target can not be unlinked before building it:
 test.write(['work', 'f1.in'], "f1.in again again\n")
 
-os.chmod(test.workpath('work', 'export'), 0o555)
-with open(f1_out, 'rb'):
-    expect = [
-        "Permission denied",
-        "The process cannot access the file because it is being used by another process",
-        "Der Prozess kann nicht auf die Datei zugreifen, da sie von einem anderen Prozess verwendet wird",
-    ]
+# This test is not designed to work if running as root
+try:
+    IS_ROOT = os.geteuid() == 0
+except AttributeError:
+    IS_ROOT = False
+if not IS_ROOT:
+    os.chmod(test.workpath('work', 'export'), 0o555)
+    with open(f1_out, 'rb'):
+        expect = [
+            "Permission denied",
+            "The process cannot access the file because it is being used by another process",
+            "Der Prozess kann nicht auf die Datei zugreifen, da sie von einem anderen Prozess verwendet wird",
+        ]
 
     test.run(chdir='work', arguments=f1_out, stderr=None, status=2)
-
     test.must_contain_any_line(test.stderr(), expect)
 
 test.pass_test()

--- a/test/VariantDir/errors.py
+++ b/test/VariantDir/errors.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Validate successful handling of errors when duplicating things in
@@ -37,6 +36,13 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
+try:
+    IS_ROOT = os.geteuid() == 0
+except AttributeError:
+    IS_ROOT = False
+if IS_ROOT:
+    test.skip_test('SConscript permissions meaningless when running as root; skipping test.\n')
+
 for dir in ['normal', 'ro-dir', 'ro-SConscript', 'ro-src']:
     test.subdir(dir, [dir, 'src'])
 
@@ -44,7 +50,7 @@ for dir in ['normal', 'ro-dir', 'ro-SConscript', 'ro-src']:
 import os.path
 VariantDir('build', 'src')
 SConscript(os.path.join('build', 'SConscript'))
-""") 
+""")
 
     test.write([dir, 'src', 'SConscript'], """\
 def fake_scan(node, env, target):

--- a/test/VariantDir/errors.py
+++ b/test/VariantDir/errors.py
@@ -33,13 +33,10 @@ import os
 import stat
 import sys
 import TestSCons
+from TestCmd import IS_ROOT
 
 test = TestSCons.TestSCons()
 
-try:
-    IS_ROOT = os.geteuid() == 0
-except AttributeError:
-    IS_ROOT = False
 if IS_ROOT:
     test.skip_test('SConscript permissions meaningless when running as root; skipping test.\n')
 

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -2003,11 +2003,15 @@ class TestCmd:
                     do_chmod(os.path.join(dirpath, name))
             do_chmod(top)
 
-    def writable(self, top, write: bool=True) -> None:
+    def writable(self, top, write: bool = True) -> None:
         """Make the specified directory tree writable or unwritable.
 
         Tree is made writable if `write` evaluates True (the default),
         else it is made not writable.
+
+        Note on Windows the only thing we can do is and/remove the
+        "readable" setting without resorting to PyWin32 - and that,
+        only as Administrator, so this is kind of pointless there.
         """
 
         if sys.platform == 'win32':
@@ -2034,7 +2038,7 @@ class TestCmd:
                     except OSError:
                         pass
                     else:
-                        os.chmod(fname, stat.S_IMODE(st[stat.ST_MODE] | 0o200))
+                        os.chmod(fname, stat.S_IMODE(st[stat.ST_MODE] | stat.S_IWRITE))
             else:
                 def do_chmod(fname) -> None:
                     try:
@@ -2043,7 +2047,7 @@ class TestCmd:
                         pass
                     else:
                         os.chmod(fname, stat.S_IMODE(
-                            st[stat.ST_MODE] & ~0o200))
+                            st[stat.ST_MODE] & ~stat.S_IWRITE))
 
         if os.path.isfile(top):
             do_chmod(top)

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -329,6 +329,10 @@ IS_WINDOWS = sys.platform == 'win32'
 IS_MACOS = sys.platform == 'darwin'
 IS_64_BIT = sys.maxsize > 2**32
 IS_PYPY = hasattr(sys, 'pypy_translation_info')
+try:
+    IS_ROOT = os.geteuid() == 0
+except AttributeError:
+    IS_ROOT = False
 NEED_HELPER = os.environ.get('SCONS_NO_DIRECT_SCRIPT')
 
 # sentinel for cases where None won't do


### PR DESCRIPTION
Although validation tests are not normally run as root, there may be circumstances when it happens - one known case is when the test suite is run as part of a particular Linux distros package construction. It isn't too hard to avoid the few places where we counted on something failing because of permissions, which don't if the user is root - added a few skips.

This is a test-only change, no impact on SCons or docs.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
