### PR TITLE
Fix DocBook XSD, making it deterministic again

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ NOTE: Python 3.6 support is deprecated and will be dropped in a future release.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Dirk Baechle:
+    - Fixed the grammar of the SCons DocBook XSD, which was reported as being
+      "not deterministic" by some XML scanners/validators.
+
   From Joseph Brill:
     - Added error handling when creating MS VC detection debug log file specified by
       SCONS_MSCOMMON_DEBUG

--- a/SCons/Tool/link.xml
+++ b/SCons/Tool/link.xml
@@ -400,9 +400,11 @@ See also &cv-link-LINKFLAGS;  for linking static objects.
 <summary>
 <para>
 Variable used to hard-code SONAME for versioned shared library/loadable module.
+</para>
 <example_commands>
 env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SONAME='libtest.so.2')
 </example_commands>
+<para>
 The variable is used, for example, by &t-link-gnulink; linker tool.
 </para>
 </summary>
@@ -414,9 +416,11 @@ The variable is used, for example, by &t-link-gnulink; linker tool.
 This will construct the <varname>SONAME</varname> using on the base library name
 (<parameter>test</parameter> in the example below) and use specified <varname>SOVERSION</varname>
 to create <varname>SONAME</varname>.
+</para>
 <example_commands>
 env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SOVERSION='2')
 </example_commands>
+<para>
 The variable is used, for example, by &t-link-gnulink; linker tool.
 </para>
 <para>

--- a/SCons/Tool/msvc.xml
+++ b/SCons/Tool/msvc.xml
@@ -837,10 +837,10 @@ and &cv-link-MSVC_SCRIPT_ARGS; are not allowed.
 
 <para>
 Example - A Visual Studio 2022 build for the Universal Windows Platform:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_UWP_APP=True)
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -1107,33 +1107,34 @@ Note: in addition to the camel case values shown above, lower case and upper cas
 
 <para>
 Example 1 - A Visual Studio 2022 build with user-defined script arguments:
+</para>
 <example_commands>
 env = environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS=['8.1', 'store', '-vcvars_ver=14.1'])
 env.Program('hello', ['hello.c'], CCFLAGS='/MD', LIBS=['kernel32', 'user32', 'runtimeobject'])
 </example_commands>
-</para>
 
 <para>
 Example 1 - Output fragment:
+</para>
 <example_commands>
 ...
 link /nologo /OUT:_build001\hello.exe kernel32.lib user32.lib runtimeobject.lib _build001\hello.obj
 LINK : fatal error LNK1104: cannot open file 'MSVCRT.lib'
 ...
 </example_commands>
-</para>
 
 <para>
 Example 2 - A Visual Studio 2022 build with user-defined script arguments and the script error policy set
 to issue a warning when msvc batch file errors are detected:
+</para>
 <example_commands>
 env = environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS=['8.1', 'store', '-vcvars_ver=14.1'], MSVC_SCRIPTERROR_POLICY='warn')
 env.Program('hello', ['hello.c'], CCFLAGS='/MD', LIBS=['kernel32', 'user32', 'runtimeobject'])
 </example_commands>
-</para>
 
 <para>
 Example 2 - Output fragment:
+</para>
 <example_commands>
 ...
 scons: warning: vc script errors detected:
@@ -1144,7 +1145,6 @@ scons: warning: vc script errors detected:
 link /nologo /OUT:_build001\hello.exe kernel32.lib user32.lib runtimeobject.lib _build001\hello.obj
 LINK : fatal error LNK1104: cannot open file 'MSVCRT.lib'
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -1265,18 +1265,18 @@ via &cv-link-MSVC_UWP_APP; and &cv-MSVC_SCRIPT_ARGS; are not allowed.
 <para>
 Example 1 - A Visual Studio 2022 build with an SDK version and a toolset version
 specified with a string argument:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS='10.0.20348.0 -vcvars_ver=14.29.30133')
 </example_commands>
-</para>
 
 <para>
 Example 2 - A Visual Studio 2022 build with an SDK version and a toolset version
 specified with a list argument:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS=['10.0.20348.0', '-vcvars_ver=14.29.30133'])
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -1378,17 +1378,17 @@ must be '14.0').
 
 <para>
 Example 1 - A Visual Studio 2022 build with a specific Windows SDK version:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SDK_VERSION='10.0.20348.0')
 </example_commands>
-</para>
 
 <para>
 Example 2 - A Visual Studio 2022 build with a specific SDK version for the Universal Windows Platform:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SDK_VERSION='10.0.20348.0', MSVC_UWP_APP=True)
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -1550,31 +1550,31 @@ toolset with the largest version number.
 
 <para>
 Example 1 - A default Visual Studio build with a partial toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_TOOLSET_VERSION='14.2')
 </example_commands>
-</para>
 
 <para>
 Example 2 - A default Visual Studio build with a partial toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_TOOLSET_VERSION='14.29')
 </example_commands>
-</para>
 
 <para>
 Example 3 - A Visual Studio 2022 build with a full toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_TOOLSET_VERSION='14.29.30133')
 </example_commands>
-</para>
 
 <para>
 Example 4 - A Visual Studio 2022 build with an SxS toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_TOOLSET_VERSION='14.29.16.11')
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -1647,10 +1647,10 @@ components.
 
 <para>
 Example - A Visual Studio 2022 build with spectre mitigated &MSVC; libraries:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SPECTRE_LIBS=True)
 </example_commands>
-</para>
 
 <para>
 Important usage details:

--- a/SCons/Tool/ninja/ninja.xml
+++ b/SCons/Tool/ninja/ninja.xml
@@ -111,13 +111,13 @@ This file is processed by the bin/SConsDoc.py module
                 </para>
 
 <!--            NOTE DO NOT INDENT example_commands CONTENTS AS IT WILL ALTER THE FORMATTING-->
-                <example_commands>
+                <screen>
 # On the command line
 --experimental=ninja
 
 # Or in your SConstruct
 SetOption('experimental', 'ninja')
-                </example_commands>
+                </screen>
 
                 <para>This functionality is subject to change and/or removal without deprecation cycle.</para>
 
@@ -127,10 +127,10 @@ SetOption('experimental', 'ninja')
                     <systemitem>import</systemitem> of the package
 <!--                    (although see &cv-link-__NINJA_NO;).-->
                     This can be done via:
-                    <example_commands>
-python -m pip install ninja
-                    </example_commands>
                 </para>
+                    <screen>
+python -m pip install ninja
+                    </screen>
 
             </note>
 

--- a/doc/generated/builders.gen
+++ b/doc/generated/builders.gen
@@ -787,8 +787,12 @@ env.Moc('foo.cpp')  # generates foo.moc
     <term><function>MOFiles</function>()</term>
     <term><replaceable>env</replaceable>.<methodname>MOFiles</methodname>()</term>
     <listitem><para>
-This builder belongs to &t-link-msgfmt; tool. The builder compiles
+This builder is set up by the &t-link-msgfmt; tool.
+The builder compiles
 <literal>PO</literal> files to <literal>MO</literal> files.
+&b-MOFiles; is a single-source builder.
+The <parameter>source</parameter> parameter
+can also be omitted if &cv-link-LINGUAS_FILE; is set.
 </para>
 
 <para>
@@ -796,19 +800,17 @@ This builder belongs to &t-link-msgfmt; tool. The builder compiles
 Create <filename>pl.mo</filename> and <filename>en.mo</filename> by compiling
 <filename>pl.po</filename> and <filename>en.po</filename>:
 </para>
-<example_commands>
-  # ...
-  env.MOFiles(['pl', 'en'])
-</example_commands>
+<programlisting language="python">
+env.MOFiles(['pl', 'en'])
+</programlisting>
 
 <para>
 <emphasis>Example 2</emphasis>.
 Compile files for languages defined in <filename>LINGUAS</filename> file:
 </para>
-<example_commands>
-  # ...
-  env.MOFiles(LINGUAS_FILE = 1)
-</example_commands>
+<programlisting language="python">
+env.MOFiles(LINGUAS_FILE=True)
+</programlisting>
 
 <para>
 <emphasis>Example 3</emphasis>.
@@ -816,21 +818,19 @@ Create <filename>pl.mo</filename> and <filename>en.mo</filename> by compiling
 <filename>pl.po</filename> and <filename>en.po</filename> plus files for
 languages defined in <filename>LINGUAS</filename> file:
 </para>
-<example_commands>
-  # ...
-  env.MOFiles(['pl', 'en'], LINGUAS_FILE = 1)
-</example_commands>
+<programlisting language="python">
+env.MOFiles(['pl', 'en'], LINGUAS_FILE=True)
+</programlisting>
 
 <para>
 <emphasis>Example 4</emphasis>.
 Compile files for languages defined in <filename>LINGUAS</filename> file
 (another version):
 </para>
-<example_commands>
-  # ...
-  env['LINGUAS_FILE'] = 1
-  env.MOFiles()
-</example_commands>
+<programlisting language="python">
+env['LINGUAS_FILE'] = True
+env.MOFiles()
+</programlisting>
 </listitem>
   </varlistentry>
   <varlistentry id="b-MSVSProject">
