### PR TITLE
Switch to using Python ternary op

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - runtest.py once again finds "external" tests, such as the tests for
       tools in scons-contrib. An earlier rework had broken this.  Fixes #4699.
     - Clarify how pre/post actions on an alias work.
+    - Replace use of old conditional expression idioms with the official
+      one from PEP 308 introduced in Python 2.5 (2006). The idiom being
+      replaced (using and/or) is regarded as error prone.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -31,6 +31,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
 
 - Nodes are now treated as PathLike objects.
 
+- Replace use of old conditional expression idioms with the official
+  one from PEP 308 introduced in Python 2.5 (2006). The idiom being
+  replaced (using and/or) is regarded as error prone.
+
 FIXES
 -----
 

--- a/SCons/Builder.py
+++ b/SCons/Builder.py
@@ -701,7 +701,7 @@ class BuilderBase:
             src_suffix = []
         elif not SCons.Util.is_List(src_suffix):
             src_suffix = [ src_suffix ]
-        self.src_suffix = [callable(suf) and suf or self.adjust_suffix(suf) for suf in src_suffix]
+        self.src_suffix = [suf if callable(suf) else self.adjust_suffix(suf) for suf in src_suffix]
 
     def get_src_suffix(self, env):
         """Get the first src_suffix in the list of src_suffixes."""

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -465,19 +465,28 @@ class TreePrinter:
         self.prune = prune
         self.status = status
         self.sLineDraw = sLineDraw
+
     def get_all_children(self, node):
         return node.all_children()
+
     def get_derived_children(self, node):
         children = node.all_children(None)
         return [x for x in children if x.has_builder()]
+
     def display(self, t) -> None:
         if self.derived:
             func = self.get_derived_children
         else:
             func = self.get_all_children
-        s = self.status and 2 or 0
-        SCons.Util.print_tree(t, func, prune=self.prune, showtags=s, lastChild=True, singleLineDraw=self.sLineDraw)
-
+        s = 2 if self.status else 0
+        SCons.Util.print_tree(
+            t,
+            func,
+            prune=self.prune,
+            showtags=s,
+            lastChild=True,
+            singleLineDraw=self.sLineDraw,
+        )
 
 def python_version_string():
     return sys.version.split()[0]

--- a/SCons/Tool/linkCommon/SharedLibrary.py
+++ b/SCons/Tool/linkCommon/SharedLibrary.py
@@ -202,7 +202,7 @@ def setup_shared_lib_logic(env) -> None:
 
     # Note this is gnu style
     env["SHLIBSONAMEFLAGS"] = "-Wl,-soname=$_SHLIBSONAME"
-    env["_SHLIBVERSION"] = "${SHLIBVERSION and '.'+SHLIBVERSION or ''}"
+    env["_SHLIBVERSION"] = "${'.' + SHLIBVERSION  if SHLIBVERSION else ''}"
     env["_SHLIBVERSIONFLAGS"] = "$SHLIBVERSIONFLAGS -Wl,-soname=$_SHLIBSONAME"
 
     env["SHLIBEMITTER"] = [lib_emitter, shlib_symlink_emitter]

--- a/SCons/Tool/msvc.py
+++ b/SCons/Tool/msvc.py
@@ -72,12 +72,12 @@ def msvc_set_PCHPDBFLAGS(env) -> None:
     if env.get('MSVC_VERSION',False):
         maj, min = msvc_version_to_maj_min(env['MSVC_VERSION'])
         if maj < 8:
-            env['PCHPDBFLAGS'] = SCons.Util.CLVar(['${(PDB and "/Yd") or ""}'])
+            env['PCHPDBFLAGS'] = SCons.Util.CLVar(['${"/Yd" if PDB else ""}'])
         else:
             env['PCHPDBFLAGS'] = ''
     else:
         # Default if we can't determine which version of MSVC we're using
-        env['PCHPDBFLAGS'] = SCons.Util.CLVar(['${(PDB and "/Yd") or ""}'])
+        env['PCHPDBFLAGS'] = SCons.Util.CLVar(['${"/Yd" if PDB else ""}'])
 
 
 def pch_emitter(target, source, env):
@@ -143,7 +143,7 @@ def gen_ccpchflags(env, target, source, for_signature):
     pch_node = get_pch_node(env, target, source)
     if not pch_node:
         return ''
-        
+
     return SCons.Util.CLVar(["/Yu$PCHSTOP", "/Fp%s" % pch_node])
 
 pch_action = SCons.Action.Action('$PCHCOM', '$PCHCOMSTR')
