### PR TITLE
Improve C scanner conditional inclusion

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -167,9 +167,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       their values taken from the default in the variable description
       (if a variable was set to the same value as the default in one
       of the input sources, it is not included in this list).
-    - The C scanner now does (limited) macro replacement on the values in
-      CPPDEFINES, to improve results of conditional source file inclusion
-      (issue #4523).
     - The (optional) C Conditional Scanner now does limited macro
       replacement on the contents of CPPDEFINES, to improve finding deps
       that are conditionally included.  Previously replacement was only

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -170,6 +170,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - The C scanner now does (limited) macro replacement on the values in
       CPPDEFINES, to improve results of conditional source file inclusion
       (issue #4523).
+    - The (optional) C Conditional Scanner now does limited macro
+      replacement on the contents of CPPDEFINES, to improve finding deps
+      that are conditionally included.  Previously replacement was only
+      done on macro definitions found in the file being scanned.
+      Only object-like macros are replaced (not function-like), and
+      only on a whole-word basis; recursion is limited to five levels
+      and does not error out if that limit is reached (issue #4523).
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -167,6 +167,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       their values taken from the default in the variable description
       (if a variable was set to the same value as the default in one
       of the input sources, it is not included in this list).
+    - The C scanner now does (limited) macro replacement on the values in
+      CPPDEFINES, to improve results of conditional source file inclusion
+      (issue #4523).
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -150,6 +150,9 @@ FIXES
   python ninja package version 1.11.1.2 changed the location and previous
   logic no longer worked.
 
+- The C scanner now does (limited) macro replacement on the values in
+  CPPDEFINES, to improve results of conditional source file inclusion
+  (issue #4523).
 
 IMPROVEMENTS
 ------------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -144,15 +144,20 @@ FIXES
   not designed to work for the root user.
 
 - Make sure unknown variables from a Variables file are recognized
-  as such (issue #4645)
+  as such. Previously only unknowns from the command line were
+  recognized (issue #4645).
 
 - Update ninja tool to use ninja.BIN_DIR to find pypi packaged ninja binary.
   python ninja package version 1.11.1.2 changed the location and previous
   logic no longer worked.
 
-- The C scanner now does (limited) macro replacement on the values in
-  CPPDEFINES, to improve results of conditional source file inclusion
-  (issue #4523).
+- The (optional) C Conditional Scanner now does limited macro
+  replacement on the contents of CPPDEFINES, to improve finding deps
+  that are conditionally included.  Previously replacement was only
+  done on macro definitions found in the file being scanned.
+  Only object-like macros are replaced (not function-like), and
+  only on a whole-word basis; recursion is limited to five levels
+  and does not error out if that limit is reached (issue #4523).
 
 IMPROVEMENTS
 ------------

--- a/SCons/Scanner/C.py
+++ b/SCons/Scanner/C.py
@@ -114,8 +114,19 @@ def dictify_CPPDEFINES(env, replace: bool = False) -> dict:
         old_ns = mapping
         loops = 0
         while loops < 5:  # don't recurse forever in case there's circular data
-            ns = {k: old_ns[v] if v in old_ns else v for k, v in old_ns.items()}
-            if old_ns == ns:
+            # this was originally written as a dict comprehension, but unrolling
+            # lets us add a finer-grained check for whether another loop is
+            # needed, rather than comparing two dicts to see if one changed.
+            again = False
+            ns = {}
+            for k, v in old_ns.items():
+                if v in old_ns:
+                    ns[k] = old_ns[v]
+                    if not again and ns[k] != v:
+                        again = True
+                else:
+                    ns[k] = v
+            if not again:
                 break
             old_ns = ns
             loops += 1

--- a/SCons/Scanner/CTests.py
+++ b/SCons/Scanner/CTests.py
@@ -572,6 +572,18 @@ class dictify_CPPDEFINESTestCase(unittest.TestCase):
             expect = {"STRING": "VALUE", "UNVALUED": None}
             self.assertEqual(d, expect)
 
+        with self.subTest("CPPDEFINES with macro replacement"):
+            env = DummyEnvironment(
+                CPPDEFINES=[
+                    ("STRING", "VALUE"),
+                    ("REPLACEABLE", "RVALUE"),
+                    ("RVALUE", "AVALUE"),
+                ]
+            )
+            d = SCons.Scanner.C.dictify_CPPDEFINES(env)
+            expect = {"STRING": "VALUE", "REPLACEABLE": "AVALUE", "RVALUE": "AVALUE"}
+            self.assertEqual(d, expect)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/SCons/Scanner/CTests.py
+++ b/SCons/Scanner/CTests.py
@@ -580,7 +580,7 @@ class dictify_CPPDEFINESTestCase(unittest.TestCase):
                     ("RVALUE", "AVALUE"),
                 ]
             )
-            d = SCons.Scanner.C.dictify_CPPDEFINES(env)
+            d = SCons.Scanner.C.dictify_CPPDEFINES(env, replace=True)
             expect = {"STRING": "VALUE", "REPLACEABLE": "AVALUE", "RVALUE": "AVALUE"}
             self.assertEqual(d, expect)
 


### PR DESCRIPTION
Simplistic macro replacement is now done on the contents of `CPPDEFINES`, to improve accuracy of conditional inclusion as compared to the real preprocessor (ref: issue #4623).  The replacement will happen for both the Conditional and the original C scanner, but since the original does not attempt to process the logic around conditional includes, it will simply have no effect on it.  EDITED: now only applied to Conditional scanner.

This should have no doc impacts: we don't say *how* scanners determine implicit dependencies, so a small tweak to that process is more like a bugfix.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
