### PR TITLE
Add Beamer Theme Support for LaTeX Scanner

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,9 +15,17 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Joseph Brill:
     - Added error handling when creating MS VC detection debug log file specified by
       SCONS_MSCOMMON_DEBUG
+      
+  From Alex James:
+    - On Darwin, PermissionErrors are now handled while trying to access
+      /etc/paths.d. This may occur if SCons is invoked in a sandboxed
+      environment (such as Nix).
 
   From Dillan Mills:
     - Fix support for short options (`-x`).
+
+  From Keith F Prussing:
+    - Added support for tracking beamer themes in the LaTeX scanner.
 
   From Mats Wichmann:
     - PackageVariable now does what the documentation always said it does
@@ -60,14 +68,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Change long-standing irritant in Environment tests - instead of using
       a while loop to pull test info from a list of tests and then delete
       the test, structure the test data as a list of tuples and iterate it.
-
-  From Alex James:
-    - On Darwin, PermissionErrors are now handled while trying to access
-      /etc/paths.d. This may occur if SCons is invoked in a sandboxed
-      environment (such as Nix).
-
-  From Keith F Prussing:
-    - Added support for tracking beamer themes in the LaTeX scanner.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -66,6 +66,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       /etc/paths.d. This may occur if SCons is invoked in a sandboxed
       environment (such as Nix).
 
+  From Keith F Prussing:
+    - Added support for tracking beamer themes in the LaTeX scanner.
+
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -33,6 +33,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   keyword arguments to Builder calls (or manually, through the
   undocumented Override method), were modified not to "leak" on item deletion.
   The item will now not be deleted from the base environment.
+- Added support for tracking beamer themes in the LaTeX scanner.
 
 FIXES
 -----

--- a/SCons/Scanner/LaTeX.py
+++ b/SCons/Scanner/LaTeX.py
@@ -169,6 +169,11 @@ class LaTeX(ScannerBase):
                      'addsectionbib': 'BIBINPUTS',
                      'makeindex': 'INDEXSTYLE',
                      'usepackage': 'TEXINPUTS',
+                     'usetheme': 'TEXINPUTS',
+                     'usecolortheme': 'TEXINPUTS',
+                     'usefonttheme': 'TEXINPUTS',
+                     'useinnertheme': 'TEXINPUTS',
+                     'useoutertheme': 'TEXINPUTS',
                      'lstinputlisting': 'TEXINPUTS'}
     env_variables = SCons.Util.unique(list(keyword_paths.values()))
     two_arg_commands = ['import', 'subimport',
@@ -193,6 +198,7 @@ class LaTeX(ScannerBase):
               | addglobalbib
               | addsectionbib
               | usepackage
+              | use(?:|color|font|inner|outer)theme(?:\s*\[[^\]]+\])?
               )
                   \s*{([^}]*)}       # first arg
               (?: \s*{([^}]*)} )?    # maybe another arg
@@ -362,6 +368,9 @@ class LaTeX(ScannerBase):
                 if inc_type in self.two_arg_commands:
                     inc_subdir = os.path.join(subdir, include[1])
                     inc_list = include[2].split(',')
+                elif re.match('use(|color|font|inner|outer)theme', inc_type):
+                    inc_list = [re.sub('use', 'beamer', inc_type) + _ + '.sty' for _ in
+                                include[1].split(',')]
                 else:
                     inc_list = include[1].split(',')
                 for inc in inc_list:
@@ -411,7 +420,7 @@ class LaTeX(ScannerBase):
             if n is None:
                 # Do not bother with 'usepackage' warnings, as they most
                 # likely refer to system-level files
-                if inc_type != 'usepackage':
+                if inc_type != 'usepackage' or re.match("use(|color|font|inner|outer)theme", inc_type):
                     SCons.Warnings.warn(
                         SCons.Warnings.DependencyWarning,
                         "No dependency generated for file: %s "

--- a/SCons/Scanner/LaTeXTests.py
+++ b/SCons/Scanner/LaTeXTests.py
@@ -63,6 +63,18 @@ test.write('test4.latex',r"""
 \only<2>{\includegraphics{inc7.png}}
 """)
 
+test.write('test5.latex',r"""
+\usetheme{scons}
+""")
+test.write('beamerthemescons.sty',r"""
+\usecolortheme[option]{scons}
+\usefonttheme{scons}
+\useinnertheme{scons}
+\useoutertheme{scons}
+""")
+for theme in ('color', 'font', 'inner', 'outer'):
+    test.write('beamer' + theme + 'themescons.sty', "\n")
+
 test.subdir('subdir')
 
 test.write('inc1.tex',"\n")
@@ -165,6 +177,16 @@ class LaTeXScannerTestCase4(unittest.TestCase):
          path = s.path(env)
          deps = s(env.File('test4.latex'), env, path)
          files = ['inc1.tex', 'inc2.tex', 'inc5.xyz', 'inc7.png']
+         deps_match(self, deps, files)
+
+class LaTeXScannerTestCase5(unittest.TestCase):
+     def runTest(self) -> None:
+         env = DummyEnvironment(TEXINPUTS=[test.workpath("subdir")],LATEXSUFFIXES = [".tex", ".ltx", ".latex"])
+         s = SCons.Scanner.LaTeX.LaTeXScanner()
+         path = s.path(env)
+         deps = s(env.File('test5.latex'), env, path)
+         files = ['beamer' + _ + 'themescons.sty' for _ in
+                  ('color', 'font', 'inner', 'outer', '')]
          deps_match(self, deps, files)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds the support for recursively scanning beamer themes as discussed in #4620. It updates the LaTeX scanner to look for `\use(|color|font|inner|outer)theme{file}` and generate the correct file name to interrogate. Similar to the `\usepacakge`, it also avoids superfluous errors if the user may be relying on a theme that is installed at the system level.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
