### PR TITLE
fix issue #4003: Resolve issue with CompilationDatabase combined with variant_dir yielding incorrect output.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -69,6 +69,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       and the code adjusted.  All internal usage, including tests,
       was dont boolean-style anyway ("if Virtualenv():").
 
+  From Edward Peek:
+    - Fix the variant dir component being missing from generated source file
+      paths with CompilationDatabase() builder (Fixes #4003).
+
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -46,6 +46,8 @@ FIXES
   setting against both enable & disable strings. (Fixes #4702)
 - MSVS: Fix significant slowdown initializing MSVC tools when vcpkg has
   been installed on the system.
+- Fix the variant dir component being missing from generated source file
+  paths with CompilationDatabase() builder (Fixes #4003).
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -156,11 +156,14 @@ def write_compilation_db(target, source, env) -> None:
         source_file = entry['file']
         output_file = entry['output']
 
+        if not source_file.is_derived():
+            source_file = source_file.srcnode()
+
         if use_abspath:
-            source_file = source_file.srcnode().abspath
+            source_file = source_file.abspath
             output_file = output_file.abspath
         else:
-            source_file = source_file.srcnode().path
+            source_file = source_file.path
             output_file = output_file.path
 
         if use_path_filter and not fnmatch.fnmatch(output_file, use_path_filter):

--- a/test/CompilationDatabase/fixture/SConstruct_variant
+++ b/test/CompilationDatabase/fixture/SConstruct_variant
@@ -46,3 +46,6 @@ env.Program('build/main', 'build/test_main.c')
 env.VariantDir('build2','src', duplicate=0)
 env.Program('build2/main', 'build2/test_main.c')
 
+env.VariantDir('build3','src', duplicate=0)
+env.InstallAs('build3/test_main_copy.c', 'src/test_main.c')
+env.Program('build3/main', 'build3/test_main_copy.c')

--- a/test/CompilationDatabase/variant_dir.py
+++ b/test/CompilationDatabase/variant_dir.py
@@ -78,6 +78,12 @@ example_rel_file = """[
         "directory": "%(workdir)s",
         "file": "%(src_file)s",
         "output": "%(output2_file)s"
+    },
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output3_file)s -c %(variant3_src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(variant3_src_file)s",
+        "output": "%(output3_file)s"
     }
 ]
 """ % {'exe': sys.executable,
@@ -85,7 +91,9 @@ example_rel_file = """[
         'src_file': os.path.join('src', 'test_main.c'),
         'output_file': os.path.join('build', 'test_main.o'),
         'output2_file': os.path.join('build2', 'test_main.o'),
-        'variant_src_file': os.path.join('build', 'test_main.c')
+        'output3_file': os.path.join('build3', 'test_main_copy.o'),
+        'variant_src_file': os.path.join('build', 'test_main.c'),
+        'variant3_src_file': os.path.join('build3', 'test_main_copy.c')
         }
 
 if sys.platform == 'win32':
@@ -108,6 +116,12 @@ example_abs_file = """[
         "directory": "%(workdir)s",
         "file": "%(abs_src_file)s",
         "output": "%(abs_output2_file)s"
+    },
+    {
+        "command": "%(exe)s mygcc.py cc -o %(output3_file)s -c %(variant3_src_file)s",
+        "directory": "%(workdir)s",
+        "file": "%(abs_variant3_src_file)s",
+        "output": "%(abs_output3_file)s"
     }
 ]
 """ % {'exe': sys.executable,
@@ -116,9 +130,14 @@ example_abs_file = """[
         'abs_src_file': os.path.join(test.workdir, 'src', 'test_main.c'),
         'abs_output_file': os.path.join(test.workdir, 'build', 'test_main.o'),
         'abs_output2_file': os.path.join(test.workdir, 'build2', 'test_main.o'),
+        'abs_output3_file': os.path.join(test.workdir, 'build3', 'test_main_copy.o'),
         'output_file': os.path.join('build', 'test_main.o'),
         'output2_file': os.path.join('build2', 'test_main.o'),
-        'variant_src_file': os.path.join('build', 'test_main.c')}
+        'output3_file': os.path.join('build3', 'test_main_copy.o'),
+        'abs_variant3_src_file': os.path.join(test.workdir, 'build3', 'test_main_copy.c'),
+        'variant_src_file': os.path.join('build', 'test_main.c'),
+        'variant3_src_file': os.path.join('build3', 'test_main_copy.c')
+        }
 
 if sys.platform == 'win32':
     example_abs_file = example_abs_file.replace('\\', '\\\\')


### PR DESCRIPTION
Fixes issue #4003.

Only do `srcnode()` mapping for files that are actually raw sources.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
