### PR TITLE
Allow parsing Nodes as `PathLike`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From John Doe:
     - Whatever John Doe did.
 
+  From Thaddeus Crews:
+    - Nodes are now treated as PathLike objects.
+
   From Mats Wichmann:
     - Fix typos in CCFLAGS test. Didn't affect the test itself, but
       didn't correctly apply the DefaultEnvironment speedup.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -29,6 +29,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 - List modifications to existing features, where the previous behavior
   wouldn't actually be considered a bug
 
+- Nodes are now treated as PathLike objects.
+
 FIXES
 -----
 

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -114,6 +114,7 @@ import SCons.Warnings
 from SCons.Debug import logInstanceCreation
 from SCons.Errors import InternalError, UserError
 from SCons.Executor import Executor
+from SCons.Node import Node
 
 class _Null:
     pass
@@ -487,10 +488,11 @@ class BuilderBase:
             # fspath() is to catch PathLike paths. We avoid the simpler
             # str(f) so as not to "lose" files that are already Nodes:
             # TypeError: expected str, bytes or os.PathLike object, not File
-            with suppress(TypeError):
-                f = os.fspath(f)
-            if SCons.Util.is_String(f):
-                f = SCons.Util.adjustixes(f, pre, suf, ensure_suffix)
+            if not isinstance(f, Node):
+                with suppress(TypeError):
+                    f = os.fspath(f)
+                if SCons.Util.is_String(f):
+                    f = SCons.Util.adjustixes(f, pre, suf, ensure_suffix)
             result.append(f)
         return result
 

--- a/SCons/BuilderTests.py
+++ b/SCons/BuilderTests.py
@@ -702,7 +702,7 @@ class BuilderTestCase(unittest.TestCase):
         """Test Builder with single_source flag set"""
         def func(target, source, env) -> None:
             """create the file"""
-            with open(str(target[0]), "w"):
+            with open(target[0], "w"):
                 pass
             if len(source) == 1 and len(target) == 1:
                 env['CNT'][0] = env['CNT'][0] + 1
@@ -759,7 +759,7 @@ class BuilderTestCase(unittest.TestCase):
         """Testing handling lists of targets and source"""
         def function2(target, source, env, tlist = [outfile, outfile2], **kw) -> int:
             for t in target:
-                with open(str(t), 'w') as f:
+                with open(t, 'w') as f:
                     f.write("function2\n")
             for t in tlist:
                 if t not in list(map(str, target)):
@@ -790,7 +790,7 @@ class BuilderTestCase(unittest.TestCase):
 
         def function3(target, source, env, tlist = [sub1_out, sub2_out]) -> int:
             for t in target:
-                with open(str(t), 'w') as f:
+                with open(t, 'w') as f:
                     f.write("function3\n")
             for t in tlist:
                 if t not in list(map(str, target)):