@@ -1360,13 +1360,13 @@ env.MSVSSolution(
                 </para>
 
 <!--            NOTE DO NOT INDENT example_commands CONTENTS AS IT WILL ALTER THE FORMATTING-->
-                <example_commands>
+                <screen>
 # On the command line
 --experimental=ninja
 
 # Or in your SConstruct
 SetOption('experimental', 'ninja')
-                </example_commands>
+                </screen>
 
                 <para>This functionality is subject to change and/or removal without deprecation cycle.</para>
 
@@ -1376,10 +1376,10 @@ SetOption('experimental', 'ninja')
                     <systemitem>import</systemitem> of the package
 <!--                    (although see &cv-link-__NINJA_NO;).-->
                     This can be done via:
-                    <example_commands>
-python -m pip install ninja
-                    </example_commands>
                 </para>
+                    <screen>
+python -m pip install ninja
+                    </screen>
 
             </note>
 
@@ -1606,41 +1606,48 @@ or
 The suffix specified by the &cv-link-PDFSUFFIX; construction variable
 (<filename>.pdf</filename> by default)
 is added automatically to the target
-if it is not already present.  Example:
+if it is not already present.
+&b-PDF; is a single-source builder.
+Example:
 </para>
 
-<example_commands>
+<programlisting language="python">
 # builds from aaa.tex
 env.PDF(target = 'aaa.pdf', source = 'aaa.tex')
 # builds bbb.pdf from bbb.dvi
 env.PDF(target = 'bbb', source = 'bbb.dvi')
-</example_commands>
+</programlisting>
 </listitem>
   </varlistentry>
   <varlistentry id="b-POInit">
     <term><function>POInit</function>()</term>
     <term><replaceable>env</replaceable>.<methodname>POInit</methodname>()</term>
     <listitem><para>
-This builder belongs to &t-link-msginit; tool. The builder initializes missing
-<literal>PO</literal> file(s) if &cv-link-POAUTOINIT; is set.  If
-&cv-link-POAUTOINIT; is not set (default), &b-POInit; prints instruction for
-user (that is supposed to be a translator), telling how the
-<literal>PO</literal> file should be initialized. In normal projects
+This builder is set up by the &t-link-msginit; tool.
+The builder initializes missing
+<literal>PO</literal> file(s) if &cv-link-POAUTOINIT; is set.
+If &cv-link-POAUTOINIT; is not set (the default),
+&b-POInit; prints instruction for the user (such as a translator),
+telling how the <literal>PO</literal> file should be initialized.
+In normal projects
 <emphasis>you should not use &b-POInit; and use &b-link-POUpdate;
 instead</emphasis>. &b-link-POUpdate; chooses intelligently between
 <command>msgmerge(1)</command> and <command>msginit(1)</command>. &b-POInit;
 always uses <command>msginit(1)</command> and should be regarded as builder for
 special purposes or for temporary use (e.g. for quick, one time initialization
 of a bunch of <literal>PO</literal> files) or for tests.
+&b-POInit; is a single-source builder.
+The <parameter>source</parameter> parameter
+can also be omitted if &cv-link-LINGUAS_FILE; is set.
 </para>
 
 <para>
 Target nodes defined through &b-POInit; are not built by default (they're
 <literal>Ignore</literal>d from <literal>'.'</literal> node) but are added to
-special <literal>Alias</literal> (<literal>'po-create'</literal> by default).
+special &f-link-Alias; (<literal>'po-create'</literal> by default).
 The alias name may be changed through the &cv-link-POCREATE_ALIAS;
-construction variable. All <literal>PO</literal> files defined through
-&b-POInit; may be easily initialized by <command>scons po-create</command>.
+&consvar;. All <literal>PO</literal> files defined through
+&b-POInit; may be easily initialized by <userinput>scons po-create</userinput>.
 </para>
 
 <para>
@@ -1648,31 +1655,27 @@ construction variable. All <literal>PO</literal> files defined through
 Initialize <filename>en.po</filename> and <filename>pl.po</filename> from
 <filename>messages.pot</filename>:
 </para>
-<example_commands>
-  # ...
-  env.POInit(['en', 'pl']) # messages.pot --&gt; [en.po, pl.po]
-</example_commands>
+<programlisting language="python">
+env.POInit(['en', 'pl']) # messages.pot --&gt; [en.po, pl.po]
+</programlisting>
 
 <para>
 <emphasis>Example 2</emphasis>.
 Initialize <filename>en.po</filename> and <filename>pl.po</filename> from
 <filename>foo.pot</filename>:
 </para>
-<example_commands>
-  # ...
-  env.POInit(['en', 'pl'], ['foo']) # foo.pot --&gt; [en.po, pl.po]
-</example_commands>
+<programlisting language="python">
+env.POInit(['en', 'pl'], ['foo']) # foo.pot --&gt; [en.po, pl.po]
+</programlisting>
 
 <para>
 <emphasis>Example 3</emphasis>.
 Initialize <filename>en.po</filename> and <filename>pl.po</filename> from
-<filename>foo.pot</filename> but using &cv-link-POTDOMAIN; construction
-variable:
+<filename>foo.pot</filename> but using the &cv-link-POTDOMAIN; &consvar;:
 </para>
-<example_commands>
-  # ...
-  env.POInit(['en', 'pl'], POTDOMAIN='foo') # foo.pot --&gt; [en.po, pl.po]
-</example_commands>
+<programlisting language="python">
+env.POInit(['en', 'pl'], POTDOMAIN='foo') # foo.pot --&gt; [en.po, pl.po]
+</programlisting>
 
 <para>
 <emphasis>Example 4</emphasis>.
@@ -1680,10 +1683,9 @@ Initialize <literal>PO</literal> files for languages defined in
 <filename>LINGUAS</filename> file. The files will be initialized from template
 <filename>messages.pot</filename>:
 </para>
-<example_commands>
-  # ...
-  env.POInit(LINGUAS_FILE = 1) # needs 'LINGUAS' file
-</example_commands>
+<programlisting language="python">
+env.POInit(LINGUAS_FILE=True)  # needs 'LINGUAS' file
+</programlisting>
 
 <para>
 <emphasis>Example 5</emphasis>.
@@ -1692,30 +1694,27 @@ Initialize <filename>en.po</filename> and <filename>pl.pl</filename>
 <filename>LINGUAS</filename> file. The files will be initialized from template
 <filename>messages.pot</filename>:
 </para>
-<example_commands>
-  # ...
-  env.POInit(['en', 'pl'], LINGUAS_FILE = 1)
-</example_commands>
+<programlisting language="python">
+env.POInit(['en', 'pl'], LINGUAS_FILE=True)
+</programlisting>
 
 <para>
 <emphasis>Example 6</emphasis>.
 You may preconfigure your environment first, and then initialize
 <literal>PO</literal> files:
 </para>
-<example_commands>
-  # ...
-  env['POAUTOINIT'] = 1
-  env['LINGUAS_FILE'] = 1
-  env['POTDOMAIN'] = 'foo'
-  env.POInit()
-</example_commands>
+<programlisting language="python">
+env['POAUTOINIT'] = True
+env['LINGUAS_FILE'] = True
+env['POTDOMAIN'] = 'foo'
+env.POInit()
+</programlisting>
 <para>
 which has same efect as:
 </para>
-<example_commands>
-  # ...
-  env.POInit(POAUTOINIT = 1, LINGUAS_FILE = 1, POTDOMAIN = 'foo')
-</example_commands>
+<programlisting language="python">
+env.POInit(POAUTOINIT=True, LINGUAS_FILE=True, POTDOMAIN='foo')
+</programlisting>
 </listitem>
   </varlistentry>
   <varlistentry id="b-PostScript">
@@ -1731,30 +1730,35 @@ or
 The suffix specified by the &cv-link-PSSUFFIX; construction variable
 (<filename>.ps</filename> by default)
 is added automatically to the target
-if it is not already present.  Example:
+if it is not already present.
+&b-PostScript; is a single-source builder.
+Example:
 </para>
 
-<example_commands>
+<programlisting language="python">
 # builds from aaa.tex
 env.PostScript(target = 'aaa.ps', source = 'aaa.tex')
 # builds bbb.ps from bbb.dvi
 env.PostScript(target = 'bbb', source = 'bbb.dvi')
-</example_commands>
+</programlisting>
 </listitem>
   </varlistentry>
   <varlistentry id="b-POTUpdate">
     <term><function>POTUpdate</function>()</term>
     <term><replaceable>env</replaceable>.<methodname>POTUpdate</methodname>()</term>
     <listitem><para>
-The builder belongs to &t-link-xgettext; tool. The builder updates target
-<literal>POT</literal> file if exists or creates one if it doesn't. The node is
-not built by default (i.e. it is <literal>Ignore</literal>d from
-<literal>'.'</literal>), but only on demand (i.e.  when given
-<literal>POT</literal> file is required or when special alias is invoked). This
-builder adds its targe node (<filename>messages.pot</filename>, say) to a
+The builder is set up by the &t-link-xgettext; tool,
+part of the &t-link-gettext; toolset.
+The builder updates the target
+<literal>POT</literal> file if exists or creates it if it doesn't.
+The target node is <emphasis>not</emphasis>
+selected for building by default (e.g. <userinput>scons .</userinput>),
+but only on demand (i.e.  when the given
+<literal>POT</literal> file is required or when special alias is invoked).
+This builder adds its target node (<filename>messages.pot</filename>, say) to a
 special alias (<literal>pot-update</literal> by default, see
 &cv-link-POTUPDATE_ALIAS;) so you can update/create them easily with
-<command>scons pot-update</command>. The file is not written until there is no
+<userinput>scons pot-update</userinput>. The file is not written until there is no
 real change in internationalized messages (or in comments that enter
 <literal>POT</literal> file).
 </para>
@@ -1774,86 +1778,87 @@ not.</para></note>
 Let's create <filename>po/</filename> directory and place following
 <filename>SConstruct</filename> script there:
 </para>
-<example_commands>
-  # SConstruct in 'po/' subdir
-  env = Environment( tools = ['default', 'xgettext'] )
-  env.POTUpdate(['foo'], ['../a.cpp', '../b.cpp'])
-  env.POTUpdate(['bar'], ['../c.cpp', '../d.cpp'])
-</example_commands>
+<programlisting language="python">
+# SConstruct in 'po/' subdir
+env = Environment(tools=['default', 'xgettext'])
+env.POTUpdate(['foo'], ['../a.cpp', '../b.cpp'])
+env.POTUpdate(['bar'], ['../c.cpp', '../d.cpp'])
+</programlisting>
 <para>
 Then invoke scons few times:
 </para>
-<example_commands>
-  user@host:$ scons             # Does not create foo.pot nor bar.pot
-  user@host:$ scons foo.pot     # Updates or creates foo.pot
-  user@host:$ scons pot-update  # Updates or creates foo.pot and bar.pot
-  user@host:$ scons -c          # Does not clean foo.pot nor bar.pot.
-</example_commands>
+<screen>
+$ scons             # Does not create foo.pot nor bar.pot
+$ scons foo.pot     # Updates or creates foo.pot
+$ scons pot-update  # Updates or creates foo.pot and bar.pot
+$ scons -c          # Does not clean foo.pot nor bar.pot.
+</screen>
 <para>
 the results shall be as the comments above say.
 </para>
 
 <para>
 <emphasis>Example 2.</emphasis>
-The &b-POTUpdate; builder may be used with no target specified, in which
-case default target <filename>messages.pot</filename> will be used. The
-default target may also be overridden by setting &cv-link-POTDOMAIN; construction
-variable or providing it as an override to &b-POTUpdate; builder:
+The <parameter>target</parameter> argument can be omitted, in which
+case the default target name <filename>messages.pot</filename> is used.
+The target may also be overridden by setting the &cv-link-POTDOMAIN;
+&consvar; or providing it as an override to the &b-POTUpdate; builder:
 </para>
-<example_commands>
-  # SConstruct script
-  env = Environment( tools = ['default', 'xgettext'] )
-  env['POTDOMAIN'] = "foo"
-  env.POTUpdate(source = ["a.cpp", "b.cpp"]) # Creates foo.pot ...
-  env.POTUpdate(POTDOMAIN = "bar", source = ["c.cpp", "d.cpp"]) # and bar.pot
-</example_commands>
+<programlisting language="python">
+# SConstruct script
+env = Environment(tools=['default', 'xgettext'])
+env['POTDOMAIN'] = "foo"
+env.POTUpdate(source=["a.cpp", "b.cpp"])  # Creates foo.pot ...
+env.POTUpdate(POTDOMAIN="bar", source=["c.cpp", "d.cpp"])  # and bar.pot
+</programlisting>
 
 <para>
 <emphasis>Example 3.</emphasis>
-The sources may be specified within separate file, for example
+The <parameter>source</parameter> parameter may also be omitted,
+if it is specified in a separate file, for example
 <filename>POTFILES.in</filename>:
 </para>
-<example_commands>
-  # POTFILES.in in 'po/' subdirectory
-  ../a.cpp
-  ../b.cpp
-  # end of file
-</example_commands>
+<programlisting>
+# POTFILES.in in 'po/' subdirectory
+../a.cpp
+../b.cpp
+# end of file
+</programlisting>
 <para>
 The name of the file (<filename>POTFILES.in</filename>) containing the list of
 sources is provided via &cv-link-XGETTEXTFROM;:
 </para>
-<example_commands>
-  # SConstruct file in 'po/' subdirectory
-  env = Environment( tools = ['default', 'xgettext'] )
-  env.POTUpdate(XGETTEXTFROM = 'POTFILES.in')
-</example_commands>
+<programlisting language="python">
+# SConstruct file in 'po/' subdirectory
+env = Environment(tools=['default', 'xgettext'])
+env.POTUpdate(XGETTEXTFROM='POTFILES.in')
+</programlisting>
 
 <para>
 <emphasis>Example 4.</emphasis>
-You may use &cv-link-XGETTEXTPATH; to define source search path. Assume, for
-example, that you have files <filename>a.cpp</filename>,
+You can use &cv-link-XGETTEXTPATH; to define the source search path.
+Assume, for example, that you have files <filename>a.cpp</filename>,
 <filename>b.cpp</filename>, <filename>po/SConstruct</filename>,
-<filename>po/POTFILES.in</filename>. Then your <literal>POT</literal>-related
-files could look as below:
+<filename>po/POTFILES.in</filename>.
+Then your <literal>POT</literal>-related files could look like this:
 </para>
-<example_commands>
-  # POTFILES.in in 'po/' subdirectory
-  a.cpp
-  b.cpp
-  # end of file
-</example_commands>
+<programlisting>
+# POTFILES.in in 'po/' subdirectory
+a.cpp
+b.cpp
+# end of file
+</programlisting>
 
-<example_commands>
-  # SConstruct file in 'po/' subdirectory
-  env = Environment( tools = ['default', 'xgettext'] )
-  env.POTUpdate(XGETTEXTFROM = 'POTFILES.in', XGETTEXTPATH='../')
-</example_commands>
+<programlisting language="python">
+# SConstruct file in 'po/' subdirectory
+env = Environment(tools=['default', 'xgettext'])
+env.POTUpdate(XGETTEXTFROM='POTFILES.in', XGETTEXTPATH='../')
+</programlisting>
 
 <para>
 <emphasis>Example 5.</emphasis>
-Multiple search directories may be defined within a list, i.e.
-<literal>XGETTEXTPATH = ['dir1', 'dir2', ...]</literal>. The order in the list
+Multiple search directories may be defined as a list, i.e.
+<literal>XGETTEXTPATH=['dir1', 'dir2', ...]</literal>. The order in the list
 determines the search order of source files. The path to the first file found
 is used.
 </para>
@@ -1861,44 +1866,44 @@ is used.
 <para>
 Let's create <filename>0/1/po/SConstruct</filename> script:
 </para>
-<example_commands>
-  # SConstruct file in '0/1/po/' subdirectory
-  env = Environment( tools = ['default', 'xgettext'] )
-  env.POTUpdate(XGETTEXTFROM = 'POTFILES.in', XGETTEXTPATH=['../', '../../'])
-</example_commands>
+<programlisting language="python">
+# SConstruct file in '0/1/po/' subdirectory
+env = Environment(tools=['default', 'xgettext'])
+env.POTUpdate(XGETTEXTFROM='POTFILES.in', XGETTEXTPATH=['../', '../../'])
+</programlisting>
 <para>
 and <filename>0/1/po/POTFILES.in</filename>:
 </para>
-<example_commands>
-  # POTFILES.in in '0/1/po/' subdirectory
-  a.cpp
-  # end of file
-</example_commands>
+<programlisting>
+# POTFILES.in in '0/1/po/' subdirectory
+a.cpp
+# end of file
+</programlisting>
 <para>
 Write two <filename>*.cpp</filename> files, the first one is
 <filename>0/a.cpp</filename>:
 </para>
-<example_commands>
-  /* 0/a.cpp */
-  gettext("Hello from ../../a.cpp")
-</example_commands>
+<programlisting language="c++">
+/* 0/a.cpp */
+gettext("Hello from ../../a.cpp")
+</programlisting>
 <para>
 and the second is <filename>0/1/a.cpp</filename>:
 </para>
-<example_commands>
-  /* 0/1/a.cpp */
-  gettext("Hello from ../a.cpp")
-</example_commands>
+<programlisting language="c++">
+/* 0/1/a.cpp */
+gettext("Hello from ../a.cpp")
+</programlisting>
 <para>
 then run scons. You'll obtain <literal>0/1/po/messages.pot</literal> with the
 message <literal>"Hello from ../a.cpp"</literal>. When you reverse order in
 <varname>$XGETTEXTFOM</varname>, i.e. when you write SConscript as
 </para>
-<example_commands>
-  # SConstruct file in '0/1/po/' subdirectory
-  env = Environment( tools = ['default', 'xgettext'] )
-  env.POTUpdate(XGETTEXTFROM = 'POTFILES.in', XGETTEXTPATH=['../../', '../'])
-</example_commands>
+<programlisting language="python">
+# SConstruct file in '0/1/po/' subdirectory
+env = Environment(tools=['default', 'xgettext'])
+env.POTUpdate(XGETTEXTFROM='POTFILES.in', XGETTEXTPATH=['../../', '../'])
+</programlisting>
 <para>
 then the <filename>messages.pot</filename> will contain
 <literal>msgid "Hello from ../../a.cpp"</literal> line and not
@@ -1911,23 +1916,29 @@ then the <filename>messages.pot</filename> will contain
     <term><function>POUpdate</function>()</term>
     <term><replaceable>env</replaceable>.<methodname>POUpdate</methodname>()</term>
     <listitem><para>
-The builder belongs to &t-link-msgmerge; tool. The builder updates
+The builder is set up by the &t-link-msgmerge; tool.
+part of the &t-link-gettext; toolset.
+The builder updates
 <literal>PO</literal> files with <command>msgmerge(1)</command>, or initializes
-missing <literal>PO</literal> files as described in documentation of
-&t-link-msginit; tool and &b-link-POInit; builder (see also
-&cv-link-POAUTOINIT;). Note, that &b-POUpdate; <emphasis>does not add its
-targets to <literal>po-create</literal> alias</emphasis> as &b-link-POInit;
-does.
+missing <literal>PO</literal> files as described in the documentation of the
+&t-link-msginit; tool and the &b-link-POInit; builder (see also
+&cv-link-POAUTOINIT;).
+&b-POUpdate; is a single-source builder.
+The <parameter>source</parameter> parameter
+can also be omitted if &cv-link-LINGUAS_FILE; is set.
 </para>
 
 <para>
-Target nodes defined through &b-POUpdate; are not built by default
-(they're <literal>Ignore</literal>d from <literal>'.'</literal> node). Instead,
-they are added automatically to special <literal>Alias</literal>
+The target nodes are <emphasis>not</emphasis>
+selected for building by default (e.g. <userinput>scons .</userinput>).
+Instead, they are added automatically to special &f-link-Alias;
 (<literal>'po-update'</literal> by default). The alias name may be changed
-through the &cv-link-POUPDATE_ALIAS; construction variable.  You can easily
-update <literal>PO</literal> files in your project by <command>scons
-po-update</command>.
+through the &cv-link-POUPDATE_ALIAS; &consvar;.  You can easily
+update <literal>PO</literal> files in your project by
+<userinput>scons po-update</userinput>.
+Note that &b-POUpdate; does not add its
+targets to the <literal>po-create</literal> alias as &b-link-POInit;
+does.
 </para>
 
 <para>
@@ -1937,49 +1948,44 @@ Update <filename>en.po</filename> and <filename>pl.po</filename> from
 assuming that the later one exists or there is rule to build it (see
 &b-link-POTUpdate;):
 </para>
-<example_commands>
-  # ...
-  env.POUpdate(['en','pl']) # messages.pot --&gt; [en.po, pl.po]
-</example_commands>
+<programlisting language="python">
+env.POUpdate(['en','pl'])  # messages.pot --&gt; [en.po, pl.po]
+</programlisting>
 
 <para>
 <emphasis>Example 2.</emphasis>
 Update <filename>en.po</filename> and <filename>pl.po</filename> from
 <filename>foo.pot</filename> template:
 </para>
-<example_commands>
-  # ...
-  env.POUpdate(['en', 'pl'], ['foo']) # foo.pot --&gt;  [en.po, pl.pl]
-</example_commands>
+<programlisting language="python">
+env.POUpdate(['en', 'pl'], ['foo'])  # foo.pot --&gt;  [en.po, pl.pl]
+</programlisting>
 
 <para>
 <emphasis>Example 3.</emphasis>
 Update <filename>en.po</filename> and <filename>pl.po</filename> from
 <filename>foo.pot</filename> (another version):
 </para>
-<example_commands>
-  # ...
-  env.POUpdate(['en', 'pl'], POTDOMAIN='foo') # foo.pot -- &gt; [en.po, pl.pl]
-</example_commands>
+<programlisting language="python">
+env.POUpdate(['en', 'pl'], POTDOMAIN='foo')  # foo.pot -- &gt; [en.po, pl.pl]
+</programlisting>
 
 <para>
 <emphasis>Example 4.</emphasis>
 Update files for languages defined in <filename>LINGUAS</filename> file. The
 files are updated from <filename>messages.pot</filename> template:
 </para>
-<example_commands>
-  # ...
-  env.POUpdate(LINGUAS_FILE = 1) # needs 'LINGUAS' file
-</example_commands>
+<programlisting language="python">
+env.POUpdate(LINGUAS_FILE=True)  # needs 'LINGUAS' file
+</programlisting>
 
 <para>
 <emphasis>Example 5.</emphasis>
 Same as above, but update from <filename>foo.pot</filename> template:
 </para>
-<example_commands>
-  # ...
-  env.POUpdate(LINGUAS_FILE = 1, source = ['foo'])
-</example_commands>
+<programlisting language="python">
+env.POUpdate(LINGUAS_FILE=True, source=['foo'])
+</programlisting>
 
 <para>
 <emphasis>Example 6.</emphasis>
@@ -1987,20 +1993,19 @@ Update <filename>en.po</filename> and <filename>pl.po</filename> plus files for
 languages defined in <filename>LINGUAS</filename> file. The files are updated
 from <filename>messages.pot</filename> template:
 </para>
-<example_commands>
-  # produce 'en.po', 'pl.po' + files defined in 'LINGUAS':
-  env.POUpdate(['en', 'pl' ], LINGUAS_FILE = 1)
-</example_commands>
+<programlisting language="python">
+# produce 'en.po', 'pl.po' + files defined in 'LINGUAS':
+env.POUpdate(['en', 'pl' ], LINGUAS_FILE=True)
+</programlisting>
 
 <para>
 <emphasis>Example 7.</emphasis>
 Use &cv-link-POAUTOINIT; to automatically initialize <literal>PO</literal> file
 if it doesn't exist:
 </para>
-<example_commands>
-  # ...
-  env.POUpdate(LINGUAS_FILE = 1, POAUTOINIT = 1)
-</example_commands>
+<programlisting language="python">
+env.POUpdate(LINGUAS_FILE=True, POAUTOINIT=True)
+</programlisting>
 
 <para>
 <emphasis>Example 8.</emphasis>
@@ -2009,13 +2014,12 @@ Update <literal>PO</literal> files for languages defined in
 <filename>foo.pot</filename> template. All necessary settings are
 pre-configured via environment.
 </para>
-<example_commands>
-  # ...
-  env['POAUTOINIT'] = 1
-  env['LINGUAS_FILE'] = 1
-  env['POTDOMAIN'] = 'foo'
-  env.POUpdate()
-</example_commands>
+<programlisting language="python">
+env['POAUTOINIT'] = True
+env['LINGUAS_FILE'] = True
+env['POTDOMAIN'] = 'foo'
+env.POUpdate()
+</programlisting>
 
 </listitem>
   </varlistentry>
@@ -2705,54 +2709,56 @@ env.Textfile(
     <term><function>Translate</function>()</term>
     <term><replaceable>env</replaceable>.<methodname>Translate</methodname>()</term>
     <listitem><para>
-This pseudo-builder belongs to &t-link-gettext; toolset. The builder extracts
-internationalized messages from source files, updates <literal>POT</literal>
-template (if necessary) and then updates <literal>PO</literal> translations (if
-necessary). If &cv-link-POAUTOINIT; is set, missing <literal>PO</literal> files
+This pseudo-Builder is part of the &t-link-gettext; toolset.
+The builder extracts internationalized messages from source files,
+updates the <literal>POT</literal> template (if necessary)
+and then updates <literal>PO</literal> translations (if necessary).
+If &cv-link-POAUTOINIT; is set, missing <literal>PO</literal> files
 will be automatically created (i.e. without translator person intervention).
 The variables &cv-link-LINGUAS_FILE; and &cv-link-POTDOMAIN; are taken into
-acount too. All other construction variables used by &b-link-POTUpdate;, and
+account too. All other construction variables used by &b-link-POTUpdate;, and
 &b-link-POUpdate; work here too.
 </para>
 
 <para>
 <emphasis>Example 1</emphasis>.
 The simplest way is to specify input files and output languages inline in
-a SCons script when invoking &b-Translate;
+a SCons script when invoking &b-Translate;:
 </para>
-<example_commands>
+<programlisting language="python">
 # SConscript in 'po/' directory
-env = Environment( tools = ["default", "gettext"] )
-env['POAUTOINIT'] = 1
-env.Translate(['en','pl'], ['../a.cpp','../b.cpp'])
-</example_commands>
+env = Environment(tools=["default", "gettext"])
+env['POAUTOINIT'] = True
+env.Translate(['en', 'pl'], ['../a.cpp', '../b.cpp'])
+</programlisting>
 
 <para>
 <emphasis>Example 2</emphasis>.
-If you wish, you may also stick to conventional style known from
+If you wish, you may also stick to the conventional style known from
 <productname>autotools</productname>, i.e. using
 <filename>POTFILES.in</filename> and <filename>LINGUAS</filename> files
+to specify the targets and sources:
 </para>
-<example_commands>
+<programlisting language="python">
 # LINGUAS
 en pl
-#end
-</example_commands>
+# end
+</programlisting>
 
-<example_commands>
+<programlisting>
 # POTFILES.in
 a.cpp
 b.cpp
 # end
-</example_commands>
+</programlisting>
 
-<example_commands>
+<programlisting language="python">
 # SConscript
-env = Environment( tools = ["default", "gettext"] )
-env['POAUTOINIT'] = 1
+env = Environment(tools=["default", "gettext"])
+env['POAUTOINIT'] = True
 env['XGETTEXTPATH'] = ['../']
-env.Translate(LINGUAS_FILE = 1, XGETTEXTFROM = 'POTFILES.in')
-</example_commands>
+env.Translate(LINGUAS_FILE=True, XGETTEXTFROM='POTFILES.in')
+</programlisting>
 
 <para>
 The last approach is perhaps the recommended one. It allows easily split
@@ -2765,7 +2771,7 @@ factor" synchronizing these two scripts is then the content of
 <filename>LINGUAS</filename> file.  Note, that the updated
 <literal>POT</literal> and <literal>PO</literal> files are usually going to be
 committed back to the repository, so they must be updated within the source
-directory (and not in variant directories). Additionaly, the file listing of
+directory (and not in variant directories). Additionally, the file listing of
 <filename>po/</filename> directory contains <filename>LINGUAS</filename> file,
 so the source tree looks familiar to translators, and they may work with the
 project in their usual way.
@@ -2775,7 +2781,7 @@ project in their usual way.
 <emphasis>Example 3</emphasis>.
 Let's prepare a development tree as below
 </para>
-<example_commands>
+<programlisting>
  project/
   + SConstruct
   + build/
@@ -2785,52 +2791,55 @@ Let's prepare a development tree as below
           + SConscript.i18n
           + POTFILES.in
           + LINGUAS
-</example_commands>
+</programlisting>
 <para>
-with <filename>build</filename> being variant directory. Write the top-level
+with <filename>build</filename> being the variant directory.
+Write the top-level
 <filename>SConstruct</filename> script as follows
 </para>
-<example_commands>
-  # SConstruct
-  env = Environment( tools = ["default", "gettext"] )
-  VariantDir('build', 'src', duplicate = 0)
-  env['POAUTOINIT'] = 1
-  SConscript('src/po/SConscript.i18n', exports = 'env')
-  SConscript('build/po/SConscript', exports = 'env')
-</example_commands>
+<programlisting language="python">
+# SConstruct
+env = Environment(tools=["default", "gettext"])
+VariantDir('build', 'src', duplicate=False)
+env['POAUTOINIT'] = True
+SConscript('src/po/SConscript.i18n', exports='env')
+SConscript('build/po/SConscript', exports='env')
+</programlisting>
 <para>
 the <filename>src/po/SConscript.i18n</filename> as
 </para>
-<example_commands>
-  # src/po/SConscript.i18n
-  Import('env')
-  env.Translate(LINGUAS_FILE=1, XGETTEXTFROM='POTFILES.in', XGETTEXTPATH=['../'])
-</example_commands>
+<programlisting language="python">
+# src/po/SConscript.i18n
+Import('env')
+env.Translate(LINGUAS_FILE=True, XGETTEXTFROM='POTFILES.in', XGETTEXTPATH=['../'])
+</programlisting>
 <para>
 and the <filename>src/po/SConscript</filename>
 </para>
-<example_commands>
-  # src/po/SConscript
-  Import('env')
-  env.MOFiles(LINGUAS_FILE = 1)
-</example_commands>
+<programlisting language="python">
+# src/po/SConscript
+Import('env')
+env.MOFiles(LINGUAS_FILE=True)
+</programlisting>
 <para>
-Such setup produces <literal>POT</literal> and <literal>PO</literal> files
-under source tree in <filename>src/po/</filename> and binary
-<literal>MO</literal> files under variant tree in
+Such a setup produces <literal>POT</literal> and <literal>PO</literal> files
+under the source tree in <filename>src/po/</filename> and binary
+<literal>MO</literal> files under the variant tree in
 <filename>build/po/</filename>. This way the <literal>POT</literal> and
 <literal>PO</literal> files are separated from other output files, which must
 not be committed back to source repositories (e.g. <literal>MO</literal>
 files).
 </para>
 
-<para>
-<note><para>In above example, the <literal>PO</literal> files are not updated,
-nor created automatically when you issue <command>scons '.'</command> command.
-The files must be updated (created) by hand via <command>scons
-po-update</command> and then <literal>MO</literal> files can be compiled by
-running <command>scons '.'</command>.</para></note>
-</para>
+<note><para>In the above example,
+the <literal>PO</literal> files are not updated,
+nor created automatically when you issue the command
+<userinput>scons .</userinput>.
+The files must be updated (created) by hand via
+<userinput>scons po-update</userinput>
+and then <literal>MO</literal> files can be compiled by
+running <userinput>scons .</userinput>.
+</para></note>
 
 </listitem>
   </varlistentry>

--- a/doc/generated/tools.gen
+++ b/doc/generated/tools.gen
@@ -465,33 +465,33 @@ Sets construction variables for the D language compiler GDC.
   <varlistentry id="t-gettext">
     <term>gettext</term>
     <listitem><para>
-This is actually a toolset, which supports internationalization and
-localization of software being constructed with SCons. The toolset loads
-following tools:
+A toolset supporting internationalization and
+localization of software being constructed with &SCons;.
+The toolset loads the following tools:
 </para>
 
 <para>
 <itemizedlist mark="opencircle">
   <listitem><para>
-    &t-link-xgettext; - to extract internationalized messages from source code to
-    <literal>POT</literal> file(s),
+    &t-link-xgettext; - extract internationalized messages from source code to
+    <literal>POT</literal> file(s).
   </para></listitem>
   <listitem><para>
-    &t-link-msginit; - may be optionally used to initialize <literal>PO</literal>
-    files,
+    &t-link-msginit; - initialize <literal>PO</literal>
+    files during initial translation of a project.
   </para></listitem>
   <listitem><para>
-    &t-link-msgmerge; - to update <literal>PO</literal> files, that already contain
+    &t-link-msgmerge; - update <literal>PO</literal> files that already contain
     translated messages,</para></listitem>
   <listitem><para>
-    &t-link-msgfmt; - to compile textual <literal>PO</literal> file to binary
-    installable <literal>MO</literal> file.
+    &t-link-msgfmt; - compile textual <literal>PO</literal> files to binary
+    installable <literal>MO</literal> files.
   </para></listitem>
 </itemizedlist>
 </para>
 
 <para>
-When you enable &t-gettext;, it internally loads all abovementioned tools,
+When you enable &t-gettext;, it internally loads all the above-mentioned tools,
 so you're encouraged to see their individual documentation.
 </para>
 
@@ -503,12 +503,12 @@ may be however interested in <emphasis>top-level</emphasis>
 </para>
 
 <para>
-To use &t-gettext; tools add <literal>'gettext'</literal> tool to your
-environment:
+To use the &t-gettext; tools, add the <literal>'gettext'</literal> tool to your
+&consenv;:
 </para>
-<example_commands>
-  env = Environment( tools = ['default', 'gettext'] )
-</example_commands>
+<programlisting language="python">
+env = Environment(tools=['default', 'gettext'])
+</programlisting>
 </listitem>
   </varlistentry>
   <varlistentry id="t-gfortran">
@@ -718,28 +718,35 @@ Sets construction variables for MinGW (Minimal Gnu on Windows).
   <varlistentry id="t-msgfmt">
     <term>msgfmt</term>
     <listitem><para>
-This scons tool is a part of scons &t-link-gettext; toolset. It provides scons
-interface to <command>msgfmt(1)</command> command, which generates binary
-message catalog (<literal>MO</literal>) from a textual translation description
-(<literal>PO</literal>).
+This tool is a part of the &t-link-gettext; toolset.
+It provides &SCons;
+an interface to the <command>msgfmt(1)</command> command
+by setting up the &b-link-MOFiles; builder,
+which generates binary message catalog (<literal>MO</literal>) files
+from a textual translation description
+(<literal>PO</literal> files).
 </para>
 <para>Sets: &cv-link-MOSUFFIX;, &cv-link-MSGFMT;, &cv-link-MSGFMTCOM;, &cv-link-MSGFMTCOMSTR;, &cv-link-MSGFMTFLAGS;, &cv-link-POSUFFIX;.</para><para>Uses: &cv-link-LINGUAS_FILE;.</para></listitem>
   </varlistentry>
   <varlistentry id="t-msginit">
     <term>msginit</term>
     <listitem><para>
-This scons tool is a part of scons &t-link-gettext; toolset. It provides
-scons interface to <command>msginit(1)</command> program, which creates new
+This tool is a part of scons &t-link-gettext; toolset. It provides
+&SCons; an interface to the <command>msginit(1)</command> program,
+by setting up the &b-link-POInit; builder,
+which creates a new
 <literal>PO</literal> file, initializing the meta information with values from
-user's environment (or options).
+the &consenv; (or options).
 </para>
 <para>Sets: &cv-link-MSGINIT;, &cv-link-MSGINITCOM;, &cv-link-MSGINITCOMSTR;, &cv-link-MSGINITFLAGS;, &cv-link-POAUTOINIT;, &cv-link-POCREATE_ALIAS;, &cv-link-POSUFFIX;, &cv-link-POTSUFFIX;, &cv-link-_MSGINITLOCALE;.</para><para>Uses: &cv-link-LINGUAS_FILE;, &cv-link-POAUTOINIT;, &cv-link-POTDOMAIN;.</para></listitem>
   </varlistentry>
   <varlistentry id="t-msgmerge">
     <term>msgmerge</term>
     <listitem><para>
-This scons tool is a part of scons &t-link-gettext; toolset. It provides
-scons interface to <command>msgmerge(1)</command> command, which merges two
+This tool is a part of scons &t-link-gettext; toolset. It provides
+&SCons; an interface to the <command>msgmerge(1)</command> command,
+by setting up the &b-link-POUpdate; builder,
+which merges two
 Uniform style <filename>.po</filename> files together.
 </para>
 <para>Sets: &cv-link-MSGMERGE;, &cv-link-MSGMERGECOM;, &cv-link-MSGMERGECOMSTR;, &cv-link-MSGMERGEFLAGS;, &cv-link-POSUFFIX;, &cv-link-POTSUFFIX;, &cv-link-POUPDATE_ALIAS;.</para><para>Uses: &cv-link-LINGUAS_FILE;, &cv-link-POAUTOINIT;, &cv-link-POTDOMAIN;.</para></listitem>
@@ -1093,10 +1100,10 @@ Sets construction variables for the Borlan
   <varlistentry id="t-xgettext">
     <term>xgettext</term>
     <listitem><para>
-This scons tool is a part of scons &t-link-gettext; toolset. It provides
-scons interface to <command>xgettext(1)</command>
-program, which extracts internationalized messages from source code. The tool
-provides &b-POTUpdate; builder to make  <literal>PO</literal>
+This tool is a part of the &t-link-gettext; toolset. It provides
+&SCons; an interface to the <command>xgettext(1)</command>
+program, which extracts internationalized messages from source code.
+The tool sets up the &b-POTUpdate; builder to make  <literal>PO</literal>
 <emphasis>Template</emphasis> files.
 </para>
 <para>Sets: &cv-link-POTSUFFIX;, &cv-link-POTUPDATE_ALIAS;, &cv-link-XGETTEXTCOM;, &cv-link-XGETTEXTCOMSTR;, &cv-link-XGETTEXTFLAGS;, &cv-link-XGETTEXTFROM;, &cv-link-XGETTEXTFROMPREFIX;, &cv-link-XGETTEXTFROMSUFFIX;, &cv-link-XGETTEXTPATH;, &cv-link-XGETTEXTPATHPREFIX;, &cv-link-XGETTEXTPATHSUFFIX;, &cv-link-_XGETTEXTDOMAIN;, &cv-link-_XGETTEXTFROMFLAGS;, &cv-link-_XGETTEXTPATHFLAGS;.</para><para>Uses: &cv-link-POTDOMAIN;.</para></listitem>

--- a/doc/generated/variables.gen
+++ b/doc/generated/variables.gen
@@ -4581,10 +4581,10 @@ It defaults to the current system line separator.
 The &cv-LINGUAS_FILE; defines file(s) containing list of additional linguas
 to be processed by &b-link-POInit;, &b-link-POUpdate; or &b-link-MOFiles;
 builders. It also affects &b-link-Translate; builder. If the variable contains
-a string, it defines name of the list file. The &cv-LINGUAS_FILE; may be a
+a string, it defines the name of the list file. The &cv-LINGUAS_FILE; may be a
 list of file names as well. If &cv-LINGUAS_FILE; is set to
-<literal>True</literal> (or non-zero numeric value), the list will be read from
-default file named
+a non-string truthy value, the list will be read from
+the file named
 <filename>LINGUAS</filename>.
 </para>
 
@@ -4852,7 +4852,7 @@ See &t-link-msgfmt; tool and &b-link-MOFiles; builder.
     </term>
     <listitem><para>
 Path to <command>msginit(1)</command> program (found via
-<literal>Detect()</literal>).
+&f-link-Detect;).
 See &t-link-msginit; tool and &b-link-POInit; builder.
 </para>
 </listitem>
@@ -4872,8 +4872,9 @@ See &t-link-msginit; tool and &b-link-POInit; builder.
       <envar>MSGINITCOMSTR</envar>
     </term>
     <listitem><para>
-String to display when <command>msginit(1)</command> is invoked
-(default: <literal>''</literal>, which means ``print &cv-link-MSGINITCOM;'').
+String to display when <command>msginit(1)</command> is invoked.
+The default is an empty string,
+which will print the command line (&cv-link-MSGINITCOM;).
 See &t-link-msginit; tool and &b-link-POInit; builder.
 </para>
 </listitem>
@@ -4928,8 +4929,9 @@ See &t-link-msgmerge; tool and &b-link-POUpdate; builder.
       <envar>MSGMERGECOMSTR</envar>
     </term>
     <listitem><para>
-String to be displayed when <command>msgmerge(1)</command> is invoked
-(default: <literal>''</literal>, which means ``print &cv-link-MSGMERGECOM;'').
+String to be displayed when <command>msgmerge(1)</command> is invoked.
+The default is an empty string,
+which will print the command line (&cv-link-MSGMERGECOM;).
 See &t-link-msgmerge; tool and &b-link-POUpdate; builder.
 </para>
 </listitem>
@@ -5199,18 +5201,18 @@ via &cv-link-MSVC_UWP_APP; and &cv-MSVC_SCRIPT_ARGS; are not allowed.
 <para>
 Example 1 - A Visual Studio 2022 build with an SDK version and a toolset version
 specified with a string argument:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS='10.0.20348.0 -vcvars_ver=14.29.30133')
 </example_commands>
-</para>
 
 <para>
 Example 2 - A Visual Studio 2022 build with an SDK version and a toolset version
 specified with a list argument:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS=['10.0.20348.0', '-vcvars_ver=14.29.30133'])
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -5310,33 +5312,34 @@ Note: in addition to the camel case values shown above, lower case and upper cas
 
 <para>
 Example 1 - A Visual Studio 2022 build with user-defined script arguments:
