### PR TITLE
Update testing intro doc

### DIFF
--- a/testing/framework/test-framework.rst
+++ b/testing/framework/test-framework.rst
@@ -37,14 +37,15 @@ There are three categories of SCons tests:
 *End-to-End Tests*
    End-to-end tests of SCons are small self-contained projects that are
    run by calling ``scons`` (or in a few cases, ``sconsign`` or ``scons-time``)
-   to execute them, and thus capture the results of
-   running all the way through an invocation - end to end.
-   They are implemented as Python scripts which are responsible for setup,
-   for running the test, and for checking conformance with expectations.
-   The tests are runnable standalone but usually executed by the test runner.
+   to execute them, and thus simulate the results of running all the
+   way through building a project - thus "end to end".
+   These tests need a Python script to drive them - setup, issuing
+   the correct command line, checking and recording results;
+   these operations are aided by using the test infrastructure modules in
+   the ``testing/framework`` subdirectory.
+   The scripts need a test runner to find end execute them
+   (the runner specifically requires a ``.py`` filename suffix on these).
    The standard tests are located in the ``test/`` subdirectory,
-   and use the test infrastructure modules in the
-   ``testing/framework`` subdirectory.
 
 *External Tests*
    For the support of external Tools (in the form of packages, preferably),

--- a/testing/framework/test-framework.rst
+++ b/testing/framework/test-framework.rst
@@ -59,7 +59,7 @@ Contrasting end-to-end and unit tests
 -------------------------------------
 
 End-to-end tests exist to verify hardened parts of the public interface:
-featurers documented in the reference manual that are available
+features documented in the reference manual that are available
 to use in a project. They accomplish this by themselves being
 complete (though usually very small) SCons projects.
 Unit tests are more for testing internal interfaces which may
@@ -80,7 +80,8 @@ However, bug reports tend describe end-to-end type behavior
 ("I put this in my SConscripts, and something went wrong"),
 so it's often useful to code an e2e test to match a bug report,
 and develop a solution that turns that to a pass.
-So pick the testing strategy that makes sense (sometimes both do).
+So pick the testing strategy that makes sense (sometimes both do) -
+and if it's possible to reduce an end-to-end test to a unit test, please do
 
 End-to-end tests are by their nature harder to debug. For the unit
 tests, you're running a test program directly, so you can drop straight
@@ -137,7 +138,7 @@ Testing Architecture
 
 The test framework provides a lot of useful functions for use within a
 test program. This includes test setup, parameterization, running tests,
-examining results and reporting outcomes. You can run a particular test
+examining results and reporting outcomes. You can run a particular unit test
 directly by making sure the Python interpreter can find the framework::
 
     $ PYTHON_PATH=testing/framework python SCons/ActionTests.py
@@ -260,8 +261,8 @@ supporting Python script files in a subdirectory which shouldn't be
 picked up as test scripts of their own.  There are two options here:
 
    * Add a file with the name ``sconstest.skip`` to your subdirectory. This
-   tells ``runtest.py`` to skip the contents of the directory completely.
-   * Create a file ``.exclude_tests`` in yur subdirectory, and in
+     tells ``runtest.py`` to skip the contents of the directory completely.
+   * Create a file ``.exclude_tests`` in your subdirectory, and in
      it list line-by-line the files to exclude from testing - the rest
      will still be picked up as long as they meet the selection criteria.
 
@@ -308,7 +309,7 @@ Line by line explanation of example
    Imports the main infrastructure for SCons tests.  This is
    normally the only part of the infrastructure that needs importing.
    If you need Python standard library modules in your code,
-   the conventio it to import those before the framework.
+   the convention it to import those before the framework.
 
 ``test = TestSCons.TestSCons()``
    Initializes an object for testing.  A fair amount happens under

--- a/testing/framework/test-framework.rst
+++ b/testing/framework/test-framework.rst
@@ -8,38 +8,47 @@ SCons Testing Framework
 Introduction
 ============
 
-SCons uses extensive automated tests to ensure quality. The primary goal
-is that users be able to upgrade from version to version without
-any surprise changes in behavior.
+SCons uses extensive automated tests to ensure quality, so users can
+safely upgrade from version to version without any surprise changes in behavior.
 
-In general, no change goes into SCons unless it has one or more new
-or modified tests that demonstrably exercise the bug being fixed or
-the feature being added.  There are exceptions to this guideline, but
-they should be just that, *exceptions*.  When in doubt, make sure
-it's tested.
+Changes to SCons code, whether fix or new feature, need testing support before
+being merged. Sometimes this might mean writing tests for an area that didn't
+have adequate, or any, testing before. Having tests isn't an
+*iron-clad policy*, but exceptions need to be okayed by the core team -
+it's good to discuss ahead of time. When in doubt, test it!
+
+This guide should provide enough information to get started. Use it together
+with existing tests to "see how it's done".  Note if you're coding in an IDE,
+you may need to add the path ``testing/framework`` to the known paths,
+or it won't recognize some symbols.
+
 
 Test organization
 =================
 
