### PR TITLE
Manpage: modify the Builder Methods section

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -179,6 +179,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       support batch mode (currently: Windows).  Change the way the changed
       and unchanged target and source lists are accounted for to resolve.
       Fixes #3029.
+    - Improve the Builder Methods intro section in manpage, making sure
+      all prose appears before the listing of methods.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700
@@ -194,7 +196,6 @@ RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700
   From Mats Wichmann:
     - Fix typos in CCFLAGS test. Didn't affect the test itself, but
       didn't correctly apply the DefaultEnvironment speedup.
-
     - New CacheDir initialization code failed on Python 3.7 for unknown
       reason (worked on 3.8+). Adjusted the approach a bit.  Fixes #4694.
     - Try to fix Windows fails on Docbook tests in case xsltproc is found.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -150,6 +150,9 @@ DOCUMENTATION
 
 - Improve the wording of AppendENVPath and PrependENVPath in manpage.
 
+- Improve the descriptive portion of the Builder Methods section in
+  the manpage: reword, reorganize.
+
 DEVELOPMENT
 -----------
 
@@ -205,6 +208,5 @@ DEVELOPMENT
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================
 .. code-block:: text
-
 
     git shortlog --no-merges -ns 4.9.1..HEAD

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -2815,71 +2815,59 @@ method (see below).
 <refsect2 id='builder_methods'>
 <title>Builder Methods</title>
 
-<para>You tell &SCons; what to build
-by calling <firstterm>Builders</firstterm>,
-functions which take particular action(s)
-to produce target(s) of a particular type
-(conventionally hinted at by the builder name, e.g. &Program;)
-from the specified source files.
-A builder call is a declaration: &SCons; enters the
-specified relationship into its internal dependency node graph,
-and only later makes the decision on whether anything is actually built,
-since this depends on command-line options,
-target selection rules, and whether the target(s) are
-out-of-date with respect to the sources.
+<para>
+Builder methods in &SCons; are special functions
+used to declare relationships in the dependency graph.
+Calling a Builder does not build anything directly,
+but records the target (what you want built),
+sources (what it’s built from),
+the &consenv; to use for build settings,
+and information the builder itself
+knows about the type of build.
+The &SCons; job runner later decides if and when
+to initiate a build using this information.
 </para>
 
 <para>
-&SCons;
-provides a number of builders, and you can also write your own
-(see <link linkend='builder_objects'>Builder Objects</link>).
-Builders are created dynamically at run-time,
-often (though not always) by tools which determine
-whether the external dependencies for the builder are satisfied,
-and which perform the necessary setup
-(see <link linkend='tools'>Tools</link>).
-Builders are attached to a &consenv; as methods.
-The available builder methods are registered as
-key-value pairs in the
-&cv-link-BUILDERS; attribute of the &consenv;,
-so the available builders can be examined.
-This example displays them for debugging purposes:
+All true Builder methods share the same function calling syntax.
+For the sake of brevity, this common signature is not included in
+the listing of Builders.
+Pseudo-Builders have more flexibility in how they are called,
+and do not necessarily follow this convention,
+as described in the text of the respective entries.
 </para>
 
 <programlisting language="python">
-env = Environment()
-print("Builders:", list(env['BUILDERS']))
+<function>Buildername</function>(<parameter>target, source, [key=val, ...]</parameter>)
 </programlisting>
 
 <para>
-Builder methods take two required arguments:
-<parameter>target</parameter>
-and
-<parameter>source</parameter>.
 The <parameter>target</parameter> and
 <parameter>source</parameter> arguments
-can be specified either as positional arguments,
-in which case <parameter>target</parameter> comes first, or as
-keyword arguments, using <parameter>target=</parameter>
-and <parameter>source=</parameter>.
-Although both arguments are nominally required,
-if there is a single source and the target can be inferred
-the <parameter>target</parameter> argument can be omitted (see below).
-Builder methods also take a variety of
-keyword arguments, described below.
+can be specified either as positional or keyword arguments.
+Some additional keyword arguments are recognized for all builders,
+and any unknown keyword arguments are treated as temporary
+&consvar; assignments.
+You can specify sources and targets as a scalar or a list,
+composed of either strings or nodes.
+For convenience, the &SCons; &f-link-Split; method
+can be used to split a single string into a list,
+using strings of white-space characters as the delimiter.
 </para>
 