--- a/SCons/Environment.xml
+++ b/SCons/Environment.xml
@@ -1248,7 +1248,7 @@ env.Command(
 
 import os
 def rename(env, target, source):
-    os.rename('.tmp', str(target[0]))
+    os.rename('.tmp', target[0])
 
 
 env.Command(
@@ -3626,7 +3626,7 @@ def create(target, source, env):
 
     Writes 'prefix=$SOURCE' into the file name given as $TARGET.
     """
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write(b'prefix=' + source[0].get_contents() + b'\n')
 
 # Fetch the prefix= argument, if any, from the command line.

--- a/SCons/Node/__init__.py
+++ b/SCons/Node/__init__.py
@@ -622,6 +622,9 @@ class Node(metaclass=NoSlotsPyPy):
         # what line in what file created the node, for example).
         Annotate(self)
 
+    def __fspath__(self) -> str:
+        return str(self)
+
     def disambiguate(self, must_exist: bool = False):
         return self
 

--- a/SCons/SConfTests.py
+++ b/SCons/SConfTests.py
@@ -295,7 +295,7 @@ int main(void) {
         """Test SConf.TryAction
         """
         def actionOK(target, source, env):
-            with open(str(target[0]), "w") as f:
+            with open(target[0], "w") as f:
                 f.write("RUN OK\n")
             return None
         def actionFAIL(target, source, env) -> int:

--- a/bin/SConsExamples.py
+++ b/bin/SConsExamples.py
@@ -547,7 +547,7 @@ def CCCom(target, source, env):
                 elif line[:11] != "STRIP CCCOM":
                     ofp.write(line)
 
-    with open(str(target[0]), "w") as fp:
+    with open(target[0], "w") as fp:
         for src in map(str, source):
             process(src, fp)
             fp.write('debug = ' + ARGUMENTS.get('debug', '0') + '\\n')

--- a/test/Actions/append.py
+++ b/test/Actions/append.py
@@ -45,13 +45,13 @@ DefaultEnvironment(tools=[])
 env=Environment()
 
 def before(env, target, source):
-    with open(str(target[0]), "wb") as f:
+    with open(target[0], "wb") as f:
         f.write(b"Foo\\n")
     with open("before.txt", "wb") as f:
         f.write(b"Bar\\n")
 
 def after(env, target, source):
-    with open(str(target[0]), "rb") as fin, open("after%s", "wb") as fout:
+    with open(target[0], "rb") as fin, open("after%s", "wb") as fout:
         fout.write(fin.read())
 
 env.Prepend(LINKCOM=Action(before))

--- a/test/Actions/exitstatfunc.py
+++ b/test/Actions/exitstatfunc.py
@@ -38,7 +38,7 @@ def always_succeed(s):
     return 0
 
 def copy_fail(target, source, env):
-    with open(str(source[0]), 'rb') as infp, open(str(target[0]), 'wb') as f:
+    with open(source[0], 'rb') as infp, open(target[0], 'wb') as f:
         f.write(infp.read())
     return 2
 

--- a/test/Actions/function.py
+++ b/test/Actions/function.py
@@ -69,7 +69,7 @@ def toto(header='%(header)s', trailer='%(trailer)s'):
         def foo(b=b):
             return %(nestedfuncexp)s
 
-        with open(str(target[0]), 'wb') as f:
+        with open(target[0], 'wb') as f:
             f.write(bytearray(header, 'utf-8'))
             for d in env['ENVDEPS']:
                 f.write(bytearray(d+'%(separator)s', 'utf-8'))

--- a/test/Actions/pre-post-fixture/work2/SConstruct
+++ b/test/Actions/pre-post-fixture/work2/SConstruct
@@ -3,7 +3,7 @@
 # Copyright The SCons Foundation
 
 def b(target, source, env):
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write((env['X'] + '\n').encode())
 
 DefaultEnvironment(tools=[])

--- a/test/Actions/pre-post-fixture/work3/SConstruct
+++ b/test/Actions/pre-post-fixture/work3/SConstruct
@@ -9,7 +9,7 @@ def post(target, source, env):
     pass
 
 def build(target, source, env):
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write(b'build()\n')
 
 DefaultEnvironment(tools=[])

--- a/test/Actions/pre-post.py
+++ b/test/Actions/pre-post.py
@@ -52,7 +52,7 @@ def before(env, target, source):
         f.write(b"Foo\\n")
     os.chmod(a, os.stat(a).st_mode | stat.S_IXUSR)
     with open("before.txt", "ab") as f:
-        f.write((os.path.splitext(str(target[0]))[0] + "\\n").encode())
+        f.write((os.path.splitext(target[0])[0] + "\\n").encode())
 
 def after(env, target, source):
     t = str(target[0])
@@ -104,11 +104,11 @@ test.write(['work4', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
 
 def pre_action(target, source, env):
-    with open(str(target[0]), 'ab') as f:
+    with open(target[0], 'ab') as f:
         f.write(('pre %%s\\n' %% source[0]).encode())
 
 def post_action(target, source, env):
-    with open(str(target[0]), 'ab') as f:
+    with open(target[0], 'ab') as f:
         f.write(('post %%s\\n' %% source[0]).encode())
 
 env = Environment(tools=[])

--- a/test/Actions/timestamp.py
+++ b/test/Actions/timestamp.py
@@ -45,7 +45,7 @@ test.not_up_to_date(arguments = 'file.out')
 
 test.write('SConstruct', """\
 def my_copy(target, source, env):
-    with open(str(target[0]), 'w') as f, open(str(source[0]), 'r') as infp:
+    with open(target[0], 'w') as f, open(source[0], 'r') as infp:
         f.write(infp.read())
 env = Environment()
 env.Decider('timestamp-match')

--- a/test/Actions/unicode-signature-fixture/SConstruct
+++ b/test/Actions/unicode-signature-fixture/SConstruct
@@ -5,7 +5,7 @@
 fnode = File(u'foo.txt')
 
 def funcact(target, source, env):
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write(b"funcact\n")
     for i in range(300):
         pass

--- a/test/Alias/action.py
+++ b/test/Alias/action.py
@@ -33,10 +33,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 def cat(target, source, env):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 
 def foo(target, source, env):

--- a/test/Alias/scanner.py
+++ b/test/Alias/scanner.py
@@ -35,10 +35,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 
 XBuilder = Builder(action = cat, src_suffix = '.x', suffix = '.c')

--- a/test/Batch/Boolean.py
+++ b/test/Batch/Boolean.py
@@ -37,7 +37,7 @@ DefaultEnvironment(tools=[])
 
 def batch_build(target, source, env):
     for t, s in zip(target, source):
-        with open(str(t), 'wb') as f, open(str(s), 'rb') as infp:
+        with open(t, 'wb') as f, open(s, 'rb') as infp:
             f.write(infp.read())
 env = Environment(tools=[])
 bb = Action(batch_build, batch_key=True)

--- a/test/Batch/callable.py
+++ b/test/Batch/callable.py
@@ -40,7 +40,7 @@ test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def batch_build(target, source, env):
     for t, s in zip(target, source):
-        with open(str(t), 'wb') as f, open(str(s), 'rb') as infp:
+        with open(t, 'wb') as f, open(s, 'rb') as infp:
             f.write(infp.read())
 if ARGUMENTS.get('BATCH_CALLABLE'):
     def batch_key(action, env, target, source):

--- a/test/Batch/generated.py
+++ b/test/Batch/generated.py
@@ -37,11 +37,11 @@ DefaultEnvironment(tools=[])
 
 def batch_build(target, source, env):
     for t, s in zip(target, source):
-        with open(str(t), 'wb') as fp:
+        with open(t, 'wb') as fp:
             if str(t) == 'f3.out':
                 with open('f3.include', 'rb') as f:
                     fp.write(f.read())
-            with open(str(s), 'rb') as f:
+            with open(s, 'rb') as f:
                 fp.write(f.read())
 env = Environment(tools=[])
 bb = Action(batch_build, batch_key=True)

--- a/test/Builder-factories.py
+++ b/test/Builder-factories.py
@@ -47,7 +47,7 @@ def mkdir(env, source, target):
         f.write(b"MakeDirectory\\n")
 MakeDirectory = Builder(action=mkdir, target_factory=Dir)
 def collect(env, source, target):
-    with open(str(target[0]), 'wb') as out:
+    with open(target[0], 'wb') as out:
         dir = str(source[0])
         for f in sorted(os.listdir(dir)):
             f = os.path.join(dir, f)

--- a/test/Builder/errors.py
+++ b/test/Builder/errors.py
@@ -38,7 +38,7 @@ sconstruct = """
 DefaultEnvironment(tools=[])
 
 def buildop(env, source, target):
-    with open(str(target[0]), 'wb') as outf, open(str(source[0]), 'r') as infp:
+    with open(target[0], 'wb') as outf, open(source[0], 'r') as infp:
         for line in inpf.readlines():
             if line.find(str(target[0])) == -1:
                 outf.write(line)

--- a/test/Builder/multi/different-actions.py
+++ b/test/Builder/multi/different-actions.py
@@ -36,9 +36,9 @@ test = TestSCons.TestSCons(match=TestSCons.match_re)
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 B = Builder(action=Action(build, varlist=['XXX']), multi=1)

--- a/test/Builder/multi/different-environments.py
+++ b/test/Builder/multi/different-environments.py
@@ -39,10 +39,10 @@ _python_ = TestSCons._python_
 test.write('build.py', r"""\
 import sys
 def build(num, target, source):
-    with open(str(target), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write('%s\n' % num)
-        for s in source:
-            with open(str(s), 'rb') as infp:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 build(sys.argv[1],sys.argv[2],sys.argv[3:])
 """)

--- a/test/Builder/multi/different-multi.py
+++ b/test/Builder/multi/different-multi.py
@@ -37,9 +37,9 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 def build2(env, target, source):

--- a/test/Builder/multi/different-order.py
+++ b/test/Builder/multi/different-order.py
@@ -39,9 +39,9 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
     for t in target:
-        with open(str(target[0]), 'wb') as f:
-            for s in source:
-                with open(str(s), 'rb') as infp:
+        with open(target[0], 'wb') as f:
+            for src in source:
+                with open(src, 'rb') as infp:
                     f.write(infp.read())
 
 B = Builder(action=build, multi=1)

--- a/test/Builder/multi/different-overrides.py
+++ b/test/Builder/multi/different-overrides.py
@@ -36,9 +36,9 @@ test = TestSCons.TestSCons(match=TestSCons.match_re)
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 B = Builder(action=build, multi=1)

--- a/test/Builder/multi/different-target-lists.py
+++ b/test/Builder/multi/different-target-lists.py
@@ -43,9 +43,9 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def build(env, target, source):
     for t in target:
-        with open(str(target[0]), 'wb') as f:
-            for s in source:
-                with open(str(s), 'rb') as infp:
+        with open(target[0], 'wb') as f:
+            for src in source:
+                with open(src, 'rb') as infp:
                     f.write(infp.read())
 
 B = Builder(action=build, multi=1)

--- a/test/Builder/multi/error.py
+++ b/test/Builder/multi/error.py
@@ -37,9 +37,9 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 B = Builder(action=build, multi=0)

--- a/test/Builder/multi/lone-target-list.py
+++ b/test/Builder/multi/lone-target-list.py
@@ -37,9 +37,9 @@ DefaultEnvironment(tools=[])
 
 def build(env, target, source):
     for t in target:
-        with open(str(target[0]), 'wb') as f:
-            for s in source:
-                with open(str(s), 'rb') as infp:
+        with open(t, 'wb') as f:
+            for src in source:
+                with open(src, 'rb') as infp:
                     f.write(infp.read())
 
 B = Builder(action=build, multi=1)

--- a/test/Builder/multi/multi.py
+++ b/test/Builder/multi/multi.py
@@ -37,9 +37,9 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 B = Builder(action=build, multi=1)

--- a/test/Builder/multi/same-actions.py
+++ b/test/Builder/multi/same-actions.py
@@ -37,9 +37,9 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 B = Builder(action=build, multi=1)

--- a/test/Builder/multi/same-overrides.py
+++ b/test/Builder/multi/same-overrides.py
@@ -37,10 +37,10 @@ _python_ = TestSCons._python_
 test.write('build.py', r"""\
 import sys
 def build(num, target, source):
-    with open(str(target), 'wb') as f:
+    with open(target, 'wb') as f:
         f.write(bytearray('%s\n'% num,'utf-8'))
-        for s in source:
-            with open(str(s), 'rb') as infp:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 build(sys.argv[1], sys.argv[2], sys.argv[3:])
 """)

--- a/test/Builder/multi/same-targets.py
+++ b/test/Builder/multi/same-targets.py
@@ -38,9 +38,9 @@ DefaultEnvironment(tools=[])
 
 def build(env, target, source):
     for t in target:
-        with open(str(t), 'wb') as f:
-            for s in source:
-                with open(str(s), 'rb') as infp:
+        with open(t, 'wb') as f:
+            for src in source:
+                with open(src, 'rb') as infp:
                     f.write(infp.read())
 
 B = Builder(action=build, multi=1)

--- a/test/Builder/non-multi.py
+++ b/test/Builder/non-multi.py
@@ -36,9 +36,9 @@ test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 B = Builder(action=build, multi=0)

--- a/test/Builder/same-actions-diff-envs.py
+++ b/test/Builder/same-actions-diff-envs.py
@@ -36,7 +36,7 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'w') as f:
+    with open(target[0], 'w') as f:
         f.write('1')
 
 B = Builder(action=build)

--- a/test/Builder/same-actions-diff-overrides.py
+++ b/test/Builder/same-actions-diff-overrides.py
@@ -36,7 +36,7 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'w') as f:
+    with open(target[0], 'w') as f:
         f.write('1')
 
 B = Builder(action=build)

--- a/test/Builder/wrapper.py
+++ b/test/Builder/wrapper.py
@@ -38,9 +38,9 @@ DefaultEnvironment(tools=[])
 import os.path
 import string
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as fp:
-        for s in map(str, source):
-            with open(s, 'rb') as infp:
+    with open(target[0], 'wb') as fp:
+        for src in source:
+            with open(src, 'rb') as infp:
                 fp.write(infp.read())
 Cat = Builder(action=cat)
 def Wrapper(env, target, source):

--- a/test/CacheDir/CacheDir.py
+++ b/test/CacheDir/CacheDir.py
@@ -56,7 +56,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')

--- a/test/CacheDir/SideEffect.py
+++ b/test/CacheDir/SideEffect.py
@@ -42,12 +42,10 @@ def copy(source, target):
         f.write(f2.read())
 
 def build(env, source, target):
-    s = str(source[0])
-    t = str(target[0])
-    copy(s, t)
+    copy(source[0], target[0])
     if target[0].side_effects:
-        with open(str(target[0].side_effects[0]), "a") as side_effect:
-            side_effect.write(s + ' -> ' + t + '\\n')
+        with open(target[0].side_effects[0], "a") as side_effect:
+            side_effect.write(str(source[0]) + ' -> ' + str(target[0]) + '\\n')
 
 CacheDir(r'%(cache)s')
 

--- a/test/CacheDir/VariantDir.py
+++ b/test/CacheDir/VariantDir.py
@@ -47,7 +47,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')

--- a/test/CacheDir/debug.py
+++ b/test/CacheDir/debug.py
@@ -56,7 +56,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')

--- a/test/CacheDir/environment.py
+++ b/test/CacheDir/environment.py
@@ -57,7 +57,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 env_cache = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env_nocache = env_cache.Clone()

--- a/test/CacheDir/option--cd.py
+++ b/test/CacheDir/option--cd.py
@@ -43,7 +43,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')

--- a/test/CacheDir/option--cf.py
+++ b/test/CacheDir/option--cf.py
@@ -44,7 +44,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')

--- a/test/CacheDir/option--cr.py
+++ b/test/CacheDir/option--cr.py
@@ -43,7 +43,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')

--- a/test/CacheDir/option--cs.py
+++ b/test/CacheDir/option--cs.py
@@ -59,7 +59,7 @@ def cat(env, source, target):
         f.write(target + "\\n")
     with open(target, "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 
 DefaultEnvironment(tools=[])  # test speedup

--- a/test/Chmod.py
+++ b/test/Chmod.py
@@ -47,7 +47,7 @@ def cat(env, source, target):
     target = str(target[0])
     with open(target, "wb") as f:
         for src in source:
-            with open(str(src), "rb") as infp:
+            with open(src, "rb") as infp:
                 f.write(infp.read())
 
 Cat = Action(cat)

--- a/test/Climb/explicit-parent--D.py
+++ b/test/Climb/explicit-parent--D.py
@@ -40,7 +40,7 @@ def cat(env, source, target):
     target = str(target[0])
     with open(target, 'wb') as ofp:
         for src in source:
-            with open(str(src), 'rb') as ifp:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('f1.out', 'f1.in')

--- a/test/Climb/explicit-parent--U.py
+++ b/test/Climb/explicit-parent--U.py
@@ -40,7 +40,7 @@ def cat(env, source, target):
     target = str(target[0])
     with open(target, 'wb') as ofp:
         for src in source:
-            with open(str(src), 'rb') as ifp:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 env = Environment(tools=[],
                   BUILDERS={'Cat':Builder(action=cat)})

--- a/test/Climb/explicit-parent-u.py
+++ b/test/Climb/explicit-parent-u.py
@@ -41,7 +41,7 @@ def cat(env, source, target):
     target = str(target[0])
     with open(target, 'wb') as ofp:
         for src in source:
-            with open(str(src), 'rb') as ifp:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 env = Environment(tools=[],
                   BUILDERS={'Cat':Builder(action=cat)})

--- a/test/Climb/option-u.py
+++ b/test/Climb/option-u.py
@@ -45,7 +45,7 @@ def cat(env, source, target):
     target = str(target[0])
     with open(target, 'wb') as ofp:
         for src in source:
-            with open(str(src), 'rb') as ifp:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 env = Environment(tools=[])
 env.Append(BUILDERS = {'Cat' : Builder(action=cat)})

--- a/test/Command.py
+++ b/test/Command.py
@@ -46,7 +46,7 @@ import os
 import sys
 
 def buildIt(env, target, source):
-    with open(str(target[0]), 'w') as f, open(str(source[0]), 'r') as infp:
+    with open(target[0], 'w') as f, open(source[0], 'r') as infp:
         xyzzy = env.get('XYZZY', '')
         if xyzzy:
             f.write(xyzzy + '\\n')

--- a/test/Copy-Action.py
+++ b/test/Copy-Action.py
@@ -46,10 +46,9 @@ Execute(Copy('d7.out', ['f10.in', 'f11.in']))
 Execute(Copy('d7.out', Glob('f?.in')))
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "w") as f:
+    with open(target[0], "w") as f:
         for src in source:
-            with open(str(src), "r") as ifp:
+            with open(src, "r") as ifp:
                 f.write(ifp.read())
 
 Cat = Action(cat)

--- a/test/Decider/switch-rebuild.py
+++ b/test/Decider/switch-rebuild.py
@@ -38,7 +38,7 @@ DefaultEnvironment(tools=[])
 Decider('%s')
 
 def build(env, target, source):
-    with open(str(target[0]), 'wt') as f, open(str(source[0]), 'rt') as ifp:
+    with open(target[0], 'wt') as f, open(source[0], 'rt') as ifp:
         f.write(ifp.read())
 B = Builder(action=build)
 env = Environment(tools=[], BUILDERS = { 'B' : B })

--- a/test/Delete.py
+++ b/test/Delete.py
@@ -43,10 +43,9 @@ Execute(Delete('symlinks/brokenlink'))
 Execute(Delete('symlinks/dirlink'))
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as ofp:
+    with open(target[0], "wb") as ofp:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 ofp.write(ifp.read())
 Cat = Action(cat)
 env = Environment()
@@ -193,10 +192,9 @@ if sys.platform != 'win32':
 
 test.write("SConstruct", """\
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as ifp:
+    with open(target[0], "wb") as ifp:
         for src in source:
-            with open(str(src), "rb") as ofp:
+            with open(src, "rb") as ofp:
                 ofp.write(ifp.read())
 Cat = Action(cat)
 env = Environment()

--- a/test/Dir/source.py
+++ b/test/Dir/source.py
@@ -44,7 +44,7 @@ test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 
 def writeTarget(target, source, env):
-    f = open(str(target[0]), 'w')
+    f = open(target[0], 'w')
     f.write("stuff\\n")
     f.close()
     return 0

--- a/test/Errors/Exception.py
+++ b/test/Errors/Exception.py
@@ -30,7 +30,7 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 test.write('SConstruct', """\
 def foo(env, target, source):
     print(str(target[0]))
-    with open(str(target[0]), 'wt') as f:
+    with open(target[0], 'wt') as f:
         f.write('foo')
 
 def exit(env, target, source):

--- a/test/Exit.py
+++ b/test/Exit.py
@@ -103,10 +103,9 @@ SConscript('subdir/SConscript')
 
 test.write(['subdir', 'SConscript'], """\
 def exit_builder(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
     Exit(27)
 env = Environment(BUILDERS = {'my_exit' : Builder(action=exit_builder)})
@@ -132,10 +131,9 @@ def exit_scanner(node, env, target):
 exitscan = Scanner(function = exit_scanner, skeys = ['.k'])
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, 'wb') as ofp:
+    with open(target[0], 'wb') as ofp:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 outf.write(ifp.read())
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})

--- a/test/FindFile.py
+++ b/test/FindFile.py
@@ -40,16 +40,16 @@ test.write(['bar', 'baz', 'testfile2'], 'test 4\n')
 test.write('SConstruct', """
 env = Environment(FILE = 'file', BAR = 'bar')
 file1 = FindFile('testfile1', [ 'foo', '.', 'bar', 'bar/baz' ])
-with open(str(file1), 'r') as f:
+with open(file1, 'r') as f:
     print(f.read())
 file2 = env.FindFile('test${FILE}1', [ 'bar', 'foo', '.', 'bar/baz' ])
-with open(str(file2), 'r') as f:
+with open(file2, 'r') as f:
     print(f.read())
 file3 = FindFile('testfile2', [ 'foo', '.', 'bar', 'bar/baz' ])
-with open(str(file3), 'r') as f:
+with open(file3, 'r') as f:
     print(f.read())
 file4 = env.FindFile('testfile2', [ '$BAR/baz', 'foo', '.', 'bar' ])
-with open(str(file4), 'r') as f:
+with open(file4, 'r') as f:
     print(f.read())
 """)
 

--- a/test/Flatten.py
+++ b/test/Flatten.py
@@ -36,10 +36,9 @@ test.subdir('work')
 
 test.write(['work', 'SConstruct'], """
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as ofp:
+    with open(target[0], "wb") as ofp:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 ofp.write(ifp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 f1 = env.Cat('../file1.out', 'file1.in')

--- a/test/Glob/Repository.py
+++ b/test/Glob/Repository.py
@@ -49,10 +49,9 @@ opts = "-Y " + test.workpath('repository')
 test.write(['repository', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as ofp:
+    with open(target[0], 'wb') as ofp:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 # Verify that we can glob a repository-only Node that exists

--- a/test/Glob/VariantDir.py
+++ b/test/Glob/VariantDir.py
@@ -49,12 +49,12 @@ SConscript('src/sub1/SConscript', src_dir = 'src', variant_dir = 'var3', duplica
 """)
 
 test.write(['src', 'SConscript'], """\
-env = Environment(tools=[]) 
+env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)
@@ -67,9 +67,9 @@ test.write(['src', 'sub1', 'SConscript'], """\
 env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)

--- a/test/Glob/basic.py
+++ b/test/Glob/basic.py
@@ -34,12 +34,12 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=[]) 
+env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)