-There are three types of SCons tests:
-
-*End-to-End Tests*
-   End-to-end tests of SCons are Python scripts (``*.py``) underneath the
-   ``test/`` subdirectory.  They use the test infrastructure modules in
-   the ``testing/framework`` subdirectory. They set up small complete
-   projects and call SCons to execute them, checking that the behavior is
-   as expected.
+There are three categories of SCons tests:
 
 *Unit Tests*
    Unit tests for individual SCons modules live underneath the
-   ``SCons/`` subdirectory and are the same base name as the module
-   to be tested, with ``Tests`` appended  to the basename. For example,
-   the unit tests for the ``Builder.py`` module are in the
-   ``BuilderTests.py`` script.  Unit tests tend to be based on assertions.
+   ``SCons/`` subdirectory (that is alongside the code they are testing)
+   and use the Python ``unittest`` module to perform assertion-based
+   testing of individual routines, classes and methods in the SCons code base.
+
+*End-to-End Tests*
+   End-to-end tests of SCons are small self-contained projects that are
+   run by calling ``scons`` (or in a few cases, ``sconsign`` or ``scons-time``)
+   to execute them, and thus capture the results of
+   running all the way through an invocation - end to end.
+   They are implemented as Python scripts which are responsible for setup,
+   for running the test, and for checking conformance with expectations.
+   The tests are runnable standalone but usually executed by the test runner.
+   The standard tests are located in the ``test/`` subdirectory,
+   and use the test infrastructure modules in the
+   ``testing/framework`` subdirectory.
 
 *External Tests*
    For the support of external Tools (in the form of packages, preferably),
-   the testing framework is extended so it can run in standalone mode.
+   the testing framework can also run in standalone mode.
    You can start it from the top-level directory of your Tool's source tree,
    where it then finds all Python scripts (``*.py``) underneath the local
    ``test/`` directory.  This implies that Tool tests have to be kept in
@@ -49,46 +58,67 @@ There are three types of SCons tests:
 Contrasting end-to-end and unit tests
 -------------------------------------
 
-In general, end-to-end tests verify hardened parts of the public interface:
-interfaces documented in the manpage that a user might use in their
-project. These cannot be broken (of course, errors can be corrected,
-though sometimes a transition period may be required).
-Unit tests are now considered for testing internal interfaces, which do
-not themselves directly have API guarantees.  An example could be using
-and end-to-end test to verify that things added by env.Append() actually
-appear correctly in issued command lines, while unit tests assure
-correct behavior given various inputs of internal routines that
-Append() may make use of. If a reported error can be tested by adding a new
-case to an existing unit test, by all means, do that, as it tends to be
-simpler and cleaner. On the other hand, reported problems that come with
-a reproducer are by their nature more like an e2e test - this is something
-a user has tried in their SConscripts that didn't have the expected result.
+End-to-end tests exist to verify hardened parts of the public interface:
+featurers documented in the reference manual that are available
+to use in a project. They accomplish this by themselves being
+complete (though usually very small) SCons projects.
+Unit tests are more for testing internal interfaces which may
+not themselves directly have public API guarantees.
+They let you hone in on the point of error much more precisely.
+As an example, an end-to-end test verifies that
+variable contents added by ``env.Append`` actually
+appear correctly in issued command lines,
+while unit tests verify that internal routine
+``SCons.Environment._add_cppdefines`` properly handles the
+complexities of combining different types of arguments
+and still produce the expected contents of the ``CPPDEFINES``
+variable being added to by the ``env.Append`` interface..
+
+If you're pursuing a fix and it can be tested by adding a new
+case to a unit test, that is often simpler and more direct.
+However, bug reports tend describe end-to-end type behavior
+("I put this in my SConscripts, and something went wrong"),
+so it's often useful to code an e2e test to match a bug report,
+and develop a solution that turns that to a pass.
+So pick the testing strategy that makes sense (sometimes both do).
 
 End-to-end tests are by their nature harder to debug. For the unit
 tests, you're running a test program directly, so you can drop straight
 into the Python debugger by calling ``runtest.py`` with the ``-d / --debug``