-<para>Because long lists of file names
-can lead to a lot of quoting in a builder call,
-&SCons;
-supplies a &f-link-Split;
-global function
-and a same-named environment method
-that splits a single string
-into a list, using
-strings of white-space characters as the delimiter
-(similar to the &Python; string <function>split</function>
-method, but succeeds even if the input isn't a string).</para>
+<para>
+When specifying path strings,
+&SCons; follows the platform's pathname conventions
+for absolute and relative paths.
+Relative paths are interpreted relative to the directory
+of the &SConscript; file being evaluated.
+&SCons; also recognizes a third way to specify path strings:
+if the string begins with the <literal>#</literal>
+character, it is evaluated relative to the top directory of the project
+(<firstterm>top-relative</firstterm>).
+Note top-relative path strings work only in &SCons; contexts,
+pure &Python; functions will not interpret them correctly.
+</para>
 
 <para>
 The following are equivalent examples of calling the
@@ -2896,47 +2884,13 @@ env.Program(target='bar', source=env.Split('bar.c foo.c'))
 env.Program('bar', source='bar.c foo.c'.split())
 </programlisting>
 
-<para>
-Sources and targets can be specified as a scalar or as a list,
-composed of either strings or nodes (more on nodes below).
-When specifying path strings,
-&Python; follows the POSIX pathname convention:
-if a string begins with the operating system pathname separator
-(on Windows both the slash and backslash separator are accepted,
-and any leading drive specifier is ignored for
-the determination) it is considered an absolute path,
-otherwise it is a relative path.
-If the path string contains no separator characters,
-it is searched for as a file in the current directory. If it
-contains separator characters, the search follows down
-from the starting point, which is the top of the directory tree for
-an absolute path and the current directory for a relative path.
-The "current directory" in this context is the directory
-of the &SConscript; file currently being processed.
+<para>Here are some examples showing source and target path manipulation
+by &SCons; - assume this code would be in an &SConscript;
+file in <filename>subdir</filename>, called by
+<userinput>SConscript("subdir")</userinput>:
 </para>
-
-<para>
-&SCons; also recognizes a third way to specify
-path strings: if the string begins with
-the <emphasis role="bold">#</emphasis> character it is
-<firstterm>top-relative</firstterm> - it works like a relative path, but the
-search follows down from the project top directory rather than
-from the current directory. The <emphasis role="bold">#</emphasis>
-can optionally be followed by a pathname separator,
-which is ignored if found in that position.
-Top-relative paths only work in places where &scons; will
-interpret the path (see some examples below).  To be
-used in other contexts the string will need to be converted
-to a relative or absolute path first.
-</para>
-
-<para>Examples:</para>
 
 <programlisting language="python">
-# The comments describing the targets that will be built
-# assume these calls are in a SConscript file in the
-# a subdirectory named "subdir".
-
 # Builds the program "subdir/foo" from "subdir/foo.c":
 env.Program('foo', 'foo.c')
 
@@ -2954,42 +2908,35 @@ env.Program('#/bar', 'bar.c')
 # SConstruct directory) from "subdir/foo.c":
 env.Program('#other/foo', 'foo.c')
 
-# This will not work, only SCons interfaces understand '#',
-# os.path.exists is pure Python:
+# Will not work, only SCons interfaces understand '#',
+# while os.path.exists is pure Python:
 if os.path.exists('#inc/foo.h'):
     env.Append(CPPPATH='#inc')
 </programlisting>
 
-<para>When the target shares the same base name
-as the source and only the suffix varies,
-and if the builder method has a suffix defined for the target file type,
-then the target argument may be omitted completely,
-and
-&scons;
-will deduce the target file name from
-the source file name.
-The following examples all build the
-executable program
-<emphasis role="bold">bar</emphasis>
-(on POSIX systems)
-or
-<emphasis role="bold">bar.exe</emphasis>
-(on Windows systems)
-from the <filename>bar.c</filename> source file:</para>
+<para>
+If &SCons; can deduce the target name from the source(s),
+the <parameter>target</parameter> argument may be omitted.
+If the Builder supports it,
+&SCons; will take the base name of the first source file
+and use it as the base name of the target,
+adding the appropriate prefix/suffix.
+For Builders designated as single-source,
+a separate target is built for each source file,
+rather than multiple sources contributing to a single target.
+If multiple sources are passed to a single-source builder,
+the target argument <emphasis>must</emphasis> be omitted,
+and each target will be given a name deduced from
+the corresponding source file.
+</para>
 
-<programlisting language="python">
-env.Program(target='bar', source='bar.c')
-env.Program('bar', source='bar.c')
-env.Program(source='bar.c')
-env.Program('bar.c')
-</programlisting>
-
-<para>The optional
+<para>
+The optional
 <parameter>srcdir</parameter>
 keyword argument specifies that
-all source file strings that are not absolute paths
+source file strings that are not absolute
 or top-relative paths
-shall be interpreted relative to the specified
+should be interpreted relative to the value of
 <parameter>srcdir</parameter>.
 The following example will build the
 <filename>build/prog</filename>
@@ -2999,33 +2946,35 @@ on Windows)
 program from the files
 <filename>src/f1.c</filename>
 and
