### PR TITLE
Fix infinite hang in wait_for_process_to_die() on Windows

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -214,6 +214,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       `local_pool`, hoping it will fix a race condition that can occurs when
       Ninja defers to SCons to build.
 
+    From Adam Simpkins:
+    - Fixed a hang in `wait_for_process_to_die()` on Windows, affecting
+      clean-up of the SCons daemon used for Ninja builds.
+
 
 RELEASE 4.8.1 -  Tue, 03 Sep 2024 17:22:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -183,6 +183,9 @@ FIXES
 - Handle case of "memoizer" as one member of a comma-separated
   --debug string - this was previously missed.
 
+- Fixed a hang in `wait_for_process_to_die()` on Windows, affecting
+  clean-up of the SCons daemon used for Ninja builds.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Tool/ninja_tool/NinjaState.py
+++ b/SCons/Tool/ninja_tool/NinjaState.py
@@ -694,8 +694,9 @@ class NinjaState:
                         pass
 
                 # wait for the server process to fully killed
-                # TODO: catch TimeoutException here and possibly do something smart.
-                wait_for_process_to_die(pid, timeout=10)
+                # TODO: update wait_for_process_to_die() to handle timeout and then catch exception
+                #       here and do something smart.
+                wait_for_process_to_die(pid)
 
             if os.path.exists(scons_daemon_dirty):
                 os.unlink(scons_daemon_dirty)

--- a/SCons/Tool/ninja_tool/NinjaState.py
+++ b/SCons/Tool/ninja_tool/NinjaState.py
@@ -694,9 +694,8 @@ class NinjaState:
                         pass
 
                 # wait for the server process to fully killed
-                # TODO: update wait_for_process_to_die() to handle timeout and then catch exception
-                #       here and do something smart.
-                wait_for_process_to_die(pid)
+                # TODO: catch TimeoutException here and possibly do something smart.
+                wait_for_process_to_die(pid, timeout=10)
 
             if os.path.exists(scons_daemon_dirty):
                 os.unlink(scons_daemon_dirty)


### PR DESCRIPTION
The ninja generator uses `wait_for_process_to_die()` to wait for a previous scons daemon process to terminate.  It previously had 3 separate implementations: one using psutil if that module was available, plus a fallback implementation for Windows, and one for non-Windows platforms.

I was encountering problems with the fallback implementation on Windows hanging forever, and not being interruptible even with Ctrl-C. Apparently the win32 `OpenProcess()` function can return a valid process handle even for already terminated processes.

This change adds an extra call to `GetExitCodeProcess()` to avoid infinitely looping if the process has in fact already exited.  I also added a timeout so that this function will eventually fail rather than hanging forever if a process does not exit.

I also removed the psutil implementation: it seemed simpler to me to avoid having multiple separate implementations with different behaviors. This appeared to be the only place in scons that depends on psutil outside of tests.  Also note that this `wait_for_process_to_die()` function is only used by the ninja tool.

I have added unit tests checking the behavior of `wait_for_process_to_die()`.  Without the `GetExitCodeProcess()` check added by this PR, the simple code in `test_wait_for_process_to_die_success()` would hang forever on Windows.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
