### PR TITLE
[WIP] MSVC: Extend the msvc cache key due to potential issues with the external cache file consistency

### DIFF
--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -352,7 +352,7 @@ def has_reg(value) -> bool:
 
 class _EnvVarsUtil:
 
-    _VARLIST_ENCODE = namedtuple('VarListEncode', [
+    _VarListEncode = namedtuple('_VarListEncode', [
         'n_elem',
         'n_char',
         'digest',
@@ -404,7 +404,7 @@ class _EnvVarsUtil:
             n_char = len(message)
             if n_elem > 1:
                 n_char -= n_elem - 1
-            encode_t = cls._VARLIST_ENCODE(
+            encode_t = cls._VarListEncode(
                 n_elem=n_elem,
                 n_char=n_char,
                 digest=digest,

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -61,6 +61,7 @@ from . import common
 from .common import (
     CONFIG_CACHE,
     debug,
+    msvc_environ_cache_key,
 )
 from .sdk import get_installed_sdks
 
@@ -2112,7 +2113,7 @@ def script_env(env, script, args=None):
 
     if script_env_cache is None:
         script_env_cache = common.read_script_env_cache()
-    cache_key = (script, args if args else None)
+    cache_key = (script, args if args else None, msvc_environ_cache_key())
     cache_data = script_env_cache.get(cache_key, None)
 
     # Brief sanity check: if we got a value for the key,

--- a/test/MSVC/msvc_cache_force_defaults.py
+++ b/test/MSVC/msvc_cache_force_defaults.py
@@ -65,8 +65,8 @@ test.write('SConstruct', textwrap.dedent(
         envcache_keys = [tuple(d['key']) for d in envcache_list]
 
     if envcache_keys:
-        # key = (script, arguments)
-        print("SCRIPT_ARGS: {}".format(envcache_keys[0][-1]))
+        # key = (script, arguments, envkeystr)
+        print("SCRIPT_ARGS: {}".format(envcache_keys[0][1]))
     """
 ))
 test.run(arguments="-Q -s", status=0, stdout=None)

--- a/test/MSVC/msvc_cache_force_defaults.py
+++ b/test/MSVC/msvc_cache_force_defaults.py
@@ -61,11 +61,12 @@ test.write('SConstruct', textwrap.dedent(
 
     envcache_keys = []
     with open(cache_file, 'r') as file:
-        envcache_list = json.load(file)
+        envcache_dict = json.load(file)
+        envcache_list = envcache_dict['records']
         envcache_keys = [tuple(d['key']) for d in envcache_list]
 
     if envcache_keys:
-        # key = (script, arguments, envkeystr)
+        # key = (script, arguments, envkeystr, envkeystr)
         print("SCRIPT_ARGS: {}".format(envcache_keys[0][1]))
     """
 ))


### PR DESCRIPTION
Prior to this PR, the msvc cache key consists of the msvc batch file and the msvc batch file arguments.  However, the cache contents are based on both the shell environment variable list and the keep variable list.  Additions to the variable lists between SCons branches/versions could be ignored when using an existing external msvc cache file.

The msvc environment shell environment variable list was moved from inside a function to global file-level in #4717 which could enable a user to extend the shell variable list.  This could yield unexpected behavior when the msvc cache is employed.

The keep list tuple is defined at file-level and the list variable is specified as the default value in the function to process the msvc output.  The optional argument is not passed from the vc code.  As written, it is effectively impossible to extend the keep list tuple and have the extended value used within the function to process the msvc output.  The function was modified to accept None rather than the original definition.  Within the function, an explicit check is made if the argument is None.

An encoded string that represents the shell list variable names and the keep list variable names is added to the msvc cache code key.  The extended key should be compatible with existing cache files as the old entries will exist on file and in memory but never be retrieved.

The encoded string is not guaranteed to to avoid collisions which could result in the erroneous cache data be used.  However, the likelihood of a collision should be remote.

For example, the encoded string for the default shell and keep variable names lists is:
```
"22:324:;KcO~6_`zMX93%fhL{_tz`ap9;C_%Mm4dPQ:7:68:Nmc+c%zY)=aG}>Ka4cxwFmq&6EzRg{IX(+}"
```

The encoded string components are separated by `:` characters.  The components for the default shell and keep variable names lists are:
* `22`: The size of the shell environment variable names list.
* `324`: The total number of characters of the shell environment variable names.
* ```;KcO~6_`zMX93%fhL{_tz`ap9;C_%Mm4dPQ```: A b85encoded string of the sha224 digest of a normalized string representing the shell variable names.
* `7`: The size of the keep variables names list.
* `68`: The total number of characters of the keep variable names.
* ```Nmc+c%zY)=aG}>Ka4cxwFmq&6EzRg{IX(+}```: A b85encoded string of the sha224 digest of a normalized string representing the keep variable names.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
