### PR TITLE
Fix Issue with SConsCPPConditionalScanner misinterpreting ifdefs suffixed with L or UL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,7 +19,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From William Deegan:
     - Fix SConsCPPConditionalScanner to properly handle #ifdefs with non number prefixing numbers followed by UL or L.
       Previously it was removing the L or UL when that should only have been done when a only numbers preceded them.
-      Fixes Issue #4623
 
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Added error handling when creating MS VC detection debug log file specified by
       SCONS_MSCOMMON_DEBUG
 
+  From William Deegan:
+    - Fix SConsCPPConditionalScanner to properly handle #ifdefs with non number prefixing numbers followed by UL or L.
+      Previously it was removing the L or UL when that should only have been done when a only numbers preceded them.
+      Fixes Issue #4623
+
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access
       /etc/paths.d. This may occur if SCons is invoked in a sandboxed

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -69,6 +69,11 @@ FIXES
 - Skip running a few validation tests if the user is root and the test is
   not designed to work for the root user.
 
+
+- Fix SConsCPPConditionalScanner to properly handle ifdefs with non number prefixing numbers followed by UL or L.
+  Previously it was removing the L or UL when that should only have been done when a only numbers preceded them.
+  Fixes Issue #4623
+
 IMPROVEMENTS
 ------------
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -69,10 +69,8 @@ FIXES
 - Skip running a few validation tests if the user is root and the test is
   not designed to work for the root user.
 
-
 - Fix SConsCPPConditionalScanner to properly handle ifdefs with non number prefixing numbers followed by UL or L.
   Previously it was removing the L or UL when that should only have been done when a only numbers preceded them.
-  Fixes Issue #4623
 
 IMPROVEMENTS
 ------------

--- a/SCons/cpp.py
+++ b/SCons/cpp.py
@@ -152,7 +152,7 @@ CPP_to_Python_Eval_List = [
     [r'defined\s+(\w+)',                 '"\\1" in __dict__'],
     [r'defined\s*\((\w+)\)',             '"\\1" in __dict__'],
     [r'(0x[0-9A-Fa-f]+)(?:L|UL)?',  '\\1'],
-    [r'(\d+)(?:L|UL)?',  '\\1'],
+    [r'^(\d+)(?:L|UL)?',  '\\1'],
 ]
 
 # Replace the string representations of the regular expressions in the

--- a/SCons/cpp.py
+++ b/SCons/cpp.py
@@ -152,7 +152,7 @@ CPP_to_Python_Eval_List = [
     [r'defined\s+(\w+)',                 '"\\1" in __dict__'],
     [r'defined\s*\((\w+)\)',             '"\\1" in __dict__'],
     [r'(0x[0-9A-Fa-f]+)(?:L|UL)?',  '\\1'],
-    [r'^(\d+)(?:L|UL)?',  '\\1'],
+    [r'^(\d+)(?:L|ULL|UL|U)?',  '\\1'],
 ]
 
 # Replace the string representations of the regular expressions in the

--- a/SCons/cppTests.py
+++ b/SCons/cppTests.py
@@ -241,6 +241,12 @@ expression_input = """
 #else
 #include <file301-no>
 #endif
+
+#if X1234UL || X1234L
+#include <file302-yes>
+#else
+#include <file302-no>
+#endif
 """
 
 
@@ -589,6 +595,8 @@ class PreProcessorTestCase(cppAllTestCase):
         ('include', '"', 'file29-yes'),
         ('include', '<', 'file30-yes'),
         ('include', '<', 'file301-yes'),
