### PR TITLE
Update Fortran FLAGS tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - runtest.py once again finds "external" tests, such as the tests for
       tools in scons-contrib. An earlier rework had broken this.  Fixes #4699.
     - Clarify how pre/post actions on an alias work.
+    - Rearrange Fortran e2e tests - "live" tests now live in a separate
+      test file and don't share with flags-only mocked tests.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/test/Fortran/F03FLAGS.py
+++ b/test/Fortran/F03FLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""
+Test handling of the dialect-specific FLAGS variable,
+using a mocked compiler.
+"""
 
 import TestSCons
 
@@ -31,40 +35,45 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
+# ref: test/fixture/mylink.py
 test.file_fixture('mylink.py')
+# ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
-                  LINKFLAGS = [],
-                  F03 = r'%(_python_)s myfortran_flags.py g03',
-                  F03FLAGS = '-x',
-                  FORTRAN = r'%(_python_)s myfortran_flags.py fortran',
-                  FORTRANFLAGS = '-y')
-env.Program(target = 'test01', source = 'test01.f')
-env.Program(target = 'test02', source = 'test02.F')
-env.Program(target = 'test03', source = 'test03.for')
-env.Program(target = 'test04', source = 'test04.FOR')
-env.Program(target = 'test05', source = 'test05.ftn')
-env.Program(target = 'test06', source = 'test06.FTN')
-env.Program(target = 'test07', source = 'test07.fpp')
-env.Program(target = 'test08', source = 'test08.FPP')
-env.Program(target = 'test13', source = 'test13.f03')
-env.Program(target = 'test14', source = 'test14.F03')
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+env = Environment(
+    LINK=r"%(_python_)s mylink.py",
+    LINKFLAGS=[],
+    F03=r"%(_python_)s myfortran_flags.py g03",
+    F03FLAGS="-x",
+    FORTRAN=r"%(_python_)s myfortran_flags.py fortran",
+    FORTRANFLAGS="-y",
+)
+env.Program(target="test01", source="test01.f")
+env.Program(target="test02", source="test02.F")
+env.Program(target="test03", source="test03.for")
+env.Program(target="test04", source="test04.FOR")
+env.Program(target="test05", source="test05.ftn")
+env.Program(target="test06", source="test06.FTN")
+env.Program(target="test07", source="test07.fpp")
+env.Program(target="test08", source="test08.FPP")
+env.Program(target="test09", source="test09.f03")
+env.Program(target="test10", source="test10.F03")
 """ % locals())
 
-test.write('test01.f',   "This is a .f file.\n#link\n#fortran\n")
-test.write('test02.F',   "This is a .F file.\n#link\n#fortran\n")
+test.write('test01.f', "This is a .f file.\n#link\n#fortran\n")
+test.write('test02.F', "This is a .F file.\n#link\n#fortran\n")
 test.write('test03.for', "This is a .for file.\n#link\n#fortran\n")
 test.write('test04.FOR', "This is a .FOR file.\n#link\n#fortran\n")
 test.write('test05.ftn', "This is a .ftn file.\n#link\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#link\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#link\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#link\n#fortran\n")
-test.write('test13.f03', "This is a .f03 file.\n#link\n#g03\n")
-test.write('test14.F03', "This is a .F03 file.\n#link\n#g03\n")
+test.write('test09.f03', "This is a .f03 file.\n#link\n#g03\n")
+test.write('test10.F03', "This is a .F03 file.\n#link\n#g03\n")
 
-test.run(arguments = '.', stderr = None)
+test.run(arguments='.', stderr=None)
 
 test.must_match('test01' + _exe, " -c -y\nThis is a .f file.\n")
 test.must_match('test02' + _exe, " -c -y\nThis is a .F file.\n")
@@ -74,56 +83,8 @@ test.must_match('test05' + _exe, " -c -y\nThis is a .ftn file.\n")
 test.must_match('test06' + _exe, " -c -y\nThis is a .FTN file.\n")
 test.must_match('test07' + _exe, " -c -y\nThis is a .fpp file.\n")
 test.must_match('test08' + _exe, " -c -y\nThis is a .FPP file.\n")
-test.must_match('test13' + _exe, " -c -x\nThis is a .f03 file.\n")
-test.must_match('test14' + _exe, " -c -x\nThis is a .F03 file.\n")
-
-
-fc = 'f03'
-g03 = test.detect_tool(fc)
-
-
-if g03:
-
-    test.file_fixture('wrapper.py')
-
-    test.write('SConstruct', """
-foo = Environment(F03 = '%(fc)s')
-f03 = foo.Dictionary('F03')
-bar = foo.Clone(F03 = r'%(_python_)s wrapper.py ' + f03, F03FLAGS = '-Ix')
-foo.Program(target = 'foo', source = 'foo.f03')
-bar.Program(target = 'bar', source = 'bar.f03')
-""" % locals())
-
-    test.write('foo.f03', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f03'
-      STOP
-      END
-""")
-
-    test.write('bar.f03', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f03'
-      STOP
-      END
-""")
-
-
-    test.run(arguments = 'foo' + _exe, stderr = None)
-
-    test.run(program = test.workpath('foo'), stdout =  " foo.f03\n")
-
-    test.must_not_exist('wrapper.out')
-
-    import sys
-    if sys.platform[:5] == 'sunos':
-        test.run(arguments = 'bar' + _exe, stderr = None)
-    else:
-        test.run(arguments = 'bar' + _exe)
-
-    test.run(program = test.workpath('bar'), stdout =  " bar.f03\n")
-
-    test.must_match('wrapper.out', "wrapper.py\n")
+test.must_match('test09' + _exe, " -c -x\nThis is a .f03 file.\n")
+test.must_match('test10' + _exe, " -c -x\nThis is a .F03 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/F08FLAGS-live.py
+++ b/test/Fortran/F08FLAGS-live.py
@@ -24,8 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+Test handling of the dialect-specific FLAGS variable, using a live compiler.
 """
 
 import sys
@@ -33,27 +32,57 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
+_exe = TestSCons._exe
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f08'
+if not test.detect_tool(fc):
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find an f08 tool; skipping test.\n')
+
+test.subdir('x')
+test.write(['x', 'dummy.i'], """\
+# Exists only such that -Ix finds the directory...
+""")
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+foo = Environment(F08='%(fc)s')
+f08 = foo.Dictionary('F08')
+bar = foo.Clone(F08=r'%(_python_)s wrapper.py ' + f08, F08FLAGS='-Ix')
+foo.Program(target='foo', source='foo.f08')
+bar.Program(target='bar', source='bar.f08')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f08', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f08'
+      END PROGRAM FOO
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f08', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f08'
+      END PROGRAM BAR
+""")
+
+test.run(arguments='foo' + _exe, stderr=None)
+test.run(program=test.workpath('foo'), stdout=" foo.f08\n")
+test.must_not_exist('wrapper.out')
+
+if sys.platform[:5] == 'sunos':
+    test.run(arguments='bar' + _exe, stderr=None)
+else:
+    test.run(arguments='bar' + _exe)
+test.run(program=test.workpath('bar'), stdout=" bar.f08\n")
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/F77FLAGS-live.py
+++ b/test/Fortran/F77FLAGS-live.py
@@ -24,8 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+Test handling of the dialect-specific FLAGS variable, using a live compiler.
 """
 
 import sys
@@ -33,27 +32,57 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
+_exe = TestSCons._exe
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f77'
+if not test.detect_tool(fc):
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find an f77 tool; skipping test.\n')
+
+directory = 'x'
+test.subdir(directory)
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+foo = Environment(F77='%(fc)s', tools=['default', 'f77'], F77FILESUFFIXES=[".f"])
+f77 = foo.Dictionary('F77')
+bar = foo.Clone(F77=r'%(_python_)s wrapper.py ' + f77, F77FLAGS='-I%(directory)s')
+foo.Program(target='foo', source='foo.f')
+bar.Program(target='bar', source='bar.f')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f'
+      STOP
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f'
+      STOP
+      END
+""")
+
+test.run(arguments='foo' + _exe, stderr=None)
+test.run(program=test.workpath('foo'), stdout=" foo.f\n")
+test.must_not_exist('wrapper.out')
+
+if sys.platform[:5] == 'sunos':
+    test.run(arguments='bar' + _exe, stderr=None)
+else:
+    test.run(arguments='bar' + _exe)
+test.run(program=test.workpath('bar'), stdout=" bar.f\n")
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/F77FLAGS.py
+++ b/test/Fortran/F77FLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,11 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""
+Test handling of the dialect-specific FLAGS variable,
+using a mocked compiler.
+"""
 
 import TestSCons
 
@@ -31,75 +35,28 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
+# ref: test/fixture/mylink.py
 test.file_fixture('mylink.py')
+# ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
-                  LINKFLAGS = [],
-                  F77 = r'%(_python_)s myfortran_flags.py g77',
-                  F77FLAGS = '-x')
-env.Program(target = 'test09', source = 'test09.f77')
-env.Program(target = 'test10', source = 'test10.F77')
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+env = Environment(
+    LINK=r'%(_python_)s mylink.py',
+    LINKFLAGS=[],
+    F77=r'%(_python_)s myfortran_flags.py g77',
+    F77FLAGS='-x',
+)
+env.Program(target='test09', source='test09.f77')
+env.Program(target='test10', source='test10.F77')
 """ % locals())
 
 test.write('test09.f77', "This is a .f77 file.\n#link\n#g77\n")
 test.write('test10.F77', "This is a .F77 file.\n#link\n#g77\n")
