### PR TITLE
Improve Repository docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Change long-standing irritant in Environment tests - instead of using
       a while loop to pull test info from a list of tests and then delete
       the test, structure the test data as a list of tuples and iterate it.
+    - Clarify documentation of Repository() in manpage and user guide.
 
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -90,7 +90,10 @@ DOCUMENTATION
   the contributor credit)
 
 - Some manpage cleanup for the gettext and pdf/ps builders.
+
 - Some clarifications in the User Guide "Environments" chapter.
+
+- Clarify documentation of Repository() in manpage and user guide.
 
 DEVELOPMENT
 -----------

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -1749,7 +1749,7 @@ class Base(SubstitutionEnvironment):
         Raises:
            ValueError: *format* is not a recognized serialization format.
 
-        .. versionchanged:: NEXT_VERSION
+        .. versionchanged:: NEXT_RELEASE
            *key* is no longer limited to a single construction variable name.
            If *key* is supplied, a formatted dictionary is generated like the
            no-arg case - previously a single *key* displayed just the value.

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -155,7 +155,7 @@ for more information.
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -166,7 +166,7 @@ for more information).
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -177,7 +177,7 @@ for more information).
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -188,7 +188,7 @@ for more information).
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -199,7 +199,7 @@ for more information).
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -210,7 +210,7 @@ for more information).
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -221,7 +221,7 @@ for more information).
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -232,7 +232,7 @@ for more information).
 <summary>
 <para>
 A reserved variable name
-that may not be set or used in a construction environment.
+that may not be set or used in a &consenv;.
 (See the manpage section "Variable Substitution"
 for more information).
 </para>
@@ -279,13 +279,12 @@ for a complete explanation of the arguments and behavior.
 <para>
 Note that the &f-env-Action;
 form of the invocation will expand
-construction variables in any argument strings,
+&consvars; in any argument strings,
 including the
 <parameter>action</parameter>
 argument, at the time it is called
-using the construction variables in the
-<replaceable>env</replaceable>
-construction environment through which
+using the &consvars; in the
+&consenv; through which
 &f-env-Action; was called.
 The &f-Action; global function
 form delays all variable expansion
@@ -862,14 +861,14 @@ for a complete explanation of the arguments and behavior.
 Note that the
 <function>env.Builder</function>()
 form of the invocation will expand
-construction variables in any arguments strings,
+&consvars; in any arguments strings,
 including the
 <parameter>action</parameter>
 argument,
 at the time it is called
-using the construction variables in the
+using the &consvars; in the
 <varname>env</varname>
-construction environment through which
+&consenv; through which
 &f-env-Builder; was called.
 The
 &f-Builder;
@@ -903,12 +902,12 @@ disables derived file caching.
 Calling the environment method
 &f-link-env-CacheDir;
 limits the effect to targets built
-through the specified construction environment.
+through the specified &consenv;.
 Calling the global function
 &f-link-CacheDir;
 sets a global default
 that will be used by all targets built
-through construction environments
+through &consenvs;
 that do not set up environment-specific
 caching by calling &f-env-CacheDir;.
 </para>
@@ -1034,7 +1033,7 @@ either as separate arguments to the
 &f-Clean;
 method, or as a list.
 &f-Clean;
-will also accept the return value of any of the construction environment
+will also accept the return value of any of the &consenv;
 Builder methods.
 Examples:
 </para>
@@ -1327,13 +1326,11 @@ for a complete explanation of the arguments and behavior.
 <summary>
 <para>
 Specifies that all up-to-date decisions for
-targets built through this construction environment
-will be handled by the specified
-<parameter>function</parameter>.
+targets built through this &consenv;
+will be handled by <parameter>function</parameter>.
 <parameter>function</parameter> can be the name of
 a function or one of the following strings
-that specify the predefined decision function
-that will be applied:
+that specify a predefined decider function:
 </para>
 
 <para>
