### PR TITLE
Fix some minor docstring Sphinx complaints

### DIFF
--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -649,7 +649,7 @@ class SubstitutionEnvironment:
            args - filename strings or nodes to convert; nodes are just
               added to the list without further processing.
            node_factory - optional factory to create the nodes; if not
-              specified, will use this environment's ``fs.File method.
+              specified, will use this environment's ``fs.File`` method.
            lookup_list - optional list of lookup functions to call to
               attempt to find the file referenced by each *args*.
            kw - keyword arguments that represent additional nodes to add.
@@ -1755,8 +1755,8 @@ class Base(SubstitutionEnvironment):
         (pretty-print) or ``<<non-serializable: function>>`` (JSON).
 
         Args:
-           key: if omitted, format the whole dict of variables,
-              else format *key*(s) with the corresponding values.
+           key: variables to format together with their values.
+             If omitted, format the whole dict of variables,
            format: specify the format to serialize to. ``"pretty"`` generates
              a pretty-printed string, ``"json"`` a JSON-formatted string.
 

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -528,7 +528,7 @@ def AddOption(*args, **kw) -> SConsOption:
     """Add a local option to the option parser - Public API.
 
     If the SCons-specific *settable* kwarg is true (default ``False``),
-    the option will allow calling :func:``SetOption`.
+    the option will allow calling :func:`SetOption`.
 
     .. versionchanged:: 4.8.0
        The *settable* parameter added to allow including the new option

--- a/SCons/Variables/ListVariable.py
+++ b/SCons/Variables/ListVariable.py
@@ -25,8 +25,8 @@
 
 A list variable allows selecting one or more from a supplied set of
 allowable values, as well as from an optional mapping of alternate names
-(such as aliases and abbreviations) and the special names ``'all'`` and
-``'none'``.  Specified values are converted during processing into values
+(such as aliases and abbreviations) and the special names "all" and
+"none".  Specified values are converted during processing into values
 only from the allowable values set.
 
 Usage example::
@@ -123,7 +123,7 @@ def _converter(val, allowedElems, mapdict) -> _ListVariable:
     for a :class:`Variables` converter: the lambda in the
     :func:`ListVariable` function arranges for us to be called correctly.
 
-    Incoming values ``all`` and ``none`` are recognized and converted
+    Incoming values "all" and "none" are recognized and converted
     into their expanded form.
     """
     if val == 'none':
@@ -189,8 +189,8 @@ def ListVariable(
     """Return a tuple describing a list variable.
 
     A List Variable is an abstraction that allows choosing one or more
-    values from a provided list of possibilities (*names). The special terms
-    ``all`` and ``none`` are also provided to help make the selection.
+    values from a provided list of possibilities (*names*). The special terms
+    "all" and "none" are also provided to help make the selection.
 
     Arguments:
        key: the name of the list variable.
@@ -198,14 +198,14 @@ def ListVariable(
           the allowed values (not including any extra names from *map*).
        default: the default value(s) for the list variable. Can be given
           as string (use commas to -separated multiple values), or as a list
-          of strings.  ``all`` or ``none`` are allowed as *default*.
-          A must-specify ListVariable can be simulated by giving a value
+          of strings.  "all" or "none" are allowed as *default*.
+          A must-specify list variable can be simulated by giving a value
           that is not part of *names*, which will cause validation to fail
-          if the variable is not given in the input sources.
+          if the variable is not supplied in the input sources.
        names: the values to choose from. Must be a list of strings.
        map: optional dictionary to map alternative names to the ones in
-          *names*, providing a form of alias. The converter will make
-          the replacement, names from *map* are not stored and will
+          *names*, providing a form of alias. The converter will perform
+          the replacement. Names from *map* are not stored, and will
           not appear in the help message.
        validator: optional callback to validate supplied values.
           The default validator is used if not specified.


### PR DESCRIPTION
These had to do with start-and-end markup pairs.


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