-
-test.run(arguments = '.', stderr = None)
-
+test.run(arguments='.', stderr=None)
 test.must_match('test09' + _exe, " -c -x\nThis is a .f77 file.\n")
 test.must_match('test10' + _exe, " -c -x\nThis is a .F77 file.\n")
-
-
-fc = 'f77'
-g77 = test.detect_tool(fc)
-
-if g77:
-
-    directory = 'x'
-    test.subdir(directory)
-
-    test.file_fixture('wrapper.py')
-
-    test.write('SConstruct', """
-foo = Environment(F77 = '%(fc)s', tools = ['default', 'f77'], F77FILESUFFIXES = [".f"])
-f77 = foo.Dictionary('F77')
-bar = foo.Clone(F77 = r'%(_python_)s wrapper.py ' + f77, F77FLAGS = '-I%(directory)s')
-foo.Program(target = 'foo', source = 'foo.f')
-bar.Program(target = 'bar', source = 'bar.f')
-""" % locals())
-
-    test.write('foo.f', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f'
-      STOP
-      END
-""")
-
-    test.write('bar.f', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f'
-      STOP
-      END
-""")
-
-
-    test.run(arguments = 'foo' + _exe, stderr = None)
-
-    test.run(program = test.workpath('foo'), stdout =  " foo.f\n")
-
-    test.must_not_exist('wrapper.out')
-
-    import sys
-    if sys.platform[:5] == 'sunos':
-        test.run(arguments = 'bar' + _exe, stderr = None)
-    else:
-        test.run(arguments = 'bar' + _exe)
-
-    test.run(program = test.workpath('bar'), stdout =  " bar.f\n")
-
-    test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/F90FLAGS-live.py
+++ b/test/Fortran/F90FLAGS-live.py
@@ -24,8 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+Test handling of the dialect-specific FLAGS variable, using a live compiler.
 """
 
 import sys
@@ -33,27 +32,53 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
+_exe = TestSCons._exe
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f90'
+if not test.detect_tool(fc):
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find an f90 tool; skipping test.\n')
+
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+foo = Environment(F90='%(fc)s')
+f90 = foo.Dictionary('F90')
+bar = foo.Clone(F90=r'%(_python_)s wrapper.py ' + f90)
+foo.Program(target='foo', source='foo.f90')
+bar.Program(target='bar', source='bar.f90')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f90', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f90'
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f90', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f90'
+      END
+""")
+
+test.run(arguments='foo' + _exe, stderr=None)
+test.run(program=test.workpath('foo'), stdout=" foo.f90\n")
+test.must_not_exist('wrapper.out')
+
+if sys.platform[:5] == 'sunos':
+    test.run(arguments='bar' + _exe, stderr=None)
+else:
+    test.run(arguments='bar' + _exe)
+test.run(program=test.workpath('bar'), stdout=" bar.f90\n")
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/F90FLAGS.py
+++ b/test/Fortran/F90FLAGS.py
@@ -23,6 +23,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test handling of the dialect-specific FLAGS variable,
+using a mocked compiler.
+"""
+
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -30,40 +35,45 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
+# ref: test/fixture/mylink.py
 test.file_fixture('mylink.py')
+# ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
-                  LINKFLAGS = [],
-                  F90 = r'%(_python_)s myfortran_flags.py g90',
-                  F90FLAGS = '-x',
-                  FORTRAN = r'%(_python_)s myfortran_flags.py fortran',
-                  FORTRANFLAGS = '-y')
-env.Program(target = 'test01', source = 'test01.f')
-env.Program(target = 'test02', source = 'test02.F')
-env.Program(target = 'test03', source = 'test03.for')
-env.Program(target = 'test04', source = 'test04.FOR')
-env.Program(target = 'test05', source = 'test05.ftn')
-env.Program(target = 'test06', source = 'test06.FTN')
-env.Program(target = 'test07', source = 'test07.fpp')
-env.Program(target = 'test08', source = 'test08.FPP')
-env.Program(target = 'test11', source = 'test11.f90')
-env.Program(target = 'test12', source = 'test12.F90')
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+env = Environment(
+    LINK=r'%(_python_)s mylink.py',
+    LINKFLAGS=[],
+    F90=r'%(_python_)s myfortran_flags.py g90',
+    F90FLAGS='-x',
+    FORTRAN=r'%(_python_)s myfortran_flags.py fortran',
+    FORTRANFLAGS='-y',
+)
+env.Program(target='test01', source='test01.f')
+env.Program(target='test02', source='test02.F')
+env.Program(target='test03', source='test03.for')
+env.Program(target='test04', source='test04.FOR')
+env.Program(target='test05', source='test05.ftn')
+env.Program(target='test06', source='test06.FTN')
+env.Program(target='test07', source='test07.fpp')
+env.Program(target='test08', source='test08.FPP')
+env.Program(target='test09', source='test09.f90')
+env.Program(target='test10', source='test10.F90')
 """ % locals())
 
