### PR TITLE
Fix ninja problems with quotes and list actions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -100,10 +100,20 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Ninja tool generate_command() fixed to call subst() with correct
       arguments in ListAction case. Unit tests added for generate_command.
       Fixes #4580.
+    - Ninja tool now quotes targets (if necessary) when calling back to
+      SCons - both in the POST request constructed to contact the
+      daemon, and in the command eventually issued from the deamon.
+      Initial suggestion from Julien Pommier. Fixes #4730.
+    - Ninja tool is adjusted to recognize and emit the right rule in
+      the case of special actions that the tool recognizes, like Copy.
+      This was working in the case of single commands, but not when part
+      of a list of actions. Recognition only happens if the special
+      action is first in the list.  Initial suggestion from Julien Pommier.
+      Fixes #4731.
 
-  From Edward Peek:
-    - Fix the variant dir component being missing from generated source file
-      paths with CompilationDatabase() builder (Fixes #4003).
+Fixes #4731
+
+
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -111,10 +111,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       action is first in the list.  Initial suggestion from Julien Pommier.
       Fixes #4731.
 
-Fixes #4731
-
-
-
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -61,6 +61,16 @@ FIXES
 - Ninja tool generate_command() fixed to call subst() with correct
   arguments in ListAction case. Unit tests added for generate_command.
 
+- Ninja tool now quotes targets (if necessary) when calling back to
+  SCons - both in the POST request constructed to contact the
+  daemon, and in the command eventually issued from the deamon.
+
+- Ninja tool is adjusted to recognize and emit the right rule in
+  the case of special actions that the tool recognizes, like Copy.
+  This was working in the case of single commands, but not when part
+  of a list of actions. Recognition only happens if the special
+  action is first in the list.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Tool/ninja_tool/ninja_daemon_build.py
+++ b/SCons/Tool/ninja_tool/ninja_daemon_build.py
@@ -40,6 +40,7 @@ import tempfile
 import hashlib
 import traceback
 import socket
+from urllib.parse import quote
 
 ninja_builddir = pathlib.Path(sys.argv[2])
 daemon_dir = pathlib.Path(tempfile.gettempdir()) / (
@@ -77,7 +78,7 @@ while True:
         if sys.argv[3] == '--exit':
             conn.request("GET", "/?exit=1")
         else:
-            conn.request("GET", "/?build=" + sys.argv[3])
+            conn.request("GET", "/?build=" + quote(sys.argv[3]))
         response = None
 
         while not response:
@@ -94,7 +95,7 @@ while True:
                 if status != 200:
                     log_error(msg.decode("utf-8"))
                     exit(1)
-                    
+
                 logging.debug(f"Request Done: {sys.argv[3]}")
                 exit(0)
 

--- a/SCons/Tool/ninja_tool/ninja_run_daemon.py
+++ b/SCons/Tool/ninja_tool/ninja_run_daemon.py
@@ -72,25 +72,10 @@ if not os.path.exists(ninja_builddir / "scons_daemon_dirty"):
     ] + sys.argv[1:]
     logging.debug(f"Starting daemon with {' '.join(cmd)}")
 
-    
-    # TODO: Remove the following when Python3.6 support is dropped.
-    if sys.platform == 'win32' and sys.version_info[0] == 3 and sys.version_info[1] == 6:
-        # on Windows with Python version 3.6, popen does not do a good job disconnecting
-        # the std handles and this make ninja hang because they stay open to the original
-        # process ninja launched. Here we can force the handles to be separated.
-        # See: https://docs.python.org/3.6/library/subprocess.html#subprocess.STARTUPINFO
-        # See Also: https://docs.python.org/3.6/library/subprocess.html#subprocess.Popen
-        # Note when you don't specify stdin, stdout, and/or stderr they default to None
-        # which indicates no output redirection will occur.
-        si = subprocess.STARTUPINFO()
-        si.dwFlags = subprocess.STARTF_USESTDHANDLES
-        p = subprocess.Popen(
-            cmd, close_fds=True, shell=False, startupinfo=si
-        )
-    else:
-        p = subprocess.Popen(
-            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=False,
-        )
+
+    p = subprocess.Popen(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=False,
+    )
     with open(daemon_dir / "pidfile", "w") as f:
         f.write(str(p.pid))
     with open(ninja_builddir / "scons_daemon_dirty", "w") as f:

--- a/SCons/Tool/ninja_tool/ninja_scons_daemon.py
+++ b/SCons/Tool/ninja_tool/ninja_scons_daemon.py
@@ -52,8 +52,6 @@ from threading import Condition
 from timeit import default_timer as timer
 from urllib.parse import urlparse, parse_qs
 
-from SCons.Subst import quote_spaces
-
 port = int(sys.argv[1])
 ninja_builddir = pathlib.Path(sys.argv[2])
 daemon_keep_alive = int(sys.argv[3])
@@ -223,6 +221,17 @@ def daemon_thread_func():
                     break
 
                 else:
+                    def quote_spaces(arg):
+                        """This is the same as SCons.Subst.quote_spaces
+
+                        Copied here because the daemon doesn't have
+                        the right context when running.
+                        """
+                        if ' ' in arg or '\t' in arg:
+                            return '"%s"' % arg
+                        else:
+                            return str(arg)
+
                     input_command = f'build {quote_spaces(building_node)}\n'
                     daemon_log("input: " + input_command.strip())
 

--- a/SCons/Tool/textfile.xml
+++ b/SCons/Tool/textfile.xml
@@ -46,19 +46,25 @@ Set &consvars; for the &b-link-Textfile; and &b-link-Substfile; builders.
 <builder name="Textfile">
 <summary>
 <para>
-The &b-Textfile; builder generates a single text file from
-a template consisting of a list of strings, replacing text
-using the &cv-link-SUBST_DICT; &consvar; (if set) -
-see &b-link-Substfile; for a description of replacement.
-The strings will be separated in the target file using the
-value of the
-&cv-link-LINESEPARATOR; &consvar;;
-the line separator is not emitted after the last string.
-Nested lists of source strings
-are flattened.
-Source strings need not literally be Python strings:
-they can be Nodes or Python objects that convert cleanly
-to &f-link-Value; nodes.
+The &b-Textfile; builder and its sibling &b-Substfile;
+create a single text file by combining one or more template inputs,
+optionally performing token replacement.
+&b-Textfile; operates on string-like sources.
+Inputs are converted to SCons &f-link-Value; nodes so they can
+be tracked for rebuild purposes.
+Anything that converts cleanly to a &f-Value; node
+is eligible to be an input source, XXX
+so you can use files as string input by using,
+for example, <literal>Value('foo.in')</literal>.
+If there is more than one source,
+corresponding text chunks in the output are separated by
+the contents of the &cv-link-LINESEPARATOR; &consvar; (if set).
+If the &cv-link-SUBST_DICT; &consvar; is set,
+it defines replaceable strings and the replacement text.
+The replacement values are first subjected to
+&consvar; substitution.
+Nested lists of source strings are flattened.
+See &b-link-Substfile; for more details of replacement.
 </para>
 
 <para>
@@ -68,7 +74,10 @@ and &cv-link-TEXTFILESUFFIX; &consvars;
 are automatically added to the target if they are not already present.
 </para>
 <para>
-By default, the target file encoding is "utf-8" and can be changed by &cv-link-FILE_ENCODING;
+By default, the target file is encoded as <literal>utf-8</literal>.
+This can be changed by setting &cv-link-FILE_ENCODING;
+</para>
+<para>
 Examples:
 </para>
 
@@ -119,20 +128,23 @@ env.Textfile(
 <builder name="Substfile">
 <summary>
 <para>
-The &b-Substfile; builder creates a single text file from
-a template consisting of a file or set of files (or nodes),
-replacing text using the &cv-link-SUBST_DICT; &consvar; (if set).
-If a set, they are concatenated into the target file
-using the value of the
-&cv-link-LINESEPARATOR; &consvar; as a separator between contents;
-the separator is not emitted after the contents of the last  file.
-Nested lists of source files
-are flattened. See also &b-link-Textfile;.
+The &b-Substfile; builder and its sibling &b-Textfile;
+create a single text file by combining one or more template inputs,
+optionally performing token replacement.
+&b-Substfile; operates on file sources.
+If there is more than one source,
+corresponding text chunks in the output are separated by
+the contents of the &cv-link-LINESEPARATOR; &consvar; (if set).
+If the &cv-link-SUBST_DICT; &consvar; is set,
+it defines replaceable strings and the replacement text.
+The replacement values are first subjected to
+&consvar; substitution.
+Nested lists of source files are flattened. See also &b-link-Textfile;.
 </para>
 
 <para>
-By default, the target file encoding is "utf-8" and can be changed by &cv-link-FILE_ENCODING;
-Examples:
+By default, the target file is encoded as <literal>utf-8</literal>.
+This can be changed by setting &cv-link-FILE_ENCODING;
 </para>
 
 <para>
@@ -143,71 +155,159 @@ the suffix is stripped and the remainder of the name is used as the default targ
 <para>
 The prefix and suffix specified by the &cv-link-SUBSTFILEPREFIX;
 and &cv-link-SUBSTFILESUFFIX; &consvars;
-(an empty string by default in both cases)
-are automatically added to the target if they are not already present.
+(both default to an empty string)
+are automatically added to the target file name
+if they are not already present (prefixes and suffixes do not duplicate).
 </para>
 
 <para>
-If a construction variable named &cv-link-SUBST_DICT; is present,
-it may be either a Python dictionary or a sequence of
+&cv-link-SUBST_DICT; may be either a Python dictionary or a list of
 (<replaceable>key</replaceable>, <replaceable>value</replaceable>) tuples.
-If it is a dictionary it is converted into a list of tuples
-with unspecified order,
-so if one key is a prefix of another key
+Any occurrence of a key in the source
+is replaced by the corresponding value from the substitution dictionary,
+which has first been processed by <function>subst</function>.
+If the value is a Python function or other callable,
+it is called (with no arguments) and the return value is used
+as the replacement text.
+Order matters:
+if one key is a substring of another key
 or if one substitution could be further expanded by another substitution,
-it is unpredictable whether the expansion will occur.
+the final result depends on the order in which the keys were seen.
+Using start-and-end markers in the key text can avoid
+unintentended problems (e.g. <literal>"@text@"</literal>
+and <literal>"@longtext@"</literal> leaves no confusion about
+what to do with <literal>"text"</literal>).
 </para>
 
-<para>
-Any occurrences of a key in the source
-are replaced by the corresponding value,
-which may be a Python callable function or a string.
-If the value is a callable, it is called with no arguments to get a string.
-Strings are <emphasis>subst</emphasis>-expanded
-and the result replaces the key.
+
+<para>Example 1: Localizing a script.
+The template is <filename>script.in</filename>:
 </para>
+
+<programlisting language="sh">
+#! /bin/sh
+# Installation paths
+PREFIX="@prefix@"
+EXEC_PREFIX="@exec_prefix@"
+
+# Script logic here
+if [ -d "$PREFIX" ]; then
+    echo "Installing to $EXEC_PREFIX"
+fi
+</programlisting>
 
 <example_commands>
+# SConstruct
 env = Environment(tools=['default'])
 
 env['prefix'] = '/usr/bin'
 script_dict = {'@prefix@': '/bin', '@exec_prefix@': '$prefix'}
 env.Substfile('script.in', SUBST_DICT=script_dict)
+</example_commands>
 
+<para>Output file <filename>script</filename>:</para>
+
+<programlisting language="sh">
+#! /bin/sh
+# Installation paths
+PREFIX="/bin"
+EXEC_PREFIX="/usr/bin"
+
+# Script logic here
+if [ -d "$PREFIX" ]; then
+    echo "Installing to $EXEC_PREFIX"
+fi
+</programlisting>
+
+<para>Example 2: Customizing a header file which provides
+version-specific program information.
+The template is <filename>config.h.in</filename>:
+</para>
+
+<programlisting language="sh">
+#define VERSION "%VERSION%"
+#define BASEAPP "%BASE%"
+</programlisting>
+
+<example_commands>
+# SConstruct
 conf_dict = {'%VERSION%': '1.2.3', '%BASE%': 'MyProg'}
-env.Substfile('config.h.in', conf_dict, SUBST_DICT=conf_dict)
+env.Substfile('config.h.in', SUBST_DICT=conf_dict)
+</example_commands>
 
-# UNPREDICTABLE - one key is a prefix of another
-bad_foo = {'$foo': '$foo', '$foobar': '$foobar'}
-env.Substfile('foo.in', SUBST_DICT=bad_foo)
+<para>Output file <filename>config.h</filename>:</para>
 
-# PREDICTABLE - keys are applied longest first
-good_foo = [('$foobar', '$foobar'), ('$foo', '$foo')]
-env.Substfile('foo.in', SUBST_DICT=good_foo)
+<programlisting language="sh">
+#define VERSION "1.2.3"
+#define BASEAPP "MyProg"
+</programlisting>
 
-# UNPREDICTABLE - one substitution could be further expanded
-bad_bar = {'@bar@': '@soap@', '@soap@': 'lye'}
-env.Substfile('bar.in', SUBST_DICT=bad_bar)
+<para>Example 3: Showing different ways of updating
+the substitution dictionary.
+Sources are
+<filename>common.in</filename>,
+<filename>pgm1.in</filename> and
+<filename>pgm2.in</filename>.
+</para>
 
-# PREDICTABLE - substitutions are expanded in order
-good_bar = (('@bar@', '@soap@'), ('@soap@', 'lye'))
-env.Substfile('bar.in', SUBST_DICT=good_bar)
+<programlisting language="c">
+// Standard header for @PROJECT@
+// Build: @BUILD_ID@
+</programlisting>
 
-# the SUBST_DICT may be in common (and not an override)
-substutions = {}
-subst = Environment(tools=['textfile'], SUBST_DICT=substitutions)
-substitutions['@foo@'] = 'foo'
-subst['SUBST_DICT']['@bar@'] = 'bar'
-subst.Substfile(
+<programlisting language="c">
+void @foo@_function() {
+    // Implementation for @PROJECT@ module 1
+}
+</programlisting>
+
+<programlisting language="c">
+void @bar@_function() {
+    // Implementation for @PROJECT@ module 2
+}
+</programlisting>
+
+<example_commands>
+# SConstruct
+substitutions = {'@PROJECT@': 'MyProject', '@BUILD_ID@': '12345'}
+env = Environment(SUBST_DICT=substitutions)
+substitutions['@foo@'] = 'foo'  # won't work: override makes a copy
+env['SUBST_DICT']['@bar@'] = 'bar'
+env.Substfile(
     'pgm1.c',
     [Value('#include "@foo@.h"'), Value('#include "@bar@.h"'), "common.in", "pgm1.in"],
 )
-subst.Substfile(
+env.Substfile(
     'pgm2.c',
     [Value('#include "@foo@.h"'), Value('#include "@bar@.h"'), "common.in", "pgm2.in"],
 )
-
 </example_commands>
+
+<para>Output files <filename>pgm1.c</filename>
+and <filename>pgm2.c</filename>:</para>
+
+<programlisting language="c">
+#include "@foo@.h"  # note wasn't substituted
+#include "bar.h"
+// Standard header for MyProject
+// Build: 12345
+
+void @foo@_function() {  # note wasn't substituted
+    // Implementation for MyProject module 1
+}
+</programlisting>
+
+<programlisting language="c">
+#include "@foo@.h"  # note wasn't substituted
+#include "bar.h"
+// Standard header for MyProject
+// Build: 12345
+
+void bar_function() {
+    // Implementation for MyProject module 2
+}
+</programlisting>
+
 </summary>
 </builder>
 

--- a/SCons/Tool/textfile.xml
+++ b/SCons/Tool/textfile.xml
@@ -46,25 +46,19 @@ Set &consvars; for the &b-link-Textfile; and &b-link-Substfile; builders.
 <builder name="Textfile">
 <summary>
 <para>
-The &b-Textfile; builder and its sibling &b-Substfile;
-create a single text file by combining one or more template inputs,
-optionally performing token replacement.
-&b-Textfile; operates on string-like sources.
-Inputs are converted to SCons &f-link-Value; nodes so they can
-be tracked for rebuild purposes.
-Anything that converts cleanly to a &f-Value; node
-is eligible to be an input source, XXX
-so you can use files as string input by using,
-for example, <literal>Value('foo.in')</literal>.
-If there is more than one source,
-corresponding text chunks in the output are separated by
-the contents of the &cv-link-LINESEPARATOR; &consvar; (if set).
-If the &cv-link-SUBST_DICT; &consvar; is set,
-it defines replaceable strings and the replacement text.
-The replacement values are first subjected to
-&consvar; substitution.
-Nested lists of source strings are flattened.
-See &b-link-Substfile; for more details of replacement.
+The &b-Textfile; builder generates a single text file from
+a template consisting of a list of strings, replacing text
+using the &cv-link-SUBST_DICT; &consvar; (if set) -
+see &b-link-Substfile; for a description of replacement.
+The strings will be separated in the target file using the
+value of the
+&cv-link-LINESEPARATOR; &consvar;;
+the line separator is not emitted after the last string.
+Nested lists of source strings
+are flattened.
+Source strings need not literally be Python strings:
+they can be Nodes or Python objects that convert cleanly
+to &f-link-Value; nodes.
 </para>
 
 <para>
@@ -74,10 +68,7 @@ and &cv-link-TEXTFILESUFFIX; &consvars;
 are automatically added to the target if they are not already present.
 </para>
 <para>
-By default, the target file is encoded as <literal>utf-8</literal>.
-This can be changed by setting &cv-link-FILE_ENCODING;
-</para>
-<para>
+By default, the target file encoding is "utf-8" and can be changed by &cv-link-FILE_ENCODING;
 Examples:
 </para>
 
@@ -128,23 +119,20 @@ env.Textfile(
 <builder name="Substfile">
 <summary>
 <para>
-The &b-Substfile; builder and its sibling &b-Textfile;
-create a single text file by combining one or more template inputs,
-optionally performing token replacement.
-&b-Substfile; operates on file sources.
-If there is more than one source,
-corresponding text chunks in the output are separated by
-the contents of the &cv-link-LINESEPARATOR; &consvar; (if set).
-If the &cv-link-SUBST_DICT; &consvar; is set,
-it defines replaceable strings and the replacement text.
-The replacement values are first subjected to
-&consvar; substitution.
-Nested lists of source files are flattened. See also &b-link-Textfile;.
+The &b-Substfile; builder creates a single text file from
+a template consisting of a file or set of files (or nodes),
+replacing text using the &cv-link-SUBST_DICT; &consvar; (if set).
+If a set, they are concatenated into the target file
+using the value of the
+&cv-link-LINESEPARATOR; &consvar; as a separator between contents;
+the separator is not emitted after the contents of the last  file.
+Nested lists of source files
+are flattened. See also &b-link-Textfile;.
 </para>
 
 <para>
-By default, the target file is encoded as <literal>utf-8</literal>.
-This can be changed by setting &cv-link-FILE_ENCODING;
+By default, the target file encoding is "utf-8" and can be changed by &cv-link-FILE_ENCODING;
+Examples:
 </para>
 
 <para>
@@ -155,159 +143,71 @@ the suffix is stripped and the remainder of the name is used as the default targ
 <para>
 The prefix and suffix specified by the &cv-link-SUBSTFILEPREFIX;
 and &cv-link-SUBSTFILESUFFIX; &consvars;
-(both default to an empty string)
-are automatically added to the target file name
-if they are not already present (prefixes and suffixes do not duplicate).
+(an empty string by default in both cases)
+are automatically added to the target if they are not already present.
 </para>
 
 <para>
-&cv-link-SUBST_DICT; may be either a Python dictionary or a list of
+If a construction variable named &cv-link-SUBST_DICT; is present,
+it may be either a Python dictionary or a sequence of
 (<replaceable>key</replaceable>, <replaceable>value</replaceable>) tuples.
-Any occurrence of a key in the source
-is replaced by the corresponding value from the substitution dictionary,
-which has first been processed by <function>subst</function>.
-If the value is a Python function or other callable,
-it is called (with no arguments) and the return value is used
-as the replacement text.
-Order matters:
-if one key is a substring of another key
+If it is a dictionary it is converted into a list of tuples
+with unspecified order,
+so if one key is a prefix of another key
 or if one substitution could be further expanded by another substitution,
-the final result depends on the order in which the keys were seen.
-Using start-and-end markers in the key text can avoid
-unintentended problems (e.g. <literal>"@text@"</literal>
-and <literal>"@longtext@"</literal> leaves no confusion about
-what to do with <literal>"text"</literal>).
+it is unpredictable whether the expansion will occur.
 </para>
 
-
-<para>Example 1: Localizing a script.
-The template is <filename>script.in</filename>:
+<para>
+Any occurrences of a key in the source
+are replaced by the corresponding value,
+which may be a Python callable function or a string.
+If the value is a callable, it is called with no arguments to get a string.
+Strings are <emphasis>subst</emphasis>-expanded
+and the result replaces the key.
 </para>
-
-<programlisting language="sh">
-#! /bin/sh
-# Installation paths
-PREFIX="@prefix@"
-EXEC_PREFIX="@exec_prefix@"
-
-# Script logic here
-if [ -d "$PREFIX" ]; then
-    echo "Installing to $EXEC_PREFIX"
-fi
-</programlisting>
 
 <example_commands>
-# SConstruct
 env = Environment(tools=['default'])
 
 env['prefix'] = '/usr/bin'
 script_dict = {'@prefix@': '/bin', '@exec_prefix@': '$prefix'}
 env.Substfile('script.in', SUBST_DICT=script_dict)
-</example_commands>
 
-<para>Output file <filename>script</filename>:</para>
-
-<programlisting language="sh">
-#! /bin/sh
-# Installation paths
-PREFIX="/bin"
-EXEC_PREFIX="/usr/bin"
-
-# Script logic here
-if [ -d "$PREFIX" ]; then
-    echo "Installing to $EXEC_PREFIX"
-fi
-</programlisting>
-
-<para>Example 2: Customizing a header file which provides
-version-specific program information.
-The template is <filename>config.h.in</filename>:
-</para>
-
-<programlisting language="sh">
-#define VERSION "%VERSION%"
-#define BASEAPP "%BASE%"
-</programlisting>
-
-<example_commands>
-# SConstruct
 conf_dict = {'%VERSION%': '1.2.3', '%BASE%': 'MyProg'}
-env.Substfile('config.h.in', SUBST_DICT=conf_dict)
-</example_commands>
+env.Substfile('config.h.in', conf_dict, SUBST_DICT=conf_dict)
 
-<para>Output file <filename>config.h</filename>:</para>
+# UNPREDICTABLE - one key is a prefix of another
+bad_foo = {'$foo': '$foo', '$foobar': '$foobar'}
+env.Substfile('foo.in', SUBST_DICT=bad_foo)
 
-<programlisting language="sh">
-#define VERSION "1.2.3"
-#define BASEAPP "MyProg"
-</programlisting>
+# PREDICTABLE - keys are applied longest first
+good_foo = [('$foobar', '$foobar'), ('$foo', '$foo')]
+env.Substfile('foo.in', SUBST_DICT=good_foo)
 
-<para>Example 3: Showing different ways of updating
-the substitution dictionary.
-Sources are
-<filename>common.in</filename>,
-<filename>pgm1.in</filename> and
-<filename>pgm2.in</filename>.
-</para>
+# UNPREDICTABLE - one substitution could be further expanded
+bad_bar = {'@bar@': '@soap@', '@soap@': 'lye'}
+env.Substfile('bar.in', SUBST_DICT=bad_bar)
 
-<programlisting language="c">
-// Standard header for @PROJECT@
-// Build: @BUILD_ID@
-</programlisting>
+# PREDICTABLE - substitutions are expanded in order
+good_bar = (('@bar@', '@soap@'), ('@soap@', 'lye'))
+env.Substfile('bar.in', SUBST_DICT=good_bar)
 
-<programlisting language="c">
-void @foo@_function() {
-    // Implementation for @PROJECT@ module 1
-}
-</programlisting>
-
-<programlisting language="c">
-void @bar@_function() {
-    // Implementation for @PROJECT@ module 2
-}
-</programlisting>
-
-<example_commands>
-# SConstruct
-substitutions = {'@PROJECT@': 'MyProject', '@BUILD_ID@': '12345'}
-env = Environment(SUBST_DICT=substitutions)
-substitutions['@foo@'] = 'foo'  # won't work: override makes a copy
-env['SUBST_DICT']['@bar@'] = 'bar'
-env.Substfile(
+# the SUBST_DICT may be in common (and not an override)
+substutions = {}
+subst = Environment(tools=['textfile'], SUBST_DICT=substitutions)
+substitutions['@foo@'] = 'foo'
+subst['SUBST_DICT']['@bar@'] = 'bar'
+subst.Substfile(
     'pgm1.c',
     [Value('#include "@foo@.h"'), Value('#include "@bar@.h"'), "common.in", "pgm1.in"],
 )
-env.Substfile(
+subst.Substfile(
     'pgm2.c',
     [Value('#include "@foo@.h"'), Value('#include "@bar@.h"'), "common.in", "pgm2.in"],
 )
+
 </example_commands>
-
-<para>Output files <filename>pgm1.c</filename>
-and <filename>pgm2.c</filename>:</para>
-
-<programlisting language="c">
-#include "@foo@.h"  # note wasn't substituted
-#include "bar.h"
-// Standard header for MyProject
-// Build: 12345
-
-void @foo@_function() {  # note wasn't substituted
-    // Implementation for MyProject module 1
-}
-</programlisting>
-
-<programlisting language="c">
-#include "@foo@.h"  # note wasn't substituted
-#include "bar.h"
-// Standard header for MyProject
-// Build: 12345
-
-void bar_function() {
-    // Implementation for MyProject module 2
-}
-</programlisting>
-
 </summary>
 </builder>
 

--- a/test/ninja/copy_function_command-4731.py
+++ b/test/ninja/copy_function_command-4731.py
@@ -21,6 +21,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Regression test for issue #4731: almost the same as copy_function_command,
+but uses a list action where the first command is Copy,
+as opposed to a simple function action. This was failing.
+"""
+
 import os
 
 import TestSCons
@@ -45,7 +51,7 @@ SetOption('experimental', 'ninja')
 DefaultEnvironment(tools=[])
 env = Environment()
 env.Tool('ninja')
-env.Command('foo2.c', ['foo.c'], Copy('$TARGET','$SOURCE'))
+env.Command('foo2.c', ['foo.c'], [Copy('$TARGET', '$SOURCE'), Chmod('$TARGET', 0x755)])
 env.Program(target='foo', source='foo2.c')
 """,
 )

--- a/test/ninja/force_scons_callback-4730.py
+++ b/test/ninja/force_scons_callback-4730.py
@@ -21,6 +21,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+"""
+Regression test for issue #4730: almost the same as force_scons_callback
+function, but uses a target name with a space in it, to make sure
+quoting is handled correctly all the way through.
+"""
+
 import os
 
 import TestSCons
@@ -41,7 +47,7 @@ ninja_bin = TestSCons.NINJA_BINARY
 test.dir_fixture("ninja-fixture")
 
 test.file_fixture(
-    "ninja_test_sconscripts/sconstruct_force_scons_callback", "SConstruct"
+    "ninja_test_sconscripts/sconstruct_force_scons_callback-4730", "SConstruct"
 )
 
 # generate simple build
@@ -55,20 +61,20 @@ if not defers:
 if defers > 1:
     test.fail_test(message=f"Too many 'Defer to SCons' messages {defers}).")
 test.must_match("out.txt", "foo.c" + os.linesep)
-test.must_match("out2.txt", "test2.cpp" + os.linesep)
+test.must_match("out words.txt", "test2.cpp" + os.linesep)
 
 # clean build and ninja files
 test.run(arguments="-c", stdout=None)
 test.must_contain_all_lines(
     test.stdout(),
-    ["Removed out.txt", "Removed out2.txt", "Removed build.ninja"]
+    ["Removed out.txt", "Removed out words.txt", "Removed build.ninja"]
 )
 
 # only generate the ninja file
 test.run(arguments="--disable-execute-ninja", stdout=None)
 test.must_contain_all_lines(test.stdout(), ["Generating: build.ninja"])
 test.must_not_exist(test.workpath("out.txt"))
-test.must_not_exist(test.workpath("out2.txt"))
+test.must_not_exist(test.workpath("out words.txt"))
 
 # run ninja independently
 program = test.workpath("run_ninja_env.bat") if IS_WINDOWS else ninja_bin
@@ -79,7 +85,7 @@ if not defers:
 if defers > 1:
     test.fail_test(message="Too many 'Defer to SCons' messages.")
 test.must_match("out.txt", "foo.c" + os.linesep)
-test.must_match("out2.txt", "test2.cpp" + os.linesep)
+test.must_match("out words.txt", "test2.cpp" + os.linesep)
 
 # only generate the ninja file with specific NINJA_SCONS_DAEMON_PORT
 test.run(arguments="PORT=9999 --disable-execute-ninja", stdout=None)

--- a/test/ninja/ninja_test_sconscripts/sconstruct_force_scons_callback-4730
+++ b/test/ninja/ninja_test_sconscripts/sconstruct_force_scons_callback-4730
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright The SCons Foundation
+
+SetOption("experimental", "ninja")
+DefaultEnvironment(tools=[])
+
+env = Environment(tools=[])
+daemon_port = ARGUMENTS.get("PORT", False)
+if daemon_port:
+    env["NINJA_SCONS_DAEMON_PORT"] = int(daemon_port)
+env.Tool("ninja")
+
+env.Command("out.txt", "foo.c", "echo $SOURCE> $TARGET")
+env.Command("out words.txt", "test2.cpp", "echo $SOURCE> $TARGET", NINJA_FORCE_SCONS_BUILD=True)


### PR DESCRIPTION
Ninja tool now quotes targets (if necessary) when calling back to SCons - both in the REST request constructed to contact the daemon, and in the command eventually issued from the daemon. 

Fixes #4730

Ninja tool is also adjusted to recognize and emit a `CMD` tagged rule in the case of a list action (... `action=[Something, LaterSomething]`). `CMD` refers to functions that have special handlers that need the source and target as arguments, in this case the `Copy` function (at least) was being categorized as a `GENERATED_CMD,` which gets no arguments, and so the copy failed.

Fixes #4731

Both of these credit to initial suggestion from Julien Pommier.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
