### PR TITLE
Add manpage `.1` files to doc tarball

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -46,6 +46,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       interesting to developers working on SCons (needed to write docs),
       even if not part of "The SCons API" itself.
       Reworded the API Docs intro sectios a bit.
+    - Include the roff (.1) manpages in the scons-doc tarball as a better
+      long-term home than in the sdist.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,6 +53,13 @@ PACKAGING
 
 - List changes in the way SCons is packaged and/or released
 
+- The generated roff (.1) manpages are now included in the
+  scons-doc tarball that is built at part of the release process,
+  in addition to the html and txt versions. For distribution
+  packaging, the manpages can be extracted from here (downloadable
+  from https://scons.org/doc/ using a a version-specific URL,
+  e.g. https://scons.org/doc/4.9.1/scons-doc-4.9.1.tar.gz).
+
 DOCUMENTATION
 -------------
 

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -582,6 +582,9 @@ else:
 
         if 'man' in targets:
             for m in man_page_list:
+                manpage = os.path.join(build, 'man', m)
+                tar_deps.append(manpage)
+                tar_list.append(manpage)
                 man, _1 = os.path.splitext(m)
 
                 pdf = os.path.join(build, 'PDF', f'{man}-man.pdf')


### PR DESCRIPTION
The three generated roff-style (.1) manpages are included in the `scons-doc` tarball which is generated at release time and uploaded to `scons.org/doc`. This provides a more natural place to grab them from if someone wants to download this tarball (its existence is not currently advertised, though one distro packager is known to use id; normally it is used to populate the documenations matrix for each version.

No scons changes involved, and not user-visible, since you have to grab the tarball explicitly.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
