### PR TITLE
Interactive mode batch + src/tgt clearing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,10 @@ ensure_newline_before_comments = true
 include_trailing_comma = true
 use_parentheses = true
 
+[test/Interactive/**]
+trim_trailing_whitespace = false
+
+
 [*.{xml,yml,yaml}]
 indent_size = 2
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -173,6 +173,10 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Python binary (for odd Windows setups + Python launcher)
     - Improve the wording of AppendENVPath and PrependENVPath in manpage.
     - Add more unit tests to internal AppendPath, PrependPath functions.
+    - Change the way the changed/unchanged target and source lists are
+      accounted for in interactive mode, to resolve a problem on Windows,
+      where those lists are considered for due to "batch mode" support.
+      Fixes #3029.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -175,9 +175,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Add more unit tests to internal AppendPath, PrependPath functions.
     - Add unit tests to show .filebase method strips only the last suffix if
       several apparent suffixes are present, and .suffix returns the last.
-    - Change the way the changed/unchanged target and source lists are
-      accounted for in interactive mode, to resolve a problem on Windows,
-      where those lists are considered for due to "batch mode" support.
+    - Incremental builds in Interactive mode could fail on platforms that
+      support batch mode (currently: Windows).  Change the way the changed
+      and unchanged target and source lists are accounted for to resolve.
       Fixes #3029.
 
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -93,9 +93,9 @@ FIXES
 - Fix the tempfile encoding test regex strings to eliminate warnings in
   python 3.12 and 3.13.
 
-- Change the way the changed/unchanged target and source lists are
-  accounted for in interactive mode, to resolve a problem on Windows,
-  where those lists are considered for due to "batch mode" support.
+- Incremental builds in Interactive mode could fail on platforms that
+  support batch mode (currently: Windows).  Change the way the changed
+  and unchanged target and source lists are accounted for to resolve.
   Fixes #3029.
 
 IMPROVEMENTS

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -93,6 +93,11 @@ FIXES
 - Fix the tempfile encoding test regex strings to eliminate warnings in
   python 3.12 and 3.13.
 
+- Change the way the changed/unchanged target and source lists are
+  accounted for in interactive mode, to resolve a problem on Windows,
+  where those lists are considered for due to "batch mode" support.
+  Fixes #3029.
+
 IMPROVEMENTS
 ------------
 

--- a/test/Interactive/Alias.py
+++ b/test/Interactive/Alias.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the ability to build an Alias in --interactive mode.
@@ -34,6 +34,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 foo = Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
 Alias('foo-alias', foo)
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/Default-None.py
+++ b/test/Interactive/Default-None.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we get the expected error message when we use a "build"
@@ -36,6 +36,9 @@ test = TestSCons.TestSCons(combine=1)
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
 Default(None)
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/Default.py
+++ b/test/Interactive/Default.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that we can use a "build" command without arguments to (re-)build
@@ -35,6 +35,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 foo_out = Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
 Default(foo_out)
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/README.md
+++ b/test/Interactive/README.md
@@ -1,0 +1,41 @@
+Testing interactive mode is tricky.
+
+In the tests, commands are issued to the interactive shell by first
+opening a session with test.start(), then user typing is simulated by
+doing test.send(text).
+
+Computers move faster than humans, so control returns to the test program
+immediately after a send() - probably long before SCons has executed
+the requested command. Since you want to check outcomes, it's necessary
+to busy-wait until the operation has completed. The framework provides
+test.wait_for() for this purpose - it doesn't return until the requested
+path exists, so it's good for actions which cause a file to be created.
+
+Unfortunately, waiting on certain actions seems to be unreliable, plus
+some situations don't have direct support. For example, a test which
+cleans then rebuilds doesn't have a way in the testing API to wait for
+a file to not exist (clean). Based on recent experience, waiting for
+a non-trivial build may not work either.  Past developers seem to have
+run into this, so many tests employ a trick: in addition to the actual
+testing targets, define rules for a couple of dummy targets:
+
+    Command('1', [], Touch('$TARGET'))
+    Command('2', [], Touch('$TARGET'))
+
+Then, instead of waiting on the result of a step under test, immediately
+issue a second command to build a dummy target, and wait on that target,
+like in this sample from test/Interactive/Default.py:
+
+    scons = test.start(arguments='-Q --interactive')
+    scons.send("build\n")
+    scons.send("build 1\n")
+    test.wait_for(test.workpath('1'))
+    test.must_match(test.workpath('foo.out'), "foo.in 1\n")
+
+So while the first build should produce "foo.out", we don't wait for
+that, but rather for the dummy file "1" from the second command; then
+the condition test can be executed as normal.
+
+It's not entirely clear why waiting for the "real" target is less
+reliable, so just leaving this README as a breadcrumb for future
+developers.

--- a/test/Interactive/added-include.py
+++ b/test/Interactive/added-include.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 This verifies the --interactive command line option's ability to
@@ -52,6 +51,9 @@ test.write('SConstruct', """
 env = Environment(CPPPATH=['.'])
 env.Command('foo.h', ['foo.h.in'], Copy('$TARGET', '$SOURCE'))
 env.Program('foo', ['foo.c'])
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/basic.py
+++ b/test/Interactive/basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify basic operation of the --interactive command line option to build
@@ -37,6 +37,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/cache-debug.py
+++ b/test/Interactive/cache-debug.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the --interactive command line option to build a target when the
@@ -36,6 +36,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 CacheDir('cache')
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/cache-disable.py
+++ b/test/Interactive/cache-disable.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the --interactive command line option to build
@@ -35,6 +35,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 CacheDir('cache')
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/cache-force.py
+++ b/test/Interactive/cache-force.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the --interactive command line option to build a target when the
@@ -35,6 +35,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 CacheDir('cache')
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/cache-show.py
+++ b/test/Interactive/cache-show.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the --interactive command line option to build a target when the
@@ -35,6 +35,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 CacheDir('cache')
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/clean.py
+++ b/test/Interactive/clean.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verifies operation of the --interactive command line option
@@ -36,6 +36,9 @@ test.write('SConstruct', """\
 Command('f1.out', 'f1.in', Copy('$TARGET', '$SOURCE'))
 Command('f2.out', 'f2.in', Copy('$TARGET', '$SOURCE'))
 Command('f3.out', 'f3.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/configure.py
+++ b/test/Interactive/configure.py
@@ -29,7 +29,6 @@ a target, while using a Configure context within the environment.
 Also tests that "b" can be used as a synonym for "build".
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 import TestCmd

--- a/test/Interactive/exit.py
+++ b/test/Interactive/exit.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify use of the "exit" subcommand.
@@ -33,6 +33,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 """)
 

--- a/test/Interactive/failure.py
+++ b/test/Interactive/failure.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that when a build fails, later builds correctly report
@@ -38,6 +38,9 @@ def fail(target, source, env):
     return 1
 Command('f1.out', 'f1.in', Action(fail))
 Command('f2.out', 'f2.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/fixture/issue3029/SConstruct
+++ b/test/Interactive/fixture/issue3029/SConstruct
@@ -3,6 +3,9 @@ import os, sys
 DefaultEnvironment(tools=[])
 env = Environment()
 
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 

--- a/test/Interactive/fixture/issue3029/SConstruct
+++ b/test/Interactive/fixture/issue3029/SConstruct
@@ -1,0 +1,23 @@
+import os, sys
+
+DefaultEnvironment(tools=[])
+env = Environment()
+
+Command('1', [], Touch('$TARGET'))
+Command('2', [], Touch('$TARGET'))
+
+if sys.platform == 'win32':
+    # Enable C++ execptions (no SEH), extern "C" defaults to nothrow
+    env.Append(CCFLAGS="/EHsc")
+
+lib_env = env.Clone()
+lib_env.Append(CPPPATH="#include")
+
+mylib = lib_env.StaticLibrary(
+    "mylib",
+    ["src/myunit.cpp", "src/otherunit.cpp"],
+    incdirs="#include",
+)
+
+env.Alias("mylib", mylib)
+env.Default(mylib)

--- a/test/Interactive/fixture/issue3029/include/myheader.hpp
+++ b/test/Interactive/fixture/issue3029/include/myheader.hpp
@@ -1,0 +1,7 @@
+#ifndef MYHEADER_HPP
+#define MYHEADER_HPP
+
+void myfunc();
+void yourfunc();
+
+#endif

--- a/test/Interactive/fixture/issue3029/src/myunit.cpp
+++ b/test/Interactive/fixture/issue3029/src/myunit.cpp
@@ -1,0 +1,13 @@
+#include "myheader.hpp"
+
+#include <iostream>
+
+void myfunc()
+{
+	std::cout << __FUNCTION__ << std::endl << std::endl;
+}
+
+void yourfunc()
+{
+	std::cout << "whatever" << "\\n" << std::flush;
+}

--- a/test/Interactive/fixture/issue3029/src/otherunit.cpp
+++ b/test/Interactive/fixture/issue3029/src/otherunit.cpp
@@ -1,0 +1,6 @@
+int otherfunc()
+{
+	const int i = 50 + 100;
+
+	return i / 4;
+}

--- a/test/Interactive/help.py
+++ b/test/Interactive/help.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the behavior of the "help" subcommand (and its "h" and "?" aliases).
@@ -33,6 +33,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 """)
 

--- a/test/Interactive/implicit-VariantDir.py
+++ b/test/Interactive/implicit-VariantDir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 This is a regression test for a bug in earlier versions of the
@@ -57,6 +56,8 @@ BUILD_ENV.Append(CPPPATH = hdr_dir)
 BUILD_ENV.VariantDir('build', 'src', duplicate = 0)
 SConscript('build/SConscript')
 
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/issue3029.py
+++ b/test/Interactive/issue3029.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+r"""
+Check that incremental builds work in interactive mode.
+
+On Windows, there was a code path where cleaning, then rebuilding
+would lead the the source file not being supplied to the build:
+
+  scons: Building targets
+  cl /Fosrc\myunit.obj /c /TP /nologo /EHsc /Iinclude
+  cl : Command line error D8003 : missing source filename
+
+This is described in detail in GH issue 3039.
+
+This is a live test - depends on running a real compiler.
+It could actually skip if not on Windows as the problem has not
+been observed there.
+"""
+
+import os
+
+import TestSCons
+
+test = TestSCons.TestSCons()
+lib = f'{TestSCons.lib_}mylib{TestSCons._lib}'
+test.dir_fixture('fixture/issue3029')
+# file: fixture/issue3029/SConstruct
+test.run(arguments='-Q mylib', stdout=None)
+test.must_exist(lib)
+
+scons = test.start(arguments='-Q --interactive')
+scons.send("clean mylib\n")
+scons.send("build 1\n")
+test.wait_for(test.workpath('1'), popen=scons)
+test.must_not_exist(test.workpath(lib))
+scons.send("build mylib\n")
+scons.send("build 2\n")
+test.wait_for(test.workpath('2'), popen=scons)
+test.must_exist(test.workpath(lib))
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:

--- a/test/Interactive/option--Q.py
+++ b/test/Interactive/option--Q.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that use of the -Q option on an individual "build" command
@@ -34,6 +34,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/option-i.py
+++ b/test/Interactive/option-i.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the -i option, specified on the build command, causes
@@ -41,6 +41,9 @@ f1 = Command('f1.out', 'f1.in', Copy('$TARGET', '$SOURCE'))
 f2 = Command('f2.out', 'f2.in', Copy('$TARGET', '$SOURCE'))
 Depends(f1, e1)
 Depends(f2, e2)
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/option-j.py
+++ b/test/Interactive/option-j.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that "build" command of --interactive mode can take a -j
@@ -95,6 +95,9 @@ f3_b = Command('f3-b.out', 'f3-b.in', f3_a_out_must_be_finished)
 Command('f1.out', f1_a + f1_b, cat)
 Command('f2.out', f2_a + f2_b, cat)
 Command('f3.out', f3_a + f3_b, cat)
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/option-k.py
+++ b/test/Interactive/option-k.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the -k option, specified on the build command, causes
@@ -40,6 +40,9 @@ f1 = Command('f1.out', 'f1.in', Copy('$TARGET', '$SOURCE'))
 Command('f2.out', 'f2.in', Copy('$TARGET', '$SOURCE'))
 Command('f3.out', 'f3.in', Copy('$TARGET', '$SOURCE'))
 Depends(f1, e1)
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 Command('3', [], Touch('$TARGET'))

--- a/test/Interactive/option-n.py
+++ b/test/Interactive/option-n.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that the -n option, specified on the build command, reports
@@ -34,6 +34,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/option-s.py
+++ b/test/Interactive/option-s.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify basic operation of the --interactive command line option
@@ -35,6 +35,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/repeat-line.py
+++ b/test/Interactive/repeat-line.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify that a blank line repeats the last (build) command.
@@ -33,6 +33,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/shell.py
+++ b/test/Interactive/shell.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -26,7 +28,6 @@ Verify the ability of the "shell" command (and its "sh" and "!" aliases)
 to shell out of interactive mode.
 """
 
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import sys
 
@@ -45,6 +46,9 @@ print('hello from shell_command.py')
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 """)
 

--- a/test/Interactive/taskmastertrace.py
+++ b/test/Interactive/taskmastertrace.py
@@ -36,6 +36,9 @@ test = TestSCons.TestSCons()
 test.write('SConstruct', """\
 DefaultEnvironment(tools=[])
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/tree.py
+++ b/test/Interactive/tree.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify basic operation of the --interactive command line option to build
@@ -37,6 +37,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 Command('2', [], Touch('$TARGET'))
 """)

--- a/test/Interactive/unknown-command.py
+++ b/test/Interactive/unknown-command.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,8 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Verify the error message when an unknown command is typed in.
@@ -33,6 +33,9 @@ test = TestSCons.TestSCons()
 
 test.write('SConstruct', """\
 Command('foo.out', 'foo.in', Copy('$TARGET', '$SOURCE'))
+
+# Hack to make interactive tests more stable
+# See: test/Interactive/README.md
 Command('1', [], Touch('$TARGET'))
 """)
 

--- a/test/Interactive/variant_dir.py
+++ b/test/Interactive/variant_dir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 XXX Put a description of the test here.
@@ -46,8 +45,8 @@ env = Environment()
 env.Append(BASEPATH=basepath)
 env.Append(ENV = {'BASEPATH' : str(Dir('#').get_abspath())})
 SConscript( 'sub1/SConscript',
-            variant_dir = 'build', 
-            duplicate=False, 
+            variant_dir = 'build',
+            duplicate=False,
             exports='env')
 Command(r'%(marker_1)s', [], Touch('$TARGET'))
 Command(r'%(marker_2)s', [], Touch('$TARGET'))

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1831,9 +1831,17 @@ else:
             restore_sconsflags(sconsflags)
         return p
 
-    def wait_for(self, fname, timeout: float = 60.0, popen=None) -> None:
-        """
-        Waits for the specified file name to exist.
+    def wait_for(self, fname, timeout: float = 20.0, popen=None):
+        """Wait for the specified file name to exist.
+
+        This interface is primarily used in the tests for interactive
+        mode, where you issue individual commands and SCons keeps running.
+
+        Wait up to *timeout* seconds for *fname* to exist.  If the
+        timeout is reached, fail the test. If *popen* is specified,
+        it is assumed to be a process started with the :meth:`start`
+        method, giving a handle to cleanup actions.
+
         """
         waited = 0.0
         while not os.path.exists(fname):
@@ -1854,7 +1862,7 @@ else:
                     sys.stderr.write(stderr)
                 self.fail_test()
             time.sleep(1.0)
-            waited = waited + 1.0
+            waited += 1.0
 
     def get_alt_cpp_suffix(self):
         """Return alternate C++ file suffix.


### PR DESCRIPTION
On Windows, where batch mode exists, the `changed_{sources,targets}` lists become important. In interactive mode, these were not cleared properly, leading to incorrect results. Moved them into the memo dict, which is already dropped when necessary, to match the other source and target entries.

Testcase constructed from the issue. Required some funny gyrations - testing interactive mode is tricky because of timing, we "send" some simulated typing, and that returns right away, not when SCons has completed the command.

Fixes #3029

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [ ] I have updated the appropriate documentation
