### PR TITLE
Fix for vcpkg run time issue in windows runner

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,18 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From John Doe:
     - Whatever John Doe did.
 
+  From Joseph Brill:
+    - The default Windows powershell 7 path is added before the default
+      Windows powershell 5 path in the limited environment in which the
+      MSVC batch files are run.  This appears to fix a runtime issue in
+      the windows runner environment when the embedded Visual Studio vcpkg
+      component initializes without a PSModulePath defined. The OS
+      environment variables and values for VCPKG_DISABLE_METRICS and
+      VCPKG_ROOT are added to the limited MSVC environment when defined.
+      At present, the VCPKG_DISABLE_METRICS and VCPKG_ROOT variables and
+      values are not propagated to the SCons environment after running
+      the MSVC batch files.
+
   From Bill Prendergast:
     - Fixed SCons.Variables.PackageVariable to correctly test the default
       setting against both enable & disable strings. (Fixes #4702)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,11 +16,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Whatever John Doe did.
 
   From Joseph Brill:
-    - The default Windows powershell 7 path is added before the default
-      Windows powershell 5 path in the limited environment in which the
-      MSVC batch files are run.  This appears to fix a runtime issue in
-      the windows runner environment when the embedded Visual Studio vcpkg
-      component initializes without a PSModulePath defined. The OS
+    - MSVS: Fix a significant MSVC/MSVC tool initialization slowdown when
+      vcpkg has been installed and the PSModulePath is not initialized
+      or propagated from the user's shell environment. To resolve this
+      The default Windows Powershell 7 path is added before the default
+      Windows Powershell 5 path in the carefully constructed
+      environment in which the MSVC batch files are run.   The shell
       environment variables and values for VCPKG_DISABLE_METRICS and
       VCPKG_ROOT are added to the limited MSVC environment when defined.
       At present, the VCPKG_DISABLE_METRICS and VCPKG_ROOT variables and

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -35,7 +35,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   one from PEP 308 introduced in Python 2.5 (2006). The idiom being
   replaced (using and/or) is regarded as error prone.
 
-- The default Windows powershell 7 path is added before the default
+- MSVS: The default Windows powershell 7 path is added before the default
   Windows powershell 5 path in the limited environment in which the
   MSVC batch files are run.
 
@@ -44,6 +44,8 @@ FIXES
 
 - Fixed SCons.Variables.PackageVariable to correctly test the default
   setting against both enable & disable strings. (Fixes #4702)
+- MSVS: Fix significant slowdown initializing MSVC tools when vcpkg has
+  been installed on the system.
 
 IMPROVEMENTS
 ------------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -35,6 +35,10 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   one from PEP 308 introduced in Python 2.5 (2006). The idiom being
   replaced (using and/or) is regarded as error prone.
 
+- The default Windows powershell 7 path is added before the default
+  Windows powershell 5 path in the limited environment in which the
+  MSVC batch files are run.
+
 FIXES
 -----
 

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -354,7 +354,6 @@ def normalize_env(env, keys, force: bool=False):
     if progfiles_ps_dir not in normenv["PATH"]:
         normenv["PATH"] = normenv["PATH"] + os.pathsep + progfiles_ps_dir
 
-    # Powershell 5
     # Without Powershell in PATH, an internal call to a telemetry
     # function (starting with a VS2019 update) can fail
     # Note can also set VSCMD_SKIP_SENDTELEMETRY to avoid this.
@@ -362,19 +361,7 @@ def normalize_env(env, keys, force: bool=False):
     if sys32_ps_dir not in normenv['PATH']:
         normenv['PATH'] = normenv['PATH'] + os.pathsep + sys32_ps_dir
 
-    psmodulepath_dirs = [
-        # Powershell 7 paths
-        os.path.join(progfiles_dir, r"PowerShell\Modules"),
-        os.path.join(progfiles_dir, r"PowerShell\7\Modules"),
-        # Powershell 5 paths
-        os.path.join(progfiles_dir, r"WindowsPowerShell\Modules"),
-        os.path.join(sys32_dir, r"WindowsPowerShell\v1.0\Modules"),
-    ]
-
-    normenv["PSModulePath"] = os.pathsep.join(psmodulepath_dirs)
-
     debug("PATH: %s", normenv['PATH'])
-    debug("PSModulePath: %s", normenv['PSModulePath'])
     return normenv
 
 
@@ -411,11 +398,11 @@ def get_output(vcbat, args=None, env=None, skip_sendtelemetry=False):
         'VS71COMNTOOLS',
         'VSCOMNTOOLS',
         'MSDevDir',
-        'VCPKG_DISABLE_METRICS',
-        'VCPKG_ROOT',
         'VSCMD_DEBUG',   # enable logging and other debug aids
         'VSCMD_SKIP_SENDTELEMETRY',
         'windir', # windows directory (SystemRoot not available in 95/98/ME)
+        'VCPKG_DISABLE_METRICS',
+        'VCPKG_ROOT',
     ]
     env['ENV'] = normalize_env(env['ENV'], vs_vc_vars, force=False)
 

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -325,6 +325,9 @@ def normalize_env(env, keys, force: bool=False):
         for k in keys:
             if k in os.environ and (force or k not in normenv):
                 normenv[k] = os.environ[k]
+                debug("keys: normenv[%s]=%s", k, normenv[k])
+            else:
+                debug("keys: skipped[%s]", k)
 
     # add some things to PATH to prevent problems:
     # Shouldn't be necessary to add system32, since the default environment
@@ -376,7 +379,7 @@ def normalize_env(env, keys, force: bool=False):
 # control execution in interesting ways.
 # Note these really should be unified - either controlled by vs.py,
 # or synced with the the common_tools_var # settings in vs.py.
-_VS_VC_VARS = [
+VS_VC_VARS = [
     'COMSPEC',  # path to "shell"
     'OS', # name of OS family: Windows_NT or undefined (95/98/ME)
     'VS170COMNTOOLS',  # path to common tools for given version
@@ -405,7 +408,7 @@ def get_output(vcbat, args=None, env=None, skip_sendtelemetry=False):
         # Create a blank environment, for use in launching the tools
         env = SCons.Environment.Environment(tools=[])
 
-    env['ENV'] = normalize_env(env['ENV'], _VS_VC_VARS, force=False)
+    env['ENV'] = normalize_env(env['ENV'], VS_VC_VARS, force=False)
 
     if skip_sendtelemetry:
         _force_vscmd_skip_sendtelemetry(env)

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -350,7 +350,7 @@ def normalize_env(env, keys, force: bool=False):
         progfiles_dir = os.path.join(sysroot_path, "Program Files")
 
     # Powershell 7
-    progfiles_ps_dir = os.path.join(progfiles_dir, r"PowerShell\7")
+    progfiles_ps_dir = os.path.join(progfiles_dir, "PowerShell", "7")
     if progfiles_ps_dir not in normenv["PATH"]:
         normenv["PATH"] = normenv["PATH"] + os.pathsep + progfiles_ps_dir
 
@@ -365,6 +365,39 @@ def normalize_env(env, keys, force: bool=False):
     return normenv
 
 
+# TODO:  Hard-coded list of the variables that (may) need to be
+# imported from os.environ[] for the chain of development batch
+# files to execute correctly. One call to vcvars*.bat may
+# end up running a dozen or more scripts, changes not only with
+# each release but with what is installed at the time. We think
+# in modern installations most are set along the way and don't
+# need to be picked from the env, but include these for safety's sake.
+# Any VSCMD variables definitely are picked from the env and
+# control execution in interesting ways.
+# Note these really should be unified - either controlled by vs.py,
+# or synced with the the common_tools_var # settings in vs.py.
+_VS_VC_VARS = [
+    'COMSPEC',  # path to "shell"
+    'OS', # name of OS family: Windows_NT or undefined (95/98/ME)
+    'VS170COMNTOOLS',  # path to common tools for given version
+    'VS160COMNTOOLS',
+    'VS150COMNTOOLS',
+    'VS140COMNTOOLS',
+    'VS120COMNTOOLS',
+    'VS110COMNTOOLS',
+    'VS100COMNTOOLS',
+    'VS90COMNTOOLS',
+    'VS80COMNTOOLS',
+    'VS71COMNTOOLS',
+    'VSCOMNTOOLS',
+    'MSDevDir',
+    'VSCMD_DEBUG',   # enable logging and other debug aids
+    'VSCMD_SKIP_SENDTELEMETRY',
+    'windir', # windows directory (SystemRoot not available in 95/98/ME)
+    'VCPKG_DISABLE_METRICS',
+    'VCPKG_ROOT',
+]
+
 def get_output(vcbat, args=None, env=None, skip_sendtelemetry=False):
     """Parse the output of given bat file, with given args."""
 
@@ -372,39 +405,7 @@ def get_output(vcbat, args=None, env=None, skip_sendtelemetry=False):
         # Create a blank environment, for use in launching the tools
         env = SCons.Environment.Environment(tools=[])
 
-    # TODO:  Hard-coded list of the variables that (may) need to be
-    # imported from os.environ[] for the chain of development batch
-    # files to execute correctly. One call to vcvars*.bat may
-    # end up running a dozen or more scripts, changes not only with
-    # each release but with what is installed at the time. We think
-    # in modern installations most are set along the way and don't
-    # need to be picked from the env, but include these for safety's sake.
-    # Any VSCMD variables definitely are picked from the env and
-    # control execution in interesting ways.
-    # Note these really should be unified - either controlled by vs.py,
-    # or synced with the the common_tools_var # settings in vs.py.
-    vs_vc_vars = [
-        'COMSPEC',  # path to "shell"
-        'OS', # name of OS family: Windows_NT or undefined (95/98/ME)
-        'VS170COMNTOOLS',  # path to common tools for given version
-        'VS160COMNTOOLS',
-        'VS150COMNTOOLS',
-        'VS140COMNTOOLS',
-        'VS120COMNTOOLS',
-        'VS110COMNTOOLS',
-        'VS100COMNTOOLS',
-        'VS90COMNTOOLS',
-        'VS80COMNTOOLS',
-        'VS71COMNTOOLS',
-        'VSCOMNTOOLS',
-        'MSDevDir',
-        'VSCMD_DEBUG',   # enable logging and other debug aids
-        'VSCMD_SKIP_SENDTELEMETRY',
-        'windir', # windows directory (SystemRoot not available in 95/98/ME)
-        'VCPKG_DISABLE_METRICS',
-        'VCPKG_ROOT',
-    ]
-    env['ENV'] = normalize_env(env['ENV'], vs_vc_vars, force=False)
+    env['ENV'] = normalize_env(env['ENV'], _VS_VC_VARS, force=False)
 
     if skip_sendtelemetry:
         _force_vscmd_skip_sendtelemetry(env)

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -38,6 +38,40 @@ import SCons.Errors
 import SCons.Util
 import SCons.Warnings
 
+
+# TODO:  Hard-coded list of the variables that (may) need to be
+# imported from os.environ[] for the chain of development batch
+# files to execute correctly. One call to vcvars*.bat may
+# end up running a dozen or more scripts, changes not only with
+# each release but with what is installed at the time. We think
+# in modern installations most are set along the way and don't
+# need to be picked from the env, but include these for safety's sake.
+# Any VSCMD variables definitely are picked from the env and
+# control execution in interesting ways.
+# Note these really should be unified - either controlled by vs.py,
+# or synced with the the common_tools_var # settings in vs.py.
+VS_VC_VARS = [
+    'COMSPEC',  # path to "shell"
+    'OS', # name of OS family: Windows_NT or undefined (95/98/ME)
+    'VS170COMNTOOLS',  # path to common tools for given version
+    'VS160COMNTOOLS',
+    'VS150COMNTOOLS',
+    'VS140COMNTOOLS',
+    'VS120COMNTOOLS',
+    'VS110COMNTOOLS',
+    'VS100COMNTOOLS',
+    'VS90COMNTOOLS',
+    'VS80COMNTOOLS',
+    'VS71COMNTOOLS',
+    'VSCOMNTOOLS',
+    'MSDevDir',
+    'VSCMD_DEBUG',   # enable logging and other debug aids
+    'VSCMD_SKIP_SENDTELEMETRY',
+    'windir', # windows directory (SystemRoot not available in 95/98/ME)
+    'VCPKG_DISABLE_METRICS',
+    'VCPKG_ROOT',
+]
+
 class MSVCCacheInvalidWarning(SCons.Warnings.WarningOnByDefault):
     pass
 
@@ -368,38 +402,7 @@ def normalize_env(env, keys, force: bool=False):
     return normenv
 
 
-# TODO:  Hard-coded list of the variables that (may) need to be
-# imported from os.environ[] for the chain of development batch
-# files to execute correctly. One call to vcvars*.bat may
-# end up running a dozen or more scripts, changes not only with
-# each release but with what is installed at the time. We think
-# in modern installations most are set along the way and don't
-# need to be picked from the env, but include these for safety's sake.
-# Any VSCMD variables definitely are picked from the env and
-# control execution in interesting ways.
-# Note these really should be unified - either controlled by vs.py,
-# or synced with the the common_tools_var # settings in vs.py.
-VS_VC_VARS = [
-    'COMSPEC',  # path to "shell"
-    'OS', # name of OS family: Windows_NT or undefined (95/98/ME)
-    'VS170COMNTOOLS',  # path to common tools for given version
-    'VS160COMNTOOLS',
-    'VS150COMNTOOLS',
-    'VS140COMNTOOLS',
-    'VS120COMNTOOLS',
-    'VS110COMNTOOLS',
-    'VS100COMNTOOLS',
-    'VS90COMNTOOLS',
-    'VS80COMNTOOLS',
-    'VS71COMNTOOLS',
-    'VSCOMNTOOLS',
-    'MSDevDir',
-    'VSCMD_DEBUG',   # enable logging and other debug aids
-    'VSCMD_SKIP_SENDTELEMETRY',
-    'windir', # windows directory (SystemRoot not available in 95/98/ME)
-    'VCPKG_DISABLE_METRICS',
-    'VCPKG_ROOT',
-]
+
 
 def get_output(vcbat, args=None, env=None, skip_sendtelemetry=False):
     """Parse the output of given bat file, with given args."""

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -480,6 +480,7 @@ def parse_output(output, keep=KEEPLIST):
                 # it.
                 path = path.strip('"')
                 dkeep[key].append(str(path))
+                debug("dkeep[%s].append(%r)", key, path)
 
     for line in output.splitlines():
         for k, value in rdk.items():

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -362,11 +362,6 @@ def normalize_env(env, keys, force: bool=False):
     if sys32_ps_dir not in normenv['PATH']:
         normenv['PATH'] = normenv['PATH'] + os.pathsep + sys32_ps_dir
 
-    debug("PATH: %s", normenv['PATH'])
-
-    if sys32_dir not in normenv["PATH"]:
-        normenv["PATH"] = normenv["PATH"] + os.pathsep + sys32_dir
-
     psmodulepath_dirs = [
         # Powershell 7 paths
         os.path.join(progfiles_dir, r"PowerShell\Modules"),
@@ -378,6 +373,7 @@ def normalize_env(env, keys, force: bool=False):
 
     normenv["PSModulePath"] = os.pathsep.join(psmodulepath_dirs)
 
+    debug("PATH: %s", normenv['PATH'])
     debug("PSModulePath: %s", normenv['PSModulePath'])
     return normenv
 


### PR DESCRIPTION
Fix for vcpkg run time in windows runner (VS2022 Enterprise).

Changes to msvc batch file invocation environment:
* Add Powershell 7 to PATH
* Import VCPKG_DISABLE_METRICS if defined
* Import VCPKG_ROOT if defined

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
