### PR TITLE
Testing: Update the packaging tar bz2 and xz tests on windows

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -74,6 +74,13 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Testing: Increase the default timeout from 20 seconds to 60
       seconds in the testing framework wait_for method.  At present, the
       wait_for method is only used for the interactive tests.
+    - GitHub: Remove the packaging tar xz test from the windows ci skip file.
+    - Testing: Update the packaging tar bz2 and xz tests on on Windows.
+      Detect if the tar bz2 and xz formats are supported for the windows
+      system tar executable using the reported version string.  The packaging
+      tar bz2 and xz tests should be skipped on Windows 10 and GitHub
+      windows-2022. The packaging tar bz2 and xz tests should be run on
+      Windows 11 and GitHub windows-2025.
 
   From Edward Peek:
     - Fix the variant dir component being missing from generated source file

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -146,6 +146,8 @@ DEVELOPMENT
 
 - GitHub: Enable the interactive tests on windows.
 
+- GitHub: Enable the packaging tar xz test on windows.
+
 - GitHub: Exclude two ninja tests that consistently fail on MacOS in
   the experimental tests workflow.
 
@@ -164,6 +166,11 @@ DEVELOPMENT
 - Testing: Increase the default timeout from 20 seconds to 60 seconds
   in the testing framework wait_for method. The timeout was increased
   during isolated experiments of the interactive tests on windows.
+
+- Testing: Update the packaging tar bz2 and xz tests on on Windows.
+  The packaging tar bz2 and xz tests should be skipped on Windows 10
+  and GitHub windows-2022. The packaging tar bz2 and xz tests should
+  be run on Windows 11 and GitHub windows-2025.
 
 - Ninja: Increase the number of generated source files in the
   iterative speedup test from 200 to 250.  Increasing the workload