@@ -256,7 +256,7 @@ def generate(env) -> None:
         static_obj.add_emitter(suffix, static_object_emitter)
         shared_obj.add_emitter(suffix, shared_object_emitter)
 
-    env['CCPDBFLAGS'] = SCons.Util.CLVar(['${(PDB and "/Z7") or ""}'])
+    env['CCPDBFLAGS'] = SCons.Util.CLVar(['${"/Z7" if PDB else ""}'])
     env['CCPCHFLAGS'] = gen_ccpchflags
     env['_MSVC_OUTPUT_FLAG'] = msvc_output_flag
     env['_CCCOMCOM']  = '$CPPFLAGS $_CPPDEFFLAGS $_CPPINCFLAGS $CCPCHFLAGS $CCPDBFLAGS'

--- a/bin/scons-diff.py
+++ b/bin/scons-diff.py
@@ -90,8 +90,10 @@ def simple_diff(a, b, fromfile='', tofile='',
     output like the simple, unadorned 'diff" command.
     """
     sm = difflib.SequenceMatcher(None, a, b)
+
     def comma(x1, x2):
-        return x1+1 == x2 and str(x2) or '%s,%s' % (x1+1, x2)
+        return x1 + 1 == str(x2) if x2 else '%s,%s' % (x1 + 1, x2)
+
     result = []
     for op, a1, a2, b1, b2 in sm.get_opcodes():
         if op == 'delete':

--- a/bin/update-release-info.py
+++ b/bin/update-release-info.py
@@ -173,7 +173,7 @@ class ReleaseInfo:
         Mon, 05 Jun 2010 21:17:15 -0700
         NEW DATE WILL BE INSERTED HERE
         """
-        min = (time.daylight and time.altzone or time.timezone) // 60
+        min = (time.altzone if time.daylight else time.timezone) // 60
         hr = min // 60
         min = -(min % 60 + hr * 100)
         self.new_date = (time.strftime('%a, %d %b %Y %X', self.release_date + (0, 0, 0))

--- a/site_scons/BuildCommandLine.py
+++ b/site_scons/BuildCommandLine.py
@@ -104,7 +104,7 @@ class BuildCommandLine:
         NEW DATE WILL BE INSERTED HERE
         """
 
-        min = (time.daylight and time.altzone or time.timezone) // 60
+        min = (time.altzone if time.daylight else time.timezone) // 60
         hr = min // 60
         min = -(min % 60 + hr * 100)
         # TODO: is it better to take the date of last rev? Externally:

--- a/test/Actions/function.py
+++ b/test/Actions/function.py
@@ -122,7 +122,7 @@ scons: done building targets.
 def runtest(arguments, expectedOutFile, expectedRebuild=True, stderr=""):
     test.run(
         arguments=arguments,
-        stdout=expectedRebuild and rebuildstr or nobuildstr,
+        stdout=rebuildstr if expectedRebuild else nobuildstr,
         stderr="",
     )
 

--- a/test/SPAWN.py
+++ b/test/SPAWN.py
@@ -42,7 +42,7 @@ with open(sys.argv[1], 'wb') as ofp:
             ofp.write(ifp.read())
 """)
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 import subprocess
 import sys
 
@@ -56,16 +56,19 @@ def my_spawn2(sh, escape, cmd, args, env):
     cp = subprocess.run(s, shell=True)
     return cp.returncode
 
-env = Environment(MY_SPAWN1 = my_spawn1,
-                  MY_SPAWN2 = my_spawn2,
-                  COMMAND = r'%(_python_)s cat.py $TARGET $SOURCES')
-env1 = env.Clone(SPAWN = my_spawn1)
+DefaultEnvironment()
+env = Environment(
+    MY_SPAWN1=my_spawn1,
+    MY_SPAWN2=my_spawn2,
+    COMMAND=r'%(_python_)s cat.py $TARGET $SOURCES',
+)
+env1 = env.Clone(SPAWN=my_spawn1)
 env1.Command('file1.out', 'file1.in', '$COMMAND')
 
-env2 = env.Clone(SPAWN = '$MY_SPAWN2')
+env2 = env.Clone(SPAWN='$MY_SPAWN2')
 env2.Command('file2.out', 'file2.in', '$COMMAND')
 
-env3 = env.Clone(SPAWN = '${USE_TWO and MY_SPAWN2 or MY_SPAWN1}')
+env3 = env.Clone(SPAWN='${MY_SPAWN2 if USE_TWO else MY_SPAWN1}')
 env3.Command('file3.out', 'file3.in', '$COMMAND', USE_TWO=0)
 env3.Command('file4.out', 'file4.in', '$COMMAND', USE_TWO=1)
 """ % locals())

--- a/test/option/help-options.py
+++ b/test/option/help-options.py
@@ -54,9 +54,9 @@ stdout = ignored_re.sub('', test.stdout())
 lines = stdout.split('\n')
 lines = [x for x in lines if x[:3] == '  -']
 lines = [x[3:] for x in lines]
-lines = [x[0] == '-' and x[1:] or x for x in lines]
+lines = [x[1:] if x.startswith('-') else x for x in lines]
 options = [x.split()[0] for x in lines]
-options = [x[-1] == ',' and x[:-1] or x for x in options]
+options = [x[:-1] if x.endswith(',') else x for x in options]
 lowered = [x.lower() for x in options]
 ordered = sorted(lowered)
 if lowered != ordered:
@@ -65,7 +65,7 @@ if lowered != ordered:
     test.fail_test()
 
 test.pass_test()
- 
+
 
 # Local Variables:
 # tab-width:4

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -699,7 +699,7 @@ def simple_diff(
     sm = difflib.SequenceMatcher(None, a, b)
 
     def comma(x1, x2):
-        return x1 + 1 == x2 and str(x2) or f'{x1 + 1},{x2}'
+        return str(x2) if x1 + 1 == x2 else f'{x1 + 1},{x2}'
 
     for op, a1, a2, b1, b2 in sm.get_opcodes():
         if op == 'delete':

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -321,7 +321,7 @@ class TestCommon(TestCmd):
         them.  Exits FAILED if any of the files does not exist or is
         not writable.
         """
-        flist = [is_List(x) and os.path.join(*x) or x for x in files]
+        flist = [os.path.join(*x) if is_List(x) else x for x in files]
         existing, missing = separate_files(flist)
         unwritable = [x for x in existing if not is_writable(x)]
         if missing:
@@ -531,7 +531,7 @@ class TestCommon(TestCmd):
         pathname will be constructed by concatenating them.  Exits FAILED
         if any of the files does not exist.
         """
-        flist = [is_List(x) and os.path.join(*x) or x for x in files]
+        flist = [os.path.join(*x) if is_List(x) else x for x in files]
         missing = [x for x in flist if not os.path.exists(x) and not os.path.islink(x)]
         if missing:
             print("Missing files: `%s'" % "', `".join(missing))
@@ -550,7 +550,7 @@ class TestCommon(TestCmd):
             if is_List(x) or is_Tuple(x):
                 xpath = os.path.join(*x)
             else:
-                xpath = is_Sequence(x) and os.path.join(x) or x
+                xpath = os.path.join(x) if is_Sequence(x) else x
             if glob.glob(xpath):
                 return
             missing.append(xpath)
@@ -669,7 +669,7 @@ class TestCommon(TestCmd):
         which case the pathname will be constructed by concatenating them.
         Exits FAILED if any of the files exists.
         """
-        flist = [is_List(x) and os.path.join(*x) or x for x in files]
+        flist = [os.path.join(*x) if is_List(x) else x for x in files]
         existing = [x for x in flist if os.path.exists(x) or os.path.islink(x)]
         if existing:
             print("Unexpected files exist: `%s'" % "', `".join(existing))
@@ -688,7 +688,7 @@ class TestCommon(TestCmd):
             if is_List(x) or is_Tuple(x):
                 xpath = os.path.join(*x)
             else:
-                xpath = is_Sequence(x) and os.path.join(x) or x
+                xpath = os.path.join(x) if is_Sequence(x) else x
             if glob.glob(xpath):
                 existing.append(xpath)
         if existing:
@@ -719,7 +719,7 @@ class TestCommon(TestCmd):
         them.  Exits FAILED if any of the files does not exist or is
         writable.
         """
-        flist = [is_List(x) and os.path.join(*x) or x for x in files]
+        flist = [os.path.join(*x) if is_List(x) else x for x in files]
         existing, missing = separate_files(flist)
         writable = [file for file in existing if is_writable(file)]
         if missing:


### PR DESCRIPTION
Python 2.5 introduced a better approach than `c and x or y` which is less error-prone, and, these days, and presumably more familiar to readers, as for the last 20 years Python programmers probably won't have been taught the and/or form.

For the most part this is behind the scenes - tools, tests, framework. It rises to visibility if someone looks hard at a few construction variables which now use the new form: `_SHLIBVERSION`, `PCHPDBFLAGS`, `CCPDBFLAGS`. There is no behavioral change even in those cases.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