-test.write('test01.f',   "This is a .f file.\n#link\n#fortran\n")
-test.write('test02.F',   "This is a .F file.\n#link\n#fortran\n")
+test.write('test01.f', "This is a .f file.\n#link\n#fortran\n")
+test.write('test02.F', "This is a .F file.\n#link\n#fortran\n")
 test.write('test03.for', "This is a .for file.\n#link\n#fortran\n")
 test.write('test04.FOR', "This is a .FOR file.\n#link\n#fortran\n")
 test.write('test05.ftn', "This is a .ftn file.\n#link\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#link\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#link\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#link\n#fortran\n")
-test.write('test11.f90', "This is a .f90 file.\n#link\n#g90\n")
-test.write('test12.F90', "This is a .F90 file.\n#link\n#g90\n")
+test.write('test09.f90', "This is a .f90 file.\n#link\n#g90\n")
+test.write('test10.F90', "This is a .F90 file.\n#link\n#g90\n")
 
-test.run(arguments = '.', stderr = None)
+test.run(arguments='.', stderr=None)
 
 test.must_match('test01' + _exe, " -c -y\nThis is a .f file.\n")
 test.must_match('test02' + _exe, " -c -y\nThis is a .F file.\n")
@@ -73,53 +83,8 @@ test.must_match('test05' + _exe, " -c -y\nThis is a .ftn file.\n")
 test.must_match('test06' + _exe, " -c -y\nThis is a .FTN file.\n")
 test.must_match('test07' + _exe, " -c -y\nThis is a .fpp file.\n")
 test.must_match('test08' + _exe, " -c -y\nThis is a .FPP file.\n")
-test.must_match('test11' + _exe, " -c -x\nThis is a .f90 file.\n")
-test.must_match('test12' + _exe, " -c -x\nThis is a .F90 file.\n")
-
-
-
-fc = 'f90'
-g90 = test.detect_tool(fc)
-
-if g90:
-
-    test.file_fixture('wrapper.py')
-
-    test.write('SConstruct', """
-foo = Environment(F90 = '%(fc)s')
-f90 = foo.Dictionary('F90')
-bar = foo.Clone(F90 = r'%(_python_)s wrapper.py ' + f90)
-foo.Program(target = 'foo', source = 'foo.f90')
-bar.Program(target = 'bar', source = 'bar.f90')
-""" % locals())
-
-    test.write('foo.f90', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f90'
-      END
-""")
-
-    test.write('bar.f90', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f90'
-      END
-""")
-
-    test.run(arguments = 'foo' + _exe, stderr = None)
-
-    test.run(program = test.workpath('foo'), stdout =  " foo.f90\n")
-
-    test.must_not_exist('wrapper.out')
-
-    import sys
-    if sys.platform[:5] == 'sunos':
-        test.run(arguments = 'bar' + _exe, stderr = None)
-    else:
-        test.run(arguments = 'bar' + _exe)
-
-    test.run(program = test.workpath('bar'), stdout =  " bar.f90\n")
-
-    test.must_match('wrapper.out', "wrapper.py\n")
+test.must_match('test09' + _exe, " -c -x\nThis is a .f90 file.\n")
+test.must_match('test10' + _exe, " -c -x\nThis is a .F90 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/F95FLAGS-live.py
+++ b/test/Fortran/F95FLAGS-live.py
@@ -24,8 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+Test handling of the dialect-specific FLAGS variable, using a live compiler.
 """
 
 import sys
@@ -33,27 +32,59 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
+_exe = TestSCons._exe
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f95'
+if not test.detect_tool(fc):
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find an f95 tool; skipping test.\n')
+
+test.subdir('x')
+test.write(['x', 'dummy.i'], """\
+# Exists only such that -Ix finds the directory...
+""")
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+foo = Environment(F95='%(fc)s')
+f95 = foo.Dictionary('F95')
+bar = foo.Clone(F95=r'%(_python_)s wrapper.py ' + f95, F95FLAGS='-Ix')
+foo.Program(target='foo', source='foo.f95')
+bar.Program(target='bar', source='bar.f95')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f95', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f95'
+      STOP
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f95', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f95'
+      STOP
+      END
+""")
+
+test.run(arguments='foo' + _exe, stderr=None)
+test.run(program=test.workpath('foo'), stdout=" foo.f95\n")
+test.must_not_exist('wrapper.out')
+
+if sys.platform.startswith('sunos'):
+    test.run(arguments='bar' + _exe, stderr=None)
+else:
+    test.run(arguments='bar' + _exe)
+test.run(program=test.workpath('bar'), stdout=" bar.f95\n")
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/F95FLAGS.py
+++ b/test/Fortran/F95FLAGS.py
@@ -23,6 +23,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test handling of the dialect-specific FLAGS variable,
+using a mocked compiler.
+"""
+
 import TestSCons
 
 _python_ = TestSCons._python_
@@ -35,7 +40,8 @@ test.file_fixture('mylink.py')
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment(
     LINK=r'%(_python_)s mylink.py',
     LINKFLAGS=[],
@@ -52,8 +58,8 @@ env.Program(target='test05', source='test05.ftn')
 env.Program(target='test06', source='test06.FTN')
 env.Program(target='test07', source='test07.fpp')
 env.Program(target='test08', source='test08.FPP')
-env.Program(target='test13', source='test13.f95')
-env.Program(target='test14', source='test14.F95')
+env.Program(target='test09', source='test09.f95')
+env.Program(target='test10', source='test10.F95')
 """ % locals())
 
 test.write('test01.f',   "This is a .f file.\n#link\n#fortran\n")
@@ -64,8 +70,8 @@ test.write('test05.ftn', "This is a .ftn file.\n#link\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#link\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#link\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#link\n#fortran\n")
-test.write('test13.f95', "This is a .f95 file.\n#link\n#g95\n")
-test.write('test14.F95', "This is a .F95 file.\n#link\n#g95\n")
+test.write('test09.f95', "This is a .f95 file.\n#link\n#g95\n")
+test.write('test10.F95', "This is a .F95 file.\n#link\n#g95\n")
 
 test.run(arguments = '.', stderr = None)
 
@@ -77,57 +83,8 @@ test.must_match('test05' + _exe, " -c -y\nThis is a .ftn file.\n")
 test.must_match('test06' + _exe, " -c -y\nThis is a .FTN file.\n")
 test.must_match('test07' + _exe, " -c -y\nThis is a .fpp file.\n")
 test.must_match('test08' + _exe, " -c -y\nThis is a .FPP file.\n")