-<filename>src/f2.c</filename>:
+<filename>src/f2.c</filename>,
+rather than looking for them in the directory of
+of the &SConscript; file being evaluated.
 </para>
 
 <programlisting language="python">
 env.Program('build/prog', ['f1.c', 'f2.c'], srcdir='src')
 </programlisting>
 
-<para>The optional
+<para>
+The optional
 <parameter>parse_flags</parameter>
 keyword argument causes behavior similar to the
 &f-link-env-MergeFlags; method, where the argument value is
 broken into individual settings and merged into the appropriate &consvars;.
+The following example adds <literal>'include'</literal> to
+the &cv-link-CPPPATH; &consvar;,
+<literal>'EBUG'</literal> to
+&cv-link-CPPDEFINES;,
+and <literal>'m'</literal> to
+&cv-link-LIBS;:
 </para>
 
 <programlisting language="python">
 env.Program('hello', 'hello.c', parse_flags='-Iinclude -DEBUG -lm')
 </programlisting>
 
-<para>This example adds 'include' to
-the &cv-link-CPPPATH; &consvar;,
-'EBUG' to
-&cv-link-CPPDEFINES;,
-and 'm' to
-&cv-link-LIBS;.
-</para>
-
-<para>The optional
+<para>
+The optional
 <parameter>chdir</parameter>
 keyword argument
 specifies that the Builder's action(s)
@@ -3041,23 +2990,10 @@ If the
 is not a string or Node
 and evaluates true,
 then &scons; will change to the
-target file's directory.</para>
-
-<warning>
-<para>
-&Python; only keeps one current directory
-location even if there are multiple threads.
-This means that use of the
-<parameter>chdir</parameter>
-argument
-will
-<emphasis>not</emphasis>
-work with the SCons
-<option>-j</option>
-option,
-because individual worker threads spawned
-by &SCons; interfere with each other
-when they start changing directory.</para>
+target file's directory.
+The original directory is restored
+after the action is complete.
+</para>
 
 <programlisting language="python">
 # scons will change to the "sub" subdirectory
