### PR TITLE
Handle --debug containing memoizer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -200,6 +200,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       attribute and to explain what's being done in the example.
     - Test framework reformatted using settings from pyproject.toml.
       Includes code embedded in docstrings.
+    - Handle case of "memoizer" as one member of a comma-separated
+      --debug string - this was previously missed.
 
     From Adam Scott:
     - Changed Ninja's TEMPLATE rule pool to use `install_pool` instead of

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -179,6 +179,9 @@ FIXES
 - Fix Issue #2281, AddPreAction() & AddPostAction() were being ignored if no action
   was specified when the Alias was initially created.
 
+- Handle case of "memoizer" as one member of a comma-separated
+  --debug string - this was previously missed.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Script/__init__.py
+++ b/SCons/Script/__init__.py
@@ -35,6 +35,7 @@ import time
 start_time = time.time()
 
 import collections
+import itertools
 import os
 from io import StringIO
 
@@ -53,9 +54,17 @@ import sys
 # to not add the shims.  So we use a special-case, up-front check for
 # the "--debug=memoizer" flag and enable Memoizer before we import any
 # of the other modules that use it.
+# Update: this breaks if the option isn't exactly "--debug=memoizer",
+# like if there is more than one debug option as a csv. Do a bit more work.
 
-_args = sys.argv + os.environ.get('SCONSFLAGS', '').split()
-if "--debug=memoizer" in _args:
+_args = sys.argv + os.environ.get("SCONSFLAGS", "").split()
+_args = (
+    arg[len("--debug=") :].split(",")
+    for arg in _args
+    if arg.startswith("--debug=")
+)
+_args = list(itertools.chain.from_iterable(_args))
+if "memoizer" in _args:
     import SCons.Memoize
     import SCons.Warnings
     try:


### PR DESCRIPTION
The memoizer statistics have to be handled specially as they use conditional decorators, those have to be enabled before any of the decorated methods are read by Python.  This worked if there was exactly `--debug=memoizer` on the commandline or in `SCONSFLAGS`, but not if it was in a multi-value option like `--debug=presub,memoizer`. Handle the up-front-check a little more completely to fix this.

No doc impacts, documented behavior not changed.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