-test.must_match('test13' + _exe, " -c -x\nThis is a .f95 file.\n")
-test.must_match('test14' + _exe, " -c -x\nThis is a .F95 file.\n")
-
-
-fc = 'f95'
-g95 = test.detect_tool(fc)
-if g95:
-    test.subdir('x')
-    test.write(['x','dummy.i'],
-"""
-# Exists only such that -Ix finds the directory...
-""")
-
-    # ref: test/fixture/wrapper.py
-    test.file_fixture('wrapper.py')
-
-    test.write('SConstruct', """
-foo = Environment(F95='%(fc)s')
-f95 = foo.Dictionary('F95')
-bar = foo.Clone(F95=r'%(_python_)s wrapper.py ' + f95, F95FLAGS='-Ix')
-foo.Program(target='foo', source='foo.f95')
-bar.Program(target='bar', source='bar.f95')
-""" % locals())
-
-    test.write('foo.f95', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f95'
-      STOP
-      END
-""")
-
-    test.write('bar.f95', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f95'
-      STOP
-      END
-""")
-
-    test.run(arguments='foo' + _exe, stderr=None)
-    test.run(program=test.workpath('foo'), stdout=" foo.f95\n")
-    test.must_not_exist('wrapper.out')
-
-    import sys
-
-    if sys.platform.startswith('sunos'):
-        test.run(arguments='bar' + _exe, stderr=None)
-    else:
-        test.run(arguments='bar' + _exe)
-
-    test.run(program=test.workpath('bar'), stdout=" bar.f95\n")
-    test.must_match('wrapper.out', "wrapper.py\n")
+test.must_match('test09' + _exe, " -c -x\nThis is a .f95 file.\n")
+test.must_match('test10' + _exe, " -c -x\nThis is a .F95 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/FORTRANCOMMONFLAGS-live.py
+++ b/test/Fortran/FORTRANCOMMONFLAGS-live.py
@@ -24,8 +24,8 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+Test that while FORTRANFLAGS is not passed to another dialect,
+FORTRANCOMMONFLAGS makes it through.
 """
 
 import sys
@@ -33,27 +33,53 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
+_exe = TestSCons._exe
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """\
+fc = 'f90'
+if not test.detect_tool(fc):
+    # gfortran names all variants the same, try it too
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find an f90 tool; skipping test.\n')
+
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
+test.write('SConstruct', """
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+foo = Environment(F90='%(fc)s')
+f90 = foo.Dictionary('F90')
+bar = foo.Clone(F90=r'%(_python_)s wrapper.py ' + f90)
+foo.Program(target='foo', source='foo.f90')
+bar.Program(target='bar', source='bar.f90')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f90', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f90'
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f90', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f90'
+      END
+""")
+
+test.run(arguments='foo' + _exe, stderr=None)
+test.run(program=test.workpath('foo'), stdout=" foo.f90\n")
+test.must_not_exist('wrapper.out')
+
+if sys.platform[:5] == 'sunos':
+    test.run(arguments='bar' + _exe, stderr=None)
+else:
+    test.run(arguments='bar' + _exe)
+test.run(program=test.workpath('bar'), stdout=" bar.f90\n")
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/FORTRANCOMMONFLAGS.py
+++ b/test/Fortran/FORTRANCOMMONFLAGS.py
@@ -35,10 +35,13 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
+# ref: test/fixture/mylink.py
 test.file_fixture('mylink.py')
+# ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """
+DefaultEnvironment(tools=[])
 env = Environment(
     LINK=r'%(_python_)s mylink.py',
     LINKFLAGS=[],
@@ -56,8 +59,8 @@ env.Program(target='test05', source='test05.ftn')
 env.Program(target='test06', source='test06.FTN')
 env.Program(target='test07', source='test07.fpp')
 env.Program(target='test08', source='test08.FPP')
-env.Program(target='test11', source='test11.f90')
-env.Program(target='test12', source='test12.F90')
+env.Program(target='test09', source='test09.f90')
+env.Program(target='test10', source='test10.F90')
 """ % locals())
 
 test.write('test01.f',   "This is a .f file.\n#link\n#fortran\n")
@@ -68,8 +71,8 @@ test.write('test05.ftn', "This is a .ftn file.\n#link\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#link\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#link\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#link\n#fortran\n")
-test.write('test11.f90', "This is a .f90 file.\n#link\n#g90\n")
-test.write('test12.F90', "This is a .F90 file.\n#link\n#g90\n")
+test.write('test09.f90', "This is a .f90 file.\n#link\n#g90\n")
+test.write('test10.F90', "This is a .F90 file.\n#link\n#g90\n")
 
 test.run(arguments = '.', stderr = None)
 
@@ -81,47 +84,8 @@ test.must_match('test05' + _exe, " -c -z -y\nThis is a .ftn file.\n")
 test.must_match('test06' + _exe, " -c -z -y\nThis is a .FTN file.\n")
 test.must_match('test07' + _exe, " -c -z -y\nThis is a .fpp file.\n")
 test.must_match('test08' + _exe, " -c -z -y\nThis is a .FPP file.\n")
-test.must_match('test11' + _exe, " -c -z -x\nThis is a .f90 file.\n")
-test.must_match('test12' + _exe, " -c -z -x\nThis is a .F90 file.\n")
-
-
-fc = 'f90'
-g90 = test.detect_tool(fc)
-if g90:
-    test.file_fixture('wrapper.py')
-
-    test.write('SConstruct', """
-foo = Environment(F90='%(fc)s')
-f90 = foo.Dictionary('F90')
-bar = foo.Clone(F90=r'%(_python_)s wrapper.py ' + f90)
-foo.Program(target='foo', source='foo.f90')
-bar.Program(target='bar', source='bar.f90')
-""" % locals())
-
-    test.write('foo.f90', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f90'
-      END
-""")
-
-    test.write('bar.f90', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f90'
-      END
-""")
-
-    test.run(arguments='foo' + _exe, stderr=None)
-    test.run(program=test.workpath('foo'), stdout=" foo.f90\n")
-    test.must_not_exist('wrapper.out')
-
-    import sys
-
-    if sys.platform[:5] == 'sunos':
-        test.run(arguments='bar' + _exe, stderr=None)
-    else:
-        test.run(arguments='bar' + _exe)
-    test.run(program=test.workpath('bar'), stdout=" bar.f90\n")
-    test.must_match('wrapper.out', "wrapper.py\n")
+test.must_match('test09' + _exe, " -c -z -x\nThis is a .f90 file.\n")
+test.must_match('test10' + _exe, " -c -z -x\nThis is a .F90 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/FORTRANFLAGS.py
+++ b/test/Fortran/FORTRANFLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 
@@ -31,26 +30,31 @@ _python_ = TestSCons._python_
 test = TestSCons.TestSCons()
 _exe = TestSCons._exe
 
+# ref: test/fixture/mylink.py
 test.file_fixture('mylink.py')
+# ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """
-env = Environment(LINK = r'%(_python_)s mylink.py',
-                  LINKFLAGS = [],
-                  FORTRAN = r'%(_python_)s myfortran_flags.py fortran',
-                  FORTRANFLAGS = '-x')
-env.Program(target = 'test01', source = 'test01.f')
-env.Program(target = 'test02', source = 'test02.F')
-env.Program(target = 'test03', source = 'test03.for')
-env.Program(target = 'test04', source = 'test04.FOR')
-env.Program(target = 'test05', source = 'test05.ftn')
-env.Program(target = 'test06', source = 'test06.FTN')
-env.Program(target = 'test07', source = 'test07.fpp')
-env.Program(target = 'test08', source = 'test08.FPP')
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+env = Environment(
+    LINK=r'%(_python_)s mylink.py',
+    LINKFLAGS=[],
+    FORTRAN=r'%(_python_)s myfortran_flags.py fortran',
+    FORTRANFLAGS='-x',
+)
+env.Program(target='test01', source='test01.f')
+env.Program(target='test02', source='test02.F')
+env.Program(target='test03', source='test03.for')
+env.Program(target='test04', source='test04.FOR')
+env.Program(target='test05', source='test05.ftn')
+env.Program(target='test06', source='test06.FTN')
+env.Program(target='test07', source='test07.fpp')
+env.Program(target='test08', source='test08.FPP')
 """ % locals())
 
-test.write('test01.f',   "This is a .f file.\n#link\n#fortran\n")
-test.write('test02.F',   "This is a .F file.\n#link\n#fortran\n")
+test.write('test01.f', "This is a .f file.\n#link\n#fortran\n")
+test.write('test02.F', "This is a .F file.\n#link\n#fortran\n")
 test.write('test03.for', "This is a .for file.\n#link\n#fortran\n")
 test.write('test04.FOR', "This is a .FOR file.\n#link\n#fortran\n")
 test.write('test05.ftn', "This is a .ftn file.\n#link\n#fortran\n")
@@ -58,7 +62,7 @@ test.write('test06.FTN', "This is a .FTN file.\n#link\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#link\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#link\n#fortran\n")
 
-test.run(arguments = '.', stderr = None)
+test.run(arguments='.', stderr=None)
 
 test.must_match('test01' + _exe, " -c -x\nThis is a .f file.\n")
 test.must_match('test02' + _exe, " -c -x\nThis is a .F file.\n")
@@ -68,56 +72,6 @@ test.must_match('test05' + _exe, " -c -x\nThis is a .ftn file.\n")
 test.must_match('test06' + _exe, " -c -x\nThis is a .FTN file.\n")
 test.must_match('test07' + _exe, " -c -x\nThis is a .fpp file.\n")
 test.must_match('test08' + _exe, " -c -x\nThis is a .FPP file.\n")
-
-
-fc = 'f77'
-g77 = test.detect_tool(fc)
-
-if g77:
-
-    directory = 'x'
-    test.subdir(directory)
-
-    test.file_fixture('wrapper.py')
-
-    test.write('SConstruct', """
-foo = Environment(FORTRAN = '%(fc)s')
-f77 = foo.Dictionary('FORTRAN')
-bar = foo.Clone(FORTRAN = r'%(_python_)s wrapper.py ' + f77, FORTRANFLAGS = '-I%(directory)s')
-foo.Program(target = 'foo', source = 'foo.f')
-bar.Program(target = 'bar', source = 'bar.f')
-""" % locals())
-
-    test.write('foo.f', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f'
-      STOP
-      END
-""")
-
-    test.write('bar.f', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f'
-      STOP
-      END
-""")
-
-
-    test.run(arguments = 'foo' + _exe, stderr = None)
-
-    test.run(program = test.workpath('foo'), stdout =  " foo.f\n")
-
-    test.must_not_exist('wrapper.out')
-
-    import sys
-    if sys.platform[:5] == 'sunos':
-        test.run(arguments = 'bar' + _exe, stderr = None)
-    else:
-        test.run(arguments = 'bar' + _exe)
-
-    test.run(program = test.workpath('bar'), stdout =  " bar.f\n")
-
-    test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF03FLAGS.py
+++ b/test/Fortran/SHF03FLAGS.py
@@ -23,6 +23,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test handling of the dialect-specific FLAGS variable for shared objects,
+using a mocked compiler.
+"""
+
 import sys
 
 import TestSCons
@@ -37,8 +42,11 @@ test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHFORTRAN=r'%(_python_)s myfortran_flags.py fortran')
-env.Append(SHFORTRANFLAGS='-x')
+env = Environment(
+    SHF03=r'%(_python_)s myfortran_flags.py g03',
+    SHFORTRAN=r'%(_python_)s myfortran_flags.py fortran',
+)
+env.Append(SHF03FLAGS='-x', SHFORTRANFLAGS='-y')
 env.SharedObject(target='test01', source='test01.f')
 env.SharedObject(target='test02', source='test02.F')
 env.SharedObject(target='test03', source='test03.for')
@@ -47,6 +55,8 @@ env.SharedObject(target='test05', source='test05.ftn')
 env.SharedObject(target='test06', source='test06.FTN')
 env.SharedObject(target='test07', source='test07.fpp')
 env.SharedObject(target='test08', source='test08.FPP')
+env.SharedObject(target='test09', source='test09.f03')
+env.SharedObject(target='test10', source='test10.F03')
 """ % locals())
 
 test.write('test01.f', "This is a .f file.\n#fortran\n")
@@ -57,16 +67,20 @@ test.write('test05.ftn', "This is a .ftn file.\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#fortran\n")
+test.write('test09.f03', "This is a .f03 file.\n#g03\n")
+test.write('test10.F03', "This is a .F03 file.\n#g03\n")
 
 test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test01' + _obj, " -c -x\nThis is a .f file.\n")
-test.must_match(obj_ + 'test02' + _obj, " -c -x\nThis is a .F file.\n")
-test.must_match(obj_ + 'test03' + _obj, " -c -x\nThis is a .for file.\n")
-test.must_match(obj_ + 'test04' + _obj, " -c -x\nThis is a .FOR file.\n")
-test.must_match(obj_ + 'test05' + _obj, " -c -x\nThis is a .ftn file.\n")
-test.must_match(obj_ + 'test06' + _obj, " -c -x\nThis is a .FTN file.\n")
-test.must_match(obj_ + 'test07' + _obj, " -c -x\nThis is a .fpp file.\n")
-test.must_match(obj_ + 'test08' + _obj, " -c -x\nThis is a .FPP file.\n")
+test.must_match(obj_ + 'test01' + _obj, " -c -y\nThis is a .f file.\n")
+test.must_match(obj_ + 'test02' + _obj, " -c -y\nThis is a .F file.\n")
+test.must_match(obj_ + 'test03' + _obj, " -c -y\nThis is a .for file.\n")
+test.must_match(obj_ + 'test04' + _obj, " -c -y\nThis is a .FOR file.\n")
+test.must_match(obj_ + 'test05' + _obj, " -c -y\nThis is a .ftn file.\n")
+test.must_match(obj_ + 'test06' + _obj, " -c -y\nThis is a .FTN file.\n")
+test.must_match(obj_ + 'test07' + _obj, " -c -y\nThis is a .fpp file.\n")
+test.must_match(obj_ + 'test08' + _obj, " -c -y\nThis is a .FPP file.\n")
+test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f03 file.\n")
+test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F03 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF08FLAGS-live.py
+++ b/test/Fortran/SHF08FLAGS-live.py
@@ -25,7 +25,7 @@
 
 """
 Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+using a live compiler.
 """
 
 import sys
@@ -33,27 +33,56 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
-
 test = TestSCons.TestSCons()
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f08'
+if not test.detect_tool(fc):
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a f08 tool; skipping test.\n')
+
+test.subdir('x')
+test.write(['x', 'dummy.i'], """\
+# Exists only such that -Ix finds the directory...
+""")
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+# foo = Environment(SHF08='%(fc)s')
+foo = Environment()
+shf08 = foo.Dictionary('SHF08')
+bar = foo.Clone(SHF08=r'%(_python_)s wrapper.py ' + shf08)
+bar.Append(SHF08FLAGS='-Ix')
+foo.SharedLibrary(target='foo/foo', source='foo.f08')
+bar.SharedLibrary(target='bar/bar', source='bar.f08')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f08', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f08'
+      STOP
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f08', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f08'
+      STOP
+      END
+""")
+
+test.run(arguments='foo', stderr=None)
+test.must_not_exist('wrapper.out')
+
+if sys.platform.startswith('sunos'):
+    test.run(arguments='bar', stderr=None)
+else:
+    test.run(arguments='bar')
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF08FLAGS.py
+++ b/test/Fortran/SHF08FLAGS.py
@@ -23,6 +23,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test handling of the dialect-specific FLAGS variable for shared objects,
+using a mocked compiler.
+"""
+
 import sys
 
 import TestSCons
@@ -37,8 +42,11 @@ test.file_fixture(['fixture', 'myfortran_flags.py'])
 
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHFORTRAN=r'%(_python_)s myfortran_flags.py fortran')
-env.Append(SHFORTRANFLAGS='-x')
+env = Environment(
+    SHF08=r'%(_python_)s myfortran_flags.py g08',
+    SHFORTRAN=r'%(_python_)s myfortran_flags.py fortran',
+)
+env.Append(SHF08FLAGS='-x', SHFORTRANFLAGS='-y')
 env.SharedObject(target='test01', source='test01.f')
 env.SharedObject(target='test02', source='test02.F')
 env.SharedObject(target='test03', source='test03.for')
@@ -47,6 +55,8 @@ env.SharedObject(target='test05', source='test05.ftn')
 env.SharedObject(target='test06', source='test06.FTN')
 env.SharedObject(target='test07', source='test07.fpp')
 env.SharedObject(target='test08', source='test08.FPP')
+env.SharedObject(target='test09', source='test09.f08')
+env.SharedObject(target='test10', source='test10.F08')
 """ % locals())
 
 test.write('test01.f', "This is a .f file.\n#fortran\n")
