### PR TITLE
Ruff/Mypy: Update excludes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -76,6 +76,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       - Change the attempted conversion of a define expansion from using int() to
         a constant expression evaluation.
 
+  From Thaddeus Crews:
+    - Ruff/Mypy: Excluded items now synced.
+
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access
       /etc/paths.d. This may occur if SCons is invoked in a sandboxed

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -177,6 +177,8 @@ DEVELOPMENT
 
 - List visible changes in the way SCons is developed
 
+- Ruff/Mypy: Excluded items now synced.
+
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================
 .. code-block:: text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,17 +73,15 @@ dist-dir = "build/dist"
 target-version = "py37" # Lowest python version supported
 extend-include = ["SConstruct", "SConscript"]
 extend-exclude = [
-    "bench",
-    "bin",
-    "doc",
-    "src",
-    "template",
-    "test",
-    "testing",
-    "timings",
-    "SCons/Tool/docbook/docbook-xsl-1.76.1",
-    "bootstrap.py",
-    "runtest.py",
+    "bench/",
+    "bin/",
+    "doc/",
+    "src/",
+    "template/",
+    "test/",
+    "testing/",
+    "timings/",
+    "SCons/Tool/docbook/docbook-xsl-1.76.1/",
 ]
 
 [tool.ruff.format]
@@ -99,3 +97,14 @@ quote-style = "preserve" # Equivalent to black's "skip-string-normalization"
 
 [tool.mypy]
 python_version = "3.8"
+exclude = [
+    "^bench/",
+    "^bin/",
+    "^doc/",
+    "^src/",
+    "^template/",
+    "^test/",
+    "^testing/",
+    "^timings/",
+    "^SCons/Tool/docbook/docbook-xsl-1.76.1/",
+]


### PR DESCRIPTION
Currently, mypy has no exclusions & ruff grandfathered too many exclusions. This rectifies both issues at once, by making the third party "docbook" library serve as the sole exclusion between them. This won't have any immediate impact in practice, given we aren't enforcing either atm; however, it ensures future refactors can properly parse all relevant files

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