-option and setting breakpoints to help examine the internal state as
-the test is running. The e2e tests are each mini SCons projects executed
-by an instance of scons in a subprocess, and the Python debugger isn't
-particularly useful in this context.
-There's a separate section of this document on that topic: see `Debugging
-end-to-end tests`_.
+option, set some breakpoints and otherwise step through examining
+internal state and how it changes as the test is running.
+The end-to-end tests are each small SCons projects executed
+by an instance of SCons in a subprocess, so the Python debugger is
+harder to bring into play in this context.
+There's a separate section devoted to debugging ideas:
+`Debugging end-to-end tests`_.
 
 
 Naming conventions
 ------------------
 
+The unit tests have the same base name as the module to be tested,
+with ``Tests`` appended. For packages, it's conventional to put the
+test file in the package directory, and there's typically only one test file
+for the whole package directory, but feel free to use multiples
+if it makes more sense. For example, there's an
+``SCons/Platform/PlatformTests.py`` which covers most of the
+Platform code, but also ``SCons/Platform/virtualenvTests.py``
+for testing the virtualenv (sub-)module.
+
 The end-to-end tests, more or less, follow this naming convention:
 
-#. All tests end with a ``.py`` suffix.
-#. In the *General* form we use
+* Tests are Python scripts, so they end with a ``.py`` suffix.
+* In the *General* form we use
 
    ``Feature.py``
-      for the test of a specified feature; try to keep this description
+      for the test of a specified feature; try to keep this name
       reasonably short
    ``Feature-x.py``
       for the test of a specified feature using option ``x``
-#. The *command line option* tests take the form
+   ``Feature-live.py``
+      for a test which explicitly uses an external tool to operate.
+* The *command line option* tests take the form
 
    ``option-x.py``
       for a lower-case single-letter option
@@ -98,8 +128,8 @@ The end-to-end tests, more or less, follow this naming convention:
    ``option--lo.py``
       long option; you can abbreviate the long option name to a
       few characters (the abbreviation must be unique, of course).
-#. Use a suitably named subdirectory if there's a whole group of
-   related test files.
+* Use a suitably named subdirectory if there's a whole group of
+   related test files, this allows easier selection.
 
 
 Testing Architecture
@@ -107,13 +137,14 @@ Testing Architecture
 
 The test framework provides a lot of useful functions for use within a
 test program. This includes test setup, parameterization, running tests,
-looking at results and reporting outcomes. You can run a particular test
+examining results and reporting outcomes. You can run a particular test
 directly by making sure the Python interpreter can find the framework::
 
     $ PYTHON_PATH=testing/framework python SCons/ActionTests.py
 
-The framework does *not* provide facilities for handling a collection of
-test programs. For that, SCons provides a driver script ``runtest.py``.
+The framework does *not* provide facilities for test selection,
+or otherwise dealing with collections of tests.
+For that, SCons provides a runner script ``runtest.py``.
 Help is available through the ``-h`` option::
 
    $ python runtest.py -h
@@ -165,7 +196,7 @@ to the screen to a file named by ``FILE``. There is also an option to
 save the results in a custom XML format.
 
 The above invocations all test against the SCons files in the current
-directory (that is, in ``./SCons``, and do not require that a packaging
+directory (that is, in ``./SCons``), and do not require that a packaging
 build of SCons be performed first.  This is the most common mode: make
 some changes, and test the effects in place.  The ``runtest.py`` script
 supports additional options to run tests against unpacked packages in the
@@ -228,16 +259,17 @@ When using fixtures, you may end up in a situation where you have
 supporting Python script files in a subdirectory which shouldn't be
 picked up as test scripts of their own.  There are two options here:
 
-#. Add a file with the name ``sconstest.skip`` to your subdirectory. This
+   * Add a file with the name ``sconstest.skip`` to your subdirectory. This
    tells ``runtest.py`` to skip the contents of the directory completely.
-#. Create a file ``.exclude_tests`` in each directory in question, and in
-   it list line-by-line the files to exclude from testing.
+   * Create a file ``.exclude_tests`` in yur subdirectory, and in
+     it list line-by-line the files to exclude from testing - the rest
+     will still be picked up as long as they meet the selection criteria.
 
 The same rules apply when testing external Tools when using the ``-e``
 option.
 
 
-Example End-to-End test script
+Example end-to-end test script
 ==============================
 
 To illustrate how the end-to-end test scripts work, let's walk through
@@ -269,14 +301,14 @@ a simple *Hello, world!* example::
 
     test.pass_test()
 
-Explanation
------------
+Line by line explanation of example
+-----------------------------------
 
 ``import TestSCons``
    Imports the main infrastructure for SCons tests.  This is
    normally the only part of the infrastructure that needs importing.
-   Sometimes other Python modules are necessary or helpful, and get
-   imported before this line.
+   If you need Python standard library modules in your code,
+   the conventio it to import those before the framework.
 
 ``test = TestSCons.TestSCons()``
    Initializes an object for testing.  A fair amount happens under
@@ -327,6 +359,7 @@ Explanation
    the test passed.  As a side effect of destroying the ``test`` object,
    the created temporary directory will be removed.
 
+
 Working with fixtures
 =====================
 
@@ -336,24 +369,21 @@ method, plus a string holding its contents, and it gets written to the test
 directory right before starting.
 
 This simple technique can be seen throughout most of the end-to-end
-tests as it was the original technique provided to test developers,
+tests as it was the original technique provided for test developers,
 but it is no longer the preferred way to write a new test.
 To develop this way, you first need to create the necessary files and
 get them to work, then convert them to an embedded string form, which may
-involve lots of extra escaping.  These embedded files are then tricky
-to maintain.  As a test grows multiple steps, it becomes less easy to
-read, since many if the embedded strings aren't quite the final files,
-and the volume of test code obscures the flow of the testing steps.
-Additionally, as SCons moves more to the use of automated code checkers
-and formatters to detect problems and keep a standard coding style for
-better readability, note that such tools don't look inside strings
-for code, so the effect is lost on them.
+involve escaping, using raw strings, and other fiddly details.
+These embedded files are then tricky to maintain - they're not
+recognized as code by editors, static checkers, or formatters.
+Readability is further hurt if the test script grows large -
+lots of files-in-strings obscure the flow of the actual testing logic.
 
 In testing parlance, a fixture is a repeatable test setup.  The SCons
-test harness allows the use of saved files or directories to be used
-in that sense: *the fixture for this test is foo*, instead of writing
-a whole bunch of strings to create files. Since these setups can be
-reusable across multiple tests, the *fixture* terminology applies well.
+test harness allows the use of saved files as well as collections of
+files in named directories to be used
+in that sense: *the fixture for this test is foo*.  Since these setups can be
+reused across multiple tests, the *fixture* terminology applies well.
 
 Note: fixtures must not be treated by SCons as runnable tests. To exclude
 them, see instructions in the above section named `Selecting tests`_.
@@ -361,37 +391,39 @@ them, see instructions in the above section named `Selecting tests`_.
 Directory fixtures
 ------------------
 
-The test harness method ``dir_fixture(srcdir, [dstdir])``
+The test method ``dir_fixture(srcdir, [dstdir])``
 copies the contents of the specified directory ``srcdir`` from
 the directory of the called test script to the current temporary test
-directory.  The ``srcdir`` name may be a list, in which case the elements
-are concatenated into a path first.  The optional ``dstdir`` is
+directory. The optional ``dstdir`` is
 used as a destination path under the temporary working directory.
-``distdir`` is created automatically, if it does not already exist.
+``dstdir`` is created automatically if it does not already exist.
+The ``srcdir`` and ``dstdir`` parameters may each be a list,
+which will be concatenated into a path string.
 
 If ``srcdir`` represents an absolute path, it is used as-is.
 Otherwise, if the harness was invoked with the environment variable
 ``FIXTURE_DIRS`` set (which ``runtest.py`` does by default),
 the test instance will present that list of directories to search
-as ``self.fixture_dirs``, each of these are additionally searched for
-a directory with the name of ``srcdir``.
+as ``self.fixture_dirs``. Each of these are additionally searched for
+a directory with the name given by ``srcdir``.
 
-A short syntax example::
+A short example showing the syntax::
 
    test = TestSCons.TestSCons()
-   test.dir_fixture('image')
+   test.dir_fixture('fixture')
    test.run()
 
-would copy all files and subdirectories from the local ``image`` directory
-to the temporary directory for the current test, then run it.
+This copies all files and subdirectories from the local ``fixture`` directory,
+or if not found, from a ``fixture`` located in one of the fixture dirs,
+to the temporary directory for the current test, before running the test.
 
-To see a real example for this in action, refer to the test named
+To see an example in action, refer to the test named
 ``test/packaging/convenience-functions/convenience-functions.py``.
+
 
 File fixtures
 -------------
-
-The method ``file_fixture(srcfile, [dstfile])``
+The test method ``file_fixture(srcfile, dstfile)``
 copies the file ``srcfile`` from the directory of the called script
 to the temporary test directory.
 The optional ``dstfile`` is used as a destination file name
@@ -399,17 +431,17 @@ under the temporary working directory, unless it is an absolute path name.
 If ``dstfile`` includes directory elements, they are
 created automatically if they don't already exist.
 The ``srcfile`` and ``dstfile`` parameters may each be a list,
-which will be concatenated into a path.
+which will be concatenated into a path string.
 
 If ``srcfile`` represents an absolute path, it is used as-is. Otherwise,
 any passed in fixture directories are used as additional places to
 search for the fixture file, as for the ``dir_fixture`` case.
 
-With the following code::
+As an example, with the following code::
 
    test = TestSCons.TestSCons()
    test.file_fixture('SConstruct')
-   test.file_fixture(['src', 'main.cpp'], ['src', 'main.cpp'])
+   test.file_fixture('src/main.cpp', 'src/main.cpp')
    test.run()
 
 The files ``SConstruct`` and ``src/main.cpp`` are copied to the
@@ -432,13 +464,20 @@ How to convert old tests to use fixtures
 ----------------------------------------
 
 Tests using the inline ``TestSCons.write()`` method can fairly easily be
-converted to the fixture based approach. For this, we need to get at the
-files as they are written to each temporary test directory,
-which we can do by taking advantage of an existing debugging aid,
-namely that ``runtest.py`` checks for the existence of an environment
-variable named ``PRESERVE``. If it is set to a non-zero value, the testing
-framework preserves the test directory instead of deleting it, and prints
-a message about its name to the screen.
+converted to the fixture based approach via a trick: you can capture
+the test directory as it is created, which will contain the files
+in their final form. To do this, set the environment variable
+``PRESERVE`` to a non-zero value when calling ``runtest.py``
+to run the test,
+and it will preserve the directory rather than getting rid of it,
+and report the path.
+A thing to keep in mind is some tests rewrite files while
+running - for example some tests create an `SConstruct``,
+then write a new one for another part of the test,
+then possibly do so again - "preserving" will only keep the state
+of the test as it exits.  For this and debugging reasons,
+it is preferred not to have tests replace the contents of key files
+during a run.
 
 So, you should be able to give the commands::
 
