### PR TITLE
Fix small problem in a yacc test

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -206,6 +206,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Includes code embedded in docstrings.
     - Handle case of "memoizer" as one member of a comma-separated
       --debug string - this was previously missed.
+    - test YACC/live.py fixed - finally started failing on an "old-style"
+      (K&R flavor) function declaration, updated.
 
     From Adam Scott:
     - Changed Ninja's TEMPLATE rule pool to use `install_pool` instead of

--- a/test/YACC/live.py
+++ b/test/YACC/live.py
@@ -65,8 +65,7 @@ int main(void)
     return yyparse();
 }
 
-int yyerror(s)
-char *s;
+int yyerror(char *s)
 {
     fprintf(stderr, "%%s\n", s);
     return 0;


### PR DESCRIPTION
Old-style declaration with the parameter types declared outside the `()` in the function decl rather than inside is warned by gcc 15, causing the test to fail (unexpected output).

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