+</para>
 <example_commands>
 env = environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS=['8.1', 'store', '-vcvars_ver=14.1'])
 env.Program('hello', ['hello.c'], CCFLAGS='/MD', LIBS=['kernel32', 'user32', 'runtimeobject'])
 </example_commands>
-</para>
 
 <para>
 Example 1 - Output fragment:
+</para>
 <example_commands>
 ...
 link /nologo /OUT:_build001\hello.exe kernel32.lib user32.lib runtimeobject.lib _build001\hello.obj
 LINK : fatal error LNK1104: cannot open file 'MSVCRT.lib'
 ...
 </example_commands>
-</para>
 
 <para>
 Example 2 - A Visual Studio 2022 build with user-defined script arguments and the script error policy set
 to issue a warning when msvc batch file errors are detected:
+</para>
 <example_commands>
 env = environment(MSVC_VERSION='14.3', MSVC_SCRIPT_ARGS=['8.1', 'store', '-vcvars_ver=14.1'], MSVC_SCRIPTERROR_POLICY='warn')
 env.Program('hello', ['hello.c'], CCFLAGS='/MD', LIBS=['kernel32', 'user32', 'runtimeobject'])
 </example_commands>
-</para>
 
 <para>
 Example 2 - Output fragment:
+</para>
 <example_commands>
 ...
 scons: warning: vc script errors detected:
