### PR TITLE
Turn `SCons.Variables.Variable` into a dataclass

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -167,9 +167,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       their values taken from the default in the variable description
       (if a variable was set to the same value as the default in one
       of the input sources, it is not included in this list).
-    - If a build Variable is created with no alises, the name of the
+    - If a build Variable is created with no aliases, the name of the
       Variable is no longer listed in its aliases. Internally, the name
-      and alises are considered together anyway so this should not have
+      and aliases are considered together anyway so this should not have
       any effect except for being visible to custom help text formatters.
     - A build Variable is now a dataclass, with initialization moving to
       the automatically provided method; the Variables class no longer

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -167,6 +167,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       their values taken from the default in the variable description
       (if a variable was set to the same value as the default in one
       of the input sources, it is not included in this list).
+    - If a build Variable is created with no alises, the name of the
+      Variable is no longer listed in its aliases. Internally, the name
+      and alises are considered together anyway so this should not have
+      any effect except for being visible to custom help text formatters.
+    - A build Variable is now a dataclass, with initialization moving to
+      the automatically provided method; the Variables class no longer
+      writes directly to a Variable (makes static checkers happier).
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -82,9 +82,9 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   (if a variable was set to the same value as the default in one
   of the input sources, it is not included in this list).
 
-- If a build Variable is created with no alises, the name of the
+- If a build Variable is created with no aliases, the name of the
   Variable is no longer listed in its aliases. Internally, the name
-  and alises are considered together anyway so this should not have
+  and aliases are considered together anyway so this should not have
   any effect except for being visible to custom help text formatters.
 
 FIXES

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -82,6 +82,11 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   (if a variable was set to the same value as the default in one
   of the input sources, it is not included in this list).
 
+- If a build Variable is created with no alises, the name of the
+  Variable is no longer listed in its aliases. Internally, the name
+  and alises are considered together anyway so this should not have
+  any effect except for being visible to custom help text formatters.
+
 FIXES
 -----
 

--- a/SCons/Variables/VariablesTests.py
+++ b/SCons/Variables/VariablesTests.py
@@ -550,7 +550,7 @@ A: a - alpha test
                  check,
                  lambda x: int(x) + 12)
 
-        opts.Add('B',
+        opts.Add(['B', 'BOPTION'],
                  'b - alpha test',
                  "42",
                  check,
@@ -566,9 +566,9 @@ A: a - alpha test
         opts.Update(env, {})
 
         expect = """\
-ANSWER 42 54 THE answer to THE question ['ANSWER']
-B 42 54 b - alpha test ['B']
-A 42 54 a - alpha test ['A']
+ANSWER 42 54 THE answer to THE question []
+B 42 54 b - alpha test ['BOPTION']
+A 42 54 a - alpha test []
 """
 
         text = opts.GenerateHelpText(env)
@@ -576,9 +576,9 @@ A 42 54 a - alpha test ['A']
             self.assertEqual(expect, text)
 
         expectAlpha = """\
-A 42 54 a - alpha test ['A']
-ANSWER 42 54 THE answer to THE question ['ANSWER']
-B 42 54 b - alpha test ['B']
+A 42 54 a - alpha test []
+ANSWER 42 54 THE answer to THE question []
+B 42 54 b - alpha test ['BOPTION']
 """
         text = opts.GenerateHelpText(env, sort=cmp)
         with self.subTest():


### PR DESCRIPTION
This moves the initialization into the `Variable` class itself, rather than being done in the `_do_add` method of the `Variables` class.  We get nice printing and comparison for free via the dataclass mechanism, so the old methods are dropped from `Variable`.

Also correct one long-standing minor inconsistency: if a list of names for a variable is given, it is split into name and aliases, with the name not duplicated into the aliases. If only one name is given (no aliases), it was also added as the sole entry in the aliases; now it is not added to the aliases.  All the SCons usages of aliases combine them back together anyway, like:

```python
    if arg in option.aliases + [option.key,]:
```

So there's no need for the behavior of the one-name form, including the name in aliases. One test did need to change for this - the test of a custom help formatter function was wired to accept the old form, but only because of the way the custom formatter in the test was written, so this is a self-contained problem.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
