### PR TITLE
Fix typos in CCFLAGS test

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,9 +12,12 @@ NOTE: Since SCons 4.9.0, Python 3.7.0 or above is required.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
+  From John Doe:
+    - Whatever John Doe did.
 
-        - Whatever John Doe did.
+  From Mats Wichmann:
+    - Fix typos in CCFLAGS test. Didn't affect the test itself, but
+      didn't correctly apply the DefaultEnvironment speedup.
 
 
 RELEASE 4.9.0 -  Sun, 02 Mar 2025 17:22:20 -0700

--- a/test/CC/CCFLAGS.py
+++ b/test/CC/CCFLAGS.py
@@ -30,7 +30,7 @@ _obj = TestSCons._obj
 
 if sys.platform == 'win32':
     import SCons.Tool.MSCommon as msc
-    
+
     if not msc.msvc_exists():
         fooflags = '-DFOO'
         barflags = '-DBAR'
@@ -44,7 +44,7 @@ else:
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
-DefaultEnvironment(tool=[])
+DefaultEnvironment(tools=[])
 foo = Environment(CCFLAGS = '%s')
 bar = Environment(CCFLAGS = '%s')
 foo.Object(target = 'foo%s', source = 'prog.c')
@@ -88,8 +88,7 @@ prog.c:  BAZ
 """)
 
 test.write('SConstruct', """
-DefaultEnvironment(tool=[])
-
+DefaultEnvironment(tools=[])
 bar = Environment(CCFLAGS = '%s')
 bar.Object(target = 'foo%s', source = 'prog.c')
 bar.Object(target = 'bar%s', source = 'prog.c')


### PR DESCRIPTION
Trivial: in two `DefaultEnvironment` calls, `tool=[]` -> `tools=[]`.  Doesn't affect the running of the tests, just enables the speedup as was intended.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
