### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -77,6 +77,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
         a constant expression evaluation.
 
   From Thaddeus Crews:
+    - Removed Python 3.6 support.
     - Ruff/Mypy: Excluded items now synced.
 
   From Alex James:

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - List modifications to existing features, where the previous behavior
   wouldn't actually be considered a bug
 
+- Removed Python 3.6 support.
+
 - Override environments, created when giving construction environment
   keyword arguments to Builder calls (or manually, through the
   undocumented Override method), were modified not to "leak" on item deletion.

--- a/ReleaseConfig
+++ b/ReleaseConfig
@@ -37,7 +37,7 @@ version_tuple = (4, 8, 2, 'a', 0)
 # when that version is used.  Python versions prior to deprecate_python_version
 # cause a warning to be issued (assuming it's not disabled).  These values are
 # mandatory and must be present in the configuration file.
-unsupported_python_version = (3, 6, 0)
+unsupported_python_version = (3, 7, 0)
 deprecated_python_version = (3, 7, 0)
 
 # If release_date is (yyyy, mm, dd, hh, mm, ss), that is used as the release

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -891,15 +891,6 @@ def scons_subproc_run(scons_env, *args, **kwargs) -> subprocess.CompletedProcess
         del kwargs['error']
     kwargs['check'] = check
 
-    # TODO: Python version-compat stuff: remap/remove too-new args if needed
-    if 'text' in kwargs and sys.version_info < (3, 7):
-        kwargs['universal_newlines'] = kwargs.pop('text')
-
-    if 'capture_output' in kwargs and sys.version_info < (3, 7):
-        capture_output = kwargs.pop('capture_output')
-        if capture_output:
-            kwargs['stdout'] = kwargs['stderr'] = PIPE
-
     # Most SCons tools/tests expect not to fail on things like missing files.
     # check=True (or error="raise") means we're okay to take an exception;
     # else we catch the likely exception and construct a dummy

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1541,8 +1541,6 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         func_matches = {
-            (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
-            (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
@@ -1723,8 +1721,6 @@ class FunctionActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
-            (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
@@ -1736,8 +1732,6 @@ class FunctionActionTestCase(unittest.TestCase):
         }
 
         meth_matches = {
-            (3, 5): bytearray(b'1, 1, 0, 0,(),(),(d\x00\x00S),(),()'),
-            (3, 6): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'1, 1, 0, 0,(),(),(d\x00S\x00),(),()'),
@@ -1978,8 +1972,6 @@ class LazyActionTestCase(unittest.TestCase):
             pass
 
         func_matches = {
-            (3, 5): bytearray(b'0, 0, 0, 0,(),(),(d\x00\x00S),(),()'),
-            (3, 6): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 7): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 8): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
             (3, 9): bytearray(b'0, 0, 0, 0,(),(),(d\x00S\x00),(),()'),
@@ -2042,8 +2034,6 @@ class ActionCallerTestCase(unittest.TestCase):
             pass
 
         matches = {
-            (3, 5): b'd\x00\x00S',
-            (3, 6): b'd\x00S\x00',
             (3, 7): b'd\x00S\x00',
             (3, 8): b'd\x00S\x00',
             (3, 9): b'd\x00S\x00',
@@ -2246,8 +2236,6 @@ class ObjectContentsTestCase(unittest.TestCase):
         # we need different expected results per version
         # Note unlike the others, this result is a tuple, use assertIn
         expected = {
-            (3, 5): (bytearray(b'3, 3, 0, 0,(),(),(|\x00\x00S),(),()'),),
-            (3, 6): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),),
             (3, 7): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),),
             (3, 8): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),),
             (3, 9): (bytearray(b'3, 3, 0, 0,(),(),(|\x00S\x00),(),()'),),
@@ -2275,12 +2263,6 @@ class ObjectContentsTestCase(unittest.TestCase):
         # Since the python bytecode has per version differences,
         # we need different expected results per version
         expected = {
-            (3, 5): bytearray(
-                b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01\x00|\x00\x00_\x00\x00d\x02\x00|\x00\x00_\x01\x00d\x00\x00S),(),(),2, 2, 0, 0,(),(),(d\x00\x00S),(),()}}{{{a=a,b=b}}}"
-            ),
-            (3, 6): bytearray(
-                b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
-            ),
             (3, 7): bytearray(
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(d\x01|\x00_\x00d\x02|\x00_\x01d\x00S\x00),(),(),2, 2, 0, 0,(),(),(d\x00S\x00),(),()}}{{{a=a,b=b}}}"
             ),
@@ -2314,12 +2296,6 @@ class ObjectContentsTestCase(unittest.TestCase):
 
         # Since the python bytecode has per version differences, we need different expected results per version
         expected = {
-            (3, 5): bytearray(
-                b'0, 0, 0, 0,(Hello, World!),(print),(e\x00\x00d\x00\x00\x83\x01\x00\x01d\x01\x00S)'
-            ),
-            (3, 6): bytearray(
-                b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'
-            ),
             (3, 7): bytearray(
                 b'0, 0, 0, 0,(Hello, World!),(print),(e\x00d\x00\x83\x01\x01\x00d\x01S\x00)'
             ),
@@ -2387,17 +2363,17 @@ class ObjectContentsTestCase(unittest.TestCase):
                 {"text": True, "check": False},
             )
 
