### PR TITLE
Update virtualenv platform, tests, docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -48,6 +48,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Reworded the API Docs intro sectios a bit.
     - Include the roff (.1) manpages in the scons-doc tarball as a better
       long-term home than in the sdist.
+    - Virtualenv support module modernized: previously looked first for an
+      obsolete mechanism the external virtualenv tool used to use, now checks
+      first for the official approach introduced in PEP 405.
+    - Add missing manpage entry for Virtualenv(). Return type is documented
+      as an empty string in case of a negative result (rather than None),
+      and the code adjusted.  All internal usage, including tests,
+      was dont boolean-style anyway ("if Virtualenv():").
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -48,6 +48,11 @@ IMPROVEMENTS
   documentation:  performance improvements (describe the circumstances
   under which they would be observed), or major code cleanups
 
+- Virtualenv support module modernized: previously looked first for an
+  unofficial approach from before venv support was made part of Python
+  in 3.3; now looks for the official approach first. This in an internal
+  detail, the API is unchanged.
+
 PACKAGING
 ---------
 
@@ -75,6 +80,11 @@ DOCUMENTATION
   SConsDoc and SConsExample are now included - their API is
   interesting to developers working on SCons (needed to write docs),
   even if not part of "The SCons API" itself.
+
+- Missing documentation for the Virtualen() function is added.
+  Note that the User Guide previously described a negative outcomee
+  as returning None.  It is now explicit that the path is returned if
+  running in a virtualenv, and an empty (falsy) string if not.
 
 DEVELOPMENT
 -----------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -81,8 +81,8 @@ DOCUMENTATION
   interesting to developers working on SCons (needed to write docs),
   even if not part of "The SCons API" itself.
 
-- Missing documentation for the Virtualen() function is added.
-  Note that the User Guide previously described a negative outcomee
+- Missing documentation for the Virtualenv() function is added.
+  Note that the User Guide previously described a negative outcome
   as returning None.  It is now explicit that the path is returned if
   running in a virtualenv, and an empty (falsy) string if not.
 

--- a/SCons/Platform/virtualenv.py
+++ b/SCons/Platform/virtualenv.py
@@ -107,15 +107,15 @@ def ImportVirtualenv(env) -> None:
     _inject_venv_path(env)
 
 
-def Virtualenv() -> str | None:
+def Virtualenv() -> str:
     """Return whether operating in a virtualenv.
 
     Returns the path to the virtualenv home if scons is executing
-    within a virtualenv, else ``None``.
+    within a virtualenv, else and empty string.
     """
     if _running_in_virtualenv():
         return sys.prefix
-    return None
+    return ""
 
 
 def IsInVirtualenv(path: str) -> bool:

--- a/SCons/Platform/virtualenv.py
+++ b/SCons/Platform/virtualenv.py
@@ -26,6 +26,8 @@
 This is support code, not a loadable Platform module.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import SCons.Util

