### PR TITLE
Clean up CC and CXX FLAGS tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,15 +15,15 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From John Doe:
     - Whatever John Doe did.
 
-  From Mats Wichmann:
-    - Clean up C and C++ FLAGS tests. Tests which use a real compiler
-      are now more clearly distinguished (-live.py suffix and docstring).
-
   From Bill Prendergast:
     - Fixed SCons.Variables.PackageVariable to correctly test the default
       setting against both enable & disable strings. (Fixes #4702)
     - Extended unittests (crudely) to test for correct/expected response
       when default setting is a boolean string.
+
+  From Mats Wichmann:
+    - Clean up C and C++ FLAGS tests. Tests which use a real compiler
+      are now more clearly distinguished (-live.py suffix and docstring).
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,9 +12,12 @@ NOTE: Since SCons 4.9.0, Python 3.7.0 or above is required.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
-      From John Doe:
+  From John Doe:
+    - Whatever John Doe did.
 
-        - Whatever John Doe did.
+  From Mats Wichmann:
+    - Clean up C and C++ FLAGS tests. Tests which use a real compiler
+      are now more clearly distinguished (-live.py suffix and docstring).
 
   From Bill Prendergast:
     - Fixed SCons.Variables.PackageVariable to correctly test the default

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -6,12 +6,12 @@ Past official release announcements appear at:
 
 ==================================================================
 
-A new SCons release, 4.9.0, is now available on the SCons download page:
+A new SCons release, X.Y.Z, is now available on the SCons download page:
 
     https://scons.org/pages/download.html
 
+Here is a summary of the changes since 4.9.1:
 
-Here is a summary of the changes since 4.9.0:
 
 NEW FUNCTIONALITY
 -----------------
@@ -63,4 +63,4 @@ Thanks to the following contributors listed below for their contributions to thi
 ==========================================================================================
 .. code-block:: text
 
-    git shortlog --no-merges -ns 4.0.1..HEAD
+    git shortlog --no-merges -ns 4.9.1..HEAD

--- a/test/CC/CCFLAGS-live.py
+++ b/test/CC/CCFLAGS-live.py
@@ -49,7 +49,7 @@ else:
     barflags = '-DBAR'
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment(CCFLAGS='{fooflags}')
 bar = Environment(CCFLAGS='{barflags}')
 
@@ -91,7 +91,7 @@ prog.c:  BAZ
 """)
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 bar = Environment(CCFLAGS='{barflags}')
 
 foo_obj = bar.Object(target='foo', source='prog.c')

--- a/test/CC/CFLAGS-live.py
+++ b/test/CC/CFLAGS-live.py
@@ -23,14 +23,21 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test behavior of CFLAGS.
+
+This is a live test, uses the detected C compiler.
+"""
+
 import sys
+
 import TestSCons
 
 test = TestSCons.TestSCons()
 
 # Make sure CFLAGS is not passed to CXX by just expanding CXXCOM
-test.write('SConstruct', """
-DefaultEnvironment(tools=[])
+test.write('SConstruct', """\
+_ = DefaultEnvironment(tools=[])
 env = Environment(CFLAGS='-xyz', CCFLAGS='-abc')
 print(env.subst('$CXXCOM'))
 print(env.subst('$CXXCOMSTR'))
@@ -40,8 +47,6 @@ print(env.subst('$SHCXXCOMSTR'))
 test.run(arguments = '.')
 test.must_not_contain_any_line(test.stdout(), ["-xyz"])
 test.must_contain_all_lines(test.stdout(), ["-abc"])
-
-_obj = TestSCons._obj
 
 # Test passing CFLAGS to C compiler by actually compiling programs
 if sys.platform == 'win32':
@@ -57,17 +62,17 @@ else:
     fooflags = '-DFOO'
     barflags = '-DBAR'
 
+test.write('SConstruct', f"""\
+_ = DefaultEnvironment(tools=[])
+foo = Environment(CFLAGS="{fooflags}")
+bar = Environment(CFLAGS="{barflags}")
 
-test.write('SConstruct', """
-foo = Environment(CFLAGS = '%s')
-bar = Environment(CFLAGS = '%s')
-foo.Object(target = 'foo%s', source = 'prog.c')
-bar.Object(target = 'bar%s', source = 'prog.c')
-foo.Program(target = 'foo', source = 'foo%s')
-bar.Program(target = 'bar', source = 'bar%s')
-foo.Program(target = 'prog', source = 'prog.c',
-            CFLAGS = '$CFLAGS -DBAR $BAZ', BAZ = '-DBAZ')
-""" % (fooflags, barflags, _obj, _obj, _obj, _obj))
+foo_obj = foo.Object(target='foo', source='prog.c')
+bar_obj = bar.Object(target='bar', source='prog.c')
+foo.Program(target='foo', source=foo_obj)
+bar.Program(target='bar', source=bar_obj)
+foo.Program(target='prog', source='prog.c', CFLAGS='$CFLAGS -DBAR $BAZ', BAZ='-DBAZ')
+""")
 
 test.write('prog.c', r"""
 #include <stdio.h>
@@ -90,30 +95,28 @@ main(int argc, char *argv[])
 }
 """)
 
-
-
-test.run(arguments = '.')
-
-test.run(program = test.workpath('foo'), stdout = "prog.c:  FOO\n")
-test.run(program = test.workpath('bar'), stdout = "prog.c:  BAR\n")
-test.run(program = test.workpath('prog'), stdout = """\
+test.run(arguments='.')
+test.run(program=test.workpath('foo'), stdout="prog.c:  FOO\n")
+test.run(program=test.workpath('bar'), stdout="prog.c:  BAR\n")
+test.run(program=test.workpath('prog'), stdout="""\
 prog.c:  FOO
 prog.c:  BAR
 prog.c:  BAZ
 """)
 
-test.write('SConstruct', """
-bar = Environment(CFLAGS = '%s')
-bar.Object(target = 'foo%s', source = 'prog.c')
-bar.Object(target = 'bar%s', source = 'prog.c')
-bar.Program(target = 'foo', source = 'foo%s')
-bar.Program(target = 'bar', source = 'bar%s')
-""" % (barflags, _obj, _obj, _obj, _obj))
+test.write('SConstruct', f"""\
+_ = DefaultEnvironment(tools=[])
+bar = Environment(CFLAGS='{barflags}')
 
-test.run(arguments = '.')
+foo_obj = bar.Object(target='foo', source='prog.c')
+bar_obj = bar.Object(target='bar', source='prog.c')
+bar.Program(target='foo', source=foo_obj)
+bar.Program(target='bar', source=bar_obj)
+""")
 
-test.run(program = test.workpath('foo'), stdout = "prog.c:  BAR\n")
-test.run(program = test.workpath('bar'), stdout = "prog.c:  BAR\n")
+test.run(arguments='.')
+test.run(program=test.workpath('foo'), stdout="prog.c:  BAR\n")
+test.run(program=test.workpath('bar'), stdout="prog.c:  BAR\n")
 
 test.pass_test()
 

--- a/test/CC/CFLAGS-live.py
+++ b/test/CC/CFLAGS-live.py
@@ -37,7 +37,7 @@ test = TestSCons.TestSCons()
 
 # Make sure CFLAGS is not passed to CXX by just expanding CXXCOM
 test.write('SConstruct', """\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 env = Environment(CFLAGS='-xyz', CCFLAGS='-abc')
 print(env.subst('$CXXCOM'))
 print(env.subst('$CXXCOMSTR'))
@@ -63,7 +63,7 @@ else:
     barflags = '-DBAR'
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment(CFLAGS="{fooflags}")
 bar = Environment(CFLAGS="{barflags}")
 
@@ -105,7 +105,7 @@ prog.c:  BAZ
 """)
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 bar = Environment(CFLAGS='{barflags}')
 
 foo_obj = bar.Object(target='foo', source='prog.c')

--- a/test/CC/SHCCFLAGS-live.py
+++ b/test/CC/SHCCFLAGS-live.py
@@ -46,7 +46,7 @@ if sys.platform.find('irix') > -1:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment(SHCCFLAGS='{fooflags}', WINDOWS_INSERT_DEF=1)
 bar = Environment(SHCCFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
@@ -113,7 +113,7 @@ test.run(program=test.workpath('fooprog'), stdout="prog.c:  FOO\n")
 test.run(program=test.workpath('barprog'), stdout="prog.c:  BAR\n")
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 bar = Environment(SHCCFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
 foo_obj = bar.SharedObject(target='foo', source='prog.c')

--- a/test/CC/SHCFLAGS-live.py
+++ b/test/CC/SHCFLAGS-live.py
@@ -46,7 +46,7 @@ if sys.platform.find('irix') > -1:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment(SHCFLAGS='{fooflags}', WINDOWS_INSERT_DEF=1)
 bar = Environment(SHCFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
@@ -113,7 +113,7 @@ test.run(program=test.workpath('fooprog'), stdout="prog.c:  FOO\n")
 test.run(program=test.workpath('barprog'), stdout="prog.c:  BAR\n")
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 bar = Environment(SHCFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
 foo_obj = bar.SharedObject(target='foo', source='prog.c')

--- a/test/CXX/CCFLAGS-live.py
+++ b/test/CXX/CCFLAGS-live.py
@@ -35,7 +35,7 @@ import TestSCons
 test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment()
 foo.Append(CCFLAGS='-DFOO', CXXFLAGS='-DCXX')
 bar = Environment()

--- a/test/CXX/CCFLAGS-live.py
+++ b/test/CXX/CCFLAGS-live.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,28 +22,29 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can set both $CCFLAGS and $CXXFLAGS and have them
 both show up on the compilation lines for C++ source files.
+
+This is a live test, uses the detected C++ compiler.
 """
 
 import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+_ = DefaultEnvironment(tools=[])
 foo = Environment()
-foo.Append(CCFLAGS = '-DFOO', CXXFLAGS = '-DCXX')
+foo.Append(CCFLAGS='-DFOO', CXXFLAGS='-DCXX')
 bar = Environment()
-bar.Append(CCFLAGS = '-DBAR', CXXFLAGS = '-DCXX')
-foo_obj = foo.Object(target = 'foo', source = 'prog.cpp')
-bar_obj = bar.Object(target = 'bar', source = 'prog.cpp')
-foo.Program(target = 'foo', source = foo_obj)
-bar.Program(target = 'bar', source = bar_obj)
+bar.Append(CCFLAGS='-DBAR', CXXFLAGS='-DCXX')
+
+foo_obj = foo.Object(target='foo', source='prog.cpp')
+bar_obj = bar.Object(target='bar', source='prog.cpp')
+foo.Program(target='foo', source=foo_obj)
+bar.Program(target='bar', source=bar_obj)
 """)
 
 test.write('prog.cpp', r"""
@@ -62,10 +65,10 @@ main(int argc, char *argv[])
 }
 """)
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
-test.run(program = test.workpath('foo'), stdout = "prog.c:  FOO\n")
-test.run(program = test.workpath('bar'), stdout = "prog.c:  BAR\n")
+test.run(program=test.workpath('foo'), stdout="prog.c:  FOO\n")
+test.run(program=test.workpath('bar'), stdout="prog.c:  BAR\n")
 
 test.pass_test()
 

--- a/test/CXX/CXXFLAGS-live.py
+++ b/test/CXX/CXXFLAGS-live.py
@@ -45,7 +45,7 @@ if sys.platform.find('irix') > -1:
 e = test.Environment()
 
 test.write('SConstruct', """\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment(WINDOWS_INSERT_DEF=1)
 foo.Append(CXXFLAGS='-DFOO')
 bar = Environment(WINDOWS_INSERT_DEF=1)
@@ -138,7 +138,7 @@ test.run(program=test.workpath('foo'), stdout="prog.c:  FOO\n")
 test.run(program=test.workpath('bar'), stdout="prog.c:  BAR\n")
 
 test.write('SConstruct', """\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 bar = Environment(WINDOWS_INSERT_DEF=1)
 bar.Append(CXXFLAGS='-DBAR')
 

--- a/test/CXX/CXXFLAGS-live.py
+++ b/test/CXX/CXXFLAGS-live.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that $CXXFLAGS settings are used to build both static
 and shared object files.
+
+This is a live test, uses the detected C++ compiler.
 """
 
 import os
@@ -34,26 +35,26 @@ import sys
 
 import TestSCons
 
-_obj = TestSCons._obj
+test = TestSCons.TestSCons()
 
 if os.name == 'posix':
     os.environ['LD_LIBRARY_PATH'] = '.'
 if sys.platform.find('irix') > -1:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
-test = TestSCons.TestSCons()
-
 e = test.Environment()
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+_ = DefaultEnvironment(tools=[])
 foo = Environment(WINDOWS_INSERT_DEF=1)
-foo.Append(CXXFLAGS = '-DFOO') 
+foo.Append(CXXFLAGS='-DFOO')
 bar = Environment(WINDOWS_INSERT_DEF=1)
-bar.Append(CXXFLAGS = '-DBAR') 
-foo_obj = foo.SharedObject(target = 'fooshared%(_obj)s', source = 'doIt.cpp')
-bar_obj = bar.SharedObject(target = 'barshared%(_obj)s', source = 'doIt.cpp')
-foo.SharedLibrary(target = 'foo', source = foo_obj)
-bar.SharedLibrary(target = 'bar', source = bar_obj)
+bar.Append(CXXFLAGS='-DBAR')
+
+foo_obj = foo.SharedObject(target='fooshared', source='doIt.cpp')
+bar_obj = bar.SharedObject(target='barshared', source='doIt.cpp')
+foo.SharedLibrary(target='foo', source=foo_obj)
+bar.SharedLibrary(target='bar', source=bar_obj)
 
 fooMain = foo.Clone(LIBS='foo', LIBPATH='.')
 foo_obj = fooMain.Object(target='foomain', source='main.c')
@@ -63,11 +64,11 @@ barMain = bar.Clone(LIBS='bar', LIBPATH='.')
 bar_obj = barMain.Object(target='barmain', source='main.c')
 barMain.Program(target='barprog', source=bar_obj)
 
-foo_obj = foo.Object(target = 'foostatic', source = 'prog.cpp')
-bar_obj = bar.Object(target = 'barstatic', source = 'prog.cpp')
-foo.Program(target = 'foo', source = foo_obj)
-bar.Program(target = 'bar', source = bar_obj)
-""" % locals())
+foo_obj = foo.Object(target='foostatic', source='prog.cpp')
+bar_obj = bar.Object(target='barstatic', source='prog.cpp')
+foo.Program(target='foo', source=foo_obj)
+bar.Program(target='bar', source=bar_obj)
+""")
 
 test.write('foo.def', r"""
 LIBRARY        "foo"
@@ -100,8 +101,7 @@ doIt()
 }
 """)
 
-test.write('main.c', r"""
-
+test.write('main.c', """\
 void doIt();
 
 int
@@ -130,36 +130,33 @@ main(int argc, char *argv[])
 }
 """)
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
-test.run(program = test.workpath('fooprog'), stdout = "doIt.cpp:  FOO\n")
-test.run(program = test.workpath('barprog'), stdout = "doIt.cpp:  BAR\n")
-test.run(program = test.workpath('foo'), stdout = "prog.c:  FOO\n")
-test.run(program = test.workpath('bar'), stdout = "prog.c:  BAR\n")
+test.run(program=test.workpath('fooprog'), stdout="doIt.cpp:  FOO\n")
+test.run(program=test.workpath('barprog'), stdout="doIt.cpp:  BAR\n")
+test.run(program=test.workpath('foo'), stdout="prog.c:  FOO\n")
+test.run(program=test.workpath('bar'), stdout="prog.c:  BAR\n")
 
-
-
-test.write('SConstruct', """
+test.write('SConstruct', """\
+_ = DefaultEnvironment(tools=[])
 bar = Environment(WINDOWS_INSERT_DEF=1)
-bar.Append(CXXFLAGS = '-DBAR') 
-foo_obj = bar.SharedObject(target = 'foo%(_obj)s', source = 'doIt.cpp')
-bar_obj = bar.SharedObject(target = 'bar%(_obj)s', source = 'doIt.cpp')
-bar.SharedLibrary(target = 'foo', source = foo_obj)
-bar.SharedLibrary(target = 'bar', source = bar_obj)
+bar.Append(CXXFLAGS='-DBAR')
+
+foo_obj = bar.SharedObject(target='foo', source='doIt.cpp')
+bar_obj = bar.SharedObject(target='bar', source='doIt.cpp')
+bar.SharedLibrary(target='foo', source=foo_obj)
+bar.SharedLibrary(target='bar', source=bar_obj)
 
 barMain = bar.Clone(LIBS='bar', LIBPATH='.')
 foo_obj = barMain.Object(target='foomain', source='main.c')
 bar_obj = barMain.Object(target='barmain', source='main.c')
 barMain.Program(target='barprog', source=foo_obj)
 barMain.Program(target='fooprog', source=bar_obj)
-""" % locals())
+""")
 
-test.run(arguments = '.')
-
-test.run(program = test.workpath('fooprog'), stdout = "doIt.cpp:  BAR\n")
-test.run(program = test.workpath('barprog'), stdout = "doIt.cpp:  BAR\n")
-
-
+test.run(arguments='.')
+test.run(program=test.workpath('fooprog'), stdout="doIt.cpp:  BAR\n")
+test.run(program=test.workpath('barprog'), stdout="doIt.cpp:  BAR\n")
 
 test.pass_test()
 

--- a/test/CXX/SHCCFLAGS-live.py
+++ b/test/CXX/SHCCFLAGS-live.py
@@ -46,7 +46,7 @@ if sys.platform.find('irix') > -1:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment(SHCCFLAGS='{fooflags}', WINDOWS_INSERT_DEF=1)
 bar = Environment(SHCCFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
@@ -113,7 +113,7 @@ test.run(program=test.workpath('fooprog'), stdout="prog.cpp:  FOO\n")
 test.run(program=test.workpath('barprog'), stdout="prog.cpp:  BAR\n")
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 bar = Environment(SHCCFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
 foo_obj = bar.SharedObject(target='foo', source='prog.cpp')

--- a/test/CXX/SHCXXFLAGS-live.py
+++ b/test/CXX/SHCXXFLAGS-live.py
@@ -46,7 +46,7 @@ if sys.platform.find('irix') > -1:
     os.environ['LD_LIBRARYN32_PATH'] = '.'
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 foo = Environment(SHCXXFLAGS='{fooflags}', WINDOWS_INSERT_DEF=1)
 bar = Environment(SHCXXFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
@@ -113,7 +113,7 @@ test.run(program=test.workpath('fooprog'), stdout="prog.cpp:  FOO\n")
 test.run(program=test.workpath('barprog'), stdout="prog.cpp:  BAR\n")
 
 test.write('SConstruct', f"""\
-_ = DefaultEnvironment(tools=[])
+DefaultEnvironment(tools=[])
 bar = Environment(SHCXXFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
 
 foo_obj = bar.SharedObject(target='foo', source='prog.cpp')

--- a/test/CXX/SHCXXFLAGS-live.py
+++ b/test/CXX/SHCXXFLAGS-live.py
@@ -26,7 +26,7 @@
 """
 Verify that $SHCXXFLAGS settings are used to build shared object files.
 
-This is a live test, uses the detected C compiler.
+This is a live test, uses the detected C and C++ compilers.
 """
 
 import os

--- a/test/CXX/SHCXXFLAGS-live.py
+++ b/test/CXX/SHCXXFLAGS-live.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Verify that $SHCXXFLAGS settings are used to build shared object files.
+
+This is a live test, uses the detected C compiler.
+"""
+
+import os
+import sys
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+e = test.Environment()
+fooflags = e['SHCXXFLAGS'] + ' -DFOO'
+barflags = e['SHCXXFLAGS'] + ' -DBAR'
+
+if os.name == 'posix':
+    os.environ['LD_LIBRARY_PATH'] = '.'
+if sys.platform.find('irix') > -1:
+    os.environ['LD_LIBRARYN32_PATH'] = '.'
+
+test.write('SConstruct', f"""\
+_ = DefaultEnvironment(tools=[])
+foo = Environment(SHCXXFLAGS='{fooflags}', WINDOWS_INSERT_DEF=1)
+bar = Environment(SHCXXFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
+
+foo_obj = foo.SharedObject(target='foo', source='prog.cpp')
+foo.SharedLibrary(target='foo', source=foo_obj)
+
+bar_obj = bar.SharedObject(target='bar', source='prog.cpp')
+bar.SharedLibrary(target='bar', source=bar_obj)
+
+fooMain = foo.Clone(LIBS='foo', LIBPATH='.')
+foo_obj = fooMain.Object(target='foomain', source='main.c')
+fooMain.Program(target='fooprog', source=foo_obj)
+
+barMain = bar.Clone(LIBS='bar', LIBPATH='.')
+barmain_obj = barMain.Object(target='barmain', source='main.c')
+barMain.Program(target='barprog', source=barmain_obj)
+""")
+
+test.write('foo.def', """\
+LIBRARY        "foo"
+DESCRIPTION    "Foo Shared Library"
+
+EXPORTS
+   doIt
+""")
+
+test.write('bar.def', """\
+LIBRARY        "bar"
+DESCRIPTION    "Bar Shared Library"
+
+EXPORTS
+   doIt
+""")
+
+test.write('prog.cpp', r"""
+#include <stdio.h>
+
+extern "C" void
+doIt()
+{
+#ifdef FOO
+        printf("prog.cpp:  FOO\n");
+#endif
+#ifdef BAR
+        printf("prog.cpp:  BAR\n");
+#endif
+}
+""")
+
+test.write('main.c', """\
+
+void doIt();
+
+int
+main(int argc, char* argv[])
+{
+    doIt();
+    return 0;
+}
+""")
+
+test.run(arguments='.')
+test.run(program=test.workpath('fooprog'), stdout="prog.cpp:  FOO\n")
+test.run(program=test.workpath('barprog'), stdout="prog.cpp:  BAR\n")
+
+test.write('SConstruct', f"""\
+_ = DefaultEnvironment(tools=[])
+bar = Environment(SHCXXFLAGS='{barflags}', WINDOWS_INSERT_DEF=1)
+
+foo_obj = bar.SharedObject(target='foo', source='prog.cpp')
+bar.SharedLibrary(target='foo', source=foo_obj)
+
+bar_obj = bar.SharedObject(target='bar', source='prog.cpp')
+bar.SharedLibrary(target='bar', source=bar_obj)
+
+barMain = bar.Clone(LIBS='bar', LIBPATH='.')
+foomain_obj = barMain.Object(target='foomain', source='main.c')
+barmain_obj = barMain.Object(target='barmain', source='main.c')
+barMain.Program(target='barprog', source=foomain_obj)
+barMain.Program(target='fooprog', source=barmain_obj)
+""")
+
+test.run(arguments='.')
+test.run(program=test.workpath('fooprog'), stdout="prog.cpp:  BAR\n")
+test.run(program=test.workpath('barprog'), stdout="prog.cpp:  BAR\n")
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
More consistency, formatting, add `test/CXX/SHCCFLAGS.py` for symmetry (`test/CC/` had one), rename tests to `-live` since they use a real compiler, and also add that note to docstring. Remove some filename suffix fiddling that wasn't needed because in this usage, SCons figures it out - and we want that as part of the test.

Testsuite-only change.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
