### PR TITLE
Manpage: note pre/post actions effect on an alias

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,7 +18,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Fix typos in CCFLAGS test. Didn't affect the test itself, but
       didn't correctly apply the DefaultEnvironment speedup.
-    - Clarify that pre/post actions on an alias apply to the alias' action.
+    - Clarify how pre/post actions on an alias work.
 
 
 RELEASE 4.9.0 -  Sun, 02 Mar 2025 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Fix typos in CCFLAGS test. Didn't affect the test itself, but
       didn't correctly apply the DefaultEnvironment speedup.
+    - Clarify that pre/post actions on an alias apply to the alias' action.
 
 
 RELEASE 4.9.0 -  Sun, 02 Mar 2025 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,6 +53,8 @@ DOCUMENTATION
   typo fixes, even if they're mentioned in src/CHANGES.txt to give
   the contributor credit)
 
+- Clarify that pre/post actions on an alias apply to the alias' action.
+
 DEVELOPMENT
 -----------
 
@@ -62,4 +64,4 @@ Thanks to the following contributors listed below for their contributions to thi
 ==========================================================================================
 .. code-block:: text
 
-    git shortlog --no-merges -ns 4.0.1..HEAD
+    git shortlog --no-merges -ns 4.9.0..HEAD

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,7 +53,7 @@ DOCUMENTATION
   typo fixes, even if they're mentioned in src/CHANGES.txt to give
   the contributor credit)
 
-- Clarify that pre/post actions on an alias apply to the alias' action.
+- Clarify how pre/post actions on an alias work.
 
 DEVELOPMENT
 -----------

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -348,12 +348,15 @@ env.other_method_name('another arg')
 </arguments>
 <summary>
 <para>
-Arranges for the specified
+Arrange for the specified
 <parameter>action</parameter>
 to be performed
 after the specified
 <parameter>target</parameter>
 has been built.
+<parameter>target</parameter>
+may be a string or Node object,
+or a list of strings or Node objects.
 <parameter>action</parameter> may be
 an Action object, or anything that
 can be converted into an Action object.
@@ -374,6 +377,15 @@ foo = Program('foo.c')
 AddPostAction(foo, Chmod('$TARGET', "a-x"))
 </example_commands>
 
+<para>
+If a <parameter>target</parameter> is an Alias target,
+<parameter>action</parameter> is associated with the
+action of the alias,
+not of any targets that alias may refer to.
+Thus, &AddPostAction; will have no effect
+if called on an alias which has no action.
+</para>
+
 </summary>
 </scons_function>
 
@@ -383,12 +395,15 @@ AddPostAction(foo, Chmod('$TARGET', "a-x"))
 </arguments>
 <summary>
 <para>
-Arranges for the specified
+Arrange for the specified
 <parameter>action</parameter>
 to be performed
 before the specified
 <parameter>target</parameter>
 is built.
+<parameter>target</parameter>
+may be a string or Node object,
+or a list of strings or Node objects.
 <parameter>action</parameter> may be
 an Action object, or anything that
 can be converted into an Action object.
@@ -406,31 +421,50 @@ one or more targets in the list.
 <para>
 Note that if any of the targets are built in multiple steps,
 the action will be invoked just
-before the "final" action that specifically
+before the action step that specifically
 generates the specified target(s).
-For example, when building an executable program
-from a specified source
+It may not always be obvious
+if the process is multi-step - for example,
+when building an executable program from a specified source
 <filename>.c</filename>
-file via an intermediate object file:
+file, &scons; will build an intermediate object file first,
+and the pre-action will follow this.
+Example:
 </para>
 
 <example_commands>
 foo = Program('foo.c')
-AddPreAction(foo, 'pre_action')
+AddPreAction(foo, 'echo "Running pre-action"')
 </example_commands>
 
 <para>
-The specified
-<literal>pre_action</literal>
-would be executed before
+The specified pre-action is executed before
 &scons;
 calls the link command that actually
 generates the executable program binary
 <filename>foo</filename>,
-not before compiling the
+but after compiling the
 <filename>foo.c</filename>
-file into an object file.
+file into an object file:
 </para>
+
+<screen>
+$ scons -Q
+gcc -o foo.o -c foo.c
+echo "Running pre-action"
+Running pre-action
+gcc -o foo foo.o
+</screen>
+
+<para>
+If a <parameter>target</parameter> is an Alias target,
+<parameter>action</parameter> is associated with the
+action of the alias,
+not with any targets that alias may refer to.
+Thus, &AddPreAction; will have no effect
+if called on an alias which has no action.
+</para>
+
 </summary>
 </scons_function>
 
@@ -440,7 +474,7 @@ file into an object file.
 </arguments>
 <summary>
 <para>
-Creates an <firstterm>alias</firstterm> target that
+Create an <firstterm>Alias</firstterm> target that
 can be used as a reference to zero or more other targets,
 specified by the optional <parameter>source</parameter> parameter.
 Aliases provide a way to give a shorter or more descriptive

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -380,10 +380,7 @@ AddPostAction(foo, Chmod('$TARGET', "a-x"))
 <para>
 If a <parameter>target</parameter> is an Alias target,
 <parameter>action</parameter> is associated with the
