### PR TITLE
Fix running individual test files when ninja is not installed

### DIFF
--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -107,10 +107,17 @@ _dll = dll_suffix
 dll_ = dll_prefix
 
 try:
+    # Note: if the ninja python package is not installed, this import statement can end
+    # up finding the scons/test/ninja directory instead, and successfully importing
+    # that directory as an implicit namespace package. Therefore if ninja is
+    # unavailable, we may not get an ImportError here, but can instead get an
+    # AttributeError when attempting to access ninja.BIN_DIR below.  This happens
+    # when running individual test files in the test/ directory, since the test/
+    # directory will then be listed as the first entry in sys.path
     import ninja
 
     NINJA_BINARY = os.path.abspath(os.path.join(ninja.BIN_DIR, 'ninja' + _exe))
-except ImportError:
+except (ImportError, AttributeError):
     NINJA_BINARY = None
 
 if sys.platform == 'cygwin':


### PR DESCRIPTION
The code in testing/framework/TestSCons.py attempted to handle an ImportError if ninja is not available.  However, when running individual test files from the scons/test/ directory, this directory is included as the first entry in sys.path.  When this happens, the `import ninja` statement succeeds, finding the scons/test/ninja/ directory and treating it as a package.  This results in an AttributeError being thrown later attempting to access `ninja.BIN_DIR`, rather than an ImportError.

I have confirmed that this change now allows `./runtest.py test/Help.py` to succeed, even when ninja is not installed.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