@@ -1440,7 +1437,7 @@ Examples:
 Decider('timestamp-match')
 
 # Use hash content signatures for any targets built
-# with the attached construction environment.
+# with the attached &consenv;.
 env.Decider('content')
 </example_commands>
 
@@ -1746,7 +1743,7 @@ only those keys and their values are serialized.
 </para>
 
 <para>
-<emphasis>Changed in NEXT_VERSION</emphasis>:
+<emphasis>Changed in NEXT_RELEASE</emphasis>:
 More than one <parameter>key</parameter> can be specified.
 The returned string always looks like a dict (or JSON equivalent);
 previously a single key serialized only the value,
@@ -2269,14 +2266,14 @@ is non-zero,
 adds the names of the default builders
 (Program, Library, etc.)
 to the global name space
-so they can be called without an explicit construction environment.
+so they can be called without an explicit &consenv;.
 (This is the default.)
 When
 <parameter>flag</parameter>
 is zero,
 the names of the default builders are removed
 from the global name space
-so that an explicit construction environment is required
+so that an explicit &consenv; is required
 to call all builders.
 </para>
 </summary>
@@ -2334,7 +2331,7 @@ env.Ignore('bar', 'bar/foobar.obj')
 The specified
 <parameter>string</parameter>
 will be preserved as-is
-and not have construction variables expanded.
+and not have &consvars; expanded.
 </para>
 </summary>
 </scons_function>
@@ -2493,7 +2490,7 @@ either as separate arguments to the
 &f-NoCache;
 method, or as a list.
 &f-NoCache;
-will also accept the return value of any of the construction environment
+will also accept the return value of any of the &consenv;
 Builder methods.
 </para>
 
@@ -2544,7 +2541,7 @@ either as separate arguments to the
 &f-NoClean;
 method, or as a list.
 &f-NoClean;
-will also accept the return value of any of the construction environment
+will also accept the return value of any of the &consenv;
 Builder methods.
 </para>
 
@@ -2589,7 +2586,7 @@ is omitted or <constant>None</constant>,
 &f-link-env-MergeFlags; is used.
 By default,
 duplicate values are not
-added to any construction variables;
+added to any &consvars;;
 you can specify
 <parameter>unique=False</parameter>
 to allow duplicate values to be added.
@@ -2613,7 +2610,7 @@ in order to distribute it to appropriate &consvars;.
 &f-env-MergeFlags; uses a separate function to
 do that processing -
 see &f-link-env-ParseFlags; for the details, including a
-a table of options and corresponding construction variables.
+a table of options and corresponding &consvars;.
 To provide alternative processing of the output of
 <parameter>command</parameter>,
 you can suppply a custom
@@ -2696,12 +2693,12 @@ function.
 Parses one or more strings containing
 typical command-line flags for GCC-style tool chains
 and returns a dictionary with the flag values
-separated into the appropriate SCons construction variables.
+separated into the appropriate SCons &consvars;.
 Intended as a companion to the
 &f-link-env-MergeFlags;
 method, but allows for the values in the returned dictionary
 to be modified, if necessary,