@@ -57,16 +67,20 @@ test.write('test05.ftn', "This is a .ftn file.\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#fortran\n")
+test.write('test09.f08', "This is a .f08 file.\n#g08\n")
+test.write('test10.F08', "This is a .F08 file.\n#g08\n")
 
 test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test01' + _obj, " -c -x\nThis is a .f file.\n")
-test.must_match(obj_ + 'test02' + _obj, " -c -x\nThis is a .F file.\n")
-test.must_match(obj_ + 'test03' + _obj, " -c -x\nThis is a .for file.\n")
-test.must_match(obj_ + 'test04' + _obj, " -c -x\nThis is a .FOR file.\n")
-test.must_match(obj_ + 'test05' + _obj, " -c -x\nThis is a .ftn file.\n")
-test.must_match(obj_ + 'test06' + _obj, " -c -x\nThis is a .FTN file.\n")
-test.must_match(obj_ + 'test07' + _obj, " -c -x\nThis is a .fpp file.\n")
-test.must_match(obj_ + 'test08' + _obj, " -c -x\nThis is a .FPP file.\n")
+test.must_match(obj_ + 'test01' + _obj, " -c -y\nThis is a .f file.\n")
+test.must_match(obj_ + 'test02' + _obj, " -c -y\nThis is a .F file.\n")
+test.must_match(obj_ + 'test03' + _obj, " -c -y\nThis is a .for file.\n")
+test.must_match(obj_ + 'test04' + _obj, " -c -y\nThis is a .FOR file.\n")
+test.must_match(obj_ + 'test05' + _obj, " -c -y\nThis is a .ftn file.\n")
+test.must_match(obj_ + 'test06' + _obj, " -c -y\nThis is a .FTN file.\n")
+test.must_match(obj_ + 'test07' + _obj, " -c -y\nThis is a .fpp file.\n")
+test.must_match(obj_ + 'test08' + _obj, " -c -y\nThis is a .FPP file.\n")
+test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f08 file.\n")
+test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F08 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF77FLAGS-live.py
+++ b/test/Fortran/SHF77FLAGS-live.py
@@ -25,7 +25,7 @@
 
 """
 Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+using a live compiler.
 """
 
 import sys
