### PR TITLE
Try to make the Windows Docbook tests pass

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,11 +19,15 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Fix typos in CCFLAGS test. Didn't affect the test itself, but
       didn't correctly apply the DefaultEnvironment speedup.
     - Try to fix Windows fails on Docbook tests in case xsltproc is found.
-      On both GitHub Actions and AppVeyor, it's found as part of
-      StrawberryPerl, which is part of the default install. Intermittent
-      fails seem caused by network issues, so propagate two xsltproc flags
-      for this that were in three of the "live" (named "cmd" here) tests,
-      but not the others. Also made other parts of the setup more consistent.
+      It's still not certain why this started failing.  On both GitHub
+      Actions and AppVeyor, it's found as part of StrawberryPerl, part of
+      the default install - maybe this wasn't the case before? The xsltproc
+      from choco install is considerably older and may have been more lenient?
+      Anyway, intermittent fails seem caused by something network related,
+      so propagate two xsltproc flags that avoid loading the dtd that were
+      present in three of the 11 "live" tests, but not the other eight.
+      Also, all 11 now pass the test-discovered xslt processor the same
+      way, which was not the case previously.
 
 
 RELEASE 4.9.0 -  Sun, 02 Mar 2025 17:22:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From Mats Wichmann:
     - Fix typos in CCFLAGS test. Didn't affect the test itself, but
       didn't correctly apply the DefaultEnvironment speedup.
+    - Try to fix Windows fails on Docbook tests in case xsltproc is found.
+      On both GitHub Actions and AppVeyor, it's found as part of
+      StrawberryPerl, which is part of the default install. Intermittent
+      fails seem caused by network issues, so propagate two xsltproc flags
+      for this that were in three of the "live" (named "cmd" here) tests,
+      but not the others. Also made other parts of the setup more consistent.
 
 
 RELEASE 4.9.0 -  Sun, 02 Mar 2025 17:22:20 -0700

--- a/SCons/Tool/docbook/__init__.py
+++ b/SCons/Tool/docbook/__init__.py
@@ -157,16 +157,22 @@ xsltproc_com_priority = ['xsltproc', 'saxon', 'saxon-xslt', 'xalan']
 # TODO: Set minimum version of saxon-xslt to be 8.x (lower than this only supports xslt 1.0.
 #       see: https://saxon.sourceforge.net/saxon6.5.5/
 #       see: https://saxon.sourceforge.net/
