### PR TITLE
FS unit test fixes for UNC paths

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -113,6 +113,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       of a list of actions. Recognition only happens if the special
       action is first in the list.  Initial suggestion from Julien Pommier.
       Fixes #4731.
+    - Fix a test problem on Windows where UNC tests failed due to incorrect
+      path munging if a non-default %TEMP% was defined (as in moving to
+      a Dev Drive). Also some cleanup.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -73,6 +73,9 @@ FIXES
   of a list of actions. Recognition only happens if the special
   action is first in the list.
 
+- Fix a test problem on Windows where UNC tests failed due to incorrect path
+  munging if a non-default %TEMP% was defined (as in moving to a Dev Drive).
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -1778,12 +1778,12 @@ class FSTestCase(_tempdirTestCase):
                 # Note that if any of the UNC paths eventually makes it to
                 # Windows, and looks syntactically valid (\\server\share), the
                 # mkdir takes a *long* time to fail with "network path not
-                # found".  If it's not syntaxtically valid, it fails
-                # immediately.  Thus, some of these tests can be very slow on
-                # the first pass.  Second pass they all "hit" on the Node
-                # lookup cache, so there's no further slowdown. Tried doing
-                # this passing create=False to the Dir() function, but that
-                # caused other problems.
+                # found".  If it's not valid syntax, it fails immediately.
+                # Thus, some of these tests can be very slow on the first pass.
+                # Second pass they all "hit" on the Node lookup cache,
+                # so there's no further slowdown. Tried doing this passing
+                # create=False to the Dir() function, but that causes a hard
+                # fail if the dir doesn't already exist, so not right either.
 
                 Dir_test('//foo', '//foo', '//')
                 Dir_test('//foo/bar', '//foo/bar', '//foo')

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -1684,7 +1684,7 @@ class FSTestCase(_tempdirTestCase):
 
             *dirs* is a list of directory names, which will be joined
             together to derive the base of the path - any "drive letter"
-            bits split off. Makes no effort to crate an actual *valid*
+            bits split off. Makes no effort to create an actual *valid*
             UNC path - does not add a server or share name, so it will not
             actually work in real life, just for string testing.
 


### PR DESCRIPTION
Managed to fail a number of UNC path tests by moving everything, even the %TEMP% directory to a dev drive from the C drive. A structuring problem meant some paths weren't trimmed of trailing slashes as they were intended to - we just do a string comparison in the cases, not a path-aware comparison, so this was enough for an error.  Resynced three similar tests, added some docstrings and comments, etc.

No doc impacts (except docstrings).

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
