### PR TITLE
Fix CacheDir initialization so works on 3.7 also

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ image:
   # linux builds done in Travis CI for now
   - Visual Studio 2017
   - Visual Studio 2019
-  #- Visual Studio 2022  # Temporary disable while failing on 14.40 build tools
+  - Visual Studio 2022
 
 cache:
   - downloads -> appveyor.yml
@@ -35,36 +35,35 @@ environment:
   SCONS_CACHE_MSVC_CONFIG: "true"
   matrix:
     # Test oldest and newest supported Pythons, and a subset in between.
-    # Skipping 3.7 and 3.9 at this time
-    - WINPYTHON: "Python312"
-    - WINPYTHON: "Python310"
-    - WINPYTHON: "Python38"
+    # Skipping 3.8, 3.10, 3.12 at this time
+    - WINPYTHON: "Python313"
+    - WINPYTHON: "Python311"
+    - WINPYTHON: "Python39"
     - WINPYTHON: "Python37"
 
 # remove sets of build jobs based on criteria below
 # to fine tune the number and platforms tested
 matrix:
   exclude:
-    # XXX test python 3.6 on Visual Studio 2017 image
-    # test python 3.8 on Visual Studio 2017 image
+    # test python 3.7 on Visual Studio 2017 image
     - image: Visual Studio 2017
-      WINPYTHON: "Python312"
+      WINPYTHON: "Python313"
     - image: Visual Studio 2017
-      WINPYTHON: "Python310"
+      WINPYTHON: "Python311"
+    - image: Visual Studio 2017
+      WINPYTHON: "Python39"
 
-    # test python 3.10 on Visual Studio 2019 image
+    # test python 3.9 on Visual Studio 2019 image
     - image: Visual Studio 2019
-      WINPYTHON: "Python312"
+      WINPYTHON: "Python313"
     - image: Visual Studio 2019
-      WINPYTHON: "Python38"
+      WINPYTHON: "Python311"
     - image: Visual Studio 2019
       WINPYTHON: "Python37"
 
-    # test python 3.12 on Visual Studio 2022 image
+    # test python 3.11, 3.13 on Visual Studio 2022 image
     - image: Visual Studio 2022
-      WINPYTHON: "Python310"
-    - image: Visual Studio 2022
-      WINPYTHON: "Python38"
+      WINPYTHON: "Python39"
     - image: Visual Studio 2022
       WINPYTHON: "Python37"
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Fix typos in CCFLAGS test. Didn't affect the test itself, but
       didn't correctly apply the DefaultEnvironment speedup.
+    - New CacheDir initialization code failed on Python 3.7 for unknown
+      reason (worked on 3.8+). Adjusted the approach a bit.  Fixes #4694.
 
 
 RELEASE 4.9.0 -  Sun, 02 Mar 2025 17:22:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -34,6 +34,9 @@ FIXES
 
 - List fixes of outright bugs
 
+- New CacheDir initialization code failed on Python 3.7 for unknown
+  reason (worked on 3.8+). Adjusted the approach a bit.  Fixes #4694.
+
 IMPROVEMENTS
 ------------
 


### PR DESCRIPTION
Although there is no indication of a change in this area of the `tempfile` module, it seems if the temporary directory has been renamed so the original no longer exists, the context manager fails on 3.7, though not on any later Python versions (maybe a bugfix rather than a planned behavior change?). Now use `mkdtemp` instead, and clean it up by hand if the rename failed (also use `os.replace` instead of `os.rename`, so it will actually fail if the destination directory existed and is nonempty, on Linux `os.rename` doesn't fail in this case).

Fixes #4694

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