--- a/test/packaging/tar/_windows_tar.py
+++ b/test/packaging/tar/_windows_tar.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Utility functions for the windows system tar executable features.
+"""
+
+import os
+import os.path
+import subprocess
+import sys
+
+if sys.platform == 'win32':
+
+    # Windows 10 and later supplies windows/system32/tar.exe (bsdtar).
+    # Not all versions support all compression types.  Check the version
+    # string for library support.
+
+    # windows tar.exe:
+    #   %systemroot%/system32/tar.exe
+
+    # tar.exe --version (Windows 10, GH windows-2022):
+    #   bsdtar 3.5.2 - libarchive 3.5.2 zlib/1.2.5.f-ipp
+
+    # tar.exe --version (Windows 11):
+    #   bsdtar 3.7.7 - libarchive 3.7.7 zlib/1.2.5.f-ipp liblzma/5.4.3 bz2lib/1.0.8 libzstd/1.5.4
+
+    # tar.exe --version (GH windows-2025):
+    #   bsdtar 3.7.7 - libarchive 3.7.7 zlib/1.2.13.1-motley liblzma/5.4.3 bz2lib/1.0.8 libzstd/1.5.5
+
+    def _is_windows_system_tar(tar):
+
+        if not tar:
+            return False
+
+        tar = os.path.normcase(os.path.abspath(tar))
+        if not os.path.exists(tar):
+            return False
+
+        if not tar.endswith('tar.exe'):
+            return False
+
+        windir = os.environ.get("SystemRoot")
+        if not windir:
+            windir = os.environ.get("windir")
+
+        if not windir:
+            windir = os.path.join(os.environ.get("SystemDrive", "C:") + os.path.sep, "Windows")
+
+        windows_tar = os.path.normcase(os.path.abspath(os.path.join(windir, "System32", "tar.exe")))
+        rval = bool(tar == windows_tar)
+
+        return rval
+
+    def _windows_system_tar_have_library(tar, libname):
+
+        is_wintar = _is_windows_system_tar(tar)
+        if not is_wintar:
+            return is_wintar, None
+
+        try:
+            result = subprocess.run([f"{tar}", "--version"], capture_output=True, text=True, check=True)
+            version_str = result.stdout.strip()
+        except:
+            version_str = None
+
+        if not version_str:
+            return is_wintar, None
+
+        # print(f"{tar} --version => {version_str!r}")
+
+        version_comps = version_str.split()
+        if len(version_comps) < 5:
+            return is_wintar, None
+
+        for indx, expected in [
+            (0, "bsdtar"), (2, "-"), (3, "libarchive"),
+        ]:
+            if version_comps[indx].lower() != expected:
+                return is_wintar, None
+
+        # bsdtar_version = version_comps[1]
+        # libarchive_version = version_comps[4]
+
+        kind = libname + "/"
+
+        have_library = False
+        for component in version_comps[5:]:
+            if component.lower().startswith(kind):
+                have_library = True
+                break
+
+        return is_wintar, have_library
+
+    def windows_system_tar_gz(tar):
+        is_wintar, have_library = _windows_system_tar_have_library(tar, 'zlib')
+        return is_wintar, have_library
+
+    def windows_system_tar_bz2(tar):
+        is_wintar, have_library = _windows_system_tar_have_library(tar, 'bz2lib')
+        return is_wintar, have_library
+
+    def windows_system_tar_xz(tar):
+        is_wintar, have_library = _windows_system_tar_have_library(tar, 'liblzma')
+        return is_wintar, have_library
+
+    def windows_system_tar_lzma(tar):
+        is_wintar, have_library = _windows_system_tar_have_library(tar, 'liblzma')
+        return is_wintar, have_library
+
+else:
+
+    def windows_system_tar_gz(tar):
+        return False, None
+
+    def windows_system_tar_bz2(tar):
+        return False, None
+
+    def windows_system_tar_xz(tar):
+        return False, None
+
+    def windows_system_tar_lzma(tar):
+        return False, None
+

--- a/test/packaging/tar/bz2_packaging.py
+++ b/test/packaging/tar/bz2_packaging.py
@@ -33,8 +33,11 @@ import TestSCons
 
 import os
 import os.path
-import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _windows_tar as wintar
+sys.path.pop(0)
 
 python = TestSCons.python
 
@@ -44,75 +47,9 @@ tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
-if sys.platform == 'win32':
-
-    # Windows 10 and later supplies windows/system32/tar.exe (bsdtar).
-    # Not all versions support bz2 compression.  Check the version string
-    # for bz2lib support.
-
-    def windows_system32_bsdtar_have_bz2(tar):
-
-        # Don't skip test if not confident this is the windows/system32/tar.exe (bsdtar).
-
-        tar = os.path.normcase(os.path.abspath(tar))
-
-        # windows tar.exe:
-        #   %systemroot%/system32/tar.exe
-
-        windir = os.environ.get("SystemRoot")
-        if not windir:
-            windir = os.environ.get("windir")
-        if windir:
-            expected = os.path.normcase(os.path.abspath(os.path.join(windir, "System32", "tar.exe")))
-            if tar != expected:
-                return False
-
-        try:
-            result = subprocess.run([f"{tar}", "--version"], capture_output=True, text=True, check=True)
-            version_str = result.stdout.strip()
-        except:
-            version_str = None
-
-        if not version_str:
-            return False
-
-        # print(f"{tar} --version => {version_str!r}")
-
-        # tar.exe --version (Windows 10, GH windows-2022):
-        #   bsdtar 3.5.2 - libarchive 3.5.2 zlib/1.2.5.f-ipp
-
-        # tar.exe --version (Windows 11):
-        #   bsdtar 3.7.7 - libarchive 3.7.7 zlib/1.2.5.f-ipp liblzma/5.4.3 bz2lib/1.0.8 libzstd/1.5.4
-
-        # tar.exe --version (GH windows-2025):
-        #   bsdtar 3.7.7 - libarchive 3.7.7 zlib/1.2.13.1-motley liblzma/5.4.3 bz2lib/1.0.8 libzstd/1.5.5
-
-        version_comps = version_str.split()
-        if len(version_comps) < 5:
-            return False
-
-        for indx, expected in [
-            (0, "bsdtar"), (2, "-"), (3, "libarchive"),
-        ]:
-            if version_comps[indx].lower() != expected:
-                return False
-
-        # Reasonably confident this is the windows/system32/tar.exe (bsdtar).
-
-        # bsdtar_version = version_comps[1]
-        # libarchive_version = version_comps[4]
-
-        for component in version_comps[5:]:
-            if component.lower().startswith("bz2lib/"):
-                # Don't skip test: bz2/bz2lib appears to be supported.
-                return False
-
-        # Skip test: bz2/bz2lib appears to be unsupported.
-        return True
-
-    skip_test = windows_system32_bsdtar_have_bz2(tar)
-    if skip_test:
-        test.skip_test('windows tar found; bz2 not supported, skipping test\n')
+is_wintar, is_bz2_supported = wintar.windows_system_tar_bz2(tar)
+if is_wintar and not is_bz2_supported:
+    test.skip_test('windows tar found; bz2 not supported, skipping test\n')
 
 test.subdir('src')
 

--- a/test/packaging/tar/bz2_packaging.py
+++ b/test/packaging/tar/bz2_packaging.py
@@ -29,25 +29,15 @@ This tests the SRC bz2 packager, which does the following:
  - create a tar package from the specified files
 """
 
-import TestSCons
+import TestSConsTar
 
-import os
-import os.path
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import _windows_tar as wintar
-sys.path.pop(0)
-
-python = TestSCons.python
-
-test = TestSCons.TestSCons()
+test = TestSConsTar.TestSConsTar()
 
 tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
