### PR TITLE
Fix Variables.PackageVariable with bool default string

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,7 +18,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Bill Prendergast:
     - Fixed SCons.Variables.PackageVariable to correctly test the default
-      setting against both enable & disable strings.
+      setting against both enable & disable strings. (Fixes #4702)
     - Extended unittests (crudely) to test for correct/expected response
       when default setting is a boolean string.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
         - Whatever John Doe did.
 
+  From Bill Prendergast:
+    - Fixed SCons.Variables.PackageVariable to correctly test the default
+      setting against both enable & disable strings.
+    - Extended unittests (crudely) to test for correct/expected response
+      when default setting is a boolean string.
+
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -32,7 +32,8 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 FIXES
 -----
 
-- List fixes of outright bugs
+- Fixed SCons.Variables.PackageVariable to correctly test the default
+  setting against both enable & disable strings. (Fixes #4702)
 
 IMPROVEMENTS
 ------------

--- a/SCons/Variables/PackageVariable.py
+++ b/SCons/Variables/PackageVariable.py
@@ -86,7 +86,7 @@ def _converter(val: str | bool, default: str) -> str | bool:
     if lval in ENABLE_STRINGS:
         # Can't return the default if it is one of the enable/disable strings;
         # test code expects a bool.
-        if default in ENABLE_STRINGS:
+        if default in ENABLE_STRINGS + DISABLE_STRINGS:
             return True
         else:
             return default

--- a/SCons/Variables/PackageVariableTests.py
+++ b/SCons/Variables/PackageVariableTests.py
@@ -92,6 +92,34 @@ class PackageVariableTestCase(unittest.TestCase):
             x = o.converter(False)
             assert not x, f"converter returned False for {t!r}"
 
+        # When the variable is created with boolean string make sure the converter
+        # returns the correct result i.e. a bool or a passed path
+        opts = SCons.Variables.Variables()
+        opts.Add(SCons.Variables.PackageVariable('test', 'test build variable help', 'yes'))
+        o = opts.options[0]
+
+        x = o.converter(str(True))
+        assert not isinstance(x, str), "converter with default str(yes) returned a string when given str(True)"
+        assert x, "converter with default str(yes) returned False for str(True)"
+        x = o.converter(str(False))
+        assert not isinstance(x, str), "converter with default str(yes) returned a string when given str(False)"
+        assert not x, "converter with default str(yes) returned True for str(False)"
+        x = o.converter('/explicit/path')
+        assert x == '/explicit/path', "converter with default str(yes) did not return path"
+
+        opts = SCons.Variables.Variables()
+        opts.Add(SCons.Variables.PackageVariable('test', 'test build variable help', 'no'))
+        o = opts.options[0]
+
+        x = o.converter(str(True))
+        assert not isinstance(x, str), "converter with default str(no) returned a string when given str(True)"
+        assert x, "converter with default str(no) returned False for str(True)"
+        x = o.converter(str(False))
+        assert not isinstance(x, str), "converter with default str(no) returned a string when given str(False)"
+        assert not x, "converter with default str(no) returned True for str(False)"
+        x = o.converter('/explicit/path')
+        assert x == '/explicit/path', "converter with default str(no) did not return path"
+
     def test_validator(self) -> None:
         """Test the PackageVariable validator"""
         opts = SCons.Variables.Variables()


### PR DESCRIPTION
when passed a 'true' string on the command line actually test default value against both ENABLE_STRINGS and DISABLE_STRINGS

Closes: #4702

See-Also: https://bugs.gentoo.org/950584

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
