### PR TITLE
WIP: experimental support for diskcache-style (sqlite backed) sconsign

### DIFF
--- a/SCons/SConsignTests.py
+++ b/SCons/SConsignTests.py
@@ -300,13 +300,15 @@ class SConsignFileTestCase(SConsignTestCase):
             assert SCons.SConsign.DB_Name == ".sconsign", SCons.SConsign.DB_Name
         else:
             assert SCons.SConsign.DB_Name == ".sconsign_{}".format(get_current_hash_algorithm_used()), SCons.SConsign.DB_Name
-        assert SCons.SConsign.DB_Module is SCons.dblite, SCons.SConsign.DB_Module
+        #assert SCons.SConsign.DB_Module is SCons.dblite, SCons.SConsign.DB_Module
+        assert SCons.SConsign.DB_Module is SCons.sdiskcache, SCons.SConsign.DB_Module
 
         SCons.SConsign.File(file)
 
         assert SCons.SConsign.DataBase == {}, SCons.SConsign.DataBase
         assert SCons.SConsign.DB_Name is file, SCons.SConsign.DB_Name
-        assert SCons.SConsign.DB_Module is SCons.dblite, SCons.SConsign.DB_Module
+        #assert SCons.SConsign.DB_Module is SCons.dblite, SCons.SConsign.DB_Module
+        assert SCons.SConsign.DB_Module is SCons.sdiskcache, SCons.SConsign.DB_Module
 
         SCons.SConsign.File(None)
 

