### PR TITLE
Fix ninja tool calling subst incorrectly.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       values are not propagated to the SCons environment after running
       the MSVC batch files.
 
+  From Edward Peek:
+    - Fix the variant dir component being missing from generated source file
+      paths with CompilationDatabase() builder (Fixes #4003).
+
   From Bill Prendergast:
     - Fixed SCons.Variables.PackageVariable to correctly test the default
       setting against both enable & disable strings. (Fixes #4702)
@@ -74,10 +78,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       fixing the handling of option-arguments specified with a space
       separator (multiple issues, harvested from PR #3799 created by Dillan Mills).
       These interfaces are not part of the public API.
-
-  From Edward Peek:
-    - Fix the variant dir component being missing from generated source file
-      paths with CompilationDatabase() builder (Fixes #4003).
+    - Ninja tool generate_command() fixed to call subst() with correct
+      arguments in ListAction case. Unit tests added for generate_command.
+      Fixes #4580.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,10 +44,15 @@ FIXES
 
 - Fixed SCons.Variables.PackageVariable to correctly test the default
   setting against both enable & disable strings. (Fixes #4702)
+
 - MSVS: Fix significant slowdown initializing MSVC tools when vcpkg has
   been installed on the system.
+
 - Fix the variant dir component being missing from generated source file
   paths with CompilationDatabase() builder (Fixes #4003).
+
+- Ninja tool generate_command() fixed to call subst() with correct
+  arguments in ListAction case. Unit tests added for generate_command.
 
 IMPROVEMENTS
 ------------

--- a/SCons/Tool/ninja_tool/Utils.py
+++ b/SCons/Tool/ninja_tool/Utils.py
@@ -363,14 +363,13 @@ def generate_command(env, node, action, targets, sources, executor: Executor | N
         cmd = _string_from_cmd_list(cmd_list[0])
     else:
         # Anything else works with genstring, this is most commonly hit by
-        # ListActions which essentially call process on all of their
-        # commands and concatenate it for us.
+        # ListActions which essentially call process() on all of their
+        # commands and concatenate the result for us.
         genstring = action.genstring(targets, sources, env)
         if executor is not None:
             cmd = env.subst(genstring, executor=executor)
         else:
-            cmd = env.subst(genstring, targets, sources)
-
+            cmd = env.subst(genstring, target=targets, source=sources)
         cmd = cmd.replace("\n", " && ").strip()
         if cmd.endswith("&&"):
             cmd = cmd[0:-2].strip()

--- a/SCons/Tool/ninja_tool/UtilsTests.py
+++ b/SCons/Tool/ninja_tool/UtilsTests.py
@@ -99,7 +99,7 @@ class TestGenerateCommand(unittest.TestCase):
 
     def test_lazy_action_str(self):
         """Test LazyAction functionality with a string value."""
-        self.env['CCCOM'] = '$CC -c -o $TARGET $SOURCE'
+        self.env['CCCOM'] = 'gcc -c -o $TARGET $SOURCE'
         action = LazyAction("CCCOM", kw={})
         cmd = generate_command(self.env, None, action, self.target, self.source)
         self.assertEqual(cmd, f"gcc -c -o {self.target[0]} {self.source[0]}")

--- a/SCons/Tool/ninja_tool/UtilsTests.py
+++ b/SCons/Tool/ninja_tool/UtilsTests.py
@@ -1,0 +1,126 @@
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Tests for the Ninja tool's Utility functions
+
+from __future__ import annotations
+
+import unittest
+
+import TestCmd
+
+from SCons.Action import CommandAction, ListAction
+from SCons.Action import CommandGeneratorAction, FunctionAction, LazyAction
+from SCons.Environment import Base as BaseEnvironment
+from SCons.Tool.ninja_tool.Utils import generate_command
+
+
+class TestGenerateCommand(unittest.TestCase):
+    """Test that generate_command returns reasonable results for Actions."""
+
+    def setUp(self):
+        self.env = BaseEnvironment()
+        self.target = ["target.o"]
+        self.source = ["source.c"]
+
+    def test_command_action(self):
+        """Test basic CommandAction handling."""
+        action = CommandAction("gcc -c -o $TARGET $SOURCE")
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        self.assertEqual(cmd, f"gcc -c -o {self.target[0]} {self.source[0]}")
+
+    def test_list_action(self):
+        """Test ListAction concatenation."""
+        actions = [
+            CommandAction("mkdir -p build"),
+            CommandAction("gcc -c -o $TARGET $SOURCE"),
+        ]
+        action = ListAction(actions)
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        self.assertEqual(cmd, f"mkdir -p build && gcc -c -o {self.target[0]} {self.source[0]}")
+
+    def test_dollar_escaping(self):
+        """Test dollar signs get properly escaped."""
+        action = CommandAction("echo $DOLLAR_VAR")
+        self.env['DOLLAR_VAR'] = "$5"
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        self.assertEqual(cmd, "echo $$5")
+
+    def test_command_generator_action(self):
+        """Test CommandGeneratorAction handling."""
+
+        def generator(target, source, env, for_signature):
+            return f"gcc -c -o {target[0]} {source[0]}"
+
+        action = CommandGeneratorAction(generator, kw={})
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        self.assertEqual(cmd, f"gcc -c -o {self.target[0]} {self.source[0]}")
+
+    def test_function_action_simple(self):
+        """Test FunctionAction with a simple function."""
+
+        def build_func(target, source, env):
+            return 0
+
+        action = FunctionAction(build_func, kw={})
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        # we could be less precise here, really just care it returns *something*
+        self.assertEqual(cmd, "build_func(target, source, env)")
+
+    def test_function_action_with_args(self):
+        """Test FunctionAction with function taking arguments."""
+
+        def build_func(target, source, env, arg1="default"):
+            return 0
+
+        action = FunctionAction(build_func, kw={'vars': ['arg1']})
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        self.assertIsNotNone(cmd)
+
+    def test_lazy_action_str(self):
+        """Test LazyAction functionality with a string value."""
+        self.env['CCCOM'] = '$CC -c -o $TARGET $SOURCE'
+        action = LazyAction("CCCOM", kw={})
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        self.assertEqual(cmd, f"gcc -c -o {self.target[0]} {self.source[0]}")
+
+    def test_lazy_action_function(self):
+        """Test LazyAction functionality with a function value."""
+
+        def generator(target, source, env, for_signature):
+            return f"gcc -c -o {target[0]} {source[0]}"
+
+        self.env['CCCOM'] = generator
+        action = LazyAction("CCCOM", kw={})
+        cmd = generate_command(self.env, None, action, self.target, self.source)
+        self.assertEqual(cmd, f"gcc -c -o {self.target[0]} {self.source[0]}")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
One path through the utility routine to generate a command line could end up calling `env.subst` with positional arguments ending up assigned to the wrong parameters. Switch to keyword argument style to make sure there's no mismatch.

A unit test file is added to make sure the different action types handled by `generate_command` are all at least minimally tested.

Fixes #4580

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