@@ -5347,7 +5350,6 @@ scons: warning: vc script errors detected:
 link /nologo /OUT:_build001\hello.exe kernel32.lib user32.lib runtimeobject.lib _build001\hello.obj
 LINK : fatal error LNK1104: cannot open file 'MSVCRT.lib'
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -5444,17 +5446,17 @@ must be '14.0').
 
 <para>
 Example 1 - A Visual Studio 2022 build with a specific Windows SDK version:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SDK_VERSION='10.0.20348.0')
 </example_commands>
-</para>
 
 <para>
 Example 2 - A Visual Studio 2022 build with a specific SDK version for the Universal Windows Platform:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SDK_VERSION='10.0.20348.0', MSVC_UWP_APP=True)
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -5542,10 +5544,10 @@ components.
 
 <para>
 Example - A Visual Studio 2022 build with spectre mitigated &MSVC; libraries:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_SPECTRE_LIBS=True)
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -5700,31 +5702,31 @@ toolset with the largest version number.
 
 <para>
 Example 1 - A default Visual Studio build with a partial toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_TOOLSET_VERSION='14.2')
 </example_commands>
-</para>
 
 <para>
 Example 2 - A default Visual Studio build with a partial toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_TOOLSET_VERSION='14.29')
 </example_commands>
-</para>
 
 <para>
 Example 3 - A Visual Studio 2022 build with a full toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_TOOLSET_VERSION='14.29.30133')
 </example_commands>