--- a/test/Glob/exclude.py
+++ b/test/Glob/exclude.py
@@ -37,12 +37,12 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=[]) 
+env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)

--- a/test/Glob/source.py
+++ b/test/Glob/source.py
@@ -38,12 +38,12 @@ test.subdir('src', 'var1', 'var2')
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=[]) 
+env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)

--- a/test/Glob/strings.py
+++ b/test/Glob/strings.py
@@ -46,12 +46,12 @@ SConscript('var2/SConscript')
 """)
 
 test.write(['src', 'SConscript'], """\
-env = Environment(tools=[]) 
+env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)

--- a/test/Glob/subdir.py
+++ b/test/Glob/subdir.py
@@ -37,12 +37,12 @@ test.subdir('subdir')
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(tools=[]) 
+env = Environment(tools=[])
 
 def concatenate(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Concatenate'] = Builder(action=concatenate)

--- a/test/Glob/subst.py
+++ b/test/Glob/subst.py
@@ -38,9 +38,9 @@ DefaultEnvironment(tools=[])
 env = Environment(tools=[], PATTERN = 'f*.in')
 
 def copy(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 env['BUILDERS']['Copy'] = Builder(action=copy)

--- a/test/HeaderGen.py
+++ b/test/HeaderGen.py
@@ -35,7 +35,7 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 def writeFile(target, contents):
-    with open(str(target[0]), 'w') as f:
+    with open(target[0], 'w') as f:
         f.write(contents)
     return 0
 
@@ -59,7 +59,7 @@ test.write('SConstruct', """\
 env = Environment()
 
 def gen_a_h(target, source, env):
-    with open(str(target[0]), 'w') as t, open(str(source[0]), 'r') as s:
+    with open(target[0], 'w') as t, open(source[0], 'r') as s:
         s.readline()
         t.write(s.readline()[:-1] + ';\\n')
 

--- a/test/Install/Install.py
+++ b/test/Install/Install.py
@@ -50,10 +50,9 @@ _SUBDIR_f4_out = os.path.join('$SUBDIR', 'f4.out')
 test.write(['work', 'SConstruct'], """\
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, 'wb') as ofp:
+    with open(target[0], 'wb') as ofp:
         for src in source:
-            with open(str(src), 'rb') as ifp:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 def my_install(dest, source, env):

--- a/test/Install/wrap-by-attribute.py
+++ b/test/Install/wrap-by-attribute.py
@@ -46,10 +46,9 @@ import os.path
 
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, 'wb') as ofp:
+    with open(target[0], 'wb') as ofp:
         for src in source:
-            with open(str(src), 'rb') as ifp:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
 
 

--- a/test/Interactive/option-j.py
+++ b/test/Interactive/option-j.py
@@ -40,8 +40,8 @@ def cat(target, source, env):
     t = str(target[0])
     os.mkdir(t + '.started')
     with open(t, 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
     os.mkdir(t + '.finished')
 
@@ -64,8 +64,8 @@ def must_wait_for_f2_b_out(target, source, env):
     while not os.path.exists(f2_b_started):
         time.sleep(1)
     with open(t, 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
     os.mkdir(t + '.finished')
 

--- a/test/Mkdir.py
+++ b/test/Mkdir.py
@@ -40,10 +40,9 @@ test.write(['work1', 'SConstruct'], """
 Execute(Mkdir('d1'))
 Execute(Mkdir(Dir('#d1-Dir')))
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 Cat = Action(cat)
 env = Environment()

--- a/test/Move.py
+++ b/test/Move.py
@@ -36,10 +36,9 @@ test.write('SConstruct', """
 Execute(Move('f1.out', 'f1.in'))
 Execute(Move('File-f1.out', File('f1.in-File')))
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 Cat = Action(cat)
 env = Environment()

--- a/test/NodeOps.py
+++ b/test/NodeOps.py
@@ -64,9 +64,9 @@ SConscript('bld/SConscript', ['Nodes'])
 if %(_E)s:
   import os
   derived = [N.is_derived() for N in Nodes]
-  real1 = [os.path.exists(str(N)) for N in Nodes]
+  real1 = [os.path.exists(N) for N in Nodes]
   exists = [N.exists() for N in Nodes]
-  real2 = [os.path.exists(str(N)) for N in Nodes]
+  real2 = [os.path.exists(N) for N in Nodes]
   for N,D,R,E,F in zip(Nodes, derived, real1, exists, real2):
     print('%%s: %%s %%s %%s %%s'%%(N,D,R,E,F))
 foo.SharedLibrary(target = 'foo', source = 'foo%(_obj)s')
@@ -119,13 +119,13 @@ import os
 Import('*')
 
 def mycopy(env, source, target):
-    with open(str(target[0]), 'wt') as fo, open(str(source[0]), 'rt') as fi:
+    with open(target[0], 'wt') as fo, open(source[0], 'rt') as fi:
         fo.write(fi.read())
 
 def exists_test(node):
-    before = os.path.exists(str(node))  # doesn't exist yet in VariantDir
+    before = os.path.exists(node)  # doesn't exist yet in VariantDir
     via_node = node.exists()            # side effect causes copy from src
-    after = os.path.exists(str(node))
+    after = os.path.exists(node)
     node.is_derived()
     import SCons.Script
     if GetOption('no_exec'):

--- a/test/Repository/LIBPATH.py
+++ b/test/Repository/LIBPATH.py
@@ -46,7 +46,7 @@ bbb_exe = env_yyy.Program('bbb', 'bbb.c')
 def write_LIBDIRFLAGS(env, target, source):
     pre = env.subst('$LIBDIRPREFIX')
     suf = env.subst('$LIBDIRSUFFIX')
-    with open(str(target[0]), 'w') as f:
+    with open(target[0], 'w') as f:
         for arg in env.subst('$_LIBDIRFLAGS', target=target).split():
             if arg[:len(pre)] == pre:
                 arg = arg[len(pre):]

--- a/test/Repository/SConscript.py
+++ b/test/Repository/SConscript.py
@@ -51,10 +51,9 @@ SConscript('src/SConscript')
 
 test.write(['rep1', 'src', 'SConscript'], """\
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "w") as ofp:
+    with open(target[0], "w") as ofp:
         for src in source:
-            with open(str(src), "r") as ifp:
+            with open(src, "r") as ifp:
                 ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
@@ -88,10 +87,9 @@ SConscript('src/SConscript')
 
 test.write(['rep2', 'src', 'SConscript'], """\
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "w") as ofp:
+    with open(target[0], "w") as ofp:
         for src in source:
-            with open(str(src), "r") as ifp:
+            with open(src, "r") as ifp:
                 ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})

--- a/test/Repository/option-f.py
+++ b/test/Repository/option-f.py
@@ -42,10 +42,9 @@ opts = "-f " + test.workpath('repository', 'SConstruct')
 test.write(['repository', 'SConstruct'], """\
 Repository(r'%s')
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as ofp:
+    with open(target[0], "wb") as ofp:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})

--- a/test/Requires/basic.py
+++ b/test/Requires/basic.py
@@ -35,9 +35,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 def append_prereq_func(target, source, env):
-    with open(str(target[0]), 'wb') as ofp:
-        for s in source:
-            with open(str(s), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp:
+        for src in source:
+            with open(src, 'rb') as ifp:
                 ofp.write(ifp.read())
         with open('prereq.out', 'rb') as ifp:
             ofp.write(ifp.read())

--- a/test/Requires/eval-order.py
+++ b/test/Requires/eval-order.py
@@ -34,9 +34,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 def copy_and_create_func(target, source, env):
-    with open(str(target[0]), 'w') as ofp:
-        for s in source:
-            with open(str(s), 'r') as ifp:
+    with open(target[0], 'w') as ofp:
+        for src in source:
+            with open(src, 'r') as ifp:
                 ofp.write(ifp.read())
     with open('file.in', 'w') as f:
         f.write("file.in 1\\n")

--- a/test/Scanner/Scanner.py
+++ b/test/Scanner/Scanner.py
@@ -117,7 +117,7 @@ def third(env, target, source):
     contents = source[0].get_contents()
     # print("TYPE:"+str(type(contents)))
     contents = contents.replace(b'getfile', b'MISSEDME')
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write(contents)
 
 kbld = Builder(action=r'%(_python_)s build.py $SOURCES $TARGET',

--- a/test/Scanner/empty-implicit.py
+++ b/test/Scanner/empty-implicit.py
@@ -37,11 +37,11 @@ test.write('SConstruct', r"""
 import os.path
 
 def scan(node, env, envkey, arg):
-    print('XScanner: node = '+os.path.split(str(node))[1])
+    print('XScanner: node = '+os.path.split(node)[1])
     return []
 
 def exists_check(node, env):
-    return os.path.exists(str(node))
+    return os.path.exists(node)
 
 XScanner = Scanner(name = 'XScanner',
                    function = scan,
@@ -50,8 +50,8 @@ XScanner = Scanner(name = 'XScanner',
                    skeys = ['.x'])
 
 def echo(env, target, source):
-    t = os.path.split(str(target[0]))[1]
-    s = os.path.split(str(source[0]))[1]
+    t = os.path.split(target[0])[1]
+    s = os.path.split(source[0])[1]
     print('create %s from %s' % (t, s))
     with open(t, 'wb') as ofb, open(s, 'rb') as ifb:
         ofb.write(ifb.read())

--- a/test/Scanner/exception.py
+++ b/test/Scanner/exception.py
@@ -67,10 +67,9 @@ def process(outf, inf):
             outf.write(line)
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, 'wb') as outf:
+    with open(target[0], 'wb') as outf:
         for src in source:
-            with open(str(src), 'rb') as inf:
+            with open(src, 'rb') as inf:
                 process(outf, inf)
 
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})

--- a/test/Scanner/no-Dir-node.py
+++ b/test/Scanner/no-Dir-node.py
@@ -81,7 +81,7 @@ sys.exit(0)
 
 test.write('SConstruct', """\
 def foo(target, source, env):
-    fp = open(str(target[0]), 'w')
+    fp = open(target[0], 'w')
     for c in sorted(source[0].children(), key=lambda t: t.name):
         fp.write('%s\\n' % c)
     fp.close()

--- a/test/Scanner/scan-once.py
+++ b/test/Scanner/scan-once.py
@@ -36,11 +36,11 @@ test.write('SConstruct', r"""
 import os.path
 
 def scan(node, env, envkey, arg):
-    print('XScanner: node = '+ os.path.split(str(node))[1])
+    print('XScanner: node = '+ os.path.split(node)[1])
     return []
 
 def exists_check(node, env):
-    return os.path.exists(str(node))
+    return os.path.exists(node)
 
 XScanner = Scanner(name = 'XScanner',
                    function = scan,
@@ -49,8 +49,8 @@ XScanner = Scanner(name = 'XScanner',
                    skeys = ['.x'])
 
 def echo(env, target, source):
-    t = os.path.split(str(target[0]))[1]
-    s = os.path.split(str(source[0]))[1]
+    t = os.path.split(target[0])[1]
+    s = os.path.split(source[0])[1]
     print('create %s from %s' % (t, s))
 
 Echo = Builder(action = Action(echo, None),

--- a/test/SideEffect/Issues/3013/files/SConstruct
+++ b/test/SideEffect/Issues/3013/files/SConstruct
@@ -6,7 +6,7 @@ DefaultEnvironment(tools=[])
 env = Environment()
 
 def make_file(target, source, env):
-    with open(str(target[0]), 'w') as f:
+    with open(target[0], 'w') as f:
         f.write('gobldygook')
     with open(str(target[0]) + '_side_effect', 'w') as side_effect:
         side_effect.write('anything')
@@ -23,4 +23,3 @@ SConscript(
     exports={'env':env},
     duplicate=0
 )
-

--- a/test/SideEffect/basic.py
+++ b/test/SideEffect/basic.py
@@ -41,9 +41,9 @@ def copy(source, target):
         f.write(f2.read())
 
 def build(env, source, target):
-    copy(str(source[0]), str(target[0]))
+    copy(source[0], target[0])
     if target[0].side_effects:
-        with open(str(target[0].side_effects[0]), "ab") as side_effect:
+        with open(target[0].side_effects[0], "ab") as side_effect:
             side_effect.write(('%%s -> %%s\\n'%%(str(source[0]), str(target[0]))).encode())
 
 Build = Builder(action=build)

--- a/test/SideEffect/variant_dir.py
+++ b/test/SideEffect/variant_dir.py
@@ -35,16 +35,16 @@ import TestSCons
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', 
+test.write('SConstruct',
 """
 def copy(source, target):
     with open(target, "wb") as f, open(source, "rb") as f2:
         f.write(f2.read())
 
 def build(env, source, target):
-    copy(str(source[0]), str(target[0]))
+    copy(source[0], target[0])
     if target[0].side_effects:
-        with open(str(target[0].side_effects[0]), "ab") as side_effect:
+        with open(target[0].side_effects[0], "ab") as side_effect:
             side_effect.write(('%s -> %s\\n'%(str(source[0]), str(target[0]))).encode())
 
 Build = Builder(action=build)

--- a/test/TARGET-dir.py
+++ b/test/TARGET-dir.py
@@ -42,10 +42,9 @@ test.subdir('src', 'build1', 'build2')
 
 test.write('SConstruct', """
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
     f.close()
 env = Environment(CPPPATH='${TARGET.dir}')

--- a/test/Touch.py
+++ b/test/Touch.py
@@ -38,10 +38,9 @@ Execute(Touch('f1'))
 Execute(Touch(File('f1-File')))
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 
 Cat = Action(cat)

--- a/test/Value/Value.py
+++ b/test/Value/Value.py
@@ -52,7 +52,7 @@ L = len(P)
 C = Custom(P)
 
 def create(target, source, env):
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write(source[0].get_contents())
 
 DefaultEnvironment(tools=[])  # test speedup
@@ -68,7 +68,7 @@ def create_value(target, source, env):
     target[0].write(source[0].get_contents())
 
 def create_value_file(target, source, env):
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write(source[0].read())
 
 env['BUILDERS']['B2'] = Builder(action=create_value)

--- a/test/VariantDir/Clean.py
+++ b/test/VariantDir/Clean.py
@@ -42,8 +42,7 @@ VariantDir('build1', '.', duplicate=1)
 
 def build_sample(target, source, env):
     targetdir = str(target[0].dir)
-    target = str(target[0])
-    with open(target, 'w') as ofd, open(str(source[0]), 'r') as ifd:
+    with open(target[0], 'w') as ofd, open(source[0], 'r') as ifd:
         ofd.write(ifd.read())
     with open(targetdir+'/sample.junk', 'w') as f:
         f.write('Side effect!\\n')

--- a/test/VariantDir/SConscript-variant_dir.py
+++ b/test/VariantDir/SConscript-variant_dir.py
@@ -57,10 +57,9 @@ var8 = Dir('../build/var8')
 var9 = Dir('../build/var9')
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as ofp:
+    with open(target[0], "wb") as ofp:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 ofp.write(ifp.read())
 
 DefaultEnvironment(tools=[])  # test speedup

--- a/test/VariantDir/VariantDir.py
+++ b/test/VariantDir/VariantDir.py
@@ -94,8 +94,8 @@ import sys
 def buildIt(target, source, env):
     if not os.path.exists('build'):
         os.mkdir('build')
-    f1=open(str(source[0]), 'r')
-    f2=open(str(target[0]), 'w')
+    f1=open(source[0], 'r')
+    f2=open(target[0], 'w')
     f2.write(f1.read())
     f2.close()
     f1.close()

--- a/test/VariantDir/errors.py
+++ b/test/VariantDir/errors.py
@@ -59,10 +59,9 @@ def fake_scan(node, env, target):
     return []
 
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "w") as f:
+    with open(target[0], "w") as f:
         for src in source:
-            with open(str(src), "r") as f2:
+            with open(src, "r") as f2:
                 f.write(f2.read())
 
 DefaultEnvironment(tools=[])  # test speedup

--- a/test/Win32/default-drive.py
+++ b/test/Win32/default-drive.py
@@ -44,10 +44,9 @@ test.subdir('src')
 
 test.write(['src', 'SConstruct'], """
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as ofp:
+    with open(target[0], "wb") as ofp:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 ofp.write(ifp.read())
 
 env = Environment(BUILDERS={'Build':Builder(action=cat)})

--- a/test/chained-build.py
+++ b/test/chained-build.py
@@ -37,7 +37,7 @@ test.subdir('w1')
 
 SConstruct1_contents = """\
 def build(env, target, source):
-    with open(str(target[0]), 'wt') as fo, open(str(source[0]), 'rt') as fi:
+    with open(target[0], 'wt') as fo, open(source[0], 'rt') as fi:
         fo.write(fi.read())
 
 env=Environment(BUILDERS={'B' : Builder(action=build)})
@@ -46,7 +46,7 @@ env.B('foo.mid', 'foo.in')
 
 SConstruct2_contents = """\
 def build(env, target, source):
-    with open(str(target[0]), 'wt') as fo, open(str(source[0]), 'rt') as fi:
+    with open(target[0], 'wt') as fo, open(source[0], 'rt') as fi:
         fo.write(fi.read())
 
 env=Environment(BUILDERS={'B' : Builder(action=build)})

--- a/test/duplicate-sources.py
+++ b/test/duplicate-sources.py
@@ -35,9 +35,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as t:
-        for s in source:
-            with open(str(s), 'rb') as s:
+    with open(target[0], 'wb') as t:
+        for src in source:
+            with open(src, 'rb') as s:
                 t.write(s.read())
 env = Environment(BUILDERS = {'Cat' : Builder(action = cat)})
 env.Cat('out.txt', ['f1.in', 'f2.in', 'f1.in'])

--- a/test/emitter.py
+++ b/test/emitter.py
@@ -41,7 +41,7 @@ SConscript('var2/SConscript')
 test.write('src/SConscript',"""
 def build(target, source, env):
     for t in target:
-        with open(str(t), "wt") as f:
+        with open(t, "wt") as f:
             f.write(str(t))
 
 def emitter(target, source, env):

--- a/test/implicit-cache/basic.py
+++ b/test/implicit-cache/basic.py
@@ -62,7 +62,7 @@ env = Environment(CPPPATH=['inc2', include])
 SConscript('variant/SConscript', "env")
 
 def copy(target, source, env):
-    with open(str(target[0]), 'wt') as fo, open(str(source[0]), 'rt') as fi:
+    with open(target[0], 'wt') as fo, open(source[0], 'rt') as fi:
         fo.write(fi.read())
 nodep = env.Command('nodeps.c', 'nodeps.in', action=copy)
 env.Program('nodeps', 'nodeps.c')

--- a/test/implicit/changed-node.py
+++ b/test/implicit/changed-node.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we don't throw an exception if a stored implicit
@@ -51,7 +50,7 @@ def lister(target, source, env):
             for l in os.listdir(source[0]):
                 ofp.write(l + '\\n')
         else:
-            ofp.write(str(source[0]) + '\\n')
+            ofp.write(f'{source[0]}\\n')
 
 builder = Builder(action=lister,
                   source_factory=Dir,
@@ -76,6 +75,7 @@ test.run('--debug=stacktrace')
 
 
 test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 SetOption('implicit_cache', 1)
 SetOption('max_drift', 1)
 
@@ -86,7 +86,7 @@ def lister(target, source, env):
             for l in os.listdir(source[0]):
                 ofp.write(l + '\\n')
         else:
-            ofp.write(str(source[0]) + '\\n')
+            ofp.write(f'{source[0]}\\n')
 
 builder = Builder(action=lister,
                   source_factory=File)

--- a/test/implicit/changed-node.py
+++ b/test/implicit/changed-node.py
@@ -46,13 +46,12 @@ SetOption('max_drift', 1)
 
 def lister(target, source, env):
     import os
-    with open(str(target[0]), 'w') as ofp:
-        s = str(source[0])
-        if os.path.isdir(s):
-            for l in os.listdir(str(source[0])):
+    with open(target[0], 'w') as ofp:
+        if os.path.isdir(source[0]):
+            for l in os.listdir(source[0]):
                 ofp.write(l + '\\n')
         else:
-            ofp.write(s + '\\n')
+            ofp.write(str(source[0]) + '\\n')
 
 builder = Builder(action=lister,
                   source_factory=Dir,
@@ -82,13 +81,12 @@ SetOption('max_drift', 1)
 
 def lister(target, source, env):
     import os.path
-    with open(str(target[0]), 'w') as ofp:
-        s = str(source[0])
-        if os.path.isdir(s):
-            for l in os.listdir(str(source[0])):
+    with open(target[0], 'w') as ofp:
+        if os.path.isdir(source[0]):
+            for l in os.listdir(source[0]):
                 ofp.write(l + '\\n')
         else:
-            ofp.write(s + '\\n')
+            ofp.write(str(source[0]) + '\\n')
 
 builder = Builder(action=lister,
                   source_factory=File)

--- a/test/no-target.py
+++ b/test/no-target.py
@@ -41,10 +41,9 @@ SConscript(r'%s')
 
 test.write(subdir_SConscript, r"""
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 
 b = Builder(action=cat, suffix='.out', src_suffix='.in')

--- a/test/option/debug-memoizer.py
+++ b/test/option/debug-memoizer.py
@@ -33,7 +33,7 @@ test = TestSCons.TestSCons(match=TestSCons.match_re_dotall)
 
 test.write('SConstruct', """
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+    with open(target[0], 'wb') as f, open(source[0], 'rb') as infp:
         f.write(infp.read())
 
 DefaultEnvironment(tools=[])

--- a/test/option/debug-memory.py
+++ b/test/option/debug-memory.py
@@ -45,7 +45,7 @@ if not IS_WINDOWS:
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as ifp:
+    with open(target[0], 'wb') as f, open(source[0], 'rb') as ifp:
         f.write(ifp.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')

--- a/test/option/debug-multiple.py
+++ b/test/option/debug-multiple.py
@@ -36,7 +36,7 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+    with open(target[0], 'wb') as f, open(source[0], 'rb') as infp:
         f.write(infp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')

--- a/test/option/debug-objects.py
+++ b/test/option/debug-objects.py
@@ -36,7 +36,7 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+    with open(target[0], 'wb') as f, open(source[0], 'rb') as infp:
         f.write(infp.read())
 env = Environment(tools=[], BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')

--- a/test/option/debug-presub.py
+++ b/test/option/debug-presub.py
@@ -40,10 +40,9 @@ sys.exit(0)
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as infp:
+            with open(src, "rb") as infp:
                 f.write(infp.read())
 FILE = Builder(action="$FILECOM")
 TEMP = Builder(action="$TEMPCOM")

--- a/test/option/fixture/SConstruct_debug_count
+++ b/test/option/fixture/SConstruct_debug_count
@@ -4,7 +4,7 @@ if ARGUMENTS.get('JSON',False):
 
 DefaultEnvironment(tools=[])
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as infp:
+    with open(target[0], 'wb') as f, open(source[0], 'rb') as infp:
         f.write(infp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=Action(cat))})
 env.Cat('file.out', 'file.in')

--- a/test/option/option--random.py
+++ b/test/option/option--random.py
@@ -34,10 +34,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConscript', """\
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 env = Environment(BUILDERS={'Cat':Builder(action=cat)})
 env.Cat('aaa.out', 'aaa.in')

--- a/test/option/warn-duplicate-environment.py
+++ b/test/option/warn-duplicate-environment.py
@@ -36,9 +36,9 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 WARN = ARGUMENTS.get('WARN')

--- a/test/option/warn-misleading-keywords.py
+++ b/test/option/warn-misleading-keywords.py
@@ -36,9 +36,9 @@ test = TestSCons.TestSCons(match = TestSCons.match_re_dotall)
 test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 def build(env, target, source):
-    with open(str(target[0]), 'wb') as f:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as f:
+        for src in source:
+            with open(src, 'rb') as infp:
                 f.write(infp.read())
 
 WARN = ARGUMENTS.get('WARN')
@@ -58,7 +58,7 @@ expect = r"""
 scons: warning: Did you mean to use `(target|source)' instead of `(targets|sources)'\?
 """ + TestSCons.file_expr
 
-test.run(arguments='.', 
+test.run(arguments='.',
          stderr=expect + expect)
 
 test.must_match(['file3a'], 'file3a.in\n')

--- a/test/sconsign/corrupt.py
+++ b/test/sconsign/corrupt.py
@@ -47,7 +47,7 @@ work2_sub__sconsign = test.workpath('work2', 'sub', database_name)
 
 SConstruct_contents = """\
 def build1(target, source, env):
-    with open(str(target[0]), 'wb') as ofp, open(str(source[0]), 'rb') as ifp:
+    with open(target[0], 'wb') as ofp, open(source[0], 'rb') as ifp:
         ofp.write(ifp.read())
     return None
 

--- a/test/sconsign/ghost-entries.py
+++ b/test/sconsign/ghost-entries.py
@@ -51,9 +51,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 def cat(target, source, env):
-    with open(str(target[0]), 'wb') as fp:
-        for s in source:
-            with open(str(s), 'rb') as infp:
+    with open(target[0], 'wb') as fp:
+        for src in source:
+            with open(src, 'rb') as infp:
                 fp.write(infp.read())
 env=Environment()
 Export('env')

--- a/test/sconsign/nonwritable.py
+++ b/test/sconsign/nonwritable.py
@@ -52,16 +52,16 @@ work2_sub3__sconsign = test.workpath('work2', 'sub3', database_name)
 
 SConstruct_contents = """\
 def build1(target, source, env):
-    with open(str(target[0]), 'wb') as fo, open(str(source[0]), 'rb') as fi:
+    with open(target[0], 'wb') as fo, open(source[0], 'rb') as fi:
         fo.write(fi.read())
     return None
 
 def build2(target, source, env):
     import os
     import os.path
-    with open(str(target[0]), 'wb') as fo, open(str(source[0]), 'rb') as fi:
+    with open(target[0], 'wb') as fo, open(source[0], 'rb') as fi:
         fo.write(fi.read())
-    dir, file = os.path.split(str(target[0]))
+    dir, file = os.path.split(target[0])
     os.chmod(dir, 0o555)
     return None
 

--- a/test/srcchange.py
+++ b/test/srcchange.py
@@ -52,7 +52,7 @@ def subrevision(target, source ,env):
     new = re.sub(r'\$REV.*?\$',
                  '$REV: %%s$'%%source[0].get_text_contents().strip(),
                  target[0].get_text_contents())
-    with open(str(target[0]),'w') as outf:
+    with open(target[0], 'w') as outf:
         outf.write(new)
 
 SubRevision = Action(subrevision)

--- a/test/suffixes.py
+++ b/test/suffixes.py
@@ -34,10 +34,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """
 def cat(env, source, target):
-    target = str(target[0])
-    with open(target, "wb") as f:
+    with open(target[0], "wb") as f:
         for src in source:
-            with open(str(src), "rb") as ifp:
+            with open(src, "rb") as ifp:
                 f.write(ifp.read())
 Cat = Builder(action=cat, suffix='.out')
 env = Environment(BUILDERS = {'Cat':Cat})

--- a/test/timestamp-fallback.py
+++ b/test/timestamp-fallback.py
@@ -57,7 +57,7 @@ test.write('SConstruct', """
 DefaultEnvironment(tools=[])
 
 def build(env, target, source):
-    with open(str(target[0]), 'wt') as ofp, open(str(source[0]), 'rt') as ifp:
+    with open(target[0], 'wt') as ofp, open(source[0], 'rt') as ifp:
         ofp.write(ifp.read())
 
 B = Builder(action = build)

--- a/test/toolpath/VariantDir.py
+++ b/test/toolpath/VariantDir.py
@@ -50,7 +50,7 @@ test.write(['subdir', 'src', 'tools', 'MyBuilder.py'], """\
 from SCons.Script import Builder
 def generate(env):
     def my_copy(target, source, env):
-        with open(str(target[0]), 'wb') as f, open(str(source[0]), 'rb') as ifp:
+        with open(target[0], 'wb') as f, open(source[0], 'rb') as ifp:
             f.write(ifp.read())
     env['BUILDERS']['MyCopy'] = Builder(action = my_copy)
 

--- a/timings/hundred/SConstruct
+++ b/timings/hundred/SConstruct
@@ -25,7 +25,7 @@ target_count = int(ARGUMENTS['TARGET_COUNT'])
 
 def copy_files( env, target, source ):
     for t, s in zip(target, source):
-        open(str(t),  'wb').write(open(str(s), 'rb').read())
+        open(t,  'wb').write(open(s, 'rb').read())
 
 source_list = ['source_%04d' % t for t in range(target_count)]
 target_list = ['target_%04d' % t for t in range(target_count)]


### PR DESCRIPTION
Adds `__fspath__` to the Node class so they can be passed directly as pathlike arguments.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
