### PR TITLE
Unknown variables from Variables file are now reported

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -150,6 +150,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       types depending on whether zero, one, or multiple construction
       variable names are given.
     - Update Clean and NoClean documentation.
+    - Make sure unknown variables from a Variables file are recognized
+      as such (issue #4645)
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -137,6 +137,9 @@ FIXES
 - Skip running a few validation tests if the user is root and the test is
   not designed to work for the root user.
 
+- Make sure unknown variables from a Variables file are recognized
+  as such (issue #4645)
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -656,12 +656,13 @@ class UnknownVariablesTestCase(unittest.TestCase):
     def test_AddOptionUpdatesUnknown(self) -> None:
         """Test updating of the 'unknown' dict.
 
-        Get one unknown from args, one from a variables file.  Add one
-        of those later, make sure it gets removed from 'unknown' when added.
+        Get one unknown from args and one from a variables file.
+        Add these later, making sure they no longer appear in unknowns
+        after the subsequent Update().
         """
         test = TestSCons.TestSCons()
         var_file = test.workpath('vars.py')
-        test.write('vars.py', 'FROMFILE="notadded"')
+        test.write('vars.py', 'FROMFILE="added"')
         opts = SCons.Variables.Variables(files=var_file)
         opts.Add('A', 'A test variable', "1")
         args = {
@@ -674,10 +675,11 @@ class UnknownVariablesTestCase(unittest.TestCase):
         r = opts.UnknownVariables()
         with self.subTest():
             self.assertEqual('notaddedyet', r['ADDEDLATER'])
-            self.assertEqual('notadded', r['FROMFILE'])
+            self.assertEqual('added', r['FROMFILE'])
             self.assertEqual('a', env['A'])
 
         opts.Add('ADDEDLATER', 'An option not present initially', "1")
+        opts.Add('FROMFILE', 'An option from a file also absent', "1")
         args = {
             'A'             : 'a',
             'ADDEDLATER'    : 'added',
@@ -686,10 +688,11 @@ class UnknownVariablesTestCase(unittest.TestCase):
 
         r = opts.UnknownVariables()
         with self.subTest():
-            self.assertEqual(1, len(r))  # should still have FROMFILE
+            self.assertEqual(0, len(r))
             self.assertNotIn('ADDEDLATER', r)
             self.assertEqual('added', env['ADDEDLATER'])
-            self.assertIn('FROMFILE', r)
+            self.assertNotIn('FROMFILE', r)
+            self.assertEqual('added', env['FROMFILE'])
 
     def test_AddOptionWithAliasUpdatesUnknown(self) -> None:
         """Test updating of the 'unknown' dict (with aliases)"""


### PR DESCRIPTION
Previously `Update` added everything from the file(s) to the local values dict by doing `exec`, and then unknown ones ended up silently dropped since they weren't declared as options. Now the result of the exec call is reprocessed, so unknowns can be collected.

No doc impacts - just making it work as documented (see linked issue).

Fixes #4645

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
