### PR TITLE
Fix 2281 aliases ignore pre post add actions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -96,6 +96,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       specified `local_only`, but the code and tests were using `keep_local`. The functionality
       more closely matches local only.  NOTE: It doesn't seem like any code in the wild was using
       local_only as we'd not received any reports of such until PR #4606 from hedger.
+    - Fix Issue #2281, AddPreAction() & AddPostAction() were being ignored if no action
+      was specified when the Alias was initially created.
 
   From Alex James:
     - On Darwin, PermissionErrors are now handled while trying to access

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -176,6 +176,8 @@ FIXES
   more closely matches local only.  NOTE: It doesn't seem like any code in the wild was using
   local_only as we'd not received any reports of such until PR #4606 from hedger.
 
+- Fix Issue #2281, AddPreAction() & AddPostAction() were being ignored if no action
+  was specified when the Alias was initially created.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Node/Alias.py
+++ b/SCons/Node/Alias.py
@@ -104,9 +104,15 @@ class Alias(SCons.Node.Node):
     #
     #
 
-    def build(self) -> None:
+    def build(self, **kw) -> None:
         """A "builder" for aliases."""
-        pass
+        if len(self.executor.post_actions) + len(self.executor.pre_actions) > 0:
+            # Only actually call Node's build() if there are any
+            # pre or post actions.
+            # Alias node's will get 1 action and Alias.build()
+            # This fixes GH Issue #2281
+            return self.really_build(self,**kw)
+
 
     def convert(self) -> None:
         try: del self.builder

--- a/SCons/Node/Alias.py
+++ b/SCons/Node/Alias.py
@@ -111,7 +111,7 @@ class Alias(SCons.Node.Node):
             # pre or post actions.
             # Alias node's will get 1 action and Alias.build()
             # This fixes GH Issue #2281
-            return self.really_build(self,**kw)
+            return self.really_build(**kw)
 
 
     def convert(self) -> None:

--- a/SCons/Node/Alias.py
+++ b/SCons/Node/Alias.py
@@ -109,7 +109,7 @@ class Alias(SCons.Node.Node):
         if len(self.executor.post_actions) + len(self.executor.pre_actions) > 0:
             # Only actually call Node's build() if there are any
             # pre or post actions.
-            # Alias node's will get 1 action and Alias.build()
+            # Alias nodes will get 1 action and Alias.build()
             # This fixes GH Issue #2281
             return self.really_build(**kw)
 

--- a/test/Alias/action.py
+++ b/test/Alias/action.py
@@ -69,6 +69,19 @@ env.Alias(['build-add2a', 'build-add2b'], action=foo)
 env.Alias('build-add3', f6)
 env.Alias('build-add3', action=foo)
 env.Alias('build-add3', action=bar)
+
+
+f7 = env.Cat('f7.out', 'f6.in')
+def build_it(target, source, env):
+    print("build_it: Goodbye")
+    return 0
+
+def string_it(target, source, env):
+    return("string it: Goodbye")
+
+s = Action(build_it, string_it)
+env.Alias('add_post_action', f7)
+env.AddPostAction('add_post_action', s)
 """)
 
 test.write('f1.in', "f1.in 1\n")
@@ -132,6 +145,9 @@ test.run(arguments = 'build-add3')
 test.must_match('f6.out', "f6.in 1\n")
 test.must_match('foo', "foo(['build-add3'], ['f6.out'])\n")
 test.must_match('bar', "bar(['build-add3'], ['f6.out'])\n")
+
+test.run(arguments = 'add_post_action')
+test.must_contain_all(test.stdout(), 'string it: Goodbye')
 
 test.pass_test()
 


### PR DESCRIPTION
If an Alias node was being created with no action specified, any actions added with AddPreAction() or AddPostAction() were being ignored because the Alias nodes build() method didn't do anything.

Now we'll check if there are any pre or post actions on the executor and if so call the real build() method from Node.Node.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