-is_wintar, is_bz2_supported = wintar.windows_system_tar_bz2(tar)
+is_wintar, is_bz2_supported = TestSConsTar.windows_system_tar_bz2(tar)
 if is_wintar and not is_bz2_supported:
     test.skip_test('windows tar found; bz2 not supported, skipping test\n')
 

--- a/test/packaging/tar/gz.py
+++ b/test/packaging/tar/gz.py
@@ -29,15 +29,17 @@ This tests the SRC 'targz' packager, which does the following:
  - create a targz package containing the specified files.
 """
 
-import TestSCons
+import TestSConsTar
 
-python = TestSCons.python
-
-test = TestSCons.TestSCons()
+test = TestSConsTar.TestSConsTar()
 
 tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
+
+is_wintar, is_gz_supported = TestSConsTar.windows_system_tar_gz(tar)
+if is_wintar and not is_gz_supported:
+    test.skip_test('windows tar found; gz not supported, skipping test\n')
 
 test.subdir('src')
 

--- a/test/packaging/tar/xz_packaging.py
+++ b/test/packaging/tar/xz_packaging.py
@@ -31,7 +31,7 @@ This tests the SRC xz packager, which does the following:
 import os
 import os.path
 import subprocess
-import TestCmd
+import sys
 import TestSCons
 
 python = TestSCons.python
@@ -41,7 +41,7 @@ tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
-if TestCmd.IS_WINDOWS:
+if sys.platform == 'win32':
 
     # Windows 10 and later supplies windows/system32/tar.exe (bsdtar).
     # Not all versions support xz compression.  Check the version string
@@ -66,14 +66,14 @@ if TestCmd.IS_WINDOWS:
 
         try:
             result = subprocess.run([f"{tar}", "--version"], capture_output=True, text=True, check=True)
-            version_str = result.stdout
+            version_str = result.stdout.strip()
         except:
             version_str = None
 
         if not version_str:
             return False
 
-        # print("tar.exe version:", version_str)
+        # print(f"{tar} --version => {version_str!r}")
 
         # tar.exe --version (Windows 10, GH windows-2022):
         #   bsdtar 3.5.2 - libarchive 3.5.2 zlib/1.2.5.f-ipp

--- a/test/packaging/tar/xz_packaging.py
+++ b/test/packaging/tar/xz_packaging.py
@@ -30,9 +30,12 @@ This tests the SRC xz packager, which does the following:
 """
 import os
 import os.path
-import subprocess
 import sys
 import TestSCons
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _windows_tar as wintar
+sys.path.pop(0)
 
 python = TestSCons.python
 
@@ -41,75 +44,9 @@ tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
-if sys.platform == 'win32':
-
-    # Windows 10 and later supplies windows/system32/tar.exe (bsdtar).
-    # Not all versions support xz compression.  Check the version string
-    # for liblzma support.
-
-    def windows_system32_bsdtar_have_xz(tar):
-
-        # Don't skip test if not confident this is the windows/system32/tar.exe (bsdtar).
-
-        tar = os.path.normcase(os.path.abspath(tar))
-
-        # windows tar.exe:
-        #   %systemroot%/system32/tar.exe
-
-        windir = os.environ.get("SystemRoot")
-        if not windir:
-            windir = os.environ.get("windir")
-        if windir:
-            expected = os.path.normcase(os.path.abspath(os.path.join(windir, "System32", "tar.exe")))
-            if tar != expected:
-                return False
-
-        try:
-            result = subprocess.run([f"{tar}", "--version"], capture_output=True, text=True, check=True)
-            version_str = result.stdout.strip()
-        except:
-            version_str = None
-
-        if not version_str:
-            return False
-
-        # print(f"{tar} --version => {version_str!r}")
-
-        # tar.exe --version (Windows 10, GH windows-2022):
-        #   bsdtar 3.5.2 - libarchive 3.5.2 zlib/1.2.5.f-ipp
-
-        # tar.exe --version (Windows 11):
-        #   bsdtar 3.7.7 - libarchive 3.7.7 zlib/1.2.5.f-ipp liblzma/5.4.3 bz2lib/1.0.8 libzstd/1.5.4
-
-        # tar.exe --version (GH windows-2025):
-        #   bsdtar 3.7.7 - libarchive 3.7.7 zlib/1.2.13.1-motley liblzma/5.4.3 bz2lib/1.0.8 libzstd/1.5.5
-
-        version_comps = version_str.split()
-        if len(version_comps) < 5:
-            return False
-
-        for indx, expected in [
-            (0, "bsdtar"), (2, "-"), (3, "libarchive"),
-        ]:
-            if version_comps[indx].lower() != expected:
-                return False
-
-        # Reasonably confident this is the windows/system32/tar.exe (bsdtar).
-
-        # bsdtar_version = version_comps[1]
-        # libarchive_version = version_comps[4]
-
-        for component in version_comps[5:]:
-            if component.lower().startswith("liblzma/"):
-                # Don't skip test: xz/liblzma appears to be supported.
-                return False
-
-        # Skip test: xz/liblzma appears to be unsupported.
-        return True
-
-    skip_test = windows_system32_bsdtar_have_xz(tar)
-    if skip_test:
-        test.skip_test('windows tar found; xz not supported, skipping test\n')
+is_wintar, is_xz_supported = wintar.windows_system_tar_xz(tar)
+if is_wintar and not is_xz_supported:
+    test.skip_test('windows tar found; xz not supported, skipping test\n')
 
 test.subdir('src')
 