-action of the alias,
-not of any targets that alias may refer to.
-Thus, &AddPostAction; will have no effect
-if called on an alias which has no action.
+action of the alias, if specified.
 </para>
 
 </summary>
@@ -425,10 +422,13 @@ before the action step that specifically
 generates the specified target(s).
 It may not always be obvious
 if the process is multi-step - for example,
-when building an executable program from a specified source
-<filename>.c</filename>
-file, &scons; will build an intermediate object file first,
-and the pre-action will follow this.
+if you use the &Program; builder to
+construct an executable program from a
+<filename>.c</filename> source file,
+&scons; builds an intermediate object file first;
+the pre-action is invoked after this step
+and just before the link command to
+generate the executable program binary.
 Example:
 </para>
 
@@ -436,17 +436,6 @@ Example:
 foo = Program('foo.c')
 AddPreAction(foo, 'echo "Running pre-action"')
 </example_commands>
-
-<para>
-The specified pre-action is executed before
-&scons;
-calls the link command that actually
-generates the executable program binary
-<filename>foo</filename>,
-but after compiling the
-<filename>foo.c</filename>
-file into an object file:
-</para>
 
 <screen>
 $ scons -Q
@@ -459,10 +448,7 @@ gcc -o foo foo.o
 <para>
 If a <parameter>target</parameter> is an Alias target,
 <parameter>action</parameter> is associated with the
-action of the alias,
-not with any targets that alias may refer to.
-Thus, &AddPreAction; will have no effect
-if called on an alias which has no action.
+action of the alias, if specified.
 </para>
 
 </summary>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -375,7 +375,7 @@ AddPostAction(foo, Chmod('$TARGET', "a-x"))
 </example_commands>
 
 <para>
-If a <parameter>target</parameter> is an &f-Alias,
+If a <parameter>target</parameter> is an &f-Alias;,
 <parameter>action</parameter> is associated with the
 action of the alias, if specified.
 </para>
@@ -440,7 +440,7 @@ gcc -o foo foo.o
 </screen>
 
 <para>
-If a <parameter>target</parameter> is an &f-Alias,
+If a <parameter>target</parameter> is an &f-Alias;,
 <parameter>action</parameter> is associated with the
 action of the alias, if specified.
 </para>

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -354,9 +354,6 @@ to be performed
 after the specified
 <parameter>target</parameter>
 has been built.
-<parameter>target</parameter>
-may be a string or Node object,
-or a list of strings or Node objects.
 <parameter>action</parameter> may be
 an Action object, or anything that
 can be converted into an Action object.
@@ -378,7 +375,7 @@ AddPostAction(foo, Chmod('$TARGET', "a-x"))
 </example_commands>
 
 <para>
-If a <parameter>target</parameter> is an Alias target,
+If a <parameter>target</parameter> is an Alias,
 <parameter>action</parameter> is associated with the
 action of the alias, if specified.
 </para>
@@ -398,9 +395,6 @@ to be performed
 before the specified
 <parameter>target</parameter>
 is built.
-<parameter>target</parameter>
-may be a string or Node object,
-or a list of strings or Node objects.
 <parameter>action</parameter> may be
 an Action object, or anything that
 can be converted into an Action object.
@@ -446,7 +440,7 @@ gcc -o foo foo.o
 </screen>
 
 <para>
-If a <parameter>target</parameter> is an Alias target,
+If a <parameter>target</parameter> is an Alias,
 <parameter>action</parameter> is associated with the
 action of the alias, if specified.
 </para>
@@ -460,7 +454,7 @@ action of the alias, if specified.
 </arguments>
 <summary>
 <para>
-Create an <firstterm>Alias</firstterm> target that
+Create an <firstterm>Alias</firstterm> node that
 can be used as a reference to zero or more other targets,
 specified by the optional <parameter>source</parameter> parameter.
 Aliases provide a way to give a shorter or more descriptive

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -375,7 +375,7 @@ AddPostAction(foo, Chmod('$TARGET', "a-x"))
 </example_commands>
 
 <para>
-If a <parameter>target</parameter> is an Alias,
+If a <parameter>target</parameter> is an &f-Alias,
 <parameter>action</parameter> is associated with the
 action of the alias, if specified.
 </para>
@@ -440,7 +440,7 @@ gcc -o foo foo.o
 </screen>
 
 <para>
-If a <parameter>target</parameter> is an Alias,
+If a <parameter>target</parameter> is an &f-Alias,
 <parameter>action</parameter> is associated with the
 action of the alias, if specified.
 </para>


### PR DESCRIPTION
`AddPostAction` and `AddPreAction` apply to the action of the alias, which may not have been clear previously (see #2281).

Expanded the example for `AddPreAction` using a multi-step build.

I don't consider that this completes the referenced issue, since it only provides information to those who happen to read those manpage snips - there is neither a warning on use nor a lessening of the impression that "it ought to work".

No code is affected. 

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