@@ -454,7 +493,7 @@ The output will then look something like this::
    PASSED
    preserved directory /tmp/testcmd.4060.twlYNI
 
-You can now copy the files from that directory to your new
+You can copy the files from that directory to your new
 *fixture* directory. Then, in the test script you simply remove all the
 tedious ``TestSCons.write()`` statements and replace them with a single
 ``TestSCons.dir_fixture()`` call.
@@ -472,20 +511,26 @@ final name as needed::
    test.file_fixture('fixture/SConstruct.part2', 'SConstruct')
    # run new test
 
+As mentioned earlier, this isn't really ideal and it's
+preferred in such cases to keep the separate names in the test
+directory, and instead vary how the tests are executed, like::
+
+   test.run(arguments=['-f', 'SConstruct.part1'])
+   test.run(arguments=['-f', 'SConstruct.part2'])
+
 
 When not to use a fixture
 -------------------------
 
-Note that some files are not appropriate for use in a fixture as-is:
-fixture files should be static. If the creation of the file involves
-interpolating data discovered during the run of the test script,
-that process should stay in the script.  Here is an example of this
-kind of usage that does not lend itself easily to a fixture::
+Static test files are well suited to fixtures, you just copy them over.
+Files with dynamically created content - usually to interpolate
+information discovered during test setup, are more problematic.
+Here's an example of a rather common pattern::
 
    import TestSCons
    _python_ = TestSCons._python_
 