--- a/SCons/sdiskcache.py
+++ b/SCons/sdiskcache.py
@@ -1,0 +1,254 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""SConsign support for diskcache. """
+
+import os
+from collections.abc import KeysView, ValuesView, ItemsView
+import diskcache
+
+DISKCACHE_SUFFIX = '.sqlite'
+DEBUG = False
+
+
+class _Diskcache:
+    """Processing of sconsign databases using diskcache.
+
+    Derived from the SCons dblite module, but much simpler, because
+    there's no exit processing needed - diskcache keeps a consistent
+    sqlite database under the covers.  We don't map prefectly,
+    since the dblite implementation leaks through into the model:
+    plenty of code expects the in-memory sconsign DB to not
+    be backed to disk _except_ on close.
+
+    Most of this is a thin wrapper around a diskcache.Cache,
+    which is stored in the _dict attribute - the "in-memory" copy.
+
+    We do want to add a few behaviors: some instances can be
+    read-only (e.g. if they are found in a repository we don't update);
+    to mirror the dbm/dblite behavior of open flags, "r" and "w"
+    expect the DB file to actually exist while "n" means it should
+    be emptied (that is, "new"); and we want to make sure there's
+    a keys method at least.
+
+    The optional *flag* argument is as for :meth:`dbm.open`.
+
+    +---------+---------------------------------------------------+
+    | Value   | Meaning                                           |
+    +=========+===================================================+
+    | ``'r'`` | Open existing database for reading only (default) |
+    +---------+---------------------------------------------------+
+    | ``'w'`` | Open existing database for reading and  writing   |
+    +---------+---------------------------------------------------+
+    | ``'c'`` | Open database for reading and writing, creating   |
+    |         | it if it doesn't exist                            |
+    +---------+---------------------------------------------------+
+    | ``'n'`` | Always create a new, empty database, open for     |
+    |         | reading and writing                               |
+    +---------+---------------------------------------------------+
+
+    Arguments:
+        file_base_name: name of db, will get DISKCACHE_SUFFIX if not present
+        flag: opening mode
+        mode: UNIX-style mode of DB files (see dbm.open), unused here.
+    """
+
+    def __init__(self, file_base_name: str, flag: str = 'r', _: int = 0x000) -> None:
+        assert flag in ("r", "w", "c", "n")
+
+        if file_base_name.endswith(DISKCACHE_SUFFIX):
+            # There's already a suffix on the file name, don't add one.
+            self._dir_name = file_base_name
+        else:
+            self._dir_name = file_base_name + DISKCACHE_SUFFIX
+
+        if not os.path.isdir(self._dir_name) and flag in ('r', 'w'):
+            raise FileNotFoundError(f"No such sconsign database: {self._dir_name}")
+        self._dict = diskcache.Cache(self._dir_name)
+        self._writable: bool = flag not in ("r",)
+        if DEBUG:
+            print(
+                f"DEBUG: opened a Cache file {self._dir_name} (writable={self._writable})"
+            )
+        if flag == "n":
+            self.clear()
+
+    def check(self, fix=False, retry=False):
+        """Call disckache 'check' routine to verify cache."""
+        self._dict.check(fix, retry)
+
+    @staticmethod
+    def close() -> None:
+        """Close the Cache file.
+
+        This exists in the SCons model because other sconsigns are
+        plain file backed, here it's a no-op.
+        """
+        return
+
+    def __getitem__(self, key):
+        """Return corresponding value for *key* from cache."""
+        return self._dict[key]
+
+    def __setitem__(self, key, value) -> None:
+        """Set correspoding *value* for *key* in cache.
+
+        Cache can be in a read-only state, just skip if so.
+        TODO: raise error instead?
+        """
+        if self._writable:
+            self._dict[key] = value
+
+    def keys(self):
+        return KeysView(self._dict)
+
+    def items(self):
+        return ItemsView(self._dict)
+
+    def values(self):
+        return ValuesView(self._dict)
+
+    def has_key(self, key) -> bool:
+        return key in self._dict
+
+    def __contains__(self, key) -> bool:
+        """Return ``True`` if *key* is found in cache."""
+        return key in self._dict
+
+    __iter__ = keys
+
+    def __len__(self) -> int:
+        """Count of items in cache including expired."""
+        return len(self._dict)
+
+    def clear(self):
+        """Remove all items from cache."""
+        return self._dict.clear()
+
+    def volume(self):
+        """Return estimated total size of cache on disk."""
+        return self._dict.volume()
+
+    def stats(self):
+        """Return cache statistics hits and misses."""
+        return self._dict.stats()
+
+    def expire(self, now=None, retry=False):
+        """Remove expired items from cache."""
+        return self._dict.expire(now, retry)
+
+    def cull(self, retry=False):
+        """Cull items from cache until volume is less than size limit."""
+        return self._dict.cull(retry)
+
+    def evict(self, tag, retry=False):
+        """Remove items with matching *tag* from cache."""
+        return self._dict.evict(tag, retry)
+
+
+def open(  # pylint: disable=redefined-builtin
+    file: str, flags: str = "r", mode: int = 0o666
+) -> _Diskcache:
+    return _Diskcache(file, flags, mode)
+
+
+def _exercise():
+    import tempfile  # pylint: disable=import-outside-toplevel
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # reading a nonexistent file with mode 'r' should fail
+        try:
+            test_cache = open(tmp + "_", "r")
+        except FileNotFoundError:
+            pass
+        else:
+            raise RuntimeError("FileNotFoundError exception expected")
+
+        # create mode creates test_cache
+        test_cache = open(tmp, "c")
+        assert len(test_cache) == 0, len(test_cache)
+        test_cache["bar"] = "foo"
+        assert test_cache["bar"] == "foo"
+        assert len(test_cache) == 1, len(test_cache)
+        test_cache.close()
+
+        # new database should be empty
+        test_cache = open(tmp, "n")
+        assert len(test_cache) == 0, len(test_cache)
+        test_cache["foo"] = "bar"
+        assert test_cache["foo"] == "bar"
+        assert len(test_cache) == 1, len(test_cache)
+        test_cache.close()
+
+        # write mode is just normal
+        test_cache = open(tmp, "w")
+        assert len(test_cache) == 1, len(test_cache)
+        assert test_cache["foo"] == "bar"
+        test_cache["bar"] = "foo"
+        assert len(test_cache) == 2, len(test_cache)
+        assert test_cache["bar"] == "foo"
+        test_cache.close()
+
+        # read-only database should silently fail to add
+        test_cache = open(tmp, "r")
+        assert len(test_cache) == 2, len(test_cache)
+        assert test_cache["foo"] == "bar"
+        assert test_cache["bar"] == "foo"
+        test_cache["ping"] = "pong"
+        assert len(test_cache) == 2, len(test_cache)
+        try:
+            test_cache["ping"]
+        except KeyError:
+            pass
+        else:
+            raise RuntimeError("KeyError exception expected")
+        test_cache.close()
+
+        # test iterators
+        test_cache = open(tmp, 'w')
+        test_cache["foobar"] = "foobar"
+        assert len(test_cache) == 3, len(test_cache)
+        expected = {"foo": "bar", "bar": "foo", "foobar": "foobar"}
+        assert dict(test_cache) == expected, f"{test_cache} != {expected}"
+        key = sorted(test_cache.keys())
+        exp = sorted(expected.keys())
+        assert key == exp, f"{key} != {exp}"
+        key = sorted(test_cache.values())
+        exp = sorted(expected.values())
+        assert key == exp, f"{key} != {exp}"
+        key = sorted(test_cache.items())
+        exp = sorted(expected.items())
+        assert key == exp, f"{key} != {exp}"
+        test_cache.close()
+
+    print("Completed _exercise()")
+
+
+if __name__ == "__main__":
+    _exercise()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
This is a low-touch conversion to use an sqlite backend instead of a flat "dblite" file for the sconsign database, without really changing SCons logic - but includes some hacks where rather than full detection, things are just commented out.

New `SCons/sdiskcache.py` module supports diskcache usage.

Definitely not ready to merge.

diskcache: https://pypi.org/project/diskcache/ and https://grantjenks.com/docs/diskcache/

Experimental: with a `--convert` flag, sconsign utility will read an existing sconsign file and set up a sqlite-backed Diskcache in `.sconsign.sqlite`.

=========================
TODO on the testing front:

* `test/Repository`: fiddling the "writable" attribute in the framework doesn't help, sqlite db opened unwritable is always unwritable, Get: `OperationalError : attempt to write a readonly database`. Affects:
```
    test/Repository/Install-Local.py
    test/Repository/Local.py
    test/Repository/SharedLibrary.py
    test/Repository/StaticLibrary.py
    test/Repository/VariantDir.py
    test/Repository/link-object.py
    test/Repository/option-n.py
    test/Repository/variants.py
```

* `test/Configure/VariantDir-SConscript.py`: hardcodes `.dblite` as the DB suffix.
* `test/Configure/implicit-cache.py`: hardcodes `.dblite` as the DB suffix.
* `test/SConsignFile/default.py`: hardcodes `.dblite` as the DB suffix
* `test/SConsignFile/explicit-file.py`: hardcodes `.dblite` as the DB suffix
* `test/option/hash-format.py`: why does this do an assert, anyway?  e.g. `Missing files: /tmp/scons/testcmd.305909.0g2s8ny7/.sconsign.dblite`
* `test/sconsign/corrupt.py`: hardcodes `.dblite`.  Since it's not a flat file, corrupt is different. Expose `Cache.check()`?
* `test/sconsign/script/Configure.py`: currently hitting unpickled data
* `test/sconsign/script/dblite.py`: possibly should just not run, but maybe add parallel one for sdiskcache
* `test/option/option-n.py`: see FW
* `testing/framework/TestSCons.py`: `get_sconsignname`, `unlink_sconsignfile` don't work for sqlite db
* Some tests should use `unlink_sconsignfile`(possibly renamed) that don't. From a grep:
```
  test/Configure/VariantDir-SConscript.py
  test/MSVS/vs-10.0-exec.py
  test/MSVS/vs-10.0Exp-exec.py
  test/MSVS/vs-11.0-exec.py
  test/MSVS/vs-11.0Exp-exec.py
  test/MSVS/vs-14.0-exec.py
  test/MSVS/vs-14.0Exp-exec.py
  test/MSVS/vs-14.1-exec.py
  test/MSVS/vs-14.2-exec.py
  test/MSVS/vs-14.3-exec.py
  test/MSVS/vs-6.0-exec.py
  test/MSVS/vs-7.0-exec.py
  test/MSVS/vs-7.1-exec.py
  test/MSVS/vs-8.0-exec.py
  test/MSVS/vs-8.0Exp-exec.py
  test/MSVS/vs-9.0-exec.py
  test/MSVS/vs-9.0Exp-exec.py
  test/option/option-n.py
  test/option/hash-format.py
```

* test/SConsignFile` - Check - may need work, or may be unique to file-based.  may need equivalent one for DB versions?


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
