### PR TITLE
tempfile: minor changes to tempfile encoding test and changes/release documentation.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -84,8 +84,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - TEMPFILE: Move encoding the tempfile contents before creating the
       tempfile due to possible encoding errors. Ensure the tempfile file
       handle is closed after writing the tempfile contents. Raise a
-      TempFileEncodeError exception when the tempfile contents encoding fails
+      UserError exception when the tempfile contents encoding fails
       for known exception types.
+    - TEMPFILE: Fix the tempfile encoding test regex strings to eliminate
+      warnings in python 3.12 and 3.13.
 
   From William Deegan:
     - Fix Issue #4746. TEMPFILE's are written with utf-8 encoding, In case

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -44,7 +44,7 @@ CHANGED/ENHANCED EXISTING FUNCTIONALITY
   these variables and values are propagated to the user's SCons
   environment after running the MSVC batch files.
 
-- TEMPFILE: A TempFileEncodeError exception is raised when encoding
+- TEMPFILE: A UserError exception is raised when encoding
   the contents of the tempfile fails due to a limited set of expected
   exceptions (e.g., UnicodeError).
 
@@ -89,6 +89,9 @@ FIXES
 
 - Tweak runtest.py and test framework to more reliably get the requested
   Python binary (for odd Windows setups + Python launcher)
+
+- Fix the tempfile encoding test regex strings to eliminate warnings in
+  python 3.12 and 3.13.
 
 IMPROVEMENTS
 ------------

--- a/test/TEMPFILE/TEMPFILEENCODING.py
+++ b/test/TEMPFILE/TEMPFILEENCODING.py
@@ -39,24 +39,24 @@ test.file_fixture('fixture/SConstruct-tempfile-encoding', 'SConstruct')
 expected_pass = """\
 Using tempfile \\S+ for command line:
 xyz \\S+
-scons\:.*
+scons:.*
 """
 
 expected_fail = """\
-tempfile encoding error: \[{exception}\] .+
-  TempFileMunge encoding\: env\['TEMPFILEENCODING'\] = {encoding!r}
-scons\:.*
+tempfile encoding error: \\[{exception}\\] .+
+  TempFileMunge encoding: env\\['TEMPFILEENCODING'\\] = {encoding!r}
+scons:.*
 """
 
 expected_pass_default = """\
-SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
+SCons[.]Platform[.]TEMPFILE_DEFAULT_ENCODING = {encoding!r}
 """ + expected_pass
 
 expected_fail_default = """\
-SCons\.Platform\.TEMPFILE_DEFAULT_ENCODING = {encoding!r}
-tempfile encoding error: \[{exception}\] .+
-  TempFileMunge encoding\: default = {encoding!r}
-scons\:.*
+SCons[.]Platform[.]TEMPFILE_DEFAULT_ENCODING = {encoding!r}
+tempfile encoding error: \\[{exception}\\] .+
+  TempFileMunge encoding: default = {encoding!r}
+scons:.*
 """
 
 for test_encoding, test_tempfileencoding, test_defaultencoding, test_expected in [


### PR DESCRIPTION
Changes:
* Fix the tempfile encoding test regex strings to eliminate warnings in python 3.12 and 3.13.
* Replace TempFileEncodeError exception name with UserError in CHANGES.txt and RELEASE.txt.

The regex strings in the tempfile encoding tests produced python warnings but still passed when using python 3.12 and 3.13.

The exception type names in CHANGES.txt and RELEASE.txt were not updated to UserError when the TempFileEncodeError exception was removed.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
