### PR TITLE
Framework: fixture methods now handle lists for dstdir

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -208,6 +208,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       --debug string - this was previously missed.
     - test YACC/live.py fixed - finally started failing on an "old-style"
       (K&R flavor) function declaration, updated.
+    - Test framework - add recognizing list-of-path-components for
+      the destination of fixtures too (matches docstrings now).
 
     From Adam Scott:
     - Changed Ninja's TEMPLATE rule pool to use `install_pool` instead of

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -1454,6 +1454,9 @@ class TestCmd:
         """
         if is_List(srcdir):
             srcdir = os.path.join(*srcdir)
+        if is_List(dstdir):
+            dstdir = os.path.join(*dstdir)
+
         spath = srcdir
         if srcdir and self.fixture_dirs and not os.path.isabs(srcdir):
             for dir in self.fixture_dirs:
@@ -1504,6 +1507,8 @@ class TestCmd:
         """
         if is_List(srcfile):
             srcfile = os.path.join(*srcfile)
+        if is_List(dstfile):
+            dstfile = os.path.join(*dstfile)
 
         srcpath, srctail = os.path.split(srcfile)
         spath = srcfile


### PR DESCRIPTION
`TestCmd.dir_fixture` and `TestCmd.file_fixture` are described as accepting a list for both source and destination. For example, the docstring for `dir_fixture`:

>  `srcdir` or `dstdir` may be a list, in which case the elements are first joined into a pathname.

However, the implementation only handled this for `srcdir`/`srcfile`. Added the same stanza for `dstdir`/`dstfile`.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