+        ('include', '<', 'file302-no'),
+
     ]
 
     undef_expect = [
@@ -719,6 +727,8 @@ class DumbPreProcessorTestCase(cppAllTestCase):
         ('include', '<', 'file30-no'),
         ('include', '<', 'file301-yes'),
         ('include', '<', 'file301-no'),
+        ('include', '<', 'file302-yes'),
+        ('include', '<', 'file302-no'),
     ]
 
     undef_expect = [

--- a/SCons/cppTests.py
+++ b/SCons/cppTests.py
@@ -236,17 +236,60 @@ expression_input = """
 #include <file30-no>
 #endif
 
-#if	123456789UL || 0x13L
-#include <file301-yes>
+#if	123456789UL
+#include <file301ul-yes>
 #else
-#include <file301-no>
+#include <file301ul-no>
 #endif
 
-#if X1234UL || X1234L
+#if 1234U
+#include <file301u-yes>
+#else
+#include <file301u-no>
+#endif
+
+#if 1234L
+#include <file301l-yes>
+#else
+#include <file301l-no>
+#endif
+
+#if 1234ULL
+#include <file301ull-yes>
+#else
+#include <file301ull-no>
+#endif
+
+#define X1234UL 1
+#if X1234UL
 #include <file302-yes>
 #else
 #include <file302-no>
 #endif
+
+#define X1234U 1
+#if X1234U
+#include <file303-yes>
+#else
+#include <file303-no>
+#endif
+
+#define X1234L 1
+#if X1234L
+#include <file304-yes>
+#else
+#include <file304-no>
+#endif
+
+#define X1234ULL 1
+#if X1234ULL
+#include <file305-yes>
+#else
+#include <file305-no>
+#endif
+
+
+
 """
 
 
@@ -486,7 +529,12 @@ class cppTestCase(unittest.TestCase):
         """Test #if with arithmetic expressions"""
         expect = self.expression_expect
         result = self.cpp.process_contents(expression_input)
-        assert expect == result, (expect, result)
+        if expect != result:
+            for e,r in zip(expect, result):
+                if e != r:
+                    print("XXXX->",end="")
+                print(f"{e}: {r}")
+        assert expect == result, f"\nexpect:{expect}\nresult:{result}"
 
     def test_undef(self) -> None:
         """Test #undef handling"""
@@ -594,8 +642,16 @@ class PreProcessorTestCase(cppAllTestCase):
         ('include', '<', 'file28-yes'),
         ('include', '"', 'file29-yes'),
         ('include', '<', 'file30-yes'),
-        ('include', '<', 'file301-yes'),
-        ('include', '<', 'file302-no'),
+
+        ('include', '<', 'file301ul-yes'),
+        ('include', '<', 'file301u-yes'),
+        ('include', '<', 'file301l-yes'),
+        ('include', '<', 'file301ull-yes'),
+
+        ('include', '<', 'file302-yes'),
+        ('include', '<', 'file303-yes'),
+        ('include', '<', 'file304-yes'),
+        ('include', '<', 'file305-yes'),
 
     ]
 
@@ -725,10 +781,24 @@ class DumbPreProcessorTestCase(cppAllTestCase):
         ('include', '"', 'file29-yes'),
         ('include', '<', 'file30-yes'),
         ('include', '<', 'file30-no'),
-        ('include', '<', 'file301-yes'),
-        ('include', '<', 'file301-no'),
+
+        ('include', '<', 'file301ul-yes'),
+        ('include', '<', 'file301ul-no'),
+        ('include', '<', 'file301u-yes'),
+        ('include', '<', 'file301u-no'),
+        ('include', '<', 'file301l-yes'),
+        ('include', '<', 'file301l-no'),
+        ('include', '<', 'file301ull-yes'),
+        ('include', '<', 'file301ull-no'),
+
         ('include', '<', 'file302-yes'),
         ('include', '<', 'file302-no'),
+        ('include', '<', 'file303-yes'),
+        ('include', '<', 'file303-no'),
+        ('include', '<', 'file304-yes'),
+        ('include', '<', 'file304-no'),
+        ('include', '<', 'file305-yes'),
+        ('include', '<', 'file305-no'),
     ]
 
     undef_expect = [


### PR DESCRIPTION
SConsCPPConditionalScanner

Was misinterpreting
#ifdef X123L
and 
#ifdef X123UL
And removing L and UL which is only appropriate when the ifdef'd symbol is numeric with L or UL suffixing.

See Issue #4623 for some more discussion.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