-xsltproc_com = {'xsltproc' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE',
-                'saxon' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE $DOCBOOK_XSLTPROCPARAMS',
-                # Note if saxon-xslt is version 5.5 the proper arguments are: (swap order of docbook_xsl and source)
-                #  'saxon-xslt' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $SOURCE $DOCBOOK_XSL  $DOCBOOK_XSLTPROCPARAMS',
-                'saxon-xslt' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE $DOCBOOK_XSLTPROCPARAMS',
-                'xalan' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -q -out $TARGET -xsl $DOCBOOK_XSL -in $SOURCE'}
-xmllint_com = {'xmllint' : '$DOCBOOK_XMLLINT $DOCBOOK_XMLLINTFLAGS --xinclude $SOURCE > $TARGET'}
-fop_com = {'fop' : '$DOCBOOK_FOP $DOCBOOK_FOPFLAGS -fo $SOURCE -pdf $TARGET',
-           'xep' : '$DOCBOOK_FOP $DOCBOOK_FOPFLAGS -valid -fo $SOURCE -pdf $TARGET',
-           'jw' : '$DOCBOOK_FOP $DOCBOOK_FOPFLAGS -f docbook -b pdf $SOURCE -o $TARGET'}
+xsltproc_com = {
+    'xsltproc': '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE',
+    'saxon': '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE $DOCBOOK_XSLTPROCPARAMS',
+    # Note if saxon-xslt is version 5.5 the proper arguments are: (swap order of docbook_xsl and source)
+    #  'saxon-xslt' : '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $SOURCE $DOCBOOK_XSL  $DOCBOOK_XSLTPROCPARAMS',
+    'saxon-xslt': '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -o $TARGET $DOCBOOK_XSL $SOURCE $DOCBOOK_XSLTPROCPARAMS',
+    'xalan': '$DOCBOOK_XSLTPROC $DOCBOOK_XSLTPROCFLAGS -q -out $TARGET -xsl $DOCBOOK_XSL -in $SOURCE',
+}
+xmllint_com = {
+    'xmllint': '$DOCBOOK_XMLLINT $DOCBOOK_XMLLINTFLAGS --xinclude $SOURCE > $TARGET'
+}
+fop_com = {
+    'fop': '$DOCBOOK_FOP $DOCBOOK_FOPFLAGS -fo $SOURCE -pdf $TARGET',
+    'xep': '$DOCBOOK_FOP $DOCBOOK_FOPFLAGS -valid -fo $SOURCE -pdf $TARGET',
+    'jw': '$DOCBOOK_FOP $DOCBOOK_FOPFLAGS -f docbook -b pdf $SOURCE -o $TARGET',
+}
 
 def __detect_cl_tool(env, chainkey, cdict, cpriority=None) -> None:
     """
@@ -180,11 +186,11 @@ def __detect_cl_tool(env, chainkey, cdict, cpriority=None) -> None:
             cpriority = cdict.keys()
         for cltool in cpriority:
             if __debug_tool_location:
-                print("DocBook: Looking for %s"%cltool)
+                print(f"DocBook: Looking for {cltool}")
             clpath = env.WhereIs(cltool)
             if clpath:
                 if __debug_tool_location:
-                    print("DocBook: Found:%s"%cltool)
+                    print(f"DocBook: Found:{cltool}")
                 env[chainkey] = clpath
                 if not env[chainkey + 'COM']:
                     env[chainkey + 'COM'] = cdict[cltool]

--- a/test/Docbook/basedir/htmlchunked/htmlchunked_cmd.py
+++ b/test/Docbook/basedir/htmlchunked/htmlchunked_cmd.py
@@ -40,11 +40,11 @@ if not (xsltproc and
 test.dir_fixture('image')
 
 # Normal invocation
-test.run(arguments=['-f','SConstruct.cmd'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','DOCBOOK_XSLTPROC=%s'%xsltproc], stderr=None)
 test.must_not_be_empty(test.workpath('output/index.html'))
 
 # Cleanup
-test.run(arguments=['-f','SConstruct.cmd','-c'])
+test.run(arguments=['-f','SConstruct.cmd','-c','DOCBOOK_XSLTPROC=%s'%xsltproc])
 test.must_not_exist(test.workpath('output/index.html'))
 
 test.pass_test()

--- a/test/Docbook/basedir/htmlchunked/image/SConstruct.cmd
+++ b/test/Docbook/basedir/htmlchunked/image/SConstruct.cmd
@@ -4,4 +4,8 @@
 
 DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
+DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
+if DOCBOOK_XSLTPROC:
+    env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookHtmlChunked('manual', xsl='html.xsl', base_dir='output/')

--- a/test/Docbook/basedir/htmlhelp/htmlhelp_cmd.py
+++ b/test/Docbook/basedir/htmlhelp/htmlhelp_cmd.py
@@ -40,13 +40,13 @@ if not (xsltproc and
 test.dir_fixture('image')
 
 # Normal invocation
-test.run(arguments=['-f','SConstruct.cmd'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','DOCBOOK_XSLTPROC=%s'%xsltproc], stderr=None)
 test.must_not_be_empty(test.workpath('output/index.html'))
 test.must_not_be_empty(test.workpath('htmlhelp.hhp'))
 test.must_not_be_empty(test.workpath('toc.hhc'))
 
 # Cleanup
-test.run(arguments=['-f','SConstruct.cmd','-c'])
+test.run(arguments=['-f','SConstruct.cmd','-c','DOCBOOK_XSLTPROC=%s'%xsltproc])
 test.must_not_exist(test.workpath('output/index.html'))
 test.must_not_exist(test.workpath('htmlhelp.hhp'))
 test.must_not_exist(test.workpath('toc.hhc'))

--- a/test/Docbook/basedir/htmlhelp/image/SConstruct.cmd
+++ b/test/Docbook/basedir/htmlhelp/image/SConstruct.cmd
@@ -4,5 +4,9 @@
 
 DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
+DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
+if DOCBOOK_XSLTPROC:
+    env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookHtmlhelp('manual', xsl='htmlhelp.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/slideshtml/image/SConstruct.cmd
+++ b/test/Docbook/basedir/slideshtml/image/SConstruct.cmd
@@ -13,6 +13,9 @@ if v >= (1, 78, 0):
 
 DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
+DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
+if DOCBOOK_XSLTPROC:
+    env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookSlidesHtml('virt'+ns_ext, xsl='slides.xsl', base_dir='output/')
 

--- a/test/Docbook/basedir/slideshtml/slideshtml_cmd.py
+++ b/test/Docbook/basedir/slideshtml/slideshtml_cmd.py
@@ -40,12 +40,12 @@ if not (xsltproc and
 test.dir_fixture('image')
 
 # Normal invocation
-test.run(arguments=['-f','SConstruct.cmd'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','DOCBOOK_XSLTPROC=%s'%xsltproc], stderr=None)
 test.must_not_be_empty(test.workpath('output/index.html'))
 test.must_contain(test.workpath('output/index.html'), 'sfForming')
 
 # Cleanup
-test.run(arguments=['-f','SConstruct.cmd','-c'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','-c','DOCBOOK_XSLTPROC=%s'%xsltproc])
 test.must_not_exist(test.workpath('output/index.html'))
 
 test.pass_test()

--- a/test/Docbook/basic/epub/image/SConstruct.cmd
+++ b/test/Docbook/basic/epub/image/SConstruct.cmd
@@ -7,5 +7,5 @@ env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:
     env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
-
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookEpub('manual')

--- a/test/Docbook/basic/html/html_cmd.py
+++ b/test/Docbook/basic/html/html_cmd.py
@@ -38,7 +38,7 @@ if not xsltproc:
 test.dir_fixture('image')
 
 # Normal invocation
-test.run(arguments=['-f','SConstruct.cmd','DOCBOOK_XSLTPROC=%s'%xsltproc])
+test.run(arguments=['-f','SConstruct.cmd','DOCBOOK_XSLTPROC=%s'%xsltproc], stderr=None)
 test.must_not_be_empty(test.workpath('manual.html'))
 
 # Cleanup

--- a/test/Docbook/basic/html/image/SConstruct.cmd
+++ b/test/Docbook/basic/html/image/SConstruct.cmd
@@ -7,6 +7,6 @@ env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:
     env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
-
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookHtml('manual')
 

--- a/test/Docbook/basic/htmlchunked/image/SConstruct.cmd
+++ b/test/Docbook/basic/htmlchunked/image/SConstruct.cmd
@@ -7,6 +7,6 @@ env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:
     env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
-
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookHtmlChunked('manual')
 

--- a/test/Docbook/basic/htmlhelp/image/SConstruct.cmd
+++ b/test/Docbook/basic/htmlhelp/image/SConstruct.cmd
@@ -7,6 +7,6 @@ env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:
     env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
-
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookHtmlhelp('manual')
 

--- a/test/Docbook/basic/man/image/SConstruct.cmd
+++ b/test/Docbook/basic/man/image/SConstruct.cmd
@@ -7,6 +7,6 @@ env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:
     env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
-
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookMan('refdb')
 

--- a/test/Docbook/basic/pdf/image/SConstruct.cmd
+++ b/test/Docbook/basic/pdf/image/SConstruct.cmd
@@ -7,6 +7,6 @@ env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
 DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
 if DOCBOOK_XSLTPROC:
     env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
-
+env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookPdf('manual')
 

--- a/test/Docbook/basic/slideshtml/image/SConstruct.cmd
+++ b/test/Docbook/basic/slideshtml/image/SConstruct.cmd
@@ -13,6 +13,9 @@ if v >= (1, 78, 0):
 
 DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
+DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
+if DOCBOOK_XSLTPROC:
+    env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookSlidesHtml(
     'virt' + ns_ext,

--- a/test/Docbook/basic/slideshtml/slideshtml_cmd.py
+++ b/test/Docbook/basic/slideshtml/slideshtml_cmd.py
@@ -40,12 +40,12 @@ if not (xsltproc and
 test.dir_fixture('image')
 
 # Normal invocation
-test.run(arguments=['-f','SConstruct.cmd'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','DOCBOOK_XSLTPROC=%s'%xsltproc], stderr=None)
 test.must_not_be_empty(test.workpath('index.html'))
 test.must_contain(test.workpath('index.html'), 'sfForming')
 
 # Cleanup
-test.run(arguments=['-f','SConstruct.cmd','-c'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','-c','DOCBOOK_XSLTPROC=%s'%xsltproc])
 test.must_not_exist(test.workpath('index.html'))
 
 test.pass_test()

--- a/test/Docbook/basic/slidespdf/image/SConstruct.cmd
+++ b/test/Docbook/basic/slidespdf/image/SConstruct.cmd
@@ -4,6 +4,9 @@
 
 DefaultEnvironment(tools=[])
 env = Environment(DOCBOOK_PREFER_XSLTPROC=1, tools=['docbook'])
+DOCBOOK_XSLTPROC = ARGUMENTS.get('DOCBOOK_XSLTPROC', "")
+if DOCBOOK_XSLTPROC:
+    env['DOCBOOK_XSLTPROC'] = DOCBOOK_XSLTPROC
 env.Append(DOCBOOK_XSLTPROCFLAGS=['--novalid', '--nonet'])
 env.DocbookSlidesPdf('virt')
 

--- a/test/Docbook/basic/slidespdf/slidespdf_cmd.py
+++ b/test/Docbook/basic/slidespdf/slidespdf_cmd.py
@@ -44,12 +44,12 @@ if not fop:
 test.dir_fixture('image')
 
 # Normal invocation
-test.run(arguments=['-f','SConstruct.cmd'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','DOCBOOK_XSLTPROC=%s'%xsltproc], stderr=None)
 test.must_not_be_empty(test.workpath('virt.fo'))
 test.must_not_be_empty(test.workpath('virt.pdf'))
 
 # Cleanup
-test.run(arguments=['-f','SConstruct.cmd','-c'], stderr=None)
+test.run(arguments=['-f','SConstruct.cmd','-c','DOCBOOK_XSLTPROC=%s'%xsltproc])
 test.must_not_exist(test.workpath('virt.fo'))
 test.must_not_exist(test.workpath('virt.pdf'))
 


### PR DESCRIPTION
Try to fix Windows fails on Docbook tests in case `xsltproc` is found. On both GitHub Actions and AppVeyor, it's found as part of StrawberryPerl, which is part of the default install. Intermittent fails seem caused by network issues (whether actual problems, or forced revectoring to https not supported by `xsltproc` according to some internet issue reports), so propagate two `xsltproc` flags for this that were in three of the "live" (named "cmd" here) tests, but not the others. Also made other parts of the setup of these tests more consistent (passing found `xsltproc` wasn't always done)

Note we don't 100% know why these 1-3 tests started failing, it's not due to an SCons change, might be due to a change to xsltproc in Strawberry, but it's not a brand-new version. However the cleanup doesn't seem like a terrible idea anyway.

Except for minor reformatting in the docbook tool, this is test only changes.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
