### PR TITLE
Update progress-printing for tools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       present in three of the 11 "live" tests, but not the other eight.
       Also, all 11 now pass the test-discovered xslt processor the same
       way, which was not the case previously.
+    - Update progress printing on three tools for SCons developers -
+      the test runner and two of the doc generators.
 
 
 RELEASE 4.9.0 -  Sun, 02 Mar 2025 17:22:20 -0700

--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -199,12 +199,11 @@ class DoctypeEntity:
         self.name = name_
         self.uri = uri_
 
-    def getEntityString(self):
-        txt = """    <!ENTITY %(perc)s %(name)s SYSTEM "%(uri)s">
-    %(perc)s%(name)s;
-""" % {'perc': perc, 'name': self.name, 'uri': self.uri}
-
-        return txt
+    def getEntityString(self) -> str:
+        return f"""\
+    <!ENTITY % {self.name} SYSTEM "{self.uri}">
+    %{self.name};
+"""
 
 
 class DoctypeDeclaration:
@@ -417,8 +416,6 @@ class SConsDocTree:
         if self.xpath_context is not None:
             self.xpath_context.xpathFreeContext()
 
-perc = "%"
-
 def validate_all_xml(dpaths, xsdfile=default_xsd):
     xmlschema_context = etree.parse(xsdfile)
 
@@ -438,10 +435,7 @@ def validate_all_xml(dpaths, xsdfile=default_xsd):
     fails = []
     fpaths = sorted(fpaths)
     for idx, fp in enumerate(fpaths):
-        fpath = os.path.join(path, fp)
-        print("%.2f%s (%d/%d) %s" % (float(idx + 1) * 100.0 /float(len(fpaths)),
-                                     perc, idx + 1, len(fpaths), fp))
-
+        print(f"{(idx + 1) / len(fpaths):7.2%} ({idx + 1}/{len(fpaths)}) {fp}")
         if not tf.validateXml(fp, xmlschema_context):
             fails.append(fp)
             continue

--- a/bin/SConsExamples.py
+++ b/bin/SConsExamples.py
@@ -309,9 +309,7 @@ def createAllExampleOutputs(dpath):
 
     for key, value in examples.items():
         # Process all scons_output tags
-        print("%.2f%s (%d/%d) %s" % (float(idx + 1) * 100.0 / float(total),
-                                     perc, idx + 1, total, key))
-
+        print(f"{(idx + 1) / total:7.2%} ({idx + 1}/{total}) {key}")
         create_scons_output(value)
         # Process all scons_example_file tags
         for r in value.files:

--- a/runtest.py
+++ b/runtest.py
@@ -796,11 +796,9 @@ def run_test(t, io_lock=None, run_async=True):
     t.command_str = " ".join(t.command_args)
     if args.printcommand:
         if args.print_progress:
-            t.headline += "%d/%d (%.2f%s) %s\n" % (
-                t.testno, total_num_tests,
-                float(t.testno) * 100.0 / float(total_num_tests),
-                "%",
-                t.command_str,
+            t.headline += (
+                f"{t.testno}/{total_num_tests} "
+                f"({t.testno / total_num_tests:7.2%}) {t.command_str}\n"
             )
         else:
             t.headline += t.command_str + "\n"


### PR DESCRIPTION
`SConsDoc`, `SConsExamples` and `runtest` now use f-strings to format the progress message - simplifies things quite a bit, since don't have to jump through as many hoops producing the percentage.

This is only about tools we use as SCons developers, does not affect SCons itself at all.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
