### PR TITLE
Set TEMPLATE rule to `install_pool` for the Ninja tool

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -191,8 +191,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       introduced in Python 3.12.8/3.13.1.
 
     From Adam Scott:
-    - Changed the TEMPLATE rule of the Ninja tool to use the `install_pool`
-      instead of `local_pool` in order to curb some race conditions.
+    - Changed Ninja's TEMPLATE rule pool to use `install_pool` instead of
+      `local_pool`, hoping it will fix a race condition that can occurs when
+      Ninja defers to SCons to build.
 
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -190,6 +190,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - The update-release-info test is adapted to accept changed help output
       introduced in Python 3.12.8/3.13.1.
 
+    From Adam Scott:
+    - Changed the TEMPLATE rule of the Ninja tool to use the `install_pool`
+      instead of `local_pool` in order to curb some race conditions.
+
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -167,6 +167,10 @@ FIXES
 - Minor modernization: make use of stat object's st_mode, st_mtime
   and other attributes rather than indexing into stat return.
 
+- Ninja's TEMPLATE rule pool changed from `local_pool` to `install_pool``
+  hoping it will fix a race condition that can occurs when Ninja defers
+  to SCons to build.
+
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/ninja_tool/NinjaState.py
+++ b/SCons/Tool/ninja_tool/NinjaState.py
@@ -231,7 +231,7 @@ class NinjaState:
             "TEMPLATE": {
                 "command": "$PYTHON_BIN $NINJA_TOOL_DIR/ninja_daemon_build.py $PORT $NINJA_DIR_PATH $out",
                 "description": "Defer to SCons to build $out",
-                "pool": "local_pool",
+                "pool": "install_pool",
                 "restat": 1
             },
             "EXIT_SCONS_DAEMON": {


### PR DESCRIPTION
This PR changes the TEMPLATE rule pool from `local_pool` (which seems to match the number of jobs supplied) to `install_pool` (which runs at half of the number of jobs supplied).

It seems to solve #4667 

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
