### PR TITLE
Change update-release-info test for Python changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -181,6 +181,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Only object-like macros are replaced (not function-like), and
       only on a whole-word basis; recursion is limited to five levels
       and does not error out if that limit is reached (issue #4523).
+    - The update-release-info test is adapted to accept changed help output
+      introduced in Python 3.12.8/3.13.1.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/test/update-release-info/update-release-info.py
+++ b/test/update-release-info/update-release-info.py
@@ -53,11 +53,24 @@ test = TestRuntest.TestRuntest(
 if not os.path.exists(test.program):
     test.skip_test("update-release-info.py is not distributed in this package\n")
 
-expected_stderr = """usage: update-release-info.py [-h] [--verbose] [--timestamp TIMESTAMP]
+expected_stderr = """\
+usage: update-release-info.py [-h] [--verbose] [--timestamp TIMESTAMP]
                               [{develop,release,post}]
 update-release-info.py: error: argument mode: invalid choice: 'bad' (choose from 'develop', 'release', 'post')
 """
-test.run(arguments='bad', stderr=expected_stderr, status=2)
+# The way the choices are rendered in help by argparse changed with
+# Python 3.12.8, # 3.13.1, 3.14.0a2. Change the test to accept either.
+expected_stderr_new = """\
+usage: update-release-info.py [-h] [--verbose] [--timestamp TIMESTAMP]
+                              [{develop,release,post}]
+update-release-info.py: error: argument mode: invalid choice: 'bad' (choose from develop, release, post)
+"""
+test.run(arguments='bad', stderr=None, status=2)
+fail_strings = [
+    expected_stderr,
+    expected_stderr_new,
+]
+test.must_contain_any_line(test.stderr(), fail_strings)
 
 # Strings to go in ReleaseConfig
 combo_strings = [


### PR DESCRIPTION
After Python introduced a change (in 3.12.8/3.13.1) in the way help text is rendered by `argparse` (no longer quoting the individual choices), the test of the "expected error" for `bin/update-release-info.py` now accepts both the old and the new text.


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
