### PR TITLE
Fix a few issues related to "building" scons

### DIFF
--- a/bin/SConsDoc.py
+++ b/bin/SConsDoc.py
@@ -69,7 +69,7 @@ Function example:
     anywhere in the document by specifying the
     &f-FUNCTION; element or the &f-env-FUNCTION; element.
     Links to this definition may be interpolated by specifying
-    the &f-link-FUNCTION: or &f-link-env-FUNCTION; element.
+    the &f-link-FUNCTION; or &f-link-env-FUNCTION; element.
     </para>
 
     <example>

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -82,8 +82,7 @@ pdf_stylesheets = ['twocolumn']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-#
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The master toctree document.
 master_doc = 'index'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,11 @@ sconsign = "SCons.Utilities.sconsign:main"
 scons-configure-cache = "SCons.Utilities.ConfigureCache:main"
 
 [project.optional-dependencies]
-dev = ["ninja", "psutil"]
+dev = [
+    "ninja",
+    "psutil",
+    "lxml < 5; sys_platform != 'win32' and python_version < '3.13'",
+]
 pkg = [
     "ninja",
     "psutil",
@@ -63,7 +67,6 @@ pkg = [
     "build",
     "twine",
     "packaging",
-    "lxml<5; sys_platform != 'win32' and python_version<3.13",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,13 @@ requires = ["setuptools"]
 name = "SCons"
 description = "Open Source next-generation build tool."
 requires-python = ">=3.7"
-license = { text = "MIT" }
+license = "MIT"  # PEP 639 form (new - setuptools >= 77.0)
+# Should include docbook license, but this fails:
+# license = "MIT AND DocBook-stylesheet"
+license-files = [
+    "LICENSE",
+    "SCons/Tool/docbook/docbook-xsl-1.76.1/COPYING",
+]
 readme = { file = "README-package.rst", content-type = "text/x-rst" }
 authors = [{ name = "William Deegan", email = "bill@baddogconsulting.com" }]
 dynamic = ["version"]
@@ -25,7 +31,6 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Unix",
     "Operating System :: MacOS",
@@ -46,21 +51,35 @@ scons = "SCons.Script.Main:main"
 sconsign = "SCons.Utilities.sconsign:main"
 scons-configure-cache = "SCons.Utilities.ConfigureCache:main"
 
+[project.optional-dependencies]
+dev = ["ninja", "psutil"]
+pkg = [
+    "ninja",
+    "psutil",
+    "readme-renderer",
+    "sphinx",
+    "sphinx-book-theme",
+    "rst2pdf",
+    "build",
+    "twine",
+    "packaging",
+    "lxml<5; sys_platform != 'win32' and python_version<3.13",
+]
+
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-license-files = ["LICENSE"]
 
 [tool.setuptools.dynamic]
 version = {attr = "SCons.__version__"}
 
 [tool.setuptools.packages.find]
-exclude = ["template"]
+include = ["SCons*"]
 namespaces = false
 
 [tool.setuptools.package-data]
 "*" = ["*.txt", "*.rst", "*.1"]
-"SCons.tool.docbook" = ["*.*"]
+"SCons.Tool.docbook" = ["*.*"]
 
 [tool.distutils.sdist]
 dist-dir = "build/dist"


### PR DESCRIPTION
Typo in `SConsDoc.py` caused Sphinx warn.  Sphinx was also issuing this notice:
```
  Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
```
so updated the conf file to reflect that evolution.

Some tweaks to `pyproject.toml` to reflect some evolution as well. Build was issuing this:
```
  SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated!!!
  Please use a simple string containing a SPDX expression for `project.license`.
  You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
```
Plus, `License` in `Classifiers` is deprecated, as is `license-files` in the `[tool.setuptools]` section (now it's supposed to be in `project.license-files`, as it's not a setuptools-specific thing any longer).

Improved, I hope, the package-finder specification.

Added optional dependencies section to match the external `requirement-dev.txt` and `requirements-pkg.txt` files. This is supposed to allow installing "in one go", like (currently untested):

```con
 python -m pip install scons[dev]
```

With one exception, this should produce an identical package build to previously, but without the complaints issued by recent setuptools. The exception is the addition of the license file for docbook-xsl in the package metadata `licenses` directory, as current packaging standards mandate (like `scons-4.9.1.dist-info/licenses/SCons/Tool/docbook/docbook-xsl-1.76.1/COPYING`). We could roll this back out, since that file was actually included in its original path already, but not flagged as a license file, just a data file; we could also store it in a more logical place - an example was to put licenses for vendored components in a subdirectory `vendor` (or similar name).