-</para>
 
 <para>
 Example 4 - A Visual Studio 2022 build with an SxS toolset version specified:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_TOOLSET_VERSION='14.29.16.11')
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -5938,10 +5940,10 @@ and &cv-link-MSVC_SCRIPT_ARGS; are not allowed.
 
 <para>
 Example - A Visual Studio 2022 build for the Universal Windows Platform:
+</para>
 <example_commands>
 env = Environment(MSVC_VERSION='14.3', MSVC_UWP_APP=True)
 </example_commands>
-</para>
 
 <para>
 Important usage details:
@@ -9133,9 +9135,11 @@ The suffix used for shared object file names.
     </term>
     <listitem><para>
 Variable used to hard-code SONAME for versioned shared library/loadable module.
+</para>
 <example_commands>
 env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SONAME='libtest.so.2')
 </example_commands>
+<para>
 The variable is used, for example, by &t-link-gnulink; linker tool.
 </para>
 </listitem>
@@ -9187,9 +9191,11 @@ for more information).
 This will construct the <varname>SONAME</varname> using on the base library name
 (<parameter>test</parameter> in the example below) and use specified <varname>SOVERSION</varname>
 to create <varname>SONAME</varname>.
+</para>
 <example_commands>
 env.SharedLibrary('test', 'test.c', SHLIBVERSION='0.1.2', SOVERSION='2')
 </example_commands>