--- a/SCons/Platform/virtualenv.xml
+++ b/SCons/Platform/virtualenv.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+SPDX-FileCopyrightText: Copyright The SCons Foundation (https://scons.org)
+SPDX-License-Identifier: MIT
+SPDX-FileType: DOCUMENTATION
+
+This file is processed by the bin/SConsDoc.py module.
+-->
+
+<!DOCTYPE sconsdoc [
+<!ENTITY % scons SYSTEM '../../doc/scons.mod'>
+%scons;
+<!ENTITY % builders-mod SYSTEM '../../doc/generated/builders.mod'>
+%builders-mod;
+<!ENTITY % functions-mod SYSTEM '../../doc/generated/functions.mod'>
+%functions-mod;
+<!ENTITY % tools-mod SYSTEM '../../doc/generated/tools.mod'>
+%tools-mod;
+<!ENTITY % variables-mod SYSTEM '../../doc/generated/variables.mod'>
+%variables-mod;
+]>
+
+<sconsdoc xmlns="http://www.scons.org/dbxsd/v1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
+<scons_function name="Virtualenv">
+<arguments signature="global">()</arguments>
+<summary>
+<para>
+If the &SCons; process is running inside a &Python;
+virtual environment,
+return the path to the directory where that environment is stored.
+Otherwise, return <literal>None</literal>.
+</para>
+</summary>
+</scons_function>
+
+</sconsdoc>

--- a/SCons/Platform/virtualenv.xml
+++ b/SCons/Platform/virtualenv.xml
@@ -30,8 +30,9 @@ This file is processed by the bin/SConsDoc.py module.
 <para>
 If the &SCons; process is running inside a &Python;
 virtual environment,
-return the path to the directory where that environment is stored.
-Otherwise, return <literal>None</literal>.
+return the path to the directory where that environment is stored,
+else an empty string.
+The result can be treated as a boolean value if the path is unneeded.
 </para>
 </summary>
 </scons_function>

--- a/SCons/Platform/virtualenvTests.py
+++ b/SCons/Platform/virtualenvTests.py
@@ -262,23 +262,25 @@ class _inject_venv_pathTestCase(unittest.TestCase):
 
 
 class VirtualenvTestCase(unittest.TestCase):
-    def test_none(self) -> None:
+    """Test the Virtualenv() function."""
+
+    def test_no_venv(self) -> None:
         def _msg(given) -> str:
-            return f"Virtualenv() should be None, not {given!r}"
+            return f"Virtualenv() should be empty, not {given!r}"
 
         with self.subTest(), SysPrefixes(_p('/prefix')):
             ve = SCons.Platform.virtualenv.Virtualenv()
-            assert ve is None, _msg(ve)
+            self.assertEqual(ve, "", msg=_msg(ve))
 
         with self.subTest(), SysPrefixes(
             _p('/base/prefix'), base_prefix=_p('/base/prefix')
         ):
             ve = SCons.Platform.virtualenv.Virtualenv()
-            assert ve is None, _msg(ve)
+            self.assertEqual(ve, "", msg=_msg(ve))
 
-    def test_not_none(self) -> None:
+    def test_virtualenv(self) -> None:
         def _msg(expected, given) -> str:
-            return f"Virtualenv() should == {_p(expected)!r}, not {repr(given)}"
+            return f"Virtualenv() should == {_p(expected)!r}, not {given!r}"
 
         with self.subTest(), SysPrefixes(
             _p('/virtualenv/prefix'), real_prefix=_p('/real/prefix')

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -251,7 +251,7 @@ Future versions of &SCons; will likely forbid such usage.
     <term><function>AddPostAction</function>(<parameter>target, action</parameter>)</term>
     <term><replaceable>env</replaceable>.<methodname>AddPostAction</methodname>(<parameter>target, action</parameter>)</term>
     <listitem><para>
-Arranges for the specified
+Arrange for the specified
 <parameter>action</parameter>
 to be performed
 after the specified
@@ -277,13 +277,19 @@ foo = Program('foo.c')
 AddPostAction(foo, Chmod('$TARGET', "a-x"))
 </example_commands>
 
+<para>
+If a <parameter>target</parameter> is an &f-Alias;,
+<parameter>action</parameter> is associated with the
+action of the alias, if specified.
+</para>
+
 </listitem>
   </varlistentry>
   <varlistentry id="f-AddPreAction">
     <term><function>AddPreAction</function>(<parameter>target, action</parameter>)</term>
     <term><replaceable>env</replaceable>.<methodname>AddPreAction</methodname>(<parameter>target, action</parameter>)</term>
     <listitem><para>
-Arranges for the specified
+Arrange for the specified
 <parameter>action</parameter>
 to be performed
 before the specified
@@ -306,38 +312,46 @@ one or more targets in the list.
 <para>
 Note that if any of the targets are built in multiple steps,
 the action will be invoked just
-before the "final" action that specifically
+before the action step that specifically
 generates the specified target(s).
-For example, when building an executable program
-from a specified source
-<filename>.c</filename>
-file via an intermediate object file:
+It may not always be obvious
+if the process is multi-step - for example,
+if you use the &Program; builder to
+construct an executable program from a
+<filename>.c</filename> source file,
+&scons; builds an intermediate object file first;
+the pre-action is invoked after this step
+and just before the link command to
+generate the executable program binary.
+Example:
 </para>
 
 <example_commands>
 foo = Program('foo.c')
-AddPreAction(foo, 'pre_action')
+AddPreAction(foo, 'echo "Running pre-action"')
 </example_commands>
 
+<screen>
+$ scons -Q
+gcc -o foo.o -c foo.c
+echo "Running pre-action"
+Running pre-action
+gcc -o foo foo.o
+</screen>
+
 <para>
-The specified
-<literal>pre_action</literal>
-would be executed before
-&scons;
-calls the link command that actually
-generates the executable program binary
-<filename>foo</filename>,
-not before compiling the
-<filename>foo.c</filename>
-file into an object file.
+If a <parameter>target</parameter> is an &f-Alias;,
+<parameter>action</parameter> is associated with the
+action of the alias, if specified.
 </para>
+
 </listitem>
   </varlistentry>
   <varlistentry id="f-Alias">
     <term><function>Alias</function>(<parameter>alias, [source, [action]]</parameter>)</term>
     <term><replaceable>env</replaceable>.<methodname>Alias</methodname>(<parameter>alias, [source, [action]]</parameter>)</term>
     <listitem><para>
-Creates an <firstterm>alias</firstterm> target that
+Create an <firstterm>Alias</firstterm> node that
 can be used as a reference to zero or more other targets,
 specified by the optional <parameter>source</parameter> parameter.
 Aliases provide a way to give a shorter or more descriptive
@@ -1139,7 +1153,7 @@ env.Command(
 
 import os
 def rename(env, target, source):
-    os.rename('.tmp', str(target[0]))
+    os.rename('.tmp', target[0])
 
 
 env.Command(
@@ -4859,7 +4873,7 @@ def create(target, source, env):
 
     Writes 'prefix=$SOURCE' into the file name given as $TARGET.
     """
-    with open(str(target[0]), 'wb') as f:
+    with open(target[0], 'wb') as f:
         f.write(b'prefix=' + source[0].get_contents() + b'\n')
 
 # Fetch the prefix= argument, if any, from the command line.
@@ -5000,6 +5014,16 @@ SConscript(dirs=['build/src','build/doc'])
 SConscript(dirs='src', variant_dir='build/src', duplicate=0)
 SConscript(dirs='doc', variant_dir='build/doc', duplicate=0)
 </example_commands>
+</listitem>
+  </varlistentry>
+  <varlistentry id="f-Virtualenv">
+    <term><function>Virtualenv</function>()</term>
+    <listitem><para>
+If the &SCons; process is running inside a &Python;
+virtual environment,
+return the path to the directory where that environment is stored.
+Otherwise, return <literal>None</literal>.
+</para>
 </listitem>
   </varlistentry>
   <varlistentry id="f-WhereIs">

--- a/doc/generated/functions.gen
+++ b/doc/generated/functions.gen
@@ -5021,8 +5021,9 @@ SConscript(dirs='doc', variant_dir='build/doc', duplicate=0)
     <listitem><para>
 If the &SCons; process is running inside a &Python;
 virtual environment,
-return the path to the directory where that environment is stored.
-Otherwise, return <literal>None</literal>.
+return the path to the directory where that environment is stored,
+else an empty string.
+The result can be treated as a boolean value if the path is unneeded.
 </para>
 </listitem>
   </varlistentry>

--- a/doc/generated/functions.mod
+++ b/doc/generated/functions.mod
@@ -89,6 +89,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-ValidateOptions "<function xmlns='http://www.scons.org/dbxsd/v1.0'>ValidateOptions</function>">
 <!ENTITY f-Value "<function xmlns='http://www.scons.org/dbxsd/v1.0'>Value</function>">
 <!ENTITY f-VariantDir "<function xmlns='http://www.scons.org/dbxsd/v1.0'>VariantDir</function>">
+<!ENTITY f-Virtualenv "<function xmlns='http://www.scons.org/dbxsd/v1.0'>Virtualenv</function>">
 <!ENTITY f-WhereIs "<function xmlns='http://www.scons.org/dbxsd/v1.0'>WhereIs</function>">
 
 <!ENTITY f-env-Action "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.Action</function>">
@@ -172,6 +173,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-env-ValidateOptions "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.ValidateOptions</function>">
 <!ENTITY f-env-Value "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.Value</function>">
 <!ENTITY f-env-VariantDir "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.VariantDir</function>">
+<!ENTITY f-env-Virtualenv "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.Virtualenv</function>">
 <!ENTITY f-env-WhereIs "<function xmlns='http://www.scons.org/dbxsd/v1.0'>env.WhereIs</function>">
 
 <!--
@@ -261,6 +263,7 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-link-ValidateOptions "<link linkend='f-ValidateOptions' xmlns='http://www.scons.org/dbxsd/v1.0'><function>ValidateOptions</function></link>">
 <!ENTITY f-link-Value "<link linkend='f-Value' xmlns='http://www.scons.org/dbxsd/v1.0'><function>Value</function></link>">
 <!ENTITY f-link-VariantDir "<link linkend='f-VariantDir' xmlns='http://www.scons.org/dbxsd/v1.0'><function>VariantDir</function></link>">
+<!ENTITY f-link-Virtualenv "<link linkend='f-Virtualenv' xmlns='http://www.scons.org/dbxsd/v1.0'><function>Virtualenv</function></link>">
 <!ENTITY f-link-WhereIs "<link linkend='f-WhereIs' xmlns='http://www.scons.org/dbxsd/v1.0'><function>WhereIs</function></link>">
 
 <!ENTITY f-link-env-Action "<link linkend='f-Action' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.Action</function></link>">
@@ -344,4 +347,5 @@ THIS IS AN AUTOMATICALLY-GENERATED FILE.  DO NOT EDIT.
 <!ENTITY f-link-env-ValidateOptions "<link linkend='f-ValidateOptions' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.ValidateOptions</function></link>">
 <!ENTITY f-link-env-Value "<link linkend='f-Value' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.Value</function></link>">
 <!ENTITY f-link-env-VariantDir "<link linkend='f-VariantDir' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.VariantDir</function></link>">
+<!ENTITY f-link-env-Virtualenv "<link linkend='f-Virtualenv' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.Virtualenv</function></link>">
 <!ENTITY f-link-env-WhereIs "<link linkend='f-WhereIs' xmlns='http://www.scons.org/dbxsd/v1.0'><function>env.WhereIs</function></link>">

--- a/doc/user/misc.xml
+++ b/doc/user/misc.xml
@@ -709,8 +709,8 @@ env.Command('directory_build_info',
     <para>
       You can query the state at runtime by calling
       the &f-link-Virtualenv; global function.
-      It returns either a path to the virtualenv's home directory,
-      or <literal>None</literal> if &SCons; is not running in a virtualenv.
+      It returns a path to the virtualenv's home directory,
+      or an empty string if &SCons; is not running in a virtualenv.
     </para>
 
     <note><para>

--- a/doc/user/misc.xml
+++ b/doc/user/misc.xml
@@ -35,24 +35,25 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-ensure-python">
   <title>Verifying the Python Version:  the &EnsurePythonVersion; Function</title>
 
     <para>
 
     Although the &SCons; code itself will run
-    on any 2.x Python version 2.7 or later,
-    you are perfectly free to make use of
-    Python syntax and modules from later versions
+    on any 3.x Python version
+    (check the release notes for the precise minimum supported release),
+    you are free to make use of
+    &Python; syntax and modules from later versions
     when writing your &SConscript; files
     or your own local modules.
     If you do this, it's usually helpful to
     configure &SCons; to exit gracefully with an error message
-    if it's being run with a version of Python
+    if it's being run with a version of &Python;
     that simply won't work with your code.
     This is especially true if you're going to use &SCons;
     to build source code that you plan to distribute publicly,
-    where you can't be sure of the Python version
+    where you can't be sure of the &Python; version
     that an anonymous remote user might use
     to try to build your software.
 
@@ -62,7 +63,7 @@ This file is processed by the bin/SConsDoc.py module.
 
     &SCons; provides an &EnsurePythonVersion; function for this.
     You simply pass it the major and minor versions
-    numbers of the version of Python you require:
+    numbers of the version of &Python; you require:
 
     </para>
 
@@ -74,21 +75,21 @@ This file is processed by the bin/SConsDoc.py module.
 
     <scons_example name="misc_EnsurePythonVersion">
       <file name="SConstruct" printme="1">
-EnsurePythonVersion(2, 5)
+EnsurePythonVersion(3, 8)
       </file>
     </scons_example>
 
     -->
 
     <sconstruct>
-EnsurePythonVersion(2, 5)
+EnsurePythonVersion(3, 8)
     </sconstruct>
 
     <para>
 
     And then &SCons; will exit with the following error
     message when a user runs it with an unsupported
-    earlier version of Python:
+    earlier version of &Python;:
 
     </para>
 
@@ -106,12 +107,12 @@ EnsurePythonVersion(2, 5)
 
     <screen>
 % <userinput>scons -Q</userinput>
-Python 2.5 or greater required, but you have Python 2.3.6
+Python 3.7 or greater required, but you have Python 3.6.5
     </screen>
 
   </section>
 
-  <section>
+  <section id="sect-ensure-scons">
   <title>Verifying the SCons Version:  the &EnsureSConsVersion; Function</title>
 
     <para>
@@ -129,7 +130,7 @@ Python 2.5 or greater required, but you have Python 2.3.6
     that verifies the version of &SCons;
     in the same
     the &EnsurePythonVersion; function
-    verifies the version of Python,
+    verifies the version of &Python;,
     by passing in the major and minor versions
     numbers of the version of SCons you require:
 
@@ -180,7 +181,7 @@ SCons 1.0 or greater required, but you have SCons 0.98.5
 
   </section>
 
-  <section>
+  <section id="sect-get-scons-version">
   <title>Accessing SCons Version:  the &GetSConsVersion; Function</title>
 
     <para>
@@ -206,7 +207,7 @@ else:
 
   </section>
 
-  <section>
+  <section id="sect-scons-exit">
   <title>Explicitly Terminating &SCons; While Reading &SConscript; Files:  the &Exit; Function</title>
 
     <para>
@@ -250,18 +251,18 @@ hello.c
     <para>
 
     Note that the &Exit; function
-    is equivalent to calling the Python
+    is equivalent to calling the &Python;
     <function>sys.exit</function> function
     (which it actually calls),
     but because &Exit; is a &SCons; function,
-    you don't have to import the Python
+    you don't have to import the &Python;
     <literal>sys</literal> module to use it.
 
     </para>
 
   </section>
 
-  <section>
+  <section id="sect-find-file">
   <title>Searching for Files:  the &FindFile; Function</title>
 
     <para>
@@ -446,13 +447,13 @@ leaf
 
   </section>
 
-  <section>
+  <section id="sect-flatten-sequence">
   <title>Handling Nested Lists:  the &Flatten; Function</title>
 
     <para>
 
     &SCons; supports a &Flatten; function
-    which takes an input Python sequence
+    which takes an input &Python; sequence
     (list or tuple)
     and returns a flattened list
     containing just the individual elements of
@@ -589,7 +590,7 @@ cc -o prog1 prog1.o prog2.o
 
   </section>
 
-  <section>
+  <section id="sect-get-launch-dir">
   <title>Finding the Invocation Directory:  the &GetLaunchDir; Function</title>
 
     <para>
@@ -613,7 +614,7 @@ env.Command('directory_build_info',
 
     Because &SCons; is usually invoked from the top-level
     directory in which the &SConstruct; file lives,
-    the Python <function>os.getcwd()</function>
+    the &Python; <function>os.getcwd()</function>
     is often equivalent.
     However, the &SCons;
     <literal>-u</literal>,
@@ -638,53 +639,89 @@ env.Command('directory_build_info',
   <!-- Former unpublished chapter now included as a section here: -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="sideeffect.xml"/>
 
-  <section>
-  <title>Virtual environments (virtualenvs)</title>
+  <section id="sect-virtualenv">
+  <title>Using Python Virtual Environments</title>
 
     <para>
 
-      Virtualenv is a tool to create isolated Python environments.
-      A python application (such as SCons) may be executed within
-      an activated virtualenv. The activation of virtualenv modifies
-      current environment by defining some virtualenv-specific variables
-      and modifying search PATH, such that executables installed within
-      virtualenv's home directory are preferred over the ones installed
-      outside of it.
+      &Python; supports lightweight "virtual environments" (usually
+      abbreviated <firstterm>virtualenv</firstterm>) which allow
+      encapsulation / isolation of package dependencies for a project.
+      When a &Python; program is executed in the context of a
+      virtualenv, the paths for package imports are amended so the
+      modules in the virtualenv are preferred. Depending on how the
+      virtualenv was configured, system paths may or may not be used
+      as a fallback (the default is not).
 
     </para>
 
     <para>
-
-      Normally, SCons uses hard-coded PATH when searching for external
-      executables, so it always picks-up executables from these pre-defined
-      locations. This applies also to python interpreter, which is invoked
-      by some custom SCons tools or test suites. This means, when running
-      SCons in a virtualenv, an eventual invocation of python interpreter from
-      SCons script will most probably jump out of virtualenv and execute
-      python executable found in hard-coded SCons PATH, not the one which is
-      executing SCons. Some users may consider this as an inconsistency.
-
+      &SCons; itself works as expected when executed within a virtualenv.
+      However, there may be issues if the project needs
+      to build using external commands written in &Python;
+      which are installed in the virtualenv,
+      or calls the &Python; interpreter to run a script.
+      &SCons; launches command actions using a special restricted
+      <envar>PATH</envar> setting which the new process uses
+      to find executables.
+      This path is part of the execution environment
+      (see  <xref linkend="sect-execution-environments"/>),
+      and by default,
+      does not contain any information about the virtualenv.
+      The result can be commands not found,
+      or scripts executed with the system default copy of &Python;
+      rather than the virtualenv one, possibly causing incorrect imports.
+      If you encounter this problem, &SCons; provides a mechanism
+      to more fully integrate with a virtualenv.
     </para>
 
     <para>
-      This issue may be overcome by using the
-      <option>--enable-virtualenv</option>
-      option. The option automatically imports virtualenv-related environment
-      variables to all created construction environment <literal>env['ENV']</literal>,
-      and modifies SCons PATH appropriately to prefer virtualenv's executables.
-      Setting environment variable <envar>SCONS_ENABLE_VIRTUALENV=1</envar>
-      will have same effect. If virtualenv support is enabled system-wide
-      by the environment variable, it may be suppressed with the
-      <option>--ignore-virtualenv</option> option.
+      Use the <option>--enable-virtualenv</option>
+      to import virtualenv-related environment variables to the
+      execution environment (&cv-link-ENV;)
+      and to modify the execution environment's <envar>PATH</envar>
+      appropriately to prefer the virtualenv executables and
+      &Python; interpreter.
     </para>
 
     <para>
-      Inside of &SConscript;, a global function <literal>Virtualenv</literal> is
-      available. It returns a path to virtualenv's home directory, or
-      <literal>None</literal> if &scons; is not running from virtualenv. Note
-      that this function returns a path even if &scons; is run from an
-      unactivated virtualenv.
+      To make this setting permanent, you can either:
     </para>
+
+    <itemizedlist>
+      <listitem>
+        <para>Add it to the <envar>SCONSFLAGS</envar> environment variable , or</para>
+      </listitem>
+      <listitem>
+        <para>Set <envar>SCONS_ENABLE_VIRTUALENV=1</envar> in your environment.</para>
+      </listitem>
+    </itemizedlist>
+
+    <para>
+      <envar>SCONSFLAGS</envar> is the preferred approach,
+      as it's easier to manage a single variable controlling &SCons;
+      behavior than multiples.
+      If enabled by environment variable,
+      the special virtualenv behavior can be disabled for the current
+      run using the <option>--ignore-virtualenv</option> option.
+    </para>
+
+    <para>
+      You can query the state at runtime by calling
+      the &f-link-Virtualenv; global function.
+      It returns either a path to the virtualenv's home directory,
+      or <literal>None</literal> if &SCons; is not running in a virtualenv.
+    </para>
+
+    <note><para>
+      &f-Virtualenv; returns a path even if &SCons;
+      is run from an unactivated virtualenv.
+      A virtualenv does not have to be activated to be used,
+      you only need to use the path to its &Python; interpreter,
+      but only an activated virtualenv makes available the
+      suitable <envar>PATH</envar> elements for &SCons; to
+      copy in when <option>--enable-virtualenv</option> is used.
+    </para></note>
 
   </section>
 

--- a/test/virtualenv/activated/option/ignore-virtualenv.py
+++ b/test/virtualenv/activated/option/ignore-virtualenv.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Ensure that the --ignore-virtualenv flag works.
@@ -38,15 +37,16 @@ test = TestSCons.TestSCons()
 if not SCons.Platform.virtualenv.Virtualenv():
     test.skip_test("No virtualenv detected, skipping\n")
 
-if not SCons.Platform.virtualenv.select_paths_in_venv(os.getenv('PATH','')):
-    test.skip_test("Virtualenv detected but looks like unactivated, skipping\n")
+if not SCons.Platform.virtualenv.select_paths_in_venv(os.getenv('PATH', '')):
+    test.skip_test("Virtualenv detected but looks unactivated, skipping\n")
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 import sys
 import SCons.Platform.virtualenv
+
 env = DefaultEnvironment(tools=[])
-print("sys.executable: %s" % repr(sys.executable))
-print("env.WhereIs('python'): %s" % repr(env.WhereIs('python')))
+print(f"sys.executable: {sys.executable!r}")
+print(f"env.WhereIs('python'): {env.WhereIs('python')!r}")
 """)
 
 os.environ['SCONS_ENABLE_VIRTUALENV'] = '1'
@@ -55,30 +55,36 @@ test.run(['-Q', '--ignore-virtualenv'])
 s = test.stdout()
 m = re.search(r"""^sys\.executable:\s*(?P<py>["']?[^"']+["']?)\s*$""", s, re.MULTILINE)
 if not m:
-    test.fail_test(message="""\
-can't determine sys.executable from stdout:
+    test.fail_test(
+        message=f"""can't determine sys.executable from stdout:
 ========= STDOUT =========
-%s
+{s}
 ==========================
-""" % s)
+""")
 
 interpreter = eval(m.group('py'))
 
-m = re.search(r"""^\s*env.WhereIs\('python'\):\s*(?P<py>["']?[^"']+["']?)\s*$""", s, re.MULTILINE)
+m = re.search(
+    r"""\s*env.WhereIs\('python'\):\s*(?P<py>["']?[^"']+["']?)\s*$""", s, re.MULTILINE
+)
 if not m:
-    test.fail_test(message="""
+    test.fail_test(message=f"""
 can't determine env.WhereIs('python') from stdout:
 ========= STDOUT =========
-%s
+{s}
 ==========================
-""" % s)
+""")
 
 python = eval(m.group('py'))
 
-test.fail_test(not SCons.Platform.virtualenv.IsInVirtualenv(interpreter),
-               message="sys.executable points outside of virtualenv")
-test.fail_test(SCons.Platform.virtualenv.IsInVirtualenv(python),
-               message="env.WhereIs('python') points to virtualenv")
+test.fail_test(
+    not SCons.Platform.virtualenv.IsInVirtualenv(interpreter),
+    message="sys.executable points outside of virtualenv",
+)
+test.fail_test(
+    SCons.Platform.virtualenv.IsInVirtualenv(python),
+    message="env.WhereIs('python') points to virtualenv",
+)
 
 test.pass_test()
 

--- a/test/virtualenv/activated/virtualenv_activated_python.py
+++ b/test/virtualenv/activated/virtualenv_activated_python.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,15 +22,12 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Check which python executable is running scons and which python executable
-would be used by scons, when we run under activated virtualenv (i.e. PATH
-contains the virtualenv's bin path). This test is skipped when ran in regular
-environment or in unactivated virtualenv.
+would be used by scons when we run under activated virtualenv (i.e., PATH
+contains the virtualenv's bin path). This test is skipped when run in a
+regular environment or in an unactivated virtualenv.
 """
 
 import TestSCons
@@ -42,14 +41,15 @@ if not SCons.Platform.virtualenv.Virtualenv():
     test.skip_test("No virtualenv detected, skipping\n")
 
 if not SCons.Platform.virtualenv.select_paths_in_venv(os.getenv('PATH')):
-    test.skip_test("Virtualenv detected but looks like unactivated, skipping\n")
+    test.skip_test("Virtualenv detected but looks unactivated, skipping\n")
 
 
-test.write('SConstruct', """
+test.write('SConstruct', """\
 import sys
+
 env = DefaultEnvironment(tools=[])
-print("sys.executable: %s" % repr(sys.executable))
-print("env.WhereIs('python'): %s" % repr(env.WhereIs('python')))
+print(f"sys.executable: {sys.executable!r}")
+print(f"env.WhereIs('python'): {env.WhereIs('python')!r}")
 """)
 
 if SCons.Platform.virtualenv.virtualenv_enabled_by_default:
@@ -60,31 +60,40 @@ else:
 s = test.stdout()
 m = re.search(r"""^sys\.executable:\s*(?P<py>["']?[^"']+["']?)\s*$""", s, re.MULTILINE)
 if not m:
-    test.fail_test(message="""\
+    test.fail_test(
+        message=f"""\
 can't determine sys.executable from stdout:
 ========= STDOUT =========
-%s
+{s}
 ==========================
-""" % s)
+""")
 
 interpreter = eval(m.group('py'))
 
-m = re.search(r"""^\s*env\.WhereIs\('python'\):\s*(?P<py>["'][^"']+["'])\s*$""", s, re.MULTILINE)
+m = re.search(
+    r"""^\s*env\.WhereIs\('python'\):\s*(?P<py>["'][^"']+["'])\s*$""", s, re.MULTILINE
+)
 if not m:
-    test.fail_test(message="""
+    test.fail_test(
+        message=f"""
 can't determine env.WhereIs('python') from stdout:
 ========= STDOUT =========
-%s
+{s}
 ==========================
-""" % s)
+""")
 
 python = eval(m.group('py'))
 
-# runing in activated virtualenv (after "activate") - PATH includes virtualenv's bin directory
-test.fail_test(not SCons.Platform.virtualenv.IsInVirtualenv(interpreter),
-               message="sys.executable points outside of virtualenv")
-test.fail_test(not SCons.Platform.virtualenv.IsInVirtualenv(python),
-               message="env.WhereIs('python') points outside of virtualenv")
+# running in an activated virtualenv (after "activate") -
+# PATH includes the virtualenv bin directory
+test.fail_test(
+    not SCons.Platform.virtualenv.IsInVirtualenv(interpreter),
+    message="sys.executable points outside of virtualenv",
+)
+test.fail_test(
+    not SCons.Platform.virtualenv.IsInVirtualenv(python),
+    message="env.WhereIs('python') points outside of virtualenv",
+)
 
 test.pass_test()
 

--- a/test/virtualenv/activated/virtualenv_detect_virtualenv.py
+++ b/test/virtualenv/activated/virtualenv_detect_virtualenv.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Check if SCons.Platform.virtualenv.Virtualenv() works in SConscripts.
@@ -37,8 +36,9 @@ ve = SCons.Platform.virtualenv.Virtualenv()
 if not ve:
     test.skip_test("Virtualenv is not active, skipping\n")
 
-test.write('SConstruct', """
-print("virtualenv: %r" % Virtualenv())
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+print(f"virtualenv: {Virtualenv()!r}")
 """)
 
 if SCons.Platform.virtualenv.virtualenv_enabled_by_default:
@@ -46,7 +46,7 @@ if SCons.Platform.virtualenv.virtualenv_enabled_by_default:
 else:
     test.run(['-Q', '--enable-virtualenv'])
 
-test.must_contain_all_lines(test.stdout(), ['virtualenv: %r' % ve])
+test.must_contain_all_lines(test.stdout(), [f'virtualenv: {ve!r}'])
 
 test.pass_test()
 

--- a/test/virtualenv/always/virtualenv_global_function.py
+++ b/test/virtualenv/always/virtualenv_global_function.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,13 +22,10 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Check which python executable is running scons and which python executable
-would be used by scons, when we run under activated virtualenv (i.e. PATH
+would be used by scons when we run in an activated virtualenv (i.e., PATH
 contains the virtualenv's bin path).
 """
 
@@ -36,28 +35,32 @@ import re
 
 test = TestSCons.TestSCons()
 
-test.write('SConstruct', """
-print("Virtualenv(): %r" % Virtualenv())
-""")
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+print(f"Virtualenv(): {Virtualenv()!r}")
+""",
+)
 
 test.run(['-Q'])
 
 s = test.stdout()
 m = re.search(r"^Virtualenv\(\):\s*(?P<ve>.+\S)\s*$", s, re.MULTILINE)
 if not m:
-    test.fail_test(message="""\
+    test.fail_test(message=f"""\
 can't determine Virtualenv() result from stdout:
 ========= STDOUT =========
-%s
+{s}
 ==========================
-""" % s)
+""")
 
 scons_ve = m.group('ve')
-our_ve = "%r" % SCons.Platform.virtualenv.Virtualenv()
+our_ve = f"{SCons.Platform.virtualenv.Virtualenv()!r}"
 
-# runing in activated virtualenv (after "activate") - PATH includes virtualenv's bin directory
-test.fail_test(scons_ve != our_ve,
-               message="Virtualenv() from SCons != Virtualenv() from caller script (%r != %r)" % (scons_ve, our_ve))
+# running in activated virtualenv (after "activate") - PATH includes virtualenv's bin directory
+test.fail_test(
+    scons_ve != our_ve,
+    message=f"Virtualenv() from SCons != Virtualenv() from caller script ({scons_ve!r} != {our_ve!r})",
+)
 
 test.pass_test()
 

--- a/test/virtualenv/regularenv/virtualenv_detect_regularenv.py
+++ b/test/virtualenv/regularenv/virtualenv_detect_regularenv.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Check if SCons.Platform.virtualenv.Virtualenv() works in SConscript.
@@ -36,8 +35,9 @@ test = TestSCons.TestSCons()
 if SCons.Platform.virtualenv.Virtualenv():
     test.skip_test("Virtualenv is active, skipping\n")
 
-test.write('SConstruct', """
-print("virtualenv: %r" % Virtualenv())
+test.write('SConstruct', """\
+DefaultEnvironment(tools=[])
+print(f"virtualenv: {Virtualenv()!r}")
 """)
 
 if SCons.Platform.virtualenv.virtualenv_enabled_by_default:
@@ -45,7 +45,7 @@ if SCons.Platform.virtualenv.virtualenv_enabled_by_default:
 else:
     test.run(['-Q', '--enable-virtualenv'])
 
-test.must_contain_all_lines(test.stdout(), ['virtualenv: %r' % None])
+test.must_contain_all_lines(test.stdout(), ["virtualenv: None"])
 
 test.pass_test()
 

--- a/test/virtualenv/regularenv/virtualenv_detect_regularenv.py
+++ b/test/virtualenv/regularenv/virtualenv_detect_regularenv.py
@@ -45,7 +45,7 @@ if SCons.Platform.virtualenv.virtualenv_enabled_by_default:
 else:
     test.run(['-Q', '--enable-virtualenv'])
 
-test.must_contain_all_lines(test.stdout(), ["virtualenv: None"])
+test.must_contain_all_lines(test.stdout(), ["virtualenv: ''"])
 
 test.pass_test()
 


### PR DESCRIPTION
Tweak the check for "are we running in a virtualenv" to be more modern, preferrring the current built-in scheme which has been standard since Python 3.3 (checking for `sys.base_prefix`).  The old way is still checked, just not first; code comments prompt us to to remove later. 

Add entry for `Virtualenv` function to manpage and update User Guide section.

Add docstrings, reformat tests and switch to f-strings.

Return an empty string from `Virtualen()` if not running in a virtualenv, instead of returning `None`. This can still be evaluated boolean-style, which all test cases and internal uses already did (e.g. if `Virtualenv():`).  Implemented in a separate git commit, in case it's necessary to revert later.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