@@ -3074,20 +3010,29 @@ env.Command(
 # "cp" command.
 env.Command('sub/dir/foo.out', 'sub/dir/foo.in', "cp foo.in foo.out", chdir=True)
 </programlisting>
+
+<warning>
+<para>
+&Python; only tracks one current directory location,
+even if there are multiple executing threads.
+This means that use of the
+<parameter>chdir</parameter>
+argument will
+<emphasis>not</emphasis>
+work with &SCons; in multi-threaded mode
+(the <link linkend="opt-jobs"><option>-j</option></link> option),
+because individual worker threads spawned
+by &SCons; interfere with each other
+when they start changing directory.</para>
 </warning>
 
-<para>Note that &SCons; will
-<emphasis>not</emphasis>
-automatically modify
-its expansion of
-&consvars; like &cv-link-TARGET;
-and &cv-link-SOURCE;
-when using the <parameter>chdir</parameter>
-keyword argument--that is,
-the expanded file names
-will still be relative to
-the project top directory,
-and consequently incorrect
+<note>
+<para>
+&SCons; does not account for
+<parameter>chdir</parameter>
+when it expands &consvars;
+like &cv-link-TARGET; and &cv-link-SOURCE;,
+so they will be incorrect
 relative to the chdir directory.
 If you use the <parameter>chdir</parameter> keyword argument,
 you will typically need to supply a different
@@ -3097,15 +3042,19 @@ expansions like
 and
 <literal>${SOURCE.file}</literal>
 to use just the filename portion of the
-target and source.</para>
+target and source,
+which will then evaluated be relative to the
+<parameter>chdir</parameter> directory.
+</para>
+</note>
 
-<para>Keyword arguments that are not specifically
-recognized are treated as &consvar;
-<firstterm>overrides</firstterm>,
-which replace or add those variables on a limited basis.
-These overrides
-will only be in effect when building the target of the builder call,
-and will not affect other parts of the build.
+<para>
+Keyword arguments that are not specifically
+recognized are treated as &consvar; assignments,
+creating an <firstterm>override</firstterm>
+for the &consenv; which is only used
+when building the target of the builder call.
+These temporary assignments do not affect the &consenv; itself.
 For example, if you want to specify
 some libraries needed by just one program:</para>
 
@@ -3113,210 +3062,190 @@ some libraries needed by just one program:</para>
 env.Program('hello', 'hello.c', LIBS=['gl', 'glut'])
 </programlisting>
 
-<para>or generate a shared library with a non-standard suffix:</para>
-
-<programlisting language="python">
-env.SharedLibrary(
-    target='word',
-    source='word.cpp',
-    SHLIBSUFFIX='.ocx',
-    LIBSUFFIXES=['.ocx'],
-)
-</programlisting>
-
-<para>Note that both the &cv-link-SHLIBSUFFIX;
-and &cv-link-LIBSUFFIXES;
-&consvars; must be set if you want &scons; to search automatically
-for dependencies on the non-standard library names;
-see the descriptions of these variables for more information.</para>
-
-<para>Although the builder methods defined by
-&scons;
-are, in fact,
-methods of a &consenv; object,
-many may also be called without an explicit environment:</para>
-
-<programlisting language="python">
-Program('hello', 'hello.c')
-SharedLibrary('word', 'word.cpp')
-</programlisting>
-
-<para>If called this way, the builder will internally use the
-&DefEnv; that consists of the tools and values that
-&scons;
-has determined are appropriate for the local system.</para>
-
-<para>Builder methods that can be called without an explicit
-environment (indicated in the listing of builders below
-without a leading <varname>env.</varname>)
-may be called from custom &Python; modules that you
-import into an &SConscript; file by adding the following
-to the &Python; module:</para>
-
-<programlisting language="python">
-from SCons.Script import *
-</programlisting>
-
 <para>
 A builder <emphasis>may</emphasis> add additional targets
-beyond those requested
+beyond those requested,
 if an attached <firstterm>Emitter</firstterm> chooses to do so
-(see <xref linkend="builder_objects"/> for more information.
-&cv-link-PROGEMITTER; is an example).
-For example, the GNU linker takes a command-line argument
-<option>-Map=<replaceable>mapfile</replaceable></option>,
-which causes it to produce a linker map file in addition
-to the executable file actually being linked.
-If the &b-link-Program; builder's emitter is configured
-to add this mapfile if the option is set,
-then two targets will be returned when you only provided for one.
-</para>
-
-<para>
+(see <xref linkend="builder_objects"/> for more information).
 For this reason,
 builder methods always return a <classname>NodeList</classname>,
 a list-like object whose elements are Nodes.
-Nodes are the internal representation of build targets or sources
+A Node is the internal representation of a target, source,
+or other entity that is included in the build graph
 (see <xref linkend="node_objects"/> for more information).
+</para>
+
+<para>
 The returned <classname>NodeList</classname> object
 can be passed to other builder methods as source(s)
 or to other &SCons; functions or methods
-where a path string would normally be accepted.
+where a path string would normally be accepted,
+for example &f-link-Default;, &f-link-Alias; or
+&f-link-AddPostAction;.
+Using a NodeList or Node obtained from a Builder call
+makes for a more portable build,
+since platform-specific names can be avoided.
+Examples:
 </para>
 
-<para> For example,
-to add a specific preprocessor define
-when compiling one specific object file
-but not the others:</para>
-
 <programlisting language="python">
+# build "bar" object with a special compiler flag:
 bar_obj_list = env.StaticObject('bar.c', CPPDEFINES='-DBAR')
-env.Program("prog", ['foo.c', bar_obj_list, 'main.c'])
-</programlisting>
 
-<para>Using a Node as in this example
-makes for a more portable build
-by avoiding having to specify
-a platform-specific object suffix
-when calling the &b-link-Program; builder method.
-</para>
+# include that object when building "prog":
+tgt = env.Program("prog", ['foo.c', bar_obj_list, 'main.c'])
 
-<para>The <classname>NodeList</classname> object
-is also convenient to pass to the &f-link-Default; function,
-for the same reason of avoiding a platform-specific name:
-</para>
-
-<programlisting language="python">
-tgt = env.Program("prog", ["foo.c", "bar.c", "main.c"])
+# add the resulting program to default targets and an alias:
 Default(tgt)
+Alias("targets", tgt)
 </programlisting>
 
-<para>Builder calls will automatically "flatten"
-lists passed as source and target, so they are free to
-contain elements which are themselves lists, such as
-<varname>bar_obj_list</varname>
-returned by the &b-link-StaticObject; call.
+<para>
+Builder calls automatically "flatten"
+lists passed as source and target,
+so they are free to contain elements which are themselves lists,
+such as a NodeList object returned by another Builder call.
 If you need to manipulate a list of lists returned by builders
 directly in &Python; code,
-you can either build a new list by hand:</para>
+you can either build a new list by hand
+or use the &SCons; &f-link-Flatten; function,
+which returns a flattened list:
+</para>
 
 <programlisting language="python">
-foo = Object('foo.c')
-bar = Object('bar.c')
+foo = Object('foo.c')  # returns a NodeList
+bar = Object('bar.c')  # returns a NodeList
+
 objects = ['begin.o'] + foo + ['middle.o'] + bar + ['end.o']
-for obj in objects:
-    print(str(obj))
+print(', '.join(str(obj) for obj in objects))
+# shows: begin.o, foo.o, middle.o, bar.o, end.o
+
+objects = Flatten(('begin.o', foo, 'middle.o', bar, 'end.o'))
+print(', '.join(str(obj) for obj in objects))
+# shows: begin.o, foo.o, middle.o, bar.o, end.o
 </programlisting>
 
-<para>Or you can use the &f-link-Flatten;
-function supplied by &SCons;
-to create a list containing just the Nodes,
-which may be more convenient:</para>
-
-<programlisting language="python">
-foo = Object('foo.c')
-bar = Object('bar.c')
-objects = Flatten(['begin.o', foo, 'middle.o', bar, 'end.o'])
-for obj in objects:
-    print(str(obj))
-</programlisting>
-
-<para>Since builder calls return
-a list-like object, not an actual &Python; list,
-it is not appropriate to use the &Python; add
-operator (<literal>+</literal> or <literal>+=</literal>)
-to append builder results to a &Python; list.
-Because the list and the object are different types,
-&Python; will not update the original list in place,
-but will instead create a new <classname>NodeList</classname> object
-containing the concatenation of the list
-elements and the builder results.
-This will cause problems for any other &Python; variables
-in your SCons configuration
-that still hold on to a reference to the original list.
-Instead, use the &Python; list
-<function>extend</function>
-method to make sure the list is updated in-place.
-Example:</para>
+<note>
+<para>
+Do not use the &Python;
+in-place addition operator (<literal>+=</literal>)
+to append a NodeList builder result to a an existing &Python; list -
+this causes a conversion to a new <classname>NodeList</classname> object.
+If the original list has other references,
+they will continue to refer to the unmodified version,
+which can have undesired results.
+Use the &Python; list <methodname>extend</methodname> method instead.
+In-place addition is fine if the object being added to
+is already a <classname>NodeList</classname>.
+</para>
 
 <programlisting language="python">
 object_files = []
+saved_object_files = object_files
 
-# Do NOT use += here:
-#    object_files += Object('bar.c')
-#
-# It will not update the object_files list in place.
-#
+# Do NOT use += here, there will be a new object_files,
+# but saved_object_files will still refer to the original list
+object_files += Object('bar.c')
+
 # Instead, use the list extend method:
 object_files.extend(Object('bar.c'))
 </programlisting>
+</note>
 
-<para>The path name for a Node's file may be used
-by passing the Node to &Python;'s built-in
-<function>str</function>
-function:</para>
+<para>
+To access the individual Node that represents the requested target file,
+use a list index
+(e.g. <literal>bar_obj_list[0]</literal>).
+The path name for a Node's file can be obtained
+by using &Python;'s string constructor <function>str</function>
+(e.g. <literal>str(bar_obj_list[0])</literal>).
+</para>
 
 <programlisting language="python">
 bar_obj_list = env.StaticObject('bar.c', CPPDEFINES='-DBAR')
 print("The path to bar_obj is:", str(bar_obj_list[0]))
 </programlisting>
 
-<para>Note that because the Builder call returns a
-<classname>NodeList</classname>,
-you have to access the first element in the list
-(<literal>bar_obj_list[0]</literal> in the example)
-to get at the Node that actually represents
-the object file.</para>
-
 <para>
-When trying to handle errors that may occur in a builder method,
-consider that the corresponding Action is executed at a different
-time than the &SConscript; file statement calling the builder.
-It is not useful to wrap a builder call in a
-<systemitem>try</systemitem> block,
-since success in the builder call is not the same as
-the builder itself succeeding.
-If necessary, a Builder's Action should be coded to exit with
-a useful exception message indicating the problem in the &SConscript; files -
-programmatically recovering from build errors is rarely useful.
+All targets of builder methods automatically depend on their sources.
+&SCons; automatically scans
+source files for various programming languages,
+eliminating the need for explicit dependency specification.
+By default, &SCons; can scan
+C source files,
+C++ source files,
+Fortran source files with
+<filename>.F</filename>
+(POSIX systems only),
+<filename>.fpp</filename>,
+or
+<filename>.FPP</filename>
+file extensions,
+and assembly language files with
+<filename>.S</filename>
+(POSIX systems only),
+<filename>.spp</filename>,
+or
+<filename>.SPP</filename>
+files extensions
+for C preprocessor dependencies.
+SCons also has default support
+for scanning D source files.
+You can also specify an explicit dependency
+using the &f-link-env-Depends; method
+of a &consenv;.
 </para>
 
 <para>
-The following builder methods are predefined in the
-&SCons; core software distribution.
-Depending on the setup of a particular
-&consenv; and on the type and software
-installation status of the underlying system,
-not all builders may be available in that
-&consenv;.
-Since the function calling signature is the same for all builders:
+Builders are created at runtime for efficiency
+and added to the &consenv; as methods.
+&SCons; provides templates for a large number
+of Builders for known build types,
+and additional Builders can be written to add to a project.
+The templates usually exist in
+<link linkend='tools'>Tool specification modules</link>,
+which, when run, can probe for the presence of required external tools,
+such as a compiler binary,
+and for other necessary conditions,
+before instantiating the Builder.
+The Builders available in a given &consenv; thus vary
+with the type of platform, how the platform is provisioned,
+and the tools selected for loading.
+The available builder methods are registered as
+key-value pairs in the &cv-link-BUILDERS; attribute of the &consenv;.
 </para>
+
+<para>
+Although a Builder is created as a method of a &consenv;,
+many may also be called as if they were a global function.
+These will be indicated in the listing of Builders below
+without a leading <varname>env.</varname>
+A Builder called this way will internally use the
+&DefEnv; to look up &consvars;:
+</para>
+
 <programlisting language="python">
-<function>Buildername</function>(<parameter>target, source, [key=val, ...]</parameter>)
+Program('hello', 'hello.c')
+SharedLibrary('word', 'word.cpp')
 </programlisting>
+
 <para>
-it is omitted in this listing for brevity.
+Builders called in the global function style
+are automatically in scope inside &SConscript; files.
+They are not in scope
+in project-specific &Python; modules that you include
+via the &Python; <literal>import</literal> statement
+from an &SConscript; file,
+and you will need to add them to that module’s global scope explicitly.
+You can do that by adding the following import to the &Python; module:
+<userinput>from SCons.Script import *</userinput>.
 </para>
+
+<para>
+The following builder methods have templates in the
+&SCons; core software distribution.
+</para>
+
 
 <!-- '\""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""" -->
 <!-- '\" BEGIN GENERATED BUILDER DESCRIPTIONS -->
@@ -3338,62 +3267,13 @@ it is omitted in this listing for brevity.
 <!-- '\" END GENERATED BUILDER DESCRIPTIONS -->
 <!-- '\""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""" -->
 
-
-<para>All
-targets of builder methods automatically depend on their sources.
-An explicit dependency can
-be specified using the
-&f-link-env-Depends;
-method of a &consenv; (see below).</para>
-
-<para>In addition,
-&scons;
-automatically scans
-source files for various programming languages,
-so the dependencies do not need to be specified explicitly.
-By default, SCons can
-C source files,
-C++ source files,
-Fortran source files with
-<filename>.F</filename>
-(POSIX systems only),
-<filename>.fpp</filename>,
-or
-<filename>.FPP</filename>
-file extensions,
-and assembly language files with
-<filename>.S</filename>
-(POSIX systems only),
-<filename>.spp</filename>,
-or
-<filename>.SPP</filename>
-files extensions
-for C preprocessor dependencies.
-SCons also has default support
-for scanning D source files,
-You can also write your own Scanners
-to add support for additional source file types.
-These can be added to the default
-Scanner object used by the
-&b-link-Object;, &b-link-StaticObject; and &b-link-SharedObject;
-Builders by adding them
-to the
-<classname>SourceFileScanner</classname>
-object.
-See <xref linkend="scanner_objects"/>
-for more information about
-defining your own Scanner objects
-and using the
-<classname>SourceFileScanner</classname>
-object.</para>
-
 </refsect2>
 
 <refsect2 id='env_methods'>
 <title>&SCons; Functions and Environment Methods</title>
 
 <para>
-&SCons; provides a variety of  &consenv; methods
+&SCons; provides a variety of &consenv; methods
 and global functions to manipulate the build configuration.
 Often, a &consenv; method and a global function with
 the same name exist for convenience.
@@ -3436,19 +3316,17 @@ with two key differences:
 <orderedlist>
 <listitem>
 <para>
-&Consenv; methods that change the environment
+&Consenv; methods that read from or change the environment
 act on the environment instance from which they are called,
-while the corresponding global function acts on
-a special “hidden” &consenv; called the Default Environment.
-In some cases, the global function may take
-an initial argument giving the object to operate on.
+while the corresponding global function reads from
+a special “hidden” &consenv; called the &DefEnv;
 </para>
 </listitem>
 <listitem>
 <para>
 String-valued arguments
 (including strings in list-valued arguments)
-are subject to construction variable expansion
+are subject to &consvar; expansion
 by the environment method form;
 variable expansion is not immediately performed in the global function.
 For example, <userinput>Default('$MYTARGET')</userinput>
@@ -6482,6 +6360,21 @@ following functions:
 <link linkend='miscellaneous_action_functions'>function Actions</link>,
 and
 <link linkend='emitter_function'>emitter functions</link>.
+</para>
+
+<para>
+When debugging errors in a custom builder method,
+remember that the builder's Action is executed asynchronously -
+the builder call in the &SConscript; only instructs
+&SCons; what you want built, while the actual building is
+scheduled later (if necessary) by the taskmaster.
+As a result, wrapping a builder call in a
+<systemitem>try</systemitem> block is not useful,
+as success in the builder call is not the same as
+the build itself succeeding.
+If necessary, code a builder's Action to exit with
+a useful error message indicating the problem in the &SConscript; file.
+Attempting programmatic recovery from build errors is rarely useful.
 </para>
 
 </refsect2>


### PR DESCRIPTION
In clarifying the detail on when a builder's target can be deduced, it seemed like the concept of a single-source builder should be introduced in this context. So now those builders we know are single-source have that notation in their entry in this section. Also mentions that pseudo-Builders may have a different calling sequence.

A chunk of text about dependencies previously appeared after the listing of builder methods, where it would be hard to spot. Moved up into the text before the listing, and integrate in a bit more smoothly.

A couple of very minor typing things adjusted along the way - mainly using `single_source` consistently as a `bool`.

There are no functional changes, so no test impacts.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