+<para>
 The variable is used, for example, by &t-link-gnulink; linker tool.
 </para>
 <para>

--- a/doc/user/external.xml
+++ b/doc/user/external.xml
@@ -309,12 +309,12 @@ env2.CompilationDatabase('compile_commands-linux64.json')
                 To enable this feature you'll need to use one of the following:
     </para>
     <!--        NOTE DO NOT INDENT example_commands CONTENTS AS IT WILL ALTER THE FORMATTING-->
-    <example_commands>
+    <screen>
 # On the command line --experimental=ninja
 
 # Or in your SConstruct
 SetOption('experimental', 'ninja')
-    </example_commands>
+    </screen>
 </note>
 
         <para>
@@ -342,7 +342,7 @@ SetOption('experimental', 'ninja')
             This can be done via:
         </para>
 
-        <example_commands>
+        <screen>
 # In a virtualenv, or "python" is the native executable:
 python -m pip install ninja
 
@@ -351,7 +351,7 @@ py -m pip install ninja
 
 # Anaconda:
 conda install -c conda-forge ninja
-        </example_commands>
+        </screen>
 
         <para>
             Reminder that like any non-default tool, you need to initialize it before use

--- a/doc/xsd/dbpoolx.xsd
+++ b/doc/xsd/dbpoolx.xsd
@@ -218,6 +218,7 @@
       <xs:group ref="descobj.class"/>
       <xs:element ref="ndxterm.class"/>
       <xs:element ref="beginpage"/>
+      <xs:element ref="example_commands"/>
     </xs:choice>
   </xs:group>
   <xs:group name="sidebar.mix">
@@ -303,11 +304,6 @@
       <xs:element ref="linespecific.class"/>
       <xs:element ref="informal.class"/>
       <xs:element ref="formal.class"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="summary.mix">
-    <xs:choice>
-      <xs:element ref="example_commands"/>
     </xs:choice>
   </xs:group>
   <xs:group name="tool.mix">
@@ -2354,6 +2350,30 @@
   <xs:attributeGroup name="sconsdoc.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
+  <!-- doc:A sconsdoc. -->
+  <xs:element name="sconsdoc" substitutionGroup="para.class">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          TODO
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element ref="tool"/>
+        <xs:element ref="builder"/>
+        <xs:element ref="scons_function"/>
+        <xs:element ref="cvar"/>
+      </xs:choice>
+      <xs:attributeGroup ref="sconsdoc.attlist"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- end of sconsdoc.element -->
+  <xs:attributeGroup name="sconsdoc.attlist">
+    <xs:attributeGroup ref="common.attrib"/>
+    <xs:attributeGroup ref="sconsdoc.role.attrib"/>
+  </xs:attributeGroup>
+  <!-- end of sconsdoc.attlist -->
+  <!-- end of sconsdoc.module -->
   <xs:attributeGroup name="example_commands.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
@@ -2382,7 +2402,7 @@
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:A summary. -->
-  <xs:element name="summary" substitutionGroup="para.class">
+  <xs:element name="summary">
     <xs:complexType mixed="true">
       <xs:annotation>
         <xs:documentation xml:lang="en">
@@ -2391,7 +2411,6 @@
       </xs:annotation>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:group ref="component.mix"/>
-        <xs:group ref="summary.mix"/>
       </xs:choice>
       <xs:attributeGroup ref="summary.attlist"/>
     </xs:complexType>
@@ -2430,7 +2449,7 @@
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:A list in which each entry is marked with a bullet or other dingbat. -->
-  <xs:element name="sets" substitutionGroup="list.class">
+  <xs:element name="sets">
     <xs:complexType mixed="true">
       <xs:annotation>
         <xs:documentation xml:lang="en">
@@ -2474,7 +2493,7 @@
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:A list in which each entry is marked with a bullet or other dingbat. -->
-  <xs:element name="uses" substitutionGroup="list.class">
+  <xs:element name="uses">
     <xs:complexType mixed="true">
       <xs:annotation>
         <xs:documentation xml:lang="en">
@@ -2514,6 +2533,85 @@
   </xs:attributeGroup>
   <!-- end of uses.attlist -->
   <!-- end of uses.module -->
+  <xs:attributeGroup name="tool.role.attrib">
+    <xs:attributeGroup ref="role.attrib"/>
+  </xs:attributeGroup>
+  <!-- doc:A paragraph. -->
+  <xs:element name="tool">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          TODO
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="para.mix"/>
+        <xs:group ref="tool.mix"/>
+      </xs:choice>
+      <xs:attributeGroup ref="tool.attlist"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- end of tool.element -->
+  <xs:attributeGroup name="tool.attlist">
+    <xs:attributeGroup ref="common.attrib"/>
+    <xs:attributeGroup ref="tool.role.attrib"/>
+    <xs:attribute name="name" type="xs:string" use="required" />
+  </xs:attributeGroup>
+  <!-- end of tool.attlist -->
+  <!-- end of tool.module -->
+  <xs:attributeGroup name="builder.role.attrib">
+    <xs:attributeGroup ref="role.attrib"/>
+  </xs:attributeGroup>
+  <!-- doc:A paragraph. -->
+  <xs:element name="builder">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          TODO
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="para.mix"/>
+        <xs:group ref="tool.mix"/>
+      </xs:choice>
+      <xs:attributeGroup ref="builder.attlist"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- end of builder.element -->
+  <xs:attributeGroup name="builder.attlist">
+    <xs:attributeGroup ref="common.attrib"/>
+    <xs:attributeGroup ref="builder.role.attrib"/>
+    <xs:attribute name="name" type="xs:string" use="required" />
+  </xs:attributeGroup>
+  <!-- end of builder.attlist -->
+  <!-- end of builder.module -->
+
+  <xs:attributeGroup name="cvar.role.attrib">
+    <xs:attributeGroup ref="role.attrib"/>
+  </xs:attributeGroup>
+  <!-- doc:A paragraph. -->
+  <xs:element name="cvar">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          TODO
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="para.mix"/>
+        <xs:element ref="summary"/>
+      </xs:choice>
+      <xs:attributeGroup ref="cvar.attlist"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- end of cvar.element -->
+  <xs:attributeGroup name="cvar.attlist">
+    <xs:attributeGroup ref="common.attrib"/>
+    <xs:attributeGroup ref="cvar.role.attrib"/>
+    <xs:attribute name="name" type="xs:string" use="required" />
+  </xs:attributeGroup>
+  <!-- end of cvar.attlist -->
+  <!-- end of cvar.module -->
   <xs:attributeGroup name="arguments.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
@@ -2540,7 +2638,32 @@
   </xs:attributeGroup>
   <!-- end of arguments.attlist -->
   <!-- end of arguments.module -->
-
+  <xs:attributeGroup name="scons_function.role.attrib">
+    <xs:attributeGroup ref="role.attrib"/>
+  </xs:attributeGroup>
+  <!-- doc:A paragraph. -->
+  <xs:element name="scons_function">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          TODO
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="para.mix"/>
+        <xs:group ref="scons_function.mix"/>
+      </xs:choice>
+      <xs:attributeGroup ref="scons_function.attlist"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- end of scons_function.element -->
+  <xs:attributeGroup name="scons_function.attlist">
+    <xs:attributeGroup ref="common.attrib"/>
+    <xs:attributeGroup ref="scons_function.role.attrib"/>
+    <xs:attribute name="name" type="xs:string" use="required" />
+  </xs:attributeGroup>
+  <!-- end of scons_function.attlist -->
+  <!-- end of scons_function.module -->
   <xs:attributeGroup name="admon.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>

