### PR TITLE
Fix any remaining references to supporting Python 3.6.x

### DIFF
--- a/README-SF.rst
+++ b/README-SF.rst
@@ -47,8 +47,10 @@ version at the SCons download page:
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.6 or higher. There should be no other
+Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
+
+The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
 
 The default SCons configuration assumes use of the Microsoft Visual C++

--- a/README-local
+++ b/README-local
@@ -43,8 +43,10 @@ scons-local package, or any SCons package, at the SCons download page:
 EXECUTION REQUIREMENTS
 ======================
 
-Running SCons requires Python 3.6 or higher. There should be no other
+Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
+
+The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
 
 The default SCons configuration assumes use of the Microsoft Visual C++

--- a/README-package.rst
+++ b/README-package.rst
@@ -80,8 +80,10 @@ http://www.scons.org/documentation.html.
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.6 or higher. There should be no other
+Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
+
+The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
 
 Some experimental features may require additional Python packages

--- a/README.rst
+++ b/README.rst
@@ -88,8 +88,10 @@ is the latest version at the
 Execution Requirements
 ======================
 
-Running SCons requires Python 3.6 or higher. There should be no other
+Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
+
+The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
 
 Some experimental features may require additional Python packages

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -98,15 +98,10 @@ The CPython project retired 3.5 in Sept 2020:
 <ulink url="https://peps.python.org/pep-0478"/>.
 </para>
 <para>
-<emphasis>Changed in version 4.8.0:</emphasis>
-support for &Python; 3.6 is deprecated and will be removed
-in a future &SCons; release.
-The CPython project retired 3.6 in Sept 2021:
-<ulink url="https://peps.python.org/pep-0494"/>.
-</para>
-<para>
 <emphasis>Changed in version 4.9.0:</emphasis>
 support for &Python; 3.6 is removed.
+The CPython project retired 3.6 in Sept 2021:
+<ulink url="https://peps.python.org/pep-0494"/>.
 </para>
 
 <para>

--- a/doc/user/build-install.xml
+++ b/doc/user/build-install.xml
@@ -173,7 +173,7 @@ Python 3.9.15
     </para>
 
     <para>
-    &SCons; will work with &Python; 3.6 or later.
+    &SCons; will work with &Python; 3.7 or later.
     If you need to install &Python; and have a choice,
     we recommend using the most recent &Python; version available.
     Newer &Python; versions have significant improvements

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,8 +1,6 @@
 language: python
 
 python:
-  - "3.5"
-  - "3.6"
   - "3.7"
   - "3.8"
 


### PR DESCRIPTION
Update remainder of text specifying python 3.6 as supported. Now all references indicate 3.7.0 or higher and indicate last version which supported 3.6.x as being SCons 4.8.1

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
