### PR TITLE
Fix tests for use with Python 3.14

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - runtest.py once again finds "external" tests, such as the tests for
       tools in scons-contrib. An earlier rework had broken this.  Fixes #4699.
     - Clarify how pre/post actions on an alias work.
+    - Fix a couple of unit tests to not fail with Python 3.14. These involve
+      bytecode and error message contents, and there was no problem with
+      SCons itself using 3.14 in its current (just-before-freeze) state.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -64,6 +64,10 @@ DEVELOPMENT
 - runtest.py once again finds "external" tests, such as the tests for
   tools in scons-contrib. An earlier rework had broken this.  Fixes #4699.
 
+- Fix a couple of unit tests to not fail with Python 3.14. These involve
+  expectations for bytecode and error message contents; there was no problem
+  with SCons itself using 3.14 in its current (just-before-freeze) state.
+
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================
 .. code-block:: text

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -1552,6 +1552,7 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
+            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
         }
 
         meth_matches = [
@@ -1732,6 +1733,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
+            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
 
         }
 
@@ -1743,6 +1745,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'1, 1, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'1, 1, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'1, 1, 0, 0,(),(),(\x95\x00g\x00),(),()'),
+            (3, 14): bytearray(b'1, 1, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
         }
 
         def factory(act, **kw):
@@ -1983,6 +1986,7 @@ class LazyActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
+            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
         }
 
         meth_matches = [
@@ -2045,6 +2049,7 @@ class ActionCallerTestCase(unittest.TestCase):
             (3, 11): b'\x97\x00d\x00S\x00',
             (3, 12): b'\x97\x00y\x00',
             (3, 13): b'\x95\x00g\x00',
+            (3, 14): b'\x80\x00P\x00"\x00',
         }
 
         with self.subTest():
@@ -2250,6 +2255,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 11): (bytearray(b'3, 3, 0, 0,(),(),(\x97\x00|\x00S\x00),(),()'),),
             (3, 12): (bytearray(b'3, 3, 0, 0,(),(),(\x97\x00|\x00S\x00),(),()'),),
             (3, 13): (bytearray(b'3, 3, 0, 0,(),(),(\x95\x00U\x00$\x00),(),()'),),
+            (3, 14): (bytearray(b'3, 3, 0, 0,(),(),(\x80\x00R\x00"\x00),(),()'),),
         }
 
         c = SCons.Action._function_contents(func1)
@@ -2288,9 +2294,13 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 13): bytearray(
                 b"{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x95\x00S\x01U\x00l\x00\x00\x00\x00\x00\x00\x00\x00\x00S\x02U\x00l\x01\x00\x00\x00\x00\x00\x00\x00\x00g\x00),(),(),2, 2, 0, 0,(),(),(\x95\x00g\x00),(),()}}{{{a=a,b=b}}}"
             ),
+            (3, 14): bytearray(
+                b'{TestClass:__main__}[[[(<class \'object\'>, ()), [(<class \'__main__.TestClass\'>, (<class \'object\'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x80\x00P\x00R\x00j\x00\x00\x00\x00\x00\x00\x00\x00\x00P\x01R\x00j\x01\x00\x00\x00\x00\x00\x00\x00\x00P\x02"\x00),(),(),2, 2, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()}}{{{a=a,b=b}}}'
+            ),
         }
 
-        self.assertEqual(c, expected[sys.version_info[:2]])
+        # self.assertEqual(c, expected[sys.version_info[:2]])
+        assert c == expected[sys.version_info[:2]], c
 
     def test_code_contents(self) -> None:
         """Test that Action._code_contents works"""
@@ -2320,6 +2330,9 @@ class ObjectContentsTestCase(unittest.TestCase):
             ),
             (3, 13): bytearray(
                 b'0, 0, 0, 0,(Hello, World!),(print),(\x95\x00\\\x00"\x00S\x005\x01\x00\x00\x00\x00\x00\x00 \x00g\x01)'
+            ),
+            (3, 14): bytearray(
+                b'0, 0, 0, 0,(Hello, World!),(print),(\x80\x00Y\x00 \x00P\x002\x01\x00\x00\x00\x00\x00\x00\x1e\x00P\x01"\x00)'
             ),
         }
 

--- a/SCons/Taskmaster/TaskmasterTests.py
+++ b/SCons/Taskmaster/TaskmasterTests.py
@@ -1161,6 +1161,7 @@ class TaskmasterTestCase(unittest.TestCase):
             "integer division or modulo",
             "integer division or modulo by zero",
             "integer division by zero",  # PyPy2
+            "division by zero",  # Python 3.14+
         ]
         assert str(exc_value) in exception_values, exc_value
 


### PR DESCRIPTION
As with every Python release, a few tests have to be fiddled to work with that release. `SCons/ActionTests` is always one of those, as it has dictionaries mapping (major, minor) version to corresponding bytecode strings. The only other outstanding one this go-round was an expected exception message for a divide-by-zero, which has changed slightly again. 3.14 is very close to feature freeze, so hopefully there won't be any further.

No changes to SCons itself, or to documentation.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