-before merging them into the construction environment.
+before merging them into the &consenv;.
 (Note that
 &f-env-MergeFlags;
 will call this method if its argument is not a dictionary,
@@ -2730,7 +2727,7 @@ See &f-link-ParseConfig; for more details.
 
 <para>
 Flag values are translated according to the prefix found,
-and added to the following construction variables:
+and added to the following &consvars;:
 </para>
 
 <example_commands>
@@ -2770,8 +2767,7 @@ and added to the following construction variables:
 Any other strings not associated with options
 are assumed to be the names of libraries
 and added to the
-&cv-LIBS;
-construction variable.
+&cv-LIBS; &consvar;.
 </para>
 
 <para>
@@ -2802,7 +2798,7 @@ selected by <parameter>plat</parameter>
 (defaults to the detected platform for the
 current system)
 that can be used to initialize
-a construction environment by passing it as the
+a &consenv; by passing it as the
 <parameter>platform</parameter> keyword argument to the
 &f-link-Environment; function.
 </para>
@@ -2999,7 +2995,7 @@ env = Environment(
 </arguments>
 <summary>
 <para>
-Replaces construction variables in the Environment
+Replaces &consvars; in the Environment
 with the specified keyword arguments.
 </para>
 
@@ -3019,50 +3015,43 @@ env.Replace(CCFLAGS='-g', FOO='foo.xxx')
 </arguments>
 <summary>
 <para>
-Specifies that
+Sets
 <parameter>directory</parameter>
-is a repository to be searched for files.
+as a repository to be searched for files contributing to the build.
 Multiple calls to
 &f-Repository;
-are legal,
-and each one adds to the list of
-repositories that will be searched.
+are allowed,
+with repositories searched in the given order.
+Repositories specified via command-line option
+have higher priority.
 </para>
 
 <para>
-To
+In
 &scons;,
-a repository is a copy of the source tree,
-from the top-level directory on down,
-which may contain
-both source files and derived files
+a repository is partial or complete copy of the source tree,
+from the top-level directory down,
+containing source files
 that can be used to build targets in
-the local source tree.
-The canonical example would be an
-official source tree maintained by an integrator.
-If the repository contains derived files,
-then the derived files should have been built using
-&scons;,
-so that the repository contains the necessary
-signature information to allow
-&scons;
-to figure out when it is appropriate to
-use the repository copy of a derived file,
-instead of building one locally.
+the current worktree.
+Repositories can also contain derived files.
+An example might be an official source tree maintained by an integrator.
+If a repository contains derived files,
+they should be the result of building with &SCons;,
+so a signature database (sconsign) is present
+in the repository,
+allowing better decisions on whether they are
+up-to-date or not.
 </para>
 
 <para>
 Note that if an up-to-date derived file
 already exists in a repository,
-&scons;
-will
+&scons; will
 <emphasis>not</emphasis>
 make a copy in the local directory tree.
-In order to guarantee that a local copy
-will be made,
-use the
-&f-link-Local;
-method.
+If you need a local copy to be made,
+use the &f-link-Local; method.
 </para>
 </summary>
 </scons_function>
@@ -3267,7 +3256,7 @@ SConsignFile(dbm_module=dbm.gnu)
 </arguments>
 <summary>
 <para>
-Sets construction variables to default values specified with the keyword
+Sets &consvars; to default values specified with the keyword
 arguments if (and only if) the variables are not already set.
 The following statements are equivalent:
 </para>

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -3202,7 +3202,7 @@ def generate(env):
         """Test the Dump() method"""
         env = self.TestEnvironment(FOO='foo', FOOFLAGS=CLVar('--bar --baz'))
 
-        # changed in NEXT_VERSION: single arg now displays as a dict,
+        # changed in NEXT_RELEASE: single arg now displays as a dict,
         #   not a bare value; more than one arg is allowed.
         with self.subTest():  # one-arg version
             self.assertEqual(env.Dump('FOO'), "{'FOO': 'foo'}")
@@ -3842,7 +3842,7 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
         """Test deleting variables from an OverrideEnvironment"""
         env, env2, env3 = self.envs
 
-        # changed in NEXT_VERSION: delete does not cascade to underlying envs
+        # changed in NEXT_RELEASE: delete does not cascade to underlying envs
         # XXX is in all three, del from env3 should affect only it
         del env3['XXX']
         with self.subTest():
@@ -3931,7 +3931,7 @@ class OverrideEnvironmentTestCase(unittest.TestCase,TestEnvironmentFixture):
         # test deletion in top override
         del env3['XXX']
         self.assertRaises(KeyError, env3.Dictionary, 'XXX')
-        # changed in NEXT_VERSION: *not* deleted from underlying envs
+        # changed in NEXT_RELEASE: *not* deleted from underlying envs
         assert 'XXX' in env2.Dictionary()
         assert 'XXX' in env.Dictionary()
 

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2464,12 +2464,15 @@ These warnings are enabled by default.</para>
     <option>--srcdir=<replaceable>repository</replaceable></option>
   </term>
   <listitem>
-<para>Search the specified <replaceable>repository</replaceable>
+<para>
+Search <replaceable>repository</replaceable>
 for any input and target
-files not found in the local directory hierarchy.  Multiple
-<option>-Y</option>
-options may be specified, in which case the
-repositories are searched in the order specified.</para>
+files not found in the local directory hierarchy.
+Multiple <option>-Y</option>
+options may be specified,
+with repositories searched in the given order.
+See &f-link-Repository; for more information.
+</para>
   </listitem>
   </varlistentry>
 </variablelist>

--- a/doc/user/repositories.xml
+++ b/doc/user/repositories.xml
@@ -102,7 +102,7 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section id="sec-repository-finding-sources">
+  <section id="sect-repository-finding-sources">
   <title>Finding source files in repositories</title>
 
     <para>
@@ -235,7 +235,7 @@ hello.c:1: hello.h: No such file or directory
 
     In order to inform the C compiler about the repositories,
     &SCons; will add appropriate source file inclusion
-    directived (<literal>-I</literal> or <literal>/I</literal> flags)
+    directives (<literal>-I</literal> or <literal>/I</literal> flags)
     to the compilation commands for each directory in the &cv-CPPPATH; list.
     So if you add the current directory to the
     &consenv; &cv-CPPPATH;:

--- a/doc/user/repositories.xml
+++ b/doc/user/repositories.xml
@@ -616,7 +616,7 @@ scons: `hello' is up-to-date.
 
     There are, however, times when you want to ensure that a
     local copy of a file always exists.
-    For example, if you are pacakging the result of the build,
+    For example, if you are packaging the result of the build,
     all the files used in the package need to be present locally,
     and the packaging tool is unlikely to know anything about
     &SCons; repositories. Similarly, if you build a unit test
@@ -691,7 +691,7 @@ foo  foo.o
 
     <para>
 
-    It can become awakward to keep having to type
+    It can become awkward to keep having to type
     <literal>-Y path-to-repo</literal> repeatedly.
     If so, the option can be placed in &SCONSFLAGS;.
 

--- a/doc/user/repositories.xml
+++ b/doc/user/repositories.xml
@@ -41,7 +41,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-repository">
   <title>The &Repository; Method</title>
 
  <!--
@@ -94,7 +94,7 @@ int main() { printf("Hello, world!\n"); }
     Multiple calls to the &Repository; method
     will simply add repositories to the global list
     that &SCons; maintains,
-    with the exception that &SCons; will automatically eliminate
+    with the exception that &SCons; will automatically filter out
     the current directory and any non-existent
     directories from the list.
 
@@ -102,7 +102,7 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sec-repository-finding-sources">
   <title>Finding source files in repositories</title>
 
     <para>
@@ -195,12 +195,12 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-repository-finding-headers">
   <title>Finding <literal>#include</literal> files in repositories</title>
 
     <para>
 
-    We've already seen that SCons will scan the contents of
+    You've already seen that SCons will scan the contents of
     a source file for <literal>#include</literal> file names
     and realize that targets built from that source file
     also depend on the <literal>#include</literal> file(s).
@@ -234,17 +234,17 @@ hello.c:1: hello.h: No such file or directory
     <para>
 
     In order to inform the C compiler about the repositories,
-    &SCons; will add appropriate
-    <literal>-I</literal> flags to the compilation commands
-    for each directory in the &cv-CPPPATH; list.
-    So if we add the current directory to the
-    construction environment &cv-CPPPATH; like so:
+    &SCons; will add appropriate source file inclusion
+    directived (<literal>-I</literal> or <literal>/I</literal> flags)
+    to the compilation commands for each directory in the &cv-CPPPATH; list.
+    So if you add the current directory to the
+    &consenv; &cv-CPPPATH;:
 
     </para>
 
     <scons_example name="repositories_CPPPATH">
       <file name="SConstruct" printme="1">
-env = Environment(CPPPATH = ['.'])
+env = Environment(CPPPATH=['.'])
 env.Program('hello.c')
 Repository('__ROOT__/usr/repository1')
       </file>
@@ -280,7 +280,7 @@ int main() { printf("Hello, world!\n"); }
 
     <scons_example name="repositories_CPPPATH3">
       <file name="SConstruct" printme="1">
-env = Environment(CPPPATH = ['dir1', 'dir2', 'dir3'])
+env = Environment(CPPPATH=['dir1', 'dir2', 'dir3'])
 env.Program('hello.c')
 Repository('__ROOT__/r1', '__ROOT__/r2')
       </file>
@@ -291,7 +291,7 @@ int main() { printf("Hello, world!\n"); }
 
     <para>
 
-    Then we'll end up with nine <literal>-I</literal> options
+    Then you'll end up with nine <literal>-I</literal> options
     on the command line,
     three (for each of the &cv-CPPPATH; directories)
     times three (for the local directory plus the two repositories):
@@ -315,7 +315,7 @@ coming into existence.)
 
 -->
 
-    <section>
+    <section id="sect-repository-header-limitations">
     <title>Limitations on <literal>#include</literal> files in repositories</title>
 
       <para>
@@ -332,7 +332,7 @@ coming into existence.)
 
       <para>
 
-      As we've seen,
+      As you've seen,
       &SCons; will compile the &hello_c; file from
       the repository if it doesn't exist in
       the local directory.
@@ -364,7 +364,7 @@ main(int argc, char *argv[])
 
       <scons_example name="repositories_quote1">
         <file name="SConstruct">
-env = Environment(CPPPATH = ['.'])
+env = Environment(CPPPATH=['.'])
 env.Program('hello.c')
 Repository('__ROOT__/usr/repository1')
         </file>
@@ -400,9 +400,9 @@ int main() { printf("Hello, world!\n"); }
         Some modern versions of C compilers do have an option
         to disable or control this behavior.
         If so, add that option to &cv-link-CFLAGS;
-        (or &cv-link-CXXFLAGS; or both) in your construction environment(s).
-        Make sure the option is used for all construction
-        environments that use C preprocessing!
+        (or &cv-link-CXXFLAGS;, or both) in your &consenvs;.
+        Make sure the option is used for all &consenv;
+        that use C preprocessing!
 
         </para>
         </listitem>
@@ -441,7 +441,7 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-repository-sconstruct">
   <title>Finding the &SConstruct; file in repositories</title>
 
     <para>
@@ -472,6 +472,18 @@ int main() { printf("Hello, world!\n"); }
 
     </para>
 
+    <para>
+
+    Note that while other files are searched through the chain of
+    repositories, &SConstruct; is special - it must be found either in
+    the current directory or the first directory
+    specified using the <literal>-Y</literal>
+    (or the <literal>--repository</literal> or
+    <literal>--srcdir</literal> synonyms)
+    command line option, or the build will abort.
+
+    </para>
+
   </section>
 
   <section>
@@ -482,9 +494,9 @@ int main() { printf("Hello, world!\n"); }
     If a repository contains not only source files,
     but also derived files (such as object files,
     libraries, or executables), &SCons; will perform
-    its normal MD5 signature calculation to
+    its normal signature calculation to
     decide if a derived file in a repository is up-to-date,
-    or the derived file must be rebuilt in the local build directory.
+    or if it needs to be rebuilt in the local build directory.
     For the &SCons; signature calculation to work correctly,
     a repository tree must contain the &sconsigndb; files
     that &SCons; uses to keep track of signature information.
@@ -535,8 +547,8 @@ int f2() { printf("file2.c\n"); }
     <para>
 
     Now, with the repository populated,
-    we only need to create the one local source file
-    we're interested in working with at the moment,
+    you only need to create the one local source file
+    you're interested in working with at the moment,
     and use the <literal>-Y</literal> option to
     tell &SCons; to fetch any other files it needs
     from the repository:
@@ -575,7 +587,7 @@ cc -o hello hello.o /usr/repository1/file1.o /usr/repository1/file2.o
     <para>
 
     If the repository tree contains the complete results of a build,
-    and we try to build from the repository
+    and you try to build from the repository
     without any files in our local tree,
     something moderately surprising happens:
 
@@ -593,8 +605,7 @@ scons: `hello' is up-to-date.
     Why does &SCons; say that the &hello; program
     is up-to-date when there is no &hello; program
     in the local build directory?
-    Because the repository (not the local directory)
-    contains the up-to-date &hello; program,
+    Because the repository contains the &hello; program,
     and &SCons; correctly determines that nothing
     needs to be done to rebuild that
     up-to-date copy of the file.
@@ -603,11 +614,17 @@ scons: `hello' is up-to-date.
 
     <para>
 
-    There are, however, many times when you want to ensure that a
+    There are, however, times when you want to ensure that a
     local copy of a file always exists.
-    A packaging or testing script, for example,
-    may assume that certain generated files exist locally.
-    To tell &SCons; to make a copy of any up-to-date repository
+    For example, if you are pacakging the result of the build,
+    all the files used in the package need to be present locally,
+    and the packaging tool is unlikely to know anything about
+    &SCons; repositories. Similarly, if you build a unit test
+    program, and then expect to run after the build,
+    it doesn't help if the test program is somewhere else
+    and wasn't rebuilt into the local directory.
+    In these cases, you can tell
+    &SCons; to make a copy of any up-to-date repository
     file in the local build directory,
     use the &Local; function:
 
@@ -626,7 +643,7 @@ int main() { printf("Hello, world!\n"); }
 
     <para>
 
-    If we then run the same command,
+    Now, if you run the same command,
     &SCons; will make a local copy of the program
     from the repository copy,
     and tell you that it is doing so:
@@ -647,6 +664,38 @@ scons: `hello' is up-to-date.
 
     </para>
 
+  </section>
+
+  <section id="sect-repository-out-of-source">
+  <title>Using Repository to separate source and build.</title>
+
+    <para>
+
+    If you want to just do a build where the build artifacts don't
+    pollute the source directory, the repository mechanism can help with that.
+    Here's an example: checkout or unpack your project in the
+    directory <filename>src</filename>,
+    and then build it in <filename>build</filename>:
+
+    </para>
+
+    <screen>
+$ <userinput>mkdir build</userinput>
+$ <userinput>cd build</userinput>
+$ <userinput>scons -Q -Y ../src</userinput>
+gcc -o foo.o -I. -I/path/to/src -c /path/to/src/foo.c
+gcc -o foo foo.o
+$ <userinput>ls</userinput>
+foo  foo.o
+    </screen>
+
+    <para>
+
+    It can become awakward to keep having to type
+    <literal>-Y path-to-repo</literal> repeatedly.
+    If so, the option can be placed in &SCONSFLAGS;.
+
+    </para>
   </section>
 
 </chapter>


### PR DESCRIPTION
Give a few more details. Add example for another usecase to the User Guide.

At the same time - convert more "construction environment" and "construction variable" to entities in files already being edited.

Normalize on NEXT_RELEASE (since 4.8.1, some changed had used NEXT_RELEASE and some on NEXT_VERSION).

No code/test changes: Environment.py was a docstring change and EnvironmentTests.py comment changes.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