--- a/doc/xsd/dbpoolx.xsd
+++ b/doc/xsd/dbpoolx.xsd
@@ -283,6 +283,7 @@
       <xs:element ref="ndxterm.class"/>
       <xs:element ref="beginpage"/>
       <xs:element ref="procedure"/>
+      <xs:element ref="scons_example"/>
     </xs:choice>
   </xs:group>
   <xs:group name="highlights.mix">

--- a/doc/xsd/dbpoolx.xsd
+++ b/doc/xsd/dbpoolx.xsd
@@ -2176,11 +2176,6 @@
   <!-- doc:An SConstruct example file. -->
   <xs:element name="sconstruct" substitutionGroup="linespecific.class">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:sequence>
         <xs:group ref="para.char.mix"/>
       </xs:sequence>
@@ -2200,11 +2195,6 @@
   <!-- doc:An SCons example. -->
   <xs:element name="scons_example" substitutionGroup="formal.class">
     <xs:complexType>
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="file"/>
         <xs:element ref="directory"/>
@@ -2227,11 +2217,6 @@
   <!-- doc:An SCons example file. -->
   <xs:element name="file">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="file.attlist"/>
     </xs:complexType>
@@ -2253,11 +2238,6 @@
   <!-- doc:An SCons example directory. -->
   <xs:element name="directory">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:sequence/>
       <xs:attributeGroup ref="directory.attlist"/>
     </xs:complexType>
@@ -2276,11 +2256,6 @@
   <!-- doc:A SCons example file. -->
   <xs:element name="scons_example_file" substitutionGroup="linespecific.class">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:sequence/>
       <xs:attributeGroup ref="scons_example_file.attlist"/>
     </xs:complexType>
@@ -2300,11 +2275,6 @@
   <!-- doc:The output of a SCons command/example. -->
   <xs:element name="scons_output" substitutionGroup="linespecific.class">
     <xs:complexType>
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="1" maxOccurs="unbounded">
         <xs:element ref="scons_output_command"/>
       </xs:choice>
@@ -2328,11 +2298,6 @@
   <!-- doc:A SCons example file. -->
   <xs:element name="scons_output_command">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="scons_output_command.attlist"/>
     </xs:complexType>
@@ -2353,11 +2318,6 @@
   <!-- doc:A sconsdoc. -->
   <xs:element name="sconsdoc" substitutionGroup="para.class">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="1" maxOccurs="unbounded">
         <xs:element ref="tool"/>
         <xs:element ref="builder"/>
@@ -2380,11 +2340,6 @@
   <!-- doc:Text that a user sees or might see on a computer screen. -->
   <xs:element name="example_commands">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="example_commands.attlist"/>
     </xs:complexType>
@@ -2404,11 +2359,6 @@
   <!-- doc:A summary. -->
   <xs:element name="summary">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:group ref="component.mix"/>
       </xs:choice>
@@ -2429,11 +2379,6 @@
   <!-- doc:A item. -->
   <xs:element name="item">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:group minOccurs="0" maxOccurs="unbounded" ref="para.char.mix"/>
       <xs:attributeGroup ref="item.attlist"/>
     </xs:complexType>
@@ -2451,11 +2396,6 @@
   <!-- doc:A list in which each entry is marked with a bullet or other dingbat. -->
   <xs:element name="sets">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:sequence>
         <xs:element minOccurs="0" ref="blockinfo"/>
         <xs:group minOccurs="0" ref="formalobject.title.content"/>
@@ -2495,11 +2435,6 @@
   <!-- doc:A list in which each entry is marked with a bullet or other dingbat. -->
   <xs:element name="uses">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:sequence>
         <xs:element minOccurs="0" ref="blockinfo"/>
         <xs:group minOccurs="0" ref="formalobject.title.content"/>
@@ -2539,11 +2474,6 @@
   <!-- doc:A paragraph. -->
   <xs:element name="tool">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:group ref="para.mix"/>
         <xs:group ref="tool.mix"/>
@@ -2565,11 +2495,6 @@
   <!-- doc:A paragraph. -->
   <xs:element name="builder">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:group ref="para.mix"/>
         <xs:group ref="tool.mix"/>
@@ -2592,11 +2517,6 @@
   <!-- doc:A paragraph. -->
   <xs:element name="cvar">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:group ref="para.mix"/>
         <xs:element ref="summary"/>
@@ -2618,11 +2538,6 @@
   <!-- doc:A general-purpose element for representing the syntax of commands or functions. -->
   <xs:element name="arguments" substitutionGroup="synop.class">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="arguments.attlist"/>
     </xs:complexType>
@@ -2644,11 +2559,6 @@
   <!-- doc:A paragraph. -->
   <xs:element name="scons_function">
     <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:group ref="para.mix"/>
         <xs:group ref="scons_function.mix"/>

--- a/doc/xsd/dbpoolx.xsd
+++ b/doc/xsd/dbpoolx.xsd
@@ -25,25 +25,25 @@
 
      This DTD extension is based on the Docbook XML information pool
      module V4.5 with:
-     
-       Copyright 1992-2004 HaL Computer Systems, Inc.,
-       O'Reilly & Associates, Inc., ArborText, Inc., Fujitsu Software
-       Corporation, Norman Walsh, Sun Microsystems, Inc., and the
-       Organization for the Advancement of Structured Information
-       Standards (OASIS).
-  
-       $Id: dbpoolx.mod 6340 2006-10-03 13:23:24Z nwalsh $
 
-     Please direct all questions, bug reports, or suggestions for
-     changes to the docbook@lists.oasis-open.org mailing list. For more
-     information, see http://www.oasis-open.org/docbook/.
+  Copyright 1992-2004 HaL Computer Systems, Inc.,
+  O'Reilly & Associates, Inc., ArborText, Inc., Fujitsu Software
+  Corporation, Norman Walsh, Sun Microsystems, Inc., and the
+  Organization for the Advancement of Structured Information
+  Standards (OASIS).
+
+  $Id: dbpoolx.mod 6340 2006-10-03 13:23:24Z nwalsh $
+
+  Please direct all questions, bug reports, or suggestions for
+  changes to the docbook@lists.oasis-open.org mailing list. For more
+  information, see http://www.oasis-open.org/docbook/.
      For the modified SCons extension files
-     
-        scons.xsd, dbpoolx.xsd, 
 
-     you can write to its developer mailing list. Check out 
+        scons.xsd, dbpoolx.xsd,
+
+     you can write to its developer mailing list. Check out
      http://www.scons.org/ and http://www.scons.org/lists.php.
- 
+
 -->
 <!-- ...................................................................... -->
 <!--
@@ -52,25 +52,25 @@
   content of DocBook documents.  Some elements are useful for general
   publishing, and others are useful specifically for computer
   documentation.
-  
+
   This module has the following dependencies on other modules:
-  
+
   o It assumes that a %notation.class; entity is defined by the
     driver file or other high-level module.  This entity is
     referenced in the NOTATION attributes for the graphic-related and
     ModeSpec elements.
-  
+
   o It assumes that an appropriately parameterized table module is
     available for use with the table-related elements.
-  
+
   In DTD driver files referring to this module, please use an entity
   declaration that uses the public identifier shown below:
-  
+
   <!ENTITY % dbpool PUBLIC
   "-//OASIS//ELEMENTS DocBook XML Information Pool V4.5//EN"
   "dbpoolx.mod">
   %dbpool;
-  
+
   See the documentation for detailed information on the parameter
   entity and module scheme used in DocBook, customizing DocBook and
   planning for interchange, and changes made since the last release
@@ -196,7 +196,7 @@
     Table entry mixture     X    X    X         X    d
     Glossary def mixture    X         X    X    X    X         e
     Legal notice mixture    X    X    X         X    f
-    
+
     a. Just Procedure; not Sidebar itself or MsgSet.
     b. No MsgSet.
     c. No Highlights.
@@ -303,11 +303,6 @@
       <xs:element ref="linespecific.class"/>
       <xs:element ref="informal.class"/>
       <xs:element ref="formal.class"/>
-      <xs:element ref="sconstruct"/>
-      <xs:element ref="scons_example"/>
-      <xs:element ref="scons_example_file"/>
-      <xs:element ref="scons_output"/>
-      <xs:element ref="sconsdoc"/>
     </xs:choice>
   </xs:group>
   <xs:group name="summary.mix">
@@ -320,7 +315,7 @@
       <xs:element ref="summary"/>
       <xs:element ref="sets"/>
       <xs:element ref="uses"/>
-    </xs:choice>  
+    </xs:choice>
   </xs:group>
   <xs:group name="scons_function.mix">
     <xs:choice>
@@ -328,7 +323,7 @@
       <xs:element ref="summary"/>
       <xs:element ref="sets"/>
       <xs:element ref="uses"/>
-    </xs:choice>  
+    </xs:choice>
   </xs:group>
   <xs:group name="admon.mix">
     <xs:choice>
@@ -426,7 +421,7 @@
     smallcptr.char.mix    X                   b                   a
     word.char.mix         X         c    X         X         X    a
     docinfo.char.mix      X         d    X    b              X    a
-    
+
     a. Just InlineGraphic; no InlineEquation.
     b. Just Replaceable; no other computer terms.
     c. Just Emphasis and Trademark; no other word elements.
@@ -2190,13 +2185,9 @@
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:sequence>
         <xs:group ref="para.char.mix"/>
-        <xs:element ref="co"/>
-        <xs:element ref="coref"/>
-        <xs:element ref="lineannotation"/>
-        <xs:element ref="textobject"/>
-      </xs:choice>
+      </xs:sequence>
       <xs:attributeGroup ref="sconstruct.attlist"/>
     </xs:complexType>
   </xs:element>
@@ -2211,7 +2202,7 @@
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:An SCons example. -->
-  <xs:element name="scons_example" substitutionGroup="linespecific.class">
+  <xs:element name="scons_example" substitutionGroup="formal.class">
     <xs:complexType>
       <xs:annotation>
         <xs:documentation xml:lang="en">
@@ -2238,20 +2229,14 @@
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:An SCons example file. -->
-  <xs:element name="file" substitutionGroup="linespecific.class">
+  <xs:element name="file">
     <xs:complexType mixed="true">
       <xs:annotation>
         <xs:documentation xml:lang="en">
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.char.mix"/>
-        <xs:element ref="co"/>
-        <xs:element ref="coref"/>
-        <xs:element ref="lineannotation"/>
-        <xs:element ref="textobject"/>
-      </xs:choice>
+      <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="file.attlist"/>
     </xs:complexType>
   </xs:element>
