### PR TITLE
Final adjustments for Python 3.14

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,8 +72,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       that can be rendered by Sphinx, and updating that text. The rest is
       minor fiddling like switching to f-strings small doc changes.
     - Fix a couple of unit tests to not fail with Python 3.14. These involve
-      bytecode and error message contents, and there was no problem with
-      SCons itself using 3.14 in its current (just-before-freeze) state.
+      bytecode strings and error message contents; there was no problem with
+      SCons itself using 3.14. Since 3.14 is now in Beta, there should
+      be no further changes.
     - Replace use of old conditional expression idioms with the official
       one from PEP 308 introduced in Python 2.5 (2006). The idiom being
       replaced (using and/or) is regarded as error prone.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -134,9 +134,10 @@ DEVELOPMENT
 
 - Clean up C and C++ FLAGS tests. Tests which use a real compiler
   are now more clearly distinguished (-live.py suffix and docstring).
+
 - Fix a couple of unit tests to not fail with Python 3.14. These involve
-  expectations for bytecode and error message contents; there was no problem
-  with SCons itself using 3.14 in its current (just-before-freeze) state.
+  expectations for bytecode strings and error message contents; there was
+  no problem with SCons itself using 3.14.
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -46,6 +46,8 @@ import unittest
 from unittest import mock
 from subprocess import PIPE
 from typing import TYPE_CHECKING
+if 'unittest.util' in __import__('sys').modules:
+    __import__('sys').modules['unittest.util']._MAX_LENGTH = 99999999
 
 import SCons.Action
 import SCons.Environment
@@ -1552,7 +1554,7 @@ class CommandGeneratorActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
-            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
+            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
         }
 
         meth_matches = [
@@ -1733,7 +1735,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
-            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
+            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
 
         }
 
@@ -1745,7 +1747,7 @@ class FunctionActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'1, 1, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'1, 1, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'1, 1, 0, 0,(),(),(\x95\x00g\x00),(),()'),
-            (3, 14): bytearray(b'1, 1, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
+            (3, 14): bytearray(b'1, 1, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
         }
 
         def factory(act, **kw):
@@ -1986,7 +1988,7 @@ class LazyActionTestCase(unittest.TestCase):
             (3, 11): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00d\x00S\x00),(),()'),
             (3, 12): bytearray(b'0, 0, 0, 0,(),(),(\x97\x00y\x00),(),()'),
             (3, 13): bytearray(b'0, 0, 0, 0,(),(),(\x95\x00g\x00),(),()'),
-            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00P\x00"\x00),(),()'),
+            (3, 14): bytearray(b'0, 0, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()'),
         }
 
         meth_matches = [
@@ -2049,7 +2051,7 @@ class ActionCallerTestCase(unittest.TestCase):
             (3, 11): b'\x97\x00d\x00S\x00',
             (3, 12): b'\x97\x00y\x00',
             (3, 13): b'\x95\x00g\x00',
-            (3, 14): b'\x80\x00P\x00"\x00',
+            (3, 14): b'\x80\x00R\x00#\x00',
         }
 
         with self.subTest():
@@ -2255,14 +2257,7 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 11): (bytearray(b"3, 3, 0, 0,(),(),(\x97\x00|\x00S\x00),(),()"),),
             (3, 12): (bytearray(b"3, 3, 0, 0,(),(),(\x97\x00|\x00S\x00),(),()"),),
             (3, 13): (bytearray(b"3, 3, 0, 0,(),(),(\x95\x00U\x00$\x00),(),()"),),
-            (3, 14): (
-                bytearray(
-                    b'3, 3, 0, 0,(),(),(\x80\x00T\x00"\x00),(),()'
-                ),  # win32 has different bytecodes
-                bytearray(
-                    b'3, 3, 0, 0,(),(),(\x80\x00R\x00"\x00),(),()'
-                ),  # every other OS?
-            ),
+            (3, 14): (bytearray(b"3, 3, 0, 0,(),(),(\x80\x00V\x00#\x00),(),()"),),
         }
 
         c = SCons.Action._function_contents(func1)
@@ -2301,16 +2296,11 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 13): bytearray(
                 b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x95\x00S\x01U\x00l\x00\x00\x00\x00\x00\x00\x00\x00\x00S\x02U\x00l\x01\x00\x00\x00\x00\x00\x00\x00\x00g\x00),(),(),2, 2, 0, 0,(),(),(\x95\x00g\x00),(),()}}{{{a=a,b=b}}}"
             ),