@@ -33,27 +33,58 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
-
 test = TestSCons.TestSCons()
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f77'
+if not test.detect_tool(fc):
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a f77 tool; skipping test.\n')
+
+directory = 'x'
+test.subdir(directory)
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+# foo = Environment(SHF77='%(fc)s')
+foo = Environment()
+shf77 = foo.Dictionary('SHF77')
+bar = foo.Clone(
+    SHF77=r'%(_python_)s wrapper.py ' + shf77,
+    tools=["default", 'f77'],
+    F77FILESUFFIXES=[".f"],
+)
+bar.Append(SHF77FLAGS='-I%(directory)s')
+foo.SharedLibrary(target='foo/foo', source='foo.f')
+bar.SharedLibrary(target='bar/bar', source='bar.f')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f'
+      STOP
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f'
+      STOP
+      END
+""")
+
+test.run(arguments='foo', stderr=None)
+test.must_not_exist('wrapper.out')
+
+if sys.platform[:5] == 'sunos':
+    test.run(arguments='bar', stderr=None)
+else:
+    test.run(arguments='bar')
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF90FLAGS-live.py
+++ b/test/Fortran/SHF90FLAGS-live.py
@@ -25,7 +25,7 @@
 
 """
 Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+using a live compiler.
 """
 
 import sys
@@ -33,27 +33,56 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
-
 test = TestSCons.TestSCons()
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f90'
+if not test.detect_tool(fc):
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a f90 tool; skipping test.\n')
+
+test.subdir('x')
+test.write(['x', 'dummy.i'], """\
+# Exists only such that -Ix finds the directory...
+""")
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+# foo = Environment(SHF90='%(fc)s')
+foo = Environment()
+shf90 = foo.Dictionary('SHF90')
+bar = foo.Clone(SHF90=r'%(_python_)s wrapper.py ' + shf90)
+bar.Append(SHF90FLAGS='-Ix')
+foo.SharedLibrary(target='foo/foo', source='foo.f90')
+bar.SharedLibrary(target='bar/bar', source='bar.f90')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f90', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f90'
+      STOP
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f90', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f90'
+      STOP
+      END
+""")
+
+test.run(arguments='foo', stderr=None)
+test.must_not_exist('wrapper.out')
+
+if sys.platform.startswith('sunos'):
+    test.run(arguments='bar', stderr=None)
+else:
+    test.run(arguments='bar')
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF90FLAGS.py
+++ b/test/Fortran/SHF90FLAGS.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,50 +22,55 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
+"""
+Test handling of the dialect-specific FLAGS variable for shared objects,
+using a mocked compiler.
+"""
+
+import sys
 
 import TestSCons
 
 _python_ = TestSCons._python_