-        # 3.6:
-        sys.version_info = (3, 6, 2)
+        # 3.7:
+        sys.version_info = (3, 7, 2)
         with self.subTest():
             self.assertEqual(
                 scons_subproc_run(env, capture_output=True),
-                {"check": False, "stdout": PIPE, "stderr": PIPE},
+                {"capture_output": True, "check": False},
             )
         with self.subTest():
             self.assertEqual(
                 scons_subproc_run(env, text=True),
-                {"check": False, "universal_newlines": True},
+                {"check": False, "text": True},
             )
         with self.subTest():
             self.assertEqual(

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -66,7 +66,7 @@ from SCons.Util.stats import count_stats, memory_stats, time_stats, ENABLE_JSON,
 from SCons import __version__ as SConsVersion
 
 # these define the range of versions SCons supports
-minimum_python_version = (3, 6, 0)
+minimum_python_version = (3, 7, 0)
 deprecated_python_version = (3, 7, 0)
 
 # ordered list of SConstruct names to look for if there is no -f flag
@@ -1355,12 +1355,6 @@ def _build_targets(fs, options, targets, target_top):
     # Let the BuildTask objects get at the options to respond to the
     # various print_* settings, tree_printer list, etc.
     BuildTask.options = options
-
-    is_pypy = platform.python_implementation() == 'PyPy'
-    # As of 3.7, python removed support for threadless platforms.
-    # See https://www.python.org/dev/peps/pep-0011/
-    is_37_or_later = sys.version_info >= (3, 7)
-    # python_has_threads = sysconfig.get_config_var('WITH_THREAD') or is_pypy or is_37_or_later
 
     # As of python 3.4 threading has a dummy_threading module for use when there is no threading
     # it's get_ident() will allways return -1, while real threading modules get_ident() will

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -87,7 +87,7 @@ and a database of information about previous builds so
 details do not have to be recalculated each run.
 </para>
 
-<para>&scons; requires &Python; 3.6 or later to run;
+<para>&scons; requires &Python; 3.7 or later to run;
 there should be no other dependencies or requirements,
 unless the experimental Ninja tool is used (requires the ninja package).
 </para>
@@ -103,6 +103,10 @@ support for &Python; 3.6 is deprecated and will be removed
 in a future &SCons; release.
 The CPython project retired 3.6 in Sept 2021:
 <ulink url="https://peps.python.org/pep-0494"/>.
+</para>
+<para>
+<emphasis>Changed in version NEXT_RELEASE:</emphasis>
+support for &Python; 3.6 is removed.
 </para>
 
 <para>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools"]
 [project]
 name = "SCons"
 description = "Open Source next-generation build tool."
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 license = { text = "MIT" }
 readme = { file = "README-package.rst", content-type = "text/x-rst" }
 authors = [{ name = "William Deegan", email = "bill@baddogconsulting.com" }]
@@ -16,7 +16,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/runtest.py
+++ b/runtest.py
@@ -784,7 +784,7 @@ def run_test(t, io_lock=None, run_async=True):
     command_args = []
     if debug:
         command_args.extend(['-m', debug])
-    if args.devmode and sys.version_info >= (3, 7, 0):
+    if args.devmode:
         command_args.append('-X dev')
     command_args.append(t.path)
     if args.runner and t.path in unittests:

--- a/scripts/scons-configure-cache.py
+++ b/scripts/scons-configure-cache.py
@@ -49,9 +49,9 @@ import os
 import sys
 
 # python compatibility check
-if sys.version_info < (3, 6, 0):
+if sys.version_info < (3, 7, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.6.0 is required.\n"
+Python >= 3.7.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/scripts/scons.py
+++ b/scripts/scons.py
@@ -42,9 +42,9 @@ import os
 import sys
 
 # Python compatibility check
-if sys.version_info < (3, 6, 0):
+if sys.version_info < (3, 7, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.6.0 is required.\n"
+Python >= 3.7.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/scripts/sconsign.py
+++ b/scripts/sconsign.py
@@ -41,9 +41,9 @@ import os
 import sys
 
 # python compatibility check
-if sys.version_info < (3, 6, 0):
+if sys.version_info < (3, 7, 0):
     msg = "scons: *** SCons version %s does not run under Python version %s.\n\
-Python >= 3.6.0 is required.\n"
+Python >= 3.7.0 is required.\n"
     sys.stderr.write(msg % (__version__, sys.version.split()[0]))
     sys.exit(1)
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -59,7 +59,7 @@ from TestCmd import PIPE
 default_version = '4.8.2ayyyymmdd'
 
 # TODO: these need to be hand-edited when there are changes
-python_version_unsupported = (3, 6, 0)
+python_version_unsupported = (3, 7, 0)
 python_version_deprecated = (3, 7, 0)
 python_version_supported_str = "3.7.0"  # str of lowest non-deprecated Python
 


### PR DESCRIPTION
Removes all references to the deprecated 3.6 version, updating documentation and tests to account for the new baseline. This is a deliberately standalone PR, as any functional changes that'd come from it are better suited for evaluation in an isolated environment.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