-            (3, 14): (
-                bytearray(
-                    b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x80\x00P\x00T\x00l\x00\x00\x00\x00\x00\x00\x00\x00\x00P\x01T\x00l\x01\x00\x00\x00\x00\x00\x00\x00\x00P\x02\"\x00),(),(),2, 2, 0, 0,(),(),(\x80\x00P\x00\"\x00),(),()}}{{{a=a,b=b}}}"
-                ),  # win32
-                bytearray(
-                    b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x80\x00P\x00R\x00j\x00\x00\x00\x00\x00\x00\x00\x00\x00P\x01R\x00j\x01\x00\x00\x00\x00\x00\x00\x00\x00P\x02\"\x00),(),(),2, 2, 0, 0,(),(),(\x80\x00P\x00\"\x00),(),()}}{{{a=a,b=b}}}"
-                ),
+            (3, 14): bytearray(
+                b"{TestClass:__main__}[[[(<class 'object'>, ()), [(<class '__main__.TestClass'>, (<class 'object'>,))]]]]{{1, 1, 0, 0,(a,b),(a,b),(\x80\x00R\x00V\x00n\x00\x00\x00\x00\x00\x00\x00\x00\x00R\x01V\x00n\x01\x00\x00\x00\x00\x00\x00\x00\x00R\x02#\x00),(),(),2, 2, 0, 0,(),(),(\x80\x00R\x00#\x00),(),()}}{{{a=a,b=b}}}"
             ),
         }
-        self.assertTrue(c in  expected[sys.version_info[:2]])
+        self.assertEqual(c, expected[sys.version_info[:2]])
 
     def test_code_contents(self) -> None:
         """Test that Action._code_contents works"""
@@ -2341,17 +2331,12 @@ class ObjectContentsTestCase(unittest.TestCase):
             (3, 13): bytearray(
                 b'0, 0, 0, 0,(Hello, World!),(print),(\x95\x00\\\x00"\x00S\x005\x01\x00\x00\x00\x00\x00\x00 \x00g\x01)'
             ),
-            (3, 14): (
-                bytearray(
-                    b'0, 0, 0, 0,(Hello, World!),(print),(\x80\x00[\x00 \x00P\x002\x01\x00\x00\x00\x00\x00\x00\x1e\x00P\x01"\x00)'
-                ),  # win32
-                bytearray(
-                    b'0, 0, 0, 0,(Hello, World!),(print),(\x80\x00Y\x00 \x00P\x002\x01\x00\x00\x00\x00\x00\x00\x1e\x00P\x01"\x00)'
-                ),
+            (3, 14): bytearray(
+                b"0, 0, 0, 0,(Hello, World!),(print),(\x80\x00]\x00!\x00R\x004\x01\x00\x00\x00\x00\x00\x00\x1f\x00R\x01#\x00)"
             ),
         }
 
-        self.assertTrue(c in  expected[sys.version_info[:2]],f"\nExpected:{expected[sys.version_info[:2]]}\nGot     :{c}")
+        self.assertEqual(c, expected[sys.version_info[:2]])
 
     def test_uncaught_exception_bubbles(self):
         """Test that scons_subproc_run bubbles uncaught exceptions"""

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -46,8 +46,10 @@ import unittest
 from unittest import mock
 from subprocess import PIPE
 from typing import TYPE_CHECKING
-if 'unittest.util' in __import__('sys').modules:
-    __import__('sys').modules['unittest.util']._MAX_LENGTH = 99999999
+
+# If assertEqual truncates strings so it's hard to see the diff, enable this:
+# if 'unittest.util' in __import__('sys').modules:
+#     __import__('sys').modules['unittest.util']._MAX_LENGTH = 99999999
 
 import SCons.Action
 import SCons.Environment


### PR DESCRIPTION
Had adapted bytecode strings during the alpha phase, but those changed again. Since this change syncs with 3.14.0b3, no further changes from the Python side are expected and we should be good to go at release.

Reworded existing CHANGES/RELEASE snips on Py 3.14 since those hadn't been in a release yet.

Note there is no CI runner set to use 3.14, so we won't see test results for this. Checked locally on Fedora and Windows.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