--- a/test/packaging/tar/xz_packaging.py
+++ b/test/packaging/tar/xz_packaging.py
@@ -28,23 +28,14 @@ __revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 This tests the SRC xz packager, which does the following:
  - create a tar package from the specified files
 """
-import os
-import os.path
-import sys
-import TestSCons
+import TestSConsTar
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import _windows_tar as wintar
-sys.path.pop(0)
-
-python = TestSCons.python
-
-test = TestSCons.TestSCons()
+test = TestSConsTar.TestSConsTar()
 tar = test.detect('TAR', 'tar')
 if not tar:
     test.skip_test('tar not found, skipping test\n')
 
-is_wintar, is_xz_supported = wintar.windows_system_tar_xz(tar)
+is_wintar, is_xz_supported = TestSConsTar.windows_system_tar_xz(tar)
 if is_wintar and not is_xz_supported:
     test.skip_test('windows tar found; xz not supported, skipping test\n')
 

--- a/testing/ci/windows_ci_skip.txt
+++ b/testing/ci/windows_ci_skip.txt
@@ -3,7 +3,6 @@ test/CPPDEFINES/pkg-config.py
 test/packaging/msi/explicit-target.py
 test/packaging/msi/file-placement.py
 test/packaging/msi/package.py
-test/packaging/tar/xz_packaging.py
 test/scons-time/run/config/python.py
 test/scons-time/run/option/python.py
 test/sconsign/script/no-SConsignFile.py

--- a/testing/framework/TestSConsTar.py
+++ b/testing/framework/TestSConsTar.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # MIT License
 #
 # Copyright The SCons Foundation
@@ -24,13 +22,34 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Utility functions for the windows system tar executable features.
+A testing framework for the SCons software construction tool.
+
+A TestSConsTar environment object is created via the usual invocation:
+
+    test = TestSConsTar()
+
+TestSConsTar is a subsclass of TestSCons, which is in turn a subclass
+of TestCommon, which is in turn is a subclass of TestCmd), and hence
+has available all of the methods and attributes from those classes,
+as well as any overridden or additional methods or attributes defined
+in this subclass.
 """
 
 import os
 import os.path
 import subprocess
 import sys
+
+from TestSCons import *
+from TestSCons import __all__
+
+__all__.extend([
+    'TestSConsTar',
+    'windows_system_tar_gz',
+    'windows_system_tar_bz2',
+    'windows_system_tar_xz',
+    'windows_system_tar_lzma',
+])
 
 if sys.platform == 'win32':
 
@@ -144,3 +163,11 @@ else:
     def windows_system_tar_lzma(tar):
         return False, None
 
+class TestSConsTar(TestSCons):
+    pass
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Rework the windows system tar executable handling in the packaging tar tests for bz2 and xz.  Remove test `test/packaging/tar/xz_packaging.py` from the windows runner skip file.

Changes:
* `test/packaging/tar/bz2_packaging.py`:
  * Remove searching for and prepending `bzip2.exe` to the environment path for windows.
  * tar.exe in Windows 10 and GH windows-2022 appears not to support bzip2 compression even when bzip2.exe is on the system path.
  * tar.exe in Windows 11 and GH windows-2025 appears to support bzip2 compression without any additions to the system path.
  * If the candidate tar.exe is the windows system tar.exe, check the version string for bz2lib support.
* `test/packaging/tar/xz_packaging.py`:
  * Remove searching for and prepending `xz.exe` to the environment path for windows.
  * tar.exe in Windows 10 and GH windows-2022 appears not to support xz compression even when xz.exe is on the system path.
  * tar.exe in Windows 11 and GH windows-2025 appears to support xz compression without any additions to the system path.
  * If the candidate tar.exe is the windows system tar.exe, check the version string for liblzma support.
* Remove `test/packaging/tar/xz_packaging.py` from the windows ci test skip file.

As of 06-Jul-2025:
* The packaging tar tests for bz2 and xz are skipped in GH windows-2022.
* The packaging tar tests for bz2 and xz are run in GH windows-2025.

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
