### PR TITLE
Add a tag to the cachedir

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,7 +15,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Joseph Brill:
     - Added error handling when creating MS VC detection debug log file specified by
       SCONS_MSCOMMON_DEBUG
-      
+
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access
       /etc/paths.d. This may occur if SCons is invoked in a sandboxed
@@ -71,6 +71,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Skip running a few validation tests if the user is root and the test is
       not designed to work for the root user.
     - Clarify documentation of Repository() in manpage and user guide.
+    - Add a tag to each CacheDir to let systems ignore backing it up
+      (per https://bford.info/cachedir/). Update the way a CacheDir
+      is created, since it now has to create two files.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -33,7 +33,12 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   keyword arguments to Builder calls (or manually, through the
   undocumented Override method), were modified not to "leak" on item deletion.
   The item will now not be deleted from the base environment.
+
 - Added support for tracking beamer themes in the LaTeX scanner.
+
+- Add a tag to each CacheDir to let systems ignore backing it up
+  (per https://bford.info/cachedir/). Update the way a CacheDir
+  is created, since it now has to create two files.
 
 FIXES
 -----

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -29,12 +29,19 @@ import json
 import os
 import stat
 import sys
+import tempfile
 import uuid
 
 import SCons.Action
 import SCons.Errors
 import SCons.Warnings
 import SCons.Util
+
+CACHE_PREFIX_LEN = 2  # first two characters used as subdirectory name
+CACHE_TAG = (
+    b"Signature: 8a477f597d28d172789f06886806bc55\n"
+    b"# SCons cache directory - see https://bford.info/cachedir/\n"
+)
 
 cache_enabled = True
 cache_debug = False
@@ -67,20 +74,20 @@ def CacheRetrieveFunc(target, source, env) -> int:
         fs.chmod(t.get_internal_path(), stat.S_IMODE(st[stat.ST_MODE]) | stat.S_IWRITE)
     return 0
 
-def CacheRetrieveString(target, source, env) -> None:
+def CacheRetrieveString(target, source, env) -> str:
     t = target[0]
     fs = t.fs
     cd = env.get_CacheDir()
     cachedir, cachefile = cd.cachepath(t)
     if t.fs.exists(cachefile):
         return "Retrieved `%s' from cache" % t.get_internal_path()
-    return None
+    return ""
 
 CacheRetrieve = SCons.Action.Action(CacheRetrieveFunc, CacheRetrieveString)
 
 CacheRetrieveSilent = SCons.Action.Action(CacheRetrieveFunc, None)
 
-def CachePushFunc(target, source, env):
+def CachePushFunc(target, source, env) -> None:
     if cache_readonly:
         return
 
@@ -134,8 +141,7 @@ CachePush = SCons.Action.Action(CachePushFunc, None)
 class CacheDir:
 
     def __init__(self, path) -> None:
-        """
-        Initialize a CacheDir object.
+        """Initialize a CacheDir object.
 
         The cache configuration is stored in the object. It
         is read from the config file in the supplied path if
@@ -147,53 +153,97 @@ class CacheDir:
         self.path = path
         self.current_cache_debug = None
         self.debugFP = None
-        self.config = dict()
-        if path is None:
-            return
+        self.config = {}
+        if path is not None:
+            self._readconfig(path)
 
-        self._readconfig(path)
+    def _add_config(self, path: str) -> None:
+        """Create the cache config file in *path*.
 
-
-    def _readconfig(self, path):
-        """
-        Read the cache config.
-
-        If directory or config file do not exist, create.  Take advantage
-        of Py3 capability in os.makedirs() and in file open(): just try
-        the operation and handle failure appropriately.
-
-        Omit the check for old cache format, assume that's old enough
-        there will be none of those left to worry about.
-
-        :param path: path to the cache directory
+        Locking isn't necessary in the normal case - when the cachedir is
+        being created - because it's written to a unique directory first,
+        before the directory is renamed. But it is legal to call CacheDir
+        with an existing directory, which may be missing the config file,
+        and in that case we do need locking. Simpler to always lock.
         """
         config_file = os.path.join(path, 'config')
+        # TODO: this breaks the "unserializable config object" test which
+        #   does some crazy stuff, so for now don't use setdefault. It does
+        #   seem like it would be better to preserve an exisiting value.
+        # self.config.setdefault('prefix_len', CACHE_PREFIX_LEN)
+        self.config['prefix_len'] = CACHE_PREFIX_LEN
+        with SCons.Util.FileLock(config_file, timeout=5, writer=True), open(
+            config_file, "x"
+        ) as config:
+            try:
+                json.dump(self.config, config)
+            except Exception:
+                msg = "Failed to write cache configuration for " + path
+                raise SCons.Errors.SConsEnvironmentError(msg)
+
+        # Add the tag file "carelessly" - the contents are not used by SCons
+        # so we don't care about the chance of concurrent writes.
         try:
-            # still use a try block even with exist_ok, might have other fails
-            os.makedirs(path, exist_ok=True)
-        except OSError:
-            msg = "Failed to create cache directory " + path
-            raise SCons.Errors.SConsEnvironmentError(msg)
+            tagfile = os.path.join(path, "CACHEDIR.TAG")
+            with open(tagfile, 'xb') as cachedir_tag:
+                cachedir_tag.write(CACHE_TAG)
+        except FileExistsError:
+            pass
+
+    def _mkdir_atomic(self, path: str) -> bool:
+        """Create cache directory at *path*.
+
+        Uses directory renaming to avoid races.  If we are actually
+        creating the dir, populate it with the metadata files at the
+        same time as that's the safest way. But it's not illegal to point
+        CacheDir at an existing directory that wasn't a cache previously,
+        so we may have to do that elsewhere, too.
+
+        Returns:
+            ``True`` if it we created the dir, ``False`` if already existed,
+
+        Raises:
+            SConsEnvironmentError: if we tried and failed to create the cache.
+        """
+        directory = os.path.abspath(path)
+        if os.path.exists(directory):
+            return False
 
         try:
-            with SCons.Util.FileLock(config_file, timeout=5, writer=True), open(
-                config_file, "x"
-            ) as config:
-                self.config['prefix_len'] = 2
-                try:
-                    json.dump(self.config, config)
-                except Exception:
-                    msg = "Failed to write cache configuration for " + path
-                    raise SCons.Errors.SConsEnvironmentError(msg)
-        except FileExistsError:
+            tempdir = tempfile.TemporaryDirectory(dir=os.path.dirname(directory))
+        except OSError as e:
+            msg = "Failed to create cache directory " + path
+            raise SCons.Errors.SConsEnvironmentError(msg) from e
+        self._add_config(tempdir.name)
+        with tempdir:
             try:
-                with SCons.Util.FileLock(config_file, timeout=5, writer=False), open(
-                    config_file
-                ) as config:
-                    self.config = json.load(config)
-            except (ValueError, json.decoder.JSONDecodeError):
-                msg = "Failed to read cache configuration for " + path
-                raise SCons.Errors.SConsEnvironmentError(msg)
+                os.rename(tempdir.name, directory)
+                return True
+            except Exception as e:
+                # did someone else get there first?
+                if os.path.isdir(directory):
+                    return False
+                msg = "Failed to create cache directory " + path
+                raise SCons.Errors.SConsEnvironmentError(msg) from e
+
+    def _readconfig(self, path: str) -> None:
+        """Read the cache config from *path*.
+
+        If directory or config file do not exist, create and populate.
+        """
+        config_file = os.path.join(path, 'config')
+        created = self._mkdir_atomic(path)
+        if not created and not os.path.isfile(config_file):
+            # Could have been passed an empty directory
+            self._add_config(path)
+        try:
+            with SCons.Util.FileLock(config_file, timeout=5, writer=False), open(
+                config_file
+            ) as config:
+                self.config = json.load(config)
+        except (ValueError, json.decoder.JSONDecodeError):
+            msg = "Failed to read cache configuration for " + path
+            raise SCons.Errors.SConsEnvironmentError(msg)
 
     def CacheDebug(self, fmt, target, cachefile) -> None:
         if cache_debug != self.current_cache_debug:
@@ -252,7 +302,7 @@ class CacheDir:
     def is_readonly(self) -> bool:
         return cache_readonly
 
-    def get_cachedir_csig(self, node):
+    def get_cachedir_csig(self, node) -> str:
         cachedir, cachefile = self.cachepath(node)
         if cachefile and os.path.exists(cachefile):
             return SCons.Util.hash_file_signature(cachefile, SCons.Node.FS.File.hash_chunksize)

--- a/test/CacheDir/CacheDir.py
+++ b/test/CacheDir/CacheDir.py
@@ -41,7 +41,7 @@ src_ccc_out = test.workpath('src', 'ccc.out')
 src_cat_out = test.workpath('src', 'cat.out')
 src_all = test.workpath('src', 'all')
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 test.write(['src', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
@@ -84,8 +84,12 @@ test.must_not_exist(src_bbb_out)
 test.must_not_exist(src_ccc_out)
 test.must_not_exist(src_all)
 # Even if you do -n, the cache will be configured.
-test.fail_test(os.listdir(cache) != ['config'])
-
+expect = ['CACHEDIR.TAG', 'config']
+found = sorted(os.listdir(cache))
+test.fail_test(
+    expect != found,
+    message=f"expected cachedir contents {expect}, found {found}",
+)
 # Verify that a normal build works correctly, and clean up.
 # This should populate the cache with our derived files.
 test.run(chdir = 'src', arguments = '.')

--- a/test/CacheDir/CacheDir_TryCompile.py
+++ b/test/CacheDir/CacheDir_TryCompile.py
@@ -38,7 +38,7 @@ test = TestSCons.TestSCons()
 
 cache = test.workpath('cache')
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 test.write(['src', 'SConstruct'], """\
 DefaultEnvironment(tools=[])

--- a/test/CacheDir/NoCache.py
+++ b/test/CacheDir/NoCache.py
@@ -31,7 +31,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'alpha', 'beta')
+test.subdir('alpha', 'beta')
 
 sconstruct = """
 DefaultEnvironment(tools=[])

--- a/test/CacheDir/SideEffect.py
+++ b/test/CacheDir/SideEffect.py
@@ -31,7 +31,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'work')
+test.subdir('work')
 
 cache = test.workpath('cache')
 

--- a/test/CacheDir/VariantDir.py
+++ b/test/CacheDir/VariantDir.py
@@ -33,7 +33,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 cache = test.workpath('cache')
 cat_out = test.workpath('cat.out')

--- a/test/CacheDir/debug.py
+++ b/test/CacheDir/debug.py
@@ -36,7 +36,7 @@ import TestSCons
 
 test = TestSCons.TestSCons(match=TestSCons.match_re)
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 cache = test.workpath('cache')
 debug_out = test.workpath('cache-debug.out')

--- a/test/CacheDir/environment.py
+++ b/test/CacheDir/environment.py
@@ -42,7 +42,7 @@ src_ccc_out = test.workpath('src', 'ccc.out')
 src_cat_out = test.workpath('src', 'cat.out')
 src_all = test.workpath('src', 'all')
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 test.write(['src', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
@@ -87,7 +87,12 @@ test.must_not_exist(src_bbb_out)
 test.must_not_exist(src_ccc_out)
 test.must_not_exist(src_all)
 # Even if you do -n, the cache will be configured.
-test.fail_test(os.listdir(cache) != ['config'])
+expect = ['CACHEDIR.TAG', 'config']
+found = sorted(os.listdir(cache))
+test.fail_test(
+    expect != found,
+    message=f"expected cachedir contents {expect}, found {found}",
+)
 
 # Verify that a normal build works correctly, and clean up.
 # This should populate the cache with our derived files.

--- a/test/CacheDir/multi-targets.py
+++ b/test/CacheDir/multi-targets.py
@@ -31,7 +31,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'multiple')
+test.subdir('multiple')
 
 cache = test.workpath('cache')
 

--- a/test/CacheDir/multiple-targets.py
+++ b/test/CacheDir/multiple-targets.py
@@ -32,8 +32,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache')
-
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def touch(env, source, target):

--- a/test/CacheDir/option--cd.py
+++ b/test/CacheDir/option--cd.py
@@ -33,7 +33,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 test.write(['src', 'SConstruct'], """
 DefaultEnvironment(tools=[])

--- a/test/CacheDir/option--cf.py
+++ b/test/CacheDir/option--cf.py
@@ -34,7 +34,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 test.write(['src', 'SConstruct'], """
 DefaultEnvironment(tools=[])
@@ -88,7 +88,6 @@ test.up_to_date(chdir = 'src', arguments = '.')
 # Blow away and recreate the CacheDir, then verify that --cache-force
 # repopulates the cache with the local built targets.  DO NOT CLEAN UP.
 shutil.rmtree(test.workpath('cache'))
-test.subdir('cache')
 
 test.run(chdir = 'src', arguments = '--cache-force .')
 
@@ -106,7 +105,6 @@ test.fail_test(os.path.exists(test.workpath('src', 'cat.out')))
 # Blow away and recreate the CacheDir, then verify that --cache-populate
 # repopulates the cache with the local built targets.  DO NOT CLEAN UP.
 shutil.rmtree(test.workpath('cache'))
-test.subdir('cache')
 
 test.run(chdir = 'src', arguments = '--cache-populate .')
 

--- a/test/CacheDir/option--cr.py
+++ b/test/CacheDir/option--cr.py
@@ -33,7 +33,7 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'src')
+test.subdir('src')
 
 test.write(['src', 'SConstruct'], """
 DefaultEnvironment(tools=[])

--- a/test/CacheDir/option--cs.py
+++ b/test/CacheDir/option--cs.py
@@ -38,7 +38,7 @@ _obj = TestSCons._obj
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'src1', 'src2')
+test.subdir('src1', 'src2')
 
 test.write(['src1', 'build.py'], r"""
 import sys
@@ -63,7 +63,7 @@ def cat(env, source, target):
                 f.write(f2.read())
 
 DefaultEnvironment(tools=[])  # test speedup
-env = Environment(tools=[], 
+env = Environment(tools=[],
                   BUILDERS={'Internal':Builder(action=cat),
                             'External':Builder(action=r'%(_python_)s build.py $TARGET $SOURCES')})
 env.External('aaa.out', 'aaa.in')

--- a/test/CacheDir/scanner-target.py
+++ b/test/CacheDir/scanner-target.py
@@ -35,8 +35,6 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache')
-
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 import SCons

--- a/test/CacheDir/source-scanner.py
+++ b/test/CacheDir/source-scanner.py
@@ -39,7 +39,7 @@ test = TestSCons.TestSCons()
 
 cache = test.workpath('cache')
 
-test.subdir('cache', 'subdir')
+test.subdir('subdir')
 
 test.write(['subdir', 'SConstruct'], """\
 DefaultEnvironment(tools=[])

--- a/test/CacheDir/up-to-date-q.py
+++ b/test/CacheDir/up-to-date-q.py
@@ -39,19 +39,19 @@ Thanks to dvitek for the test case.
 # 1. Set up two identical C project directories called 'alpha' and
 #    'beta', which use the same cache
 # 2. Invoke scons on 'alpha'
-# 3. Invoke scons on 'beta', which successfully draws output 
+# 3. Invoke scons on 'beta', which successfully draws output
 #    files from the cache
 # 4. Invoke scons again, asserting (with -q) that 'beta' is up to date
 #
 # Step 4 failed in 0.96.93.  In practice, this problem would lead to
-# lots of unecessary fetches from the cache during incremental 
+# lots of unecessary fetches from the cache during incremental
 # builds (because they behaved like non-incremental builds).
 
 import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.subdir('cache', 'alpha', 'beta')
+test.subdir('alpha', 'beta')
 
 foo_c = """
 int main(void){ return 0; }

--- a/test/CacheDir/value_dependencies.py
+++ b/test/CacheDir/value_dependencies.py
@@ -37,7 +37,6 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.dir_fixture('value_dependencies')
-test.subdir('cache')
 
 # First build, populates the cache
 test.run(arguments='.')


### PR DESCRIPTION
Since there are now two files to make when a cachedir is created, use the temporary-dir -> rename technique.

`CacheDir` tests no longer pre-create the cache directory, they should be verifying it's created properly upon request (one unit test still makes sure passing an existing empty directory works, too).

There are no externally visible changes (except the new tag file if someone goes and explicitly looks, but that's an "implementation detail", not part of the behavior).

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