-
 _obj = TestSCons._shobj
 obj_ = TestSCons.shobj_
 
 test = TestSCons.TestSCons()
+# ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """
-env = Environment(SHF90 = r'%(_python_)s myfortran_flags.py g90',
-                  SHFORTRAN = r'%(_python_)s myfortran_flags.py fortran')
-env.Append(SHF90FLAGS = '-x',
-           SHFORTRANFLAGS = '-y')
-env.SharedObject(target = 'test01', source = 'test01.f')
-env.SharedObject(target = 'test02', source = 'test02.F')
-env.SharedObject(target = 'test03', source = 'test03.for')
-env.SharedObject(target = 'test04', source = 'test04.FOR')
-env.SharedObject(target = 'test05', source = 'test05.ftn')
-env.SharedObject(target = 'test06', source = 'test06.FTN')
-env.SharedObject(target = 'test07', source = 'test07.fpp')
-env.SharedObject(target = 'test08', source = 'test08.FPP')
-env.SharedObject(target = 'test11', source = 'test11.f90')
-env.SharedObject(target = 'test12', source = 'test12.F90')
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+env = Environment(
+    SHF90=r'%(_python_)s myfortran_flags.py g90',
+    SHFORTRAN=r'%(_python_)s myfortran_flags.py fortran',
+)
+env.Append(SHF90FLAGS='-x', SHFORTRANFLAGS='-y')
+env.SharedObject(target='test01', source='test01.f')
+env.SharedObject(target='test02', source='test02.F')
+env.SharedObject(target='test03', source='test03.for')
+env.SharedObject(target='test04', source='test04.FOR')
+env.SharedObject(target='test05', source='test05.ftn')
+env.SharedObject(target='test06', source='test06.FTN')
+env.SharedObject(target='test07', source='test07.fpp')
+env.SharedObject(target='test08', source='test08.FPP')
+env.SharedObject(target='test09', source='test09.f90')
+env.SharedObject(target='test10', source='test10.F90')
 """ % locals())
 
-test.write('test01.f',   "This is a .f file.\n#fortran\n")
-test.write('test02.F',   "This is a .F file.\n#fortran\n")
+test.write('test01.f', "This is a .f file.\n#fortran\n")
+test.write('test02.F', "This is a .F file.\n#fortran\n")
 test.write('test03.for', "This is a .for file.\n#fortran\n")
 test.write('test04.FOR', "This is a .FOR file.\n#fortran\n")
 test.write('test05.ftn', "This is a .ftn file.\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#fortran\n")
-test.write('test11.f90', "This is a .f90 file.\n#g90\n")
-test.write('test12.F90', "This is a .F90 file.\n#g90\n")
+test.write('test09.f90', "This is a .f90 file.\n#g90\n")
+test.write('test10.F90', "This is a .F90 file.\n#g90\n")
 
-test.run(arguments = '.', stderr = None)
-
+test.run(arguments='.', stderr=None)
 test.must_match(obj_ + 'test01' + _obj, " -c -y\nThis is a .f file.\n")
 test.must_match(obj_ + 'test02' + _obj, " -c -y\nThis is a .F file.\n")
 test.must_match(obj_ + 'test03' + _obj, " -c -y\nThis is a .for file.\n")
@@ -72,51 +79,8 @@ test.must_match(obj_ + 'test05' + _obj, " -c -y\nThis is a .ftn file.\n")
 test.must_match(obj_ + 'test06' + _obj, " -c -y\nThis is a .FTN file.\n")
 test.must_match(obj_ + 'test07' + _obj, " -c -y\nThis is a .fpp file.\n")
 test.must_match(obj_ + 'test08' + _obj, " -c -y\nThis is a .FPP file.\n")
-test.must_match(obj_ + 'test11' + _obj, " -c -x\nThis is a .f90 file.\n")
-test.must_match(obj_ + 'test12' + _obj, " -c -x\nThis is a .F90 file.\n")
-
-fc = 'f90'
-g90 = test.detect_tool(fc)
-
-if g90:
-
-    test.file_fixture('wrapper.py')
-
-    test.write('SConstruct', """
-foo = Environment(SHF90 = '%(fc)s')
-shf90 = foo.Dictionary('SHF90')
-bar = foo.Clone(SHF90 = r'%(_python_)s wrapper.py ' + shf90)
-bar.Append(SHF90FLAGS = '-Ix')
-foo.SharedLibrary(target = 'foo/foo', source = 'foo.f90')
-bar.SharedLibrary(target = 'bar/bar', source = 'bar.f90')
-""" % locals())
-
-    test.write('foo.f90', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f90'
-      STOP
-      END
-""")
-
-    test.write('bar.f90', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f90'
-      STOP
-      END
-""")
-
-
-    test.run(arguments = 'foo', stderr = None)
-
-    test.must_not_exist('wrapper.out')
-
-    import sys
-    if sys.platform[:5] == 'sunos':
-        test.run(arguments = 'bar', stderr = None)
-    else:
-        test.run(arguments = 'bar')
-
-    test.must_match('wrapper.out', "wrapper.py\n")
+test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f90 file.\n")
+test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F90 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF95FLAGS-live.py
+++ b/test/Fortran/SHF95FLAGS-live.py
@@ -25,7 +25,7 @@
 
 """
 Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+using a live compiler.
 """
 
 import sys
@@ -33,27 +33,56 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
-
 test = TestSCons.TestSCons()
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f95'
+if not test.detect_tool(fc):
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a f95 tool; skipping test.\n')
+
+test.subdir('x')
+test.write(['x', 'dummy.i'], """\
+# Exists only such that -Ix finds the directory...
+""")
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+# foo = Environment(SHF95='%(fc)s')
+foo = Environment()
+shf95 = foo.Dictionary('SHF95')
+bar = foo.Clone(SHF95=r'%(_python_)s wrapper.py ' + shf95)
+bar.Append(SHF95FLAGS='-Ix')
+foo.SharedLibrary(target='foo/foo', source='foo.f95')
+bar.SharedLibrary(target='bar/bar', source='bar.f95')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f95', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f95'
+      STOP
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f95', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f95'
+      STOP
+      END
+""")
+
+test.run(arguments='foo', stderr=None)
+test.must_not_exist('wrapper.out')
+
+if sys.platform.startswith('sunos'):
+    test.run(arguments='bar', stderr=None)
+else:
+    test.run(arguments='bar')
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHF95FLAGS.py
+++ b/test/Fortran/SHF95FLAGS.py
@@ -23,10 +23,16 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test handling of the dialect-specific FLAGS variable for shared objects,
+using a mocked compiler.
+"""
+
+import sys
+
 import TestSCons
 
 _python_ = TestSCons._python_
-
 _obj = TestSCons._shobj
 obj_ = TestSCons.shobj_
 
@@ -34,7 +40,8 @@ test = TestSCons.TestSCons()
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
 env = Environment(
     SHF95=r'%(_python_)s myfortran_flags.py g95',
     SHFORTRAN=r'%(_python_)s myfortran_flags.py fortran',
@@ -48,20 +55,20 @@ env.SharedObject(target='test05', source='test05.ftn')
 env.SharedObject(target='test06', source='test06.FTN')
 env.SharedObject(target='test07', source='test07.fpp')
 env.SharedObject(target='test08', source='test08.FPP')
-env.SharedObject(target='test13', source='test13.f95')
-env.SharedObject(target='test14', source='test14.F95')
+env.SharedObject(target='test09', source='test09.f95')
+env.SharedObject(target='test10', source='test10.F95')
 """ % locals())
 
