### PR TITLE
Clean up the C/C++ compiler variable tests

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -61,8 +61,13 @@ DOCUMENTATION
 DEVELOPMENT
 -----------
 
+- List visible changes in the way SCons is developed
+
 - runtest.py once again finds "external" tests, such as the tests for
   tools in scons-contrib. An earlier rework had broken this.  Fixes #4699.
+
+- Clean up C and C++ FLAGS tests. Tests which use a real compiler
+  are now more clearly distinguished (-live.py suffix and docstring).
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/test/CXX/CXX.py
+++ b/test/CXX/CXX.py
@@ -23,6 +23,10 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Test the C++ compiler name variable $CXX, calling a mocked compiler.
+"""
+
 import sys
 import TestSCons
 
@@ -34,19 +38,21 @@ test = TestSCons.TestSCons()
 test.file_fixture('mylink.py')
 test.dir_fixture('CXX-fixture')
 
-test.write('SConstruct', """
+test.write('SConstruct', f"""\
+DefaultEnvironment(tools=[])
 env = Environment(
-    LINK=r'%(_python_)s mylink.py',
+    LINK=r'{_python_} mylink.py',
     LINKFLAGS=[],
-    CXX=r'%(_python_)s myc++.py',
+    CXX=r'{_python_} myc++.py',
     CXXFLAGS=[],
 )
+
 env.Program(target='test1', source='test1.cc')
 env.Program(target='test2', source='test2.cpp')
 env.Program(target='test3', source='test3.cxx')
 env.Program(target='test4', source='test4.c++')
 env.Program(target='test5', source='test5.C++')
-""" % locals())
+""")
 
 test.write('test1.cc', r"""This is a .cc file.
 /*c++*/
@@ -73,79 +79,33 @@ test.write('test5.C++', r"""This is a .C++ file.
 #link
 """)
 
-test.run(arguments = '.', stderr = None)
-
+test.run(arguments='.', stderr=None)
 test.must_match('test1' + _exe, "This is a .cc file.\n", mode='r')
-
 test.must_match('test2' + _exe, "This is a .cpp file.\n", mode='r')
-
 test.must_match('test3' + _exe, "This is a .cxx file.\n", mode='r')
-
 test.must_match('test4' + _exe, "This is a .c++ file.\n", mode='r')
-
 test.must_match('test5' + _exe, "This is a .C++ file.\n", mode='r')
 
 if TestSCons.case_sensitive_suffixes('.c', '.C'):
-    test.write('SConstruct', """
+    test.write('SConstruct2', f"""\
+DefaultEnvironment(tools=[])
 env = Environment(
-    LINK=r'%(_python_)s mylink.py',
+    LINK=r'{_python_} mylink.py',
     LINKFLAGS=[],
-    CXX=r'%(_python_)s myc++.py',
+    CXX=r'{_python_} myc++.py',
     CXXFLAGS=[],
 )
+
 env.Program(target='test6', source='test6.C')
-""" % locals())
+""")
 
     test.write('test6.C', r"""This is a .C file.
 /*c++*/
 #link
 """)
 
-    test.run(arguments = '.', stderr = None)
+    test.run(arguments=['-f', 'SConstruct2', '.'], stderr=None)
     test.must_match('test6' + _exe, "This is a .C file.\n", mode='r')
-
-test.file_fixture('wrapper.py')
-
-test.write('SConstruct', """
-foo = Environment()
-cxx = foo.Dictionary('CXX')
-bar = Environment(CXX=r'%(_python_)s wrapper.py ' + cxx)
-foo.Program(target='foo', source='foo.cxx')
-bar.Program(target='bar', source='bar.cxx')
-""" % locals())
-
-test.write('foo.cxx', r"""
-#include <stdio.h>
-#include <stdlib.h>
-int
-main(int argc, char *argv[])
-{
-        argv[argc++] = (char *)"--";
-        printf("foo.cxx\n");
-        exit (0);
-}
-""")
-
-test.write('bar.cxx', r"""
-#include <stdio.h>
-#include <stdlib.h>
-int
-main(int argc, char *argv[])
-{
-        argv[argc++] = (char *)"--";
-        printf("foo.cxx\n");
-        exit (0);
-}
-""")
-
-
-test.run(arguments = 'foo' + _exe)
-
-test.must_not_exist(test.workpath('wrapper.out'))
-
-test.run(arguments = 'bar' + _exe)
-
-test.must_match('wrapper.out', "wrapper.py\n", mode='r')
 
 test.pass_test()
 


### PR DESCRIPTION
Tests now don't combine flags-only cases (don't use a real compiler) with live cases (do require a compiler) in the same test file.

This differs from #4693 as that one worked on `*FLAGS` variables, this one works on the variables naming the compilers (`CC`, `CXX` and shared-lib variants).

This is a test-only change, no doc impacts.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