-   test.write('SConstruct', f"""
+   test.write('SConstruct', f"""\
    cc = Environment().Dictionary('CC')
    env = Environment(
        LINK=r'{_python_} mylink.py',
@@ -497,39 +542,79 @@ kind of usage that does not lend itself easily to a fixture::
    env.Program(target='test1', source='test1.c')
    """
 
-Here the value of ``_python_`` from the test program is
-pasted in via f-string formatting. A fixture would be hard to use
-here because we don't know the value of ``_python_`` until runtime
-(also note that as it will be an absolute pathname, it's entered using
-Python raw string notation to avoid interpretation problems on Windows,
+Here the value of ``_python_`` (the path to the Python executable
+actually in use for the test) is obtained by the test program from
+the framework, and pasted in via f-string formatting in setting up
+the string that will make up the contents of the ``SConstruct``.
+A simple fixture isn't useful here because the value of ``_python_``
+isn't known until runtime (also note that as it will be an
+absolute pathname, it is entered using Python raw string notation
+to avoid interpretation problems on Windows,
 where the path separator is a backslash).
 
 The other files created in this test may still be candidates for
 use as fixture files, however.
 
+There's another approach that can be used in this case,
+letting you still use a fixture file:
+instead of using string interpolation at setup time,
+consider passing values at run-time via command-line arguments.
+In the example above, you can replace the substitution
+of ``_python_`` at file-writing time with a check for a variable
+from the command line, and substitute that at run-time,
+so instead of the above sequence in the test script,
+put this in a new file ``fixture/SConstruct``::
+
+   python = ARGUMENTS.get('PYTHON', 'python')
+   cc = Environment().Dictionary('CC')
+   env = Environment(
+       LINK=rf'{python} mylink.py',
+       LINKFLAGS=[],
+       CC=rf'{python} mycc.py',
+       CXX=cc,
+       CXXFLAGS=[],
+   )
+   env.Program(target='test1', source='test1.c')
+
+Read this in as a file fixture::
+
+   test.file_fixture(srcfile='fixture/SConstruct')
+
+For this to work, you have to supply ``PYTHON`` in the argument list,
+so it appears in ``ARGUMENTS`` at run-time::
+
+   test.run(arguments=rf'PYTHON={_python_}')
+
 
 Debugging end-to-end tests
 ==========================
 
-The end-to-end tests are hand-crafted SCons projects, so testing
-involves running an instance of scons with those inputs. The
-tests treat the SCons invocation as a *black box*,
+An end-to-end tests is a hand-crafted SCons project,
+so testing involves building (or cleaning) that project
+with suitable arguments to control the behavior.
+The tests treat the SCons invocation as a *black box*,
 usually looking for *external* effects of the test - targets are
-created, created files have expected contents, files properly
+created, generated files have expected contents, files are properly
 removed on clean, etc.  They often also look for
-the flow of messages from SCons.
+the flow of messages from SCons, which is unfortunately a bit fragile
+(many a test has been broken by a new Python version changing
+the precise format of an exception message, for example).
+Some tests do have test code inside the generated files,
+and based on the result emit special known strings that
+the test can look for.
 
 Simple tricks like inserting ``print`` statements in the SCons code
-itself don't really help as they end up disrupting those external
-effects (e.g. ``test.run(stdout="Some text")``, but with the
-``print``, ``stdout`` contains the extra print output and the
-result doesn't match).
+itself don't really help as they end up disrupting expected output.
+For example, ``test.run(stdout="Some text")``
+expects a simple string on the standard output stream,
+but the presence of a ``print`` in the code means that appears
+in the output, too, and the string matching will fail the test.
 
 Even more irritatingly, added text can cause other tests to fail and
 obscure the error you're looking for.  Say you have three different
 tests in a script exercising different code paths for the same feature,
 and the third one is unexpectedly failing. You add some debug prints to
-the affected part of scons, and now the first test of the three starts
+the affected part of SCons, and now the first test of the three starts
 failing, aborting the test run before it even gets to the third test -
 the one you were trying to debug.
 
@@ -582,22 +667,28 @@ Test infrastructure
 The main end-to-end test API is defined in the ``TestSCons`` class.
 ``TestSCons`` is a subclass of ``TestCommon``,
 which is a subclass of ``TestCmd``.
-``TestSCons`` provides the help for using an instance of SCons during
-the run.
-
-The unit tests do not run an instance of SCons separately, but instead
-import the modules of SCons that they intend to test. Those tests
-should use the ``TestCmd`` class - it is intended for runnable scripts.
-
+``TestCmd`` provides facilities for generically "running a command".
+``TestCommon`` wraps this with features for result and error handling.
+``TestSCons`` specializes that into support for
+specifically running the command ``scons``
+(there are related classes ``TestSConsign`` for runing ``sconsign``
+and ``TestSCons_time`` for running timing tests using ``bin/scons_time.py``.
 Those classes are defined in Python files of the same name
 in ``testing/framework``.
-Start in ``testing/framework/TestCmd.py`` for the base API definitions, like how
-to create files (``test.write()``) and run commands (``test.run()``).
+Start in ``testing/framework/TestCmd.py`` for the base API definitions,
+like how to create files (``test.write()``)
+and run commands (``test.run()``).
+
+The unit tests do not run a separate instance of SCons, but instead
+import the SCons module that they intend to test. Those tests
+can usually use the ``TestCmd`` class for testing infrastructure
+(temporary directory, file creation, etc.), while the test classes
+themselves normally derive from ``unittest.TestCase``.
 
 The match functions work like this:
 
 ``TestSCons.match_re``
-   match each line with an RE
+   match each line with a regular expression.
 
    * Splits the lines into a list (unless they already are)
    * splits the REs at newlines (unless already a list)
@@ -606,7 +697,7 @@ The match functions work like this:
      REs as lines.
 
 ``TestSCons.match_re_dotall``
-   match all the lines against a single RE
+   match all the lines against a single regular expression.
 
    * Joins the lines with newline (unless already a string)
    * joins the REs with newline (unless it's a string) and puts ``^..$``
@@ -633,14 +724,17 @@ be split on spaces, pre-split it yourself, and pass the list, like::
    test.run(arguments=["-f", "SConstruct2", "FOO=Two Words"])
 
 
-Avoiding tests based on tool existence
-======================================
+Avoiding tests based on tool (non-)existence
+============================================
 
 For many tests, if the tool being tested is backed by an external program
 which is not installed on the machine under test, it may not be worth
 proceeding with the test. For example, it's hard to test compiling code with
 a C compiler if no C compiler exists. In this case, the test should be
 skipped.
+
+End-to-end
+----------
 
 Here's a simple example for end-to-end tests::
 
@@ -652,10 +746,27 @@ See ``testing/framework/TestSCons.py`` for the ``detect_tool()`` method.
 It calls the tool's ``generate()`` method, and then looks for the given
 program (tool name by default) in ``env['ENV']['PATH']``.
 
-The ``where_is()`` method can be used to look for programs that
-are do not have tool specifications. The existing test code
+``test.where_is()`` can be used to look for programs that
+do not have tool specifications (or you just don't want to
+involve a specific tool). The existing test code
 will have many samples of using either or both of these to detect
 if it is worth even proceeding with a test.
+
+There's an additional consideration for e2e tests: when a project
+developer needs a tool that requires some unique setup
+(in particular, the path to find an external executable),
+they can just adjust their build to make it work in their environment.
+It's not practical to change a bunch of tests in the test suite to do a
+similar thing. Calling ``test.where_is()`` might return a positive
+response based on searching the shell's ``PATH`` environment
+variable (which it checks if no specific paths to search are given),
+but that does not guarantee the copy of SCons launched to run
+the actual testcase will find it, so it may be necessary to
+pass the path to the test, perhaps via an argument to ``test.run()``.
+
+
+Unit Tests
+----------
 
 For the unit tests, there are decorators for conditional skipping and
 other actions that will produce the correct output display and statistics
@@ -685,84 +796,110 @@ plumbed into the environment.  These things can be tested by mocking the
 behavior of the executable.  Many examples of this can be found in the
 ``test`` directory. See for example ``test/subdivide.py``.
 
-Testing DOs and DONTs
-=====================
 
-There's no question that having to write tests in order to get a change
-approved - even an apparently trivial change - does make it a little harder
-to contribute to the SCons code base - but the requirement to have features
-and bugfixes testable is a necessary part of ensuring SCons quality.
-Thinking of SCons development in terms of the red/green model from
-Test Driven Development should make things a little easier.
+Testing DOs and DONT'S
+======================
 
-If you are working on an SCons bug, try to come up with a simple
-reproducer first.  Bug reports (even your own!) are often like *I tried
-to do this but it surprisingly failed*, and a reproducer is normally an
-``SConstruct`` along with, probably, some supporting files such as source
-files, data files, subsidiary SConscripts, etc.  Try to make this example
-as simple and clean as possible.  No, this isn't necessarily easy to do,
-but winnowing down what triggers a problem and removing the stuff that
-doesn't actually contribute to triggering the problem it is a step that
-lets you (and later readers) more clearly understand what is going on.
-You don't have to turn this into a formal testcase yet, but keep this
-reproducer around, and document with it what you expect to happen,
-and what actually happens.  This material will help produce an E2E
-test later, and this is something you *may* be able to get help with,
-if the way the tests are usually written and the test harness proves
-too confusing.  With a clean test in hand (make sure it's failing!)
-you can go ahead an code up a fix and make sure it passes with the fix
-in place.  Jumping straight to a fix without working on a testcase like
-this will often lead to a disappointing *how do I come up with a test
-so the maintainer will be willing to merge* phase. Asking questions on
-a public forum can be productive here.
+We know that needing to write tests makes the job of contributing
+code to SCons more cumbersome. But as noted in the introduction,
+the testing strategy is extremely important to SCons, it has allowed
+the project to serve many users with very few nasty surprises
+(won't lie and say there has *never* been a surprise!)
+for over two decades. We suggest thinking in terms of test-driven
+development for your contribution: you'll need something to show
+that your change actually works anyway.  If it's a bug report,
+this may be the minimum viable reproducer; if it's a new feature,
+you still want to show how something that couldn't be done
+before can now be done.  Code that up first, and document your
+expectations (for yourself as much as anyone), and use it when
+developing the fix/feature.  Often that code can be converted into
+a test that will fit into the SCons testuite without doing too
+much extra work.  If that work looks too daunting, please ask
+for help - tips, advice, and coding help may all be available.
 
-E2E-specific Suggestions:
 
-* Do not require the use of an external tool unless necessary.
+E2E-specific suggestions
+------------------------
+
+* **DO** group tests by topic area. This makes selection easier,
+  for example the tests specific to the ``yacc`` tool can be run using
+  ``runtest.py test/YACC``
+* **DO** keep tests simple.  Some tests are by their nature complex,
+  but narrowing in on a specific feature makes for easier debugging -
+  more simpler test files is easier on future maintainers than a huge
+  compilcated one.
+* **DON'T** gang too many things together in one file (related to
+  the previous item). It's cleaner if
+  they're split into different files unless they share complex
+  infrastructure. This helps avoid the problem of "fail fast":
+  a test aborts when it detects a failure condition,
+  and the other tests in the same file don't ever run,
+  which may keep you from seeing a pattern exposed
+  when several related tests all fail.
+* **DON'T** require the use of an external executable "unless necessary".
   Usually the SCons behavior is the thing we want to test,
-  not the behavior of the external tool. *Necessary* is not a precise term -
-  sometimes it would be too time-consuming to write a script to mock
-  a compiler with an extensive set of options, and sometimes it's
-  not a good idea to assume you know what all those will do vs what
-  the real tool does; there may be other good reasons for just going
-  ahead and calling the external tool.
-* If using an external tool, be prepared to skip the test if it is unavailable.
-* Do not combine tests that need an external tool with ones that
-  do not - split these into separate test files. There is no concept
-  of partial skip for e2e tests, so if you successfully complete seven
+  not the behavior of the external tool. *Unless necessary* is
+  intentionally vague, use your judgement. If it's a ton of work to
+  mock an executable's behavior, perhaps in the combinations of
+  different flags, don't. However, if you don't actually need the
+  output (files or stderr/stdout) of an external, try to avoid.
+* **DO** be prepared to skip a test using an external tool
+  if it is unavailable. We want the tests to be runnable in many
+  configurations, and not produce tons of fails jut because
+  that configuration didn't install some things. Yes, we know
+  tons of things will fail if you don't have a findable C compiler -
+  sorry!
+* **DON'T** combine tests that need an external tool with ones that
+  do not, split them into separate test files. e2e tests can't do a
+  partial skip, so if you successfully complete seven
   of eight tests, and then come to a conditional "skip if tool missing"
-  or "skip if on Windows", and that branch is taken, then the
-  whole test file ends up skipped, and the seven that ran will
-  never be recorded.  Some tests follow the convention of creating a
-  second test file with the ending ``-live`` for the part that requires
-  actually running the external tool.
-* In testing, *fail fast* is not always the best policy - if you can think
-  of many scenarios that could go wrong and they are all run linearly in
-  a single test file, then you only hear about the first one that fails.
-  In some cases it may make sense to split them out a bit more, so you
-  can see several fails at once, which may show a helpful failure pattern
-  you wouldn't spot from a single fail.
-* Use test fixtures where it makes sense, and in particular, try to
-  make use of shareable mocked tools, which, by getting lots of use,
-  will be better debugged (that is, don't have each test produce its
-  own ``myfortan.py`` or ``mylex.py`` etc. unless they need drastically
-  different behaviors).
+  or "skip if on Windows", then the whole test file ends up marked as a skip.
+  On the other side, if you have a platform or tool-specific condition
+  that does not issue a ``skip_test``, then part of your test may be
+  skipped and you'll see no indication of that in the output log.
+  Splitting gives you a more complete picture.
+* **DO** leave hints when a test requires external executables.
+  The current convention is to use the word "live" in the test name,
+  either as an ending ( (e.g. ``test/AS/as-live.py``)
+  or use it as the entire name of the test (e.g. ``test/SWIG/live.py``).
+* **DO** use test fixtures where it makes sense. Real files are easier
+  to read than strings embedded in a test script used to create those
+  files - not just by humans, but by editors, checkers and formatters.
+  And in particular, try to make use of shareable mocked tools, which,
+  by getting lots of use, will be better debugged than single-use ones
+  (e.g., try to avoid each Fortran test containing its own mock compiler
+  ``myfortan.py`` - all those copies will have to be maintained).
 
-Unittest-specific hints:
+Unittest-specific hints
+-----------------------
 
-- Let the ``unittest`` module help!  Lots of the existing tests just
-  use a bare ``assert`` call for checks, which works fine, but then
-  you are responsible for preparing the message if it fails.  The base
-  ``TestCase`` class has methods which know how to display many things,
-  for example ``self.assertEqual()`` displays in what way the two arguments
-  differ if they are *not* equal. Checking for am expected exception can
-  be done with ``self.assertRaises()`` rather than crafting a stub of
-  code using a try block for this situation.
-- The *fail fast* consideration applies here, too: try not to fail a whole
-  testcase on the first problem, if there are more checks to go.
-  Again, existing tests may use elaborate tricks for this, but modern
-  ``unittest`` has a ``subTest`` context manager that can be used to wrap
-  each distinct piece and not abort the testcase for a failing subtest
-  (to be fair, this functionality is a recent addition, after most SCons
-  unit tests were written - but it should be used going forward).
+* **DO** test at an appropriate level. A "unit" of SCons behavior is
+  something with predictable outcomes, which has multiple consumers.
+  A convenience function used by only one other function may not need
+  its own tests, as long as the caller is suitably tested.
+* **DO** keep tests independent. This is just standard testing practice -
+  a test in one function should not depend on the results of an earlier
+  test in the same function. Make sure they have independent setup,
+  either by repeating the setup, or splitting into a separate function.
+* **DO** consider whether "fail fast" is appropriate. Tests within a
+  test function can be made independent by using the ``unittest``
+  module's ``subTest`` method - if one subtest fails, results will be
+  collected and execution continues, which may be more helpful in some
+  cases. This is a comparatively recent addition to ``unittest`` (Python
+  3.4), so much of SCons' body of unit tests was written without the
+  advantage of that feature.
+* **DO** make use of helpful ``unittest`` features.  In particular,
+  using basic ``assert`` statements leaves you responsible for the output
+  if the test fails. Even in simple cases this tends to look awkward.
+  The various assert methods, on the other hand, provide decent formatting
+  of output on failure, often showing where two complex elements differ,
+  and you only need to add something for output if it needs specialization.
+  Compare::
+
+    assert out, "expected string", out
+    self.assertEqual(out, "expected string")
+
+  There is an assert method for checking that an exception happens
+  (``self.assertRaises``), which is more readable than hand-coding something
+  with a ``try`` block to check the exception was raised. Please use this!
 


### PR DESCRIPTION
This does not affect SCons at all - only updates the document (which is eventually duplicated on the Wiki) about making use of the SCons test framework.

It's not going to be easy to review in the classical way, maybe just scan through the full doc and see if it makes sense this way?

https://scons.org/guidelines.html

This is not a version-associated change, so it doesn't get a Project association or CHANGES/RELEASE entries.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