-test.write('test01.f',   "This is a .f file.\n#fortran\n")
-test.write('test02.F',   "This is a .F file.\n#fortran\n")
+test.write('test01.f', "This is a .f file.\n#fortran\n")
+test.write('test02.F', "This is a .F file.\n#fortran\n")
 test.write('test03.for', "This is a .for file.\n#fortran\n")
 test.write('test04.FOR', "This is a .FOR file.\n#fortran\n")
 test.write('test05.ftn', "This is a .ftn file.\n#fortran\n")
 test.write('test06.FTN', "This is a .FTN file.\n#fortran\n")
 test.write('test07.fpp', "This is a .fpp file.\n#fortran\n")
 test.write('test08.FPP', "This is a .FPP file.\n#fortran\n")
-test.write('test13.f95', "This is a .f95 file.\n#g95\n")
-test.write('test14.F95', "This is a .F95 file.\n#g95\n")
+test.write('test09.f95', "This is a .f95 file.\n#g95\n")
+test.write('test10.F95', "This is a .F95 file.\n#g95\n")
 
 test.run(arguments='.', stderr=None)
 test.must_match(obj_ + 'test01' + _obj, " -c -y\nThis is a .f file.\n")
@@ -72,53 +79,8 @@ test.must_match(obj_ + 'test05' + _obj, " -c -y\nThis is a .ftn file.\n")
 test.must_match(obj_ + 'test06' + _obj, " -c -y\nThis is a .FTN file.\n")
 test.must_match(obj_ + 'test07' + _obj, " -c -y\nThis is a .fpp file.\n")
 test.must_match(obj_ + 'test08' + _obj, " -c -y\nThis is a .FPP file.\n")
-test.must_match(obj_ + 'test13' + _obj, " -c -x\nThis is a .f95 file.\n")
-test.must_match(obj_ + 'test14' + _obj, " -c -x\nThis is a .F95 file.\n")
-
-fc = 'f95'
-g95 = test.detect_tool(fc)
-if g95:
-    test.subdir('x')
-    test.write(['x','dummy.i'],
-"""
-# Exists only such that -Ix finds the directory...
-""")
-
-    # ref: test/fixture/wrapper.py
-    test.file_fixture('wrapper.py')
-    test.write('SConstruct', """
-foo = Environment(SHF95='%(fc)s')
-shf95 = foo.Dictionary('SHF95')
-bar = foo.Clone(SHF95=r'%(_python_)s wrapper.py ' + shf95)
-bar.Append(SHF95FLAGS='-Ix')
-foo.SharedLibrary(target='foo/foo', source='foo.f95')
-bar.SharedLibrary(target='bar/bar', source='bar.f95')
-""" % locals())
-
-    test.write('foo.f95', r"""
-      PROGRAM FOO
-      PRINT *,'foo.f95'
-      STOP
-      END
-""")
-
-    test.write('bar.f95', r"""
-      PROGRAM BAR
-      PRINT *,'bar.f95'
-      STOP
-      END
-""")
-
-    test.run(arguments='foo', stderr=None)
-    test.must_not_exist('wrapper.out')
-
-    import sys
-
-    if sys.platform.startswith('sunos'):
-        test.run(arguments='bar', stderr=None)
-    else:
-        test.run(arguments='bar')
-    test.must_match('wrapper.out', "wrapper.py\n")
+test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f95 file.\n")
+test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F95 file.\n")
 
 test.pass_test()
 

--- a/test/Fortran/SHFORTRANFLAGS-live.py
+++ b/test/Fortran/SHFORTRANFLAGS-live.py
@@ -25,7 +25,7 @@
 
 """
 Test handling of the dialect-specific FLAGS variable for shared objects,
-using a mocked compiler.
+using a live compiler.
 """
 
 import sys
@@ -33,27 +33,54 @@ import sys
 import TestSCons
 
 _python_ = TestSCons._python_
-_obj = TestSCons._shobj
-obj_ = TestSCons.shobj_
-
 test = TestSCons.TestSCons()
+
 # ref: test/Fortran/fixture/myfortran_flags.py
 test.file_fixture(['fixture', 'myfortran_flags.py'])
 
+fc = 'f77'
+if not test.detect_tool(fc):
+    fc = 'gfortran'
+    if not test.detect_tool(fc):
+        test.skip_test('Could not find a fortran tool; skipping test.\n')
+
+directory = 'x'
+test.subdir(directory)
+# ref: test/fixture/wrapper.py
+test.file_fixture('wrapper.py')
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
-env = Environment(SHF77=r'%(_python_)s myfortran_flags.py g77')
-env.Append(SHF77FLAGS='-x')
-env.SharedObject(target='test09', source='test09.f77')
-env.SharedObject(target='test10', source='test10.F77')
+# foo = Environment(SHFORTRAN='%(fc)s')
+foo = Environment()
+shfortran = foo.Dictionary('SHFORTRAN')
+bar = foo.Clone(SHFORTRAN=r'%(_python_)s wrapper.py ' + shfortran)
+bar.Append(SHFORTRANFLAGS='-I%(directory)s')
+foo.SharedLibrary(target='foo/foo', source='foo.f')
+bar.SharedLibrary(target='bar/bar', source='bar.f')
 """ % locals())
 
-test.write('test09.f77', "This is a .f77 file.\n#g77\n")
-test.write('test10.F77', "This is a .F77 file.\n#g77\n")
+test.write('foo.f', r"""
+      PROGRAM FOO
+      PRINT *,'foo.f'
+      STOP
+      END
+""")
 
-test.run(arguments='.', stderr=None)
-test.must_match(obj_ + 'test09' + _obj, " -c -x\nThis is a .f77 file.\n")
-test.must_match(obj_ + 'test10' + _obj, " -c -x\nThis is a .F77 file.\n")
+test.write('bar.f', r"""
+      PROGRAM BAR
+      PRINT *,'bar.f'
+      STOP
+      END
+""")
+
+test.run(arguments='foo', stderr=None)
+test.must_not_exist('wrapper.out')
+
+if sys.platform[:5] == 'sunos':
+    test.run(arguments='bar', stderr=None)
+else:
+    test.run(arguments='bar')
+test.must_match('wrapper.out', "wrapper.py\n")
 
 test.pass_test()
 


### PR DESCRIPTION
Tests formerly containing both are split into a flags-handling-only section using a mocked tool, and a live section using a real compiler, in a new file. General cleanup. Added shared-object-flags tests for two dialects that didn't have one.

Test-only changes, so no doc impacts.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