@@ -2270,20 +2255,14 @@
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:An SCons example directory. -->
-  <xs:element name="directory" substitutionGroup="linespecific.class">
+  <xs:element name="directory">
     <xs:complexType mixed="true">
       <xs:annotation>
         <xs:documentation xml:lang="en">
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.char.mix"/>
-        <xs:element ref="co"/>
-        <xs:element ref="coref"/>
-        <xs:element ref="lineannotation"/>
-        <xs:element ref="textobject"/>
-      </xs:choice>
+      <xs:sequence/>
       <xs:attributeGroup ref="directory.attlist"/>
     </xs:complexType>
   </xs:element>
@@ -2306,13 +2285,7 @@
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.char.mix"/>
-        <xs:element ref="co"/>
-        <xs:element ref="coref"/>
-        <xs:element ref="lineannotation"/>
-        <xs:element ref="textobject"/>
-      </xs:choice>
+      <xs:sequence/>
       <xs:attributeGroup ref="scons_example_file.attlist"/>
     </xs:complexType>
   </xs:element>
@@ -2336,7 +2309,7 @@
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
         <xs:element ref="scons_output_command"/>
       </xs:choice>
       <xs:attributeGroup ref="scons_output.attlist"/>
@@ -2357,20 +2330,14 @@
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:A SCons example file. -->
-  <xs:element name="scons_output_command" substitutionGroup="linespecific.class">
+  <xs:element name="scons_output_command">
     <xs:complexType mixed="true">
       <xs:annotation>
         <xs:documentation xml:lang="en">
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.char.mix"/>
-        <xs:element ref="co"/>
-        <xs:element ref="coref"/>
-        <xs:element ref="lineannotation"/>
-        <xs:element ref="textobject"/>
-      </xs:choice>
+      <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="scons_output_command.attlist"/>
     </xs:complexType>
   </xs:element>
@@ -2387,48 +2354,18 @@
   <xs:attributeGroup name="sconsdoc.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
-  <!-- doc:A sconsdoc. -->
-  <xs:element name="sconsdoc" substitutionGroup="para.class">
-    <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element ref="tool"/>
-        <xs:element ref="builder"/>
-        <xs:element ref="scons_function"/>
-        <xs:element ref="cvar"/>
-      </xs:choice>
-      <xs:attributeGroup ref="sconsdoc.attlist"/>
-    </xs:complexType>
-  </xs:element>
-  <!-- end of sconsdoc.element -->
-  <xs:attributeGroup name="sconsdoc.attlist">
-    <xs:attributeGroup ref="common.attrib"/>
-    <xs:attributeGroup ref="sconsdoc.role.attrib"/>
-  </xs:attributeGroup>
-  <!-- end of sconsdoc.attlist -->
-  <!-- end of sconsdoc.module -->
   <xs:attributeGroup name="example_commands.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
   <!-- doc:Text that a user sees or might see on a computer screen. -->
-  <xs:element name="example_commands" substitutionGroup="linespecific.class">
+  <xs:element name="example_commands">
     <xs:complexType mixed="true">
       <xs:annotation>
         <xs:documentation xml:lang="en">
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.char.mix"/>
-        <xs:element ref="co"/>
-        <xs:element ref="coref"/>
-        <xs:element ref="textobject"/>
-        <xs:element ref="lineannotation"/>
-      </xs:choice>
+      <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="example_commands.attlist"/>
     </xs:complexType>
   </xs:element>
@@ -2466,7 +2403,7 @@
   </xs:attributeGroup>
   <!-- end of summary.attlist -->
   <!-- end of summary.module -->
-  
+
   <xs:attributeGroup name="item.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
@@ -2577,85 +2514,6 @@
   </xs:attributeGroup>
   <!-- end of uses.attlist -->
   <!-- end of uses.module -->
-  <xs:attributeGroup name="tool.role.attrib">
-    <xs:attributeGroup ref="role.attrib"/>
-  </xs:attributeGroup>
-  <!-- doc:A paragraph. -->
-  <xs:element name="tool" substitutionGroup="para.class">
-    <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.mix"/>
-        <xs:group ref="tool.mix"/>
-      </xs:choice>
-      <xs:attributeGroup ref="tool.attlist"/>
-    </xs:complexType>
-  </xs:element>
-  <!-- end of tool.element -->
-  <xs:attributeGroup name="tool.attlist">
-    <xs:attributeGroup ref="common.attrib"/>
-    <xs:attributeGroup ref="tool.role.attrib"/>
-    <xs:attribute name="name" type="xs:string" use="required" />
-  </xs:attributeGroup>
-  <!-- end of tool.attlist -->
-  <!-- end of tool.module -->
-  <xs:attributeGroup name="builder.role.attrib">
-    <xs:attributeGroup ref="role.attrib"/>
-  </xs:attributeGroup>
-  <!-- doc:A paragraph. -->
-  <xs:element name="builder" substitutionGroup="para.class">
-    <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.mix"/>
-        <xs:group ref="tool.mix"/>
-      </xs:choice>
-      <xs:attributeGroup ref="builder.attlist"/>
-    </xs:complexType>
-  </xs:element>
-  <!-- end of builder.element -->
-  <xs:attributeGroup name="builder.attlist">
-    <xs:attributeGroup ref="common.attrib"/>
-    <xs:attributeGroup ref="builder.role.attrib"/>
-    <xs:attribute name="name" type="xs:string" use="required" />
-  </xs:attributeGroup>
-  <!-- end of builder.attlist -->
-  <!-- end of builder.module -->
-  
-  <xs:attributeGroup name="cvar.role.attrib">
-    <xs:attributeGroup ref="role.attrib"/>
-  </xs:attributeGroup>
-  <!-- doc:A paragraph. -->
-  <xs:element name="cvar" substitutionGroup="para.class">
-    <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.mix"/>
-        <xs:element ref="summary"/>
-      </xs:choice>
-      <xs:attributeGroup ref="cvar.attlist"/>
-    </xs:complexType>
-  </xs:element>
-  <!-- end of cvar.element -->
-  <xs:attributeGroup name="cvar.attlist">
-    <xs:attributeGroup ref="common.attrib"/>
-    <xs:attributeGroup ref="cvar.role.attrib"/>
-    <xs:attribute name="name" type="xs:string" use="required" />
-  </xs:attributeGroup>
-  <!-- end of cvar.attlist -->
-  <!-- end of cvar.module -->
   <xs:attributeGroup name="arguments.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
@@ -2667,15 +2525,7 @@
           TODO
         </xs:documentation>
       </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.char.mix"/>
-        <xs:element ref="graphic"/>
-        <xs:element ref="mediaobject"/>
-        <xs:element ref="co"/>
-        <xs:element ref="coref"/>
-        <xs:element ref="textobject"/>
-        <xs:element ref="lineannotation"/>
-      </xs:choice>
+      <xs:group ref="para.char.mix"/>
       <xs:attributeGroup ref="arguments.attlist"/>
     </xs:complexType>
   </xs:element>
@@ -2690,33 +2540,7 @@
   </xs:attributeGroup>
   <!-- end of arguments.attlist -->
   <!-- end of arguments.module -->
-  <xs:attributeGroup name="scons_function.role.attrib">
-    <xs:attributeGroup ref="role.attrib"/>
-  </xs:attributeGroup>
-  <!-- doc:A paragraph. -->
-  <xs:element name="scons_function" substitutionGroup="para.class">
-    <xs:complexType mixed="true">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          TODO
-        </xs:documentation>
-      </xs:annotation>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="para.char.mix"/>
-        <xs:group ref="para.mix"/>
-        <xs:group ref="scons_function.mix"/>
-      </xs:choice>
-      <xs:attributeGroup ref="scons_function.attlist"/>
-    </xs:complexType>
-  </xs:element>
-  <!-- end of scons_function.element -->
-  <xs:attributeGroup name="scons_function.attlist">
-    <xs:attributeGroup ref="common.attrib"/>
-    <xs:attributeGroup ref="scons_function.role.attrib"/>
-    <xs:attribute name="name" type="xs:string" use="required" />
-  </xs:attributeGroup>
-  <!-- end of scons_function.attlist -->
-  <!-- end of scons_function.module -->
+
   <xs:attributeGroup name="admon.role.attrib">
     <xs:attributeGroup ref="role.attrib"/>
   </xs:attributeGroup>
@@ -3405,26 +3229,26 @@
   <!--
     Units: global unit of measure in which coordinates in
     this spec are expressed:
-    
+
     - CALSPair "x1,y1 x2,y2": lower-left and upper-right
     coordinates in a rectangle describing repro area in which
     graphic is placed, where X and Y dimensions are each some
     number 0..10000 (taken from CALS graphic attributes)
-    
+
     - LineColumn "line column": line number and column number
     at which to start callout text in "linespecific" content
-    
+
     - LineRange "startline endline": whole lines from startline
     to endline in "linespecific" content
-    
+
     - LineColumnPair "line1 col1 line2 col2": starting and ending
     points of area in "linespecific" content that starts at
     first position and ends at second position (including the
     beginnings of any intervening lines)
-    
+
     - Other: directive to look at value of OtherUnits attribute
     to get implementation-specific keyword
-    
+
     The default is implementation-specific; usually dependent on
     the parent element (GraphicCO gets CALSPair, ProgramListingCO
     and ScreenCO get LineColumn)

--- a/doc/xsd/xml.xsd
+++ b/doc/xsd/xml.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
            elementFormDefault="qualified"
            targetNamespace="http://www.w3.org/XML/1998/namespace">
-  <xs:import schemaLocation="scons.xsd"/>
+  <xs:import schemaLocation="scons.xsd" namespace="http://www.scons.org/dbxsd/v1.0"/>
   <xs:attribute name="base"/>
   <xs:attribute name="space">
     <xs:simpleType>


### PR DESCRIPTION
## Overview of changes
Back when I created the first version of the SCons DocBook XSD, a lot of cruft was added by copy-n-paste. In addition, most SCons tags were allowed to appear 'almost everywhere', leading to it being reported as "not deterministic" by some XML scanners/validators.

This got corrected, and the new grammar is much stricter now, regarding where SCons-specific XML tags may be used. 
I also had to patch doc files in several places accordingly.

## Contributor Checklist:

* [x] I have tested the new XSD by running "docs-validate.py", "docs-update-generated.py" and a full release build locally.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`).
* [x] I have checked whether the appropriate documentation should be updated, but found this to be n/a.
