### PR TITLE
Add remaining links to User Guide sections

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -88,11 +88,6 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       for known exception types.
     - TEMPFILE: Fix the tempfile encoding test regex strings to eliminate
       warnings in python 3.12 and 3.13.
-    - Add tags to the remaining section headers in the User Guide. This is
-      visible only in two ways: it's possible to link to any section now,
-      and the generated html will no longer have obscure links
-      (e.g. https://scons.org/doc/production/HTML/scons-user.html#id1514)
-      that may change over time.
 
   From William Deegan:
     - Fix Issue #4746. TEMPFILE's are written with utf-8 encoding, In case
@@ -188,6 +183,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       and unchanged target and source lists are accounted for to resolve.
       Fixes #3029.
     - Improve documentation of builder methods and builder objects.
+    - Add tags to the remaining section headers in the User Guide. This is
+      visible only in two ways: it's possible to link to any section now,
+      and the generated html will no longer have obscure links
+      (e.g. https://scons.org/doc/production/HTML/scons-user.html#id1514)
+      that may change over time.
 
 
 RELEASE 4.9.1 -  Thu, 27 Mar 2025 11:40:20 -0700

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -88,6 +88,11 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       for known exception types.
     - TEMPFILE: Fix the tempfile encoding test regex strings to eliminate
       warnings in python 3.12 and 3.13.
+    - Add tags to the remaining section headers in the User Guide. This is
+      visible only in two ways: it's possible to link to any section now,
+      and the generated html will no longer have obscure links
+      (e.g. https://scons.org/doc/production/HTML/scons-user.html#id1514)
+      that may change over time.
 
   From William Deegan:
     - Fix Issue #4746. TEMPFILE's are written with utf-8 encoding, In case

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -156,6 +156,10 @@ DOCUMENTATION
 
 - Improve documentation of builder methods and builder objects.
 
+- All the User Guide sections now have textual anchors, meaning there
+  no longer be build-generated numeric tags like
+  https://scons.org/doc/production/HTML/scons-user.html#id1514
+
 DEVELOPMENT
 -----------
 

--- a/doc/user/actions.xml
+++ b/doc/user/actions.xml
@@ -29,7 +29,9 @@ This file is processed by the bin/SConsDoc.py module.
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
 <title>&SCons; Actions</title>
 
-<!--
+<!-- TOOD: placeholder file, not currently included in build -->
+
+<!-- cons reference documentation:
 
 =head1 Build actions
 
@@ -272,10 +274,10 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </para>
 
-  <section>
+  <section id="sect-cmdstr-actions">
   <title>Command Strings as Actions</title>
 
-    <section>
+    <section id="sect-suppress-cmdline">
     <title>Suppressing Command-Line Printing</title>
 
     <para>
@@ -286,7 +288,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
     </section>
 
-    <section>
+    <section id="sect-ignore-exit-status">
     <title>Ignoring Exit Status</title>
 
     <para>
@@ -299,7 +301,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </section>
 
-  <section>
+  <section id="sect-arglist-actions">
   <title>Argument Lists as Actions</title>
 
   <para>
@@ -310,7 +312,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </section>
 
-  <section>
+  <section id="sect-python-func-actions">
   <title>Python Functions as Actions</title>
 
   <para>
@@ -321,10 +323,10 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </section>
 
-  <section>
+  <section id="sect-modify-printing">
   <title>Modifying How an Action is Printed</title>
 
-    <section>
+    <section id="sect-strfunc-cmdstr">
     <title>XXX:  the &strfunction; keyword argument</title>
 
     <para>
@@ -335,7 +337,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
     </section>
 
-    <section>
+    <section id="sect-cmdstr-cmdstr">
     <title>XXX:  the &cmdstr; keyword argument</title>
 
     <para>
@@ -348,7 +350,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </section>
 
-  <section>
+  <section id="sect-varlist">
   <title>Making an Action Depend on Variable Contents:  the &varlist; keyword argument</title>
 
   <para>
@@ -359,7 +361,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </section>
 
-  <section>
+  <section id="sect-chdir">
   <title>chdir=1</title>
 
   <para>
@@ -370,7 +372,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </section>
 
-  <section>
+  <section id="sect-batch-key">
   <title>Batch Building of Multiple Targets from Separate Sources:  the &batch_key; keyword argument</title>
 
   <para>
@@ -381,7 +383,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   </section>
 
-  <section>
+  <section id="sect-exitstatfunc">
   <title>Manipulating the Exit Status of an Action:  the &exitstatfunc; keyword argument</title>
 
   <para>
@@ -396,7 +398,7 @@ b = Builder(action = Action('build &lt; $SOURCE &gt; $TARGET'))
 
   ???
 
-  <section>
+  <section id="sect-presub">
   <title>presub=</title>
 
   <para>

--- a/doc/user/ant.xml
+++ b/doc/user/ant.xml
@@ -29,13 +29,15 @@ This file is processed by the bin/SConsDoc.py module.
           xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
 <title>Converting From Ant</title>
 
+<!-- TOOD: placeholder file, not currently included in build -->
+
  <para>
 
    XXX
 
  </para>
 
- <section>
+ <section id="sect-ant-diff">
  <title>Differences Between &Ant; and &SCons;</title>
 
    <para>
@@ -46,7 +48,7 @@ This file is processed by the bin/SConsDoc.py module.
 
  </section>
 
- <section>
+ <section id="sect-ant-adv">
  <title>Advantages of &SCons; Over &Ant;</title>
 
    <para>

--- a/doc/user/build-install.xml
+++ b/doc/user/build-install.xml
@@ -366,7 +366,7 @@ $ <emphasis>activate a virtualenv and run 'scons' to use that version</emphasis>
 
   <!--
 
-  <section>
+  <section id="sect-python-basics">
   <title>Python Basics</title>
 
     <para>

--- a/doc/user/builders-built-in.xml
+++ b/doc/user/builders-built-in.xml
@@ -28,7 +28,8 @@ This file is processed by the bin/SConsDoc.py module.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
 
-<!-- NOTE: this file is incomplete, and main.xml does not currently include it -->
+<!-- TOOD: placeholder file, not currently included in build -->
+
 <title>Built-In Builders</title>
 
   <para>
@@ -47,7 +48,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-build-program">
   <title>Programs:  the &Program; Builder</title>
 
     <para>
@@ -214,7 +215,7 @@ int goodbye() { printf("Goodbye, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-build-objfiles">
   <title>Object-File Builders</title>
 
     <para>
@@ -226,7 +227,7 @@ int goodbye() { printf("Goodbye, world!\n"); }
 
     </para>
 
-    <section>
+    <section id="sect-build-staticobj">
     <title>The &StaticObject; Builder</title>
 
       <para>
@@ -305,7 +306,7 @@ StaticObject('file.c')
 
     </section>
 
-    <section>
+    <section id="sect-build-sharedobj">
     <title>The &SharedObject; Builder</title>
 
       <para>
@@ -384,7 +385,7 @@ SharedObject('file.c')
 
     </section>
 
-    <section>
+    <section id="sect-build-obj">
     <title>The &Object; Builder</title>
 
       <para>
@@ -398,7 +399,7 @@ SharedObject('file.c')
 
   </section>
 
-  <section>
+  <section id="sect-build-libraries">
   <title>Library Builders</title>
 
     <para>
@@ -408,7 +409,7 @@ SharedObject('file.c')
 
     </para>
 
-    <section>
+    <section id="sect-build-staticlib">
     <title>The &StaticLibrary; Builder</title>
 
       <para>
@@ -482,7 +483,7 @@ StaticLibrary(['file.c', 'another.c'])
 
     </section>
 
-    <section>
+    <section id="sect-build-sharedlib">
     <title>The &SharedLibrary; Builder</title>
 
       <para>
@@ -556,7 +557,7 @@ SharedLibrary(['file.c', 'another.c'])
 
     </section>
 
-    <section>
+    <section id="sect-build-lib">
     <title>The &Library; Builder</title>
 
       <para>
@@ -570,7 +571,7 @@ SharedLibrary(['file.c', 'another.c'])
 
   </section>
 
-  <section>
+  <section id="sect-build-pch">
   <title>Pre-Compiled Headers:  the &PCH; Builder</title>
 
     <para>
@@ -581,7 +582,7 @@ SharedLibrary(['file.c', 'another.c'])
 
   </section>
 
-  <section>
+  <section id="sect-build-res">
   <title>&MSVC; Resource Files: the &RES; Builder</title>
 
     <para>
@@ -592,7 +593,7 @@ SharedLibrary(['file.c', 'another.c'])
 
   </section>
 
-  <section>
+  <section id="sect-srcfiles">
   <title>Source Files</title>
 
     <para>
@@ -606,7 +607,7 @@ SharedLibrary(['file.c', 'another.c'])
 
     </para>
 
-    <section>
+    <section id="sect-build-cfile">
     <title>The &CFile; Builder</title>
 
       <para>
@@ -625,7 +626,7 @@ XXX CFile() screen
 
     </section>
 
-    <section>
+    <section id="sect-build-cxxfile">
     <title>The &CXXFile; Builder</title>
 
       <para>
@@ -646,7 +647,7 @@ XXX CXXFILE() screen
 
   </section>
 
-  <section>
+  <section id="sect-doc-builders">
   <title>Documents</title>
 
     <para>
@@ -656,7 +657,7 @@ XXX CXXFILE() screen
 
     </para>
 
-    <section>
+    <section id="sect-build-dvi">
     <title>The &DVI; Builder</title>
 
       <para>
@@ -675,7 +676,7 @@ XXX DVI() screen
 
     </section>
 
-    <section>
+    <section id="sect-build-pdf">
     <title>The &PDF; Builder</title>
 
       <para>
@@ -686,7 +687,7 @@ XXX DVI() screen
 
     </section>
 
-    <section>
+    <section id="sect-build-postscript">
     <title>The &PostScript; Builder</title>
 
       <para>
@@ -707,7 +708,7 @@ XXX PostScript() screen
 
   </section>
 
-  <section>
+  <section id="sect-archives">
   <title>Archives</title>
 
     <para>
@@ -717,7 +718,7 @@ XXX PostScript() screen
 
     </para>
 
-    <section>
+    <section id="sect-build-tar">
     <title>The &Tar; Builder</title>
 
       <para>
@@ -804,7 +805,7 @@ directory/file
 
     </section>
 
-    <section>
+    <section id="sect-build-zip">
     <title>The &Zip; Builder</title>
 
       <para>
@@ -848,7 +849,7 @@ file2
 
   </section>
 
-  <section>
+  <section id="sect-java-builders">
   <title>Java</title>
 
     <para>
@@ -858,7 +859,7 @@ file2
 
     </para>
 
-    <section>
+    <section id="sect-build-java">
     <title>Building Class Files:  the &Java; Builder</title>
 
       <para>
@@ -894,7 +895,7 @@ XXX Java() screen
 
     </section>
 
-    <section>
+    <section id="sect-build-jar">
     <title>The &Jar; Builder</title>
 
       <para>
@@ -915,7 +916,7 @@ XXX Jar() screen
 
     </section>
 
-    <section>
+    <section id="sect-build-javah">
     <title>Building C header and stub files:  the &JavaH; Builder</title>
 
       <para>
@@ -934,7 +935,7 @@ XXX JavaH() screen
 
     </section>
 
-    <section>
+    <section id="sect-build-rmic">
     <title>Building RMI stub and skeleton class files:  the &RMIC; Builder</title>
 
       <para>

--- a/doc/user/builders-commands.xml
+++ b/doc/user/builders-commands.xml
@@ -29,7 +29,7 @@ This file is processed by the bin/SConsDoc.py module.
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
 <title>Not Writing a Builder:  the &Command; Builder</title>
 
-  <!--
+  <!-- cons reference documentation:
 
   =head2 The C<Command> method
 

--- a/doc/user/builders-writing.xml
+++ b/doc/user/builders-writing.xml
@@ -47,7 +47,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-builders-external">
   <title>Writing Builders That Execute External Commands</title>
 
     <para>
@@ -76,7 +76,7 @@ bld = Builder(action='foobuild &lt; $SOURCE &gt; $TARGET')
 
   </section>
 
-  <section>
+  <section id="sect-builders-attaching">
   <title>Attaching a Builder to a &ConsEnv;</title>
 
     <para>
@@ -268,7 +268,7 @@ env.Program('hello.c')
 
   </section>
 
-  <section>
+  <section id="sect-builders-suffix">
   <title>Letting &SCons; Handle The File Suffixes</title>
 
     <para>
@@ -337,7 +337,7 @@ env.Foo('file2')
 
   </section>
 
-  <section>
+  <section id="sect-builders-function">
   <title>Builders That Execute Python Functions</title>
 
     <para>
@@ -474,7 +474,7 @@ file.input
 
   </section>
 
-  <section>
+  <section id="sect-builders-generator">
   <title>Builders That Create Actions Using a &Generator;</title>
 
     <para>
@@ -644,7 +644,7 @@ env.Foo('file')
 
   </section>
 
-  <section>
+  <section id="sect-builders-emitter">
   <title>Builders That Modify the Target or Source Lists Using an &Emitter;</title>
 
     <para>
@@ -800,7 +800,7 @@ cat
 
   </section>
 
-  <section>
+  <section id="sect-builders-adding-emitter">
   <title>Modifying a Builder by adding an Emitter</title>
 
     <para>
@@ -920,7 +920,7 @@ main()
 
   -->
 
-  <section>
+  <section id="sect-builders-tools-placement">
   <title>Where To Put Your Custom Builders and Tools</title>
 
     <para>

--- a/doc/user/caching.xml
+++ b/doc/user/caching.xml
@@ -45,7 +45,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-caching-setup">
   <title>Specifying the Derived-File Cache Directory</title>
 
     <para>
@@ -163,7 +163,7 @@ CacheDir('/usr/local/build_cache')
 
   </section>
 
-  <section>
+  <section id="sect-caching-consistency">
   <title>Keeping Build Output Consistent</title>
 
     <para>
@@ -207,7 +207,7 @@ CacheDir('/usr/local/build_cache')
 
   </section>
 
-  <section>
+  <section id="sect-caching-nocache">
   <title>Not Using the Derived-File Cache for Specific Files</title>
 
     <para>
@@ -274,7 +274,7 @@ Retrieved `hello' from cache
 
   </section>
 
-  <section>
+  <section id="sect-caching-disable">
   <title>Disabling the Derived-File Cache</title>
 
     <para>
@@ -314,7 +314,7 @@ Retrieved `hello' from cache
 
   </section>
 
-  <section>
+  <section id="sect-caching-populate">
   <title>Populating a Derived-File Cache With Already-Built Files</title>
 
     <para>
@@ -369,7 +369,7 @@ Retrieved `hello' from cache
 
   </section>
 
-  <section>
+  <section id="sect-caching-random">
   <title>Minimizing Cache Contention:  the <option>--random</option> Option</title>
 
     <para>
@@ -511,7 +511,7 @@ Program('prog', ['f1.c', 'f2.c', 'f3.c', 'f4.c', 'f5.c'])
 
   </section>
 
-  <section>
+  <section id="sect-caching-custom">
     <title>Using a Custom CacheDir Class</title>
 
     <para>
@@ -566,7 +566,7 @@ env.CacheDir('scons-cache', custom_class=CustomCacheDir)
 
   <!--
 
-  <section>
+  <section id="sect-caching-troubleshoot">
   <title>Troubleshooting Shared Caching:  the &cache-debug; Option</title>
 
     <para>
@@ -582,7 +582,7 @@ env.CacheDir('scons-cache', custom_class=CustomCacheDir)
 
   <!--
 
-  <section>
+  <section id="sect-caching-manage">
 
     <para>
 

--- a/doc/user/depends.xml
+++ b/doc/user/depends.xml
@@ -80,7 +80,7 @@ int main() { printf("Hello, world!\n"); }
 
   </para>
 
-  <section>
+  <section id="sect-decider-function">
   <title>Deciding When an Input File Has Changed:  the &Decider; Function</title>
 
     <para>
@@ -102,7 +102,7 @@ int main() { printf("Hello, world!\n"); }
 
     </para>
 
-    <section>
+    <section id="sect-contentsigs">
     <title>Using Content Signatures to Decide if a File Has Changed</title>
 
       <para>
@@ -171,7 +171,7 @@ Decider('content')
 
       </para>
 
-      <section>
+      <section id="sect-csig-ramifications">
       <title>Ramifications of Using Content Signatures</title>
 
         <para>
@@ -225,7 +225,7 @@ Decider('content')
 
     </section>
 
-    <section>
+    <section id="sect-timestamps">
     <title>Using Time Stamps to Decide If a File Has Changed</title>
 
       <para>
@@ -366,7 +366,7 @@ int main() { printf("Hello, world!\n"); }
 
     </section>
 
-    <section>
+    <section id="sect-csig-timestamp">
     <title>Deciding If a File Has Changed Using Both MD Signatures and Time Stamps</title>
 
       <para>
@@ -466,7 +466,7 @@ cc -o hello hello.o
 
     </section>
 
-    <section>
+    <section id="sect-custom-decider">
     <title>Extending &SCons;: Writing Your Own Custom &Decider; Function</title>
 
       <para>
@@ -667,7 +667,7 @@ env.Install("install", "test.txt")
 
     </section>
 
-    <section>
+    <section id="sect-mixing-deciders">
     <title>Mixing Different Ways of Deciding If a File Has Changed</title>
 
       <para>
@@ -737,7 +737,7 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-implicit-deps">
   <title>Implicit Dependencies:  The &cv-CPPPATH; Construction Variable</title>
 
     <para>
@@ -879,7 +879,7 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-implicit-cache">
   <title>Caching Implicit Dependencies</title>
 
     <para>
@@ -987,7 +987,7 @@ SetOption('implicit_cache', 1)
 
     </itemizedlist>
 
-    <section>
+    <section id="sect-implicit-deps-changed">
     <title>The &implicit-deps-changed; Option</title>
 
       <para>
@@ -1021,7 +1021,7 @@ SetOption('implicit_cache', 1)
 
     </section>
 
-    <section>
+    <section id="sect-implicit-deps-unchanged">
     <title>The &implicit-deps-unchanged; Option</title>
 
       <para>
@@ -1065,7 +1065,7 @@ SetOption('implicit_cache', 1)
 
     <!--
 
-    <section>
+    <section id="sect-max-drift">
     <title>XXX max drift</title>
 
       XXX SetOption('max_drift')
@@ -1076,7 +1076,7 @@ SetOption('implicit_cache', 1)
 
   </section>
 
-  <section>
+  <section id="sect-depends-function">
   <title>Explicit Dependencies:  the &Depends; Function</title>
 
     <para>
@@ -1143,7 +1143,7 @@ cc -o hello hello.o
 
   </section>
 
-  <section>
+  <section id="sect-parse-depends-function">
   <title>Dependencies From External Files:  the &ParseDepends;
   Function</title>
 
@@ -1317,7 +1317,7 @@ scons: `.' is up to date.
 
   </section>
 
-  <section>
+  <section id="sect-ignore-function">
   <title>Ignoring Dependencies:  the &Ignore; Function</title>
 
     <para>
@@ -1427,7 +1427,7 @@ int main() { printf("Hello!\n"); }
     </scons_output>
   </section>
 
-  <section>
+  <section id="sect-requires-function">
   <title>Order-Only Dependencies:  the &Requires; Function</title>
 
     <para>
@@ -1589,7 +1589,7 @@ int main() { printf("Hello, %s!  I was built: %s\n", date); }
 
   </section>
 
-  <section>
+  <section id="sect-alwaysbuild-function">
   <title>The &AlwaysBuild; Function</title>
 
     <para>
@@ -1661,7 +1661,7 @@ int main() { printf("Hello, %s!\n", string); }
 
   <!--
 
-  <section>
+  <section id="sect-salt-method">
   <title>The &Salt; Method</title>
 
     <para>

--- a/doc/user/environments.xml
+++ b/doc/user/environments.xml
@@ -597,7 +597,7 @@ void main() { }
 
     </para>
 
-    <section id="sec-creating-consenv">
+    <section id="sect-creating-consenv">
     <title>Creating a &ConsEnv;: the &Environment; Function</title>
 
       <para>
@@ -1058,7 +1058,7 @@ def_env = DefaultEnvironment(tools=['gcc', 'gnulink'], CC='/usr/local/bin/gcc')
 
     </section>
 
-    <section id='multiple_construction_envs'>
+    <section id='sect-multiple-construction-envs'>
     <title>Multiple &ConsEnvs;</title>
 
       <para>
@@ -1632,7 +1632,7 @@ env.PrependUnique(CCFLAGS=['-g'])
 
       </section>
 
-      <section id="builder_overrides">
+      <section id="sect-builder-overrides">
       <title>Overriding &ConsVar; Settings</title>
 
       <para>
@@ -1751,7 +1751,7 @@ void main() {
       the same target with different sets of flags or other construction
       variables will lead to the
       <computeroutput>scons: *** Two environments with different actions...</computeroutput>
-      error described in <xref linkend="multiple_construction_envs"/>
+      error described in <xref linkend="sect-multiple-construction-envs"/>
       above. In this case you will actually want to create separate
       environments.
 

--- a/doc/user/errors.xml
+++ b/doc/user/errors.xml
@@ -29,13 +29,15 @@ This file is processed by the bin/SConsDoc.py module.
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
 <title>Errors</title>
 
+<!-- TOOD: placeholder file, not currently included in build -->
+
  <para>
 
    XXX
 
  </para>
 
- <section>
+ <section id="sect-errors-xxx">
  <title>XXX</title>
 
    <para>

--- a/doc/user/example.xml
+++ b/doc/user/example.xml
@@ -27,6 +27,9 @@ This file is processed by the bin/SConsDoc.py module.
           xmlns="http://www.scons.org/dbxsd/v1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
+<!-- TOOD: placeholder file, not currently included in build -->
+
 <title>Complex &SCons; Example</title>
 
  <para>
@@ -35,7 +38,7 @@ This file is processed by the bin/SConsDoc.py module.
 
  </para>
 
- <section>
+ <section id="sect-complex-example-xxx">
  <title>XXX</title>
 
    <para>

--- a/doc/user/external.xml
+++ b/doc/user/external.xml
@@ -49,7 +49,7 @@ This file is processed by the bin/SConsDoc.py module.
 
     </para>
 
-    <section>
+    <section id="sect-external-cdb">
         <title>Creating a Compilation Database</title>
 
         <para>
@@ -279,7 +279,7 @@ env2.CompilationDatabase('compile_commands-linux64.json')
 
     </section>
 
-    <section>
+    <section id="sect-external-ninja">
         <title>Ninja Build Generator</title>
 <note>
     <para>

--- a/doc/user/factories.xml
+++ b/doc/user/factories.xml
@@ -44,7 +44,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-factories-intro">
   <title>Copying Files or Directories:  The &Copy; Factory</title>
 
     <para>
@@ -183,7 +183,7 @@ Command("LinkIn", "FileOrDirectoryOut", Copy("$TARGET", "$SOURCE", symlinks=Fals
 
   </section>
 
-  <section>
+  <section id="sect-factories-delete">
   <title>Deleting Files or Directories:  The &Delete; Factory</title>
 
     <para>
@@ -290,7 +290,7 @@ Command(
 
   </section>
 
-  <section>
+  <section id="sect-factories-move">
   <title>Moving (Renaming) Files or Directories:  The &Move; Factory</title>
 
     <para>
@@ -338,7 +338,7 @@ touch $*
 
   </section>
 
-  <section>
+  <section id="sect-factories-touch">
   <title>Updating the Modification Time of a File:  The &Touch; Factory</title>
 
     <para>
@@ -378,7 +378,7 @@ SConscript('S')
 
   </section>
 
-  <section>
+  <section id="sect-factories-mkdir">
   <title>Creating a Directory:  The &Mkdir; Factory</title>
 
     <para>
@@ -432,7 +432,7 @@ touch $*
 
   </section>
 
-  <section>
+  <section id="sect-factories-chmod">
   <title>Changing File or Directory Permissions:  The &Chmod; Factory</title>
 
     <para>
@@ -472,7 +472,7 @@ Command(
 
   </section>
 
-  <section>
+  <section id="sect-execute-function">
   <title>Executing an action immediately:  the &Execute; Function</title>
 
     <para>

--- a/doc/user/file-removal.xml
+++ b/doc/user/file-removal.xml
@@ -46,7 +46,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-fileremoval-intro">
   <title>Preventing target removal during build: the &Precious; Function</title>
 
     <para>
@@ -100,7 +100,7 @@ int f3() { }
 
   </section>
 
-  <section>
+  <section id="sect-fileremoval-noclean">
   <title>Preventing target removal during clean: the &NoClean; Function</title>
 
     <para>
@@ -151,7 +151,7 @@ int f3() { }
 
   </section>
 
-  <section>
+  <section id="sect-fileremoval-clean">
   <title>Removing additional files during clean: the &Clean; Function</title>
 
     <para>

--- a/doc/user/gettext.xml
+++ b/doc/user/gettext.xml
@@ -36,7 +36,7 @@ This file is processed by the bin/SConsDoc.py module.
   translation templates similarly to how it's done with autotools.
   </para>
 
-  <section>
+  <section id="sect-gettext-prereq">
   <title>Prerequisites</title>
   <para>
     To follow examples provided in this chapter set up your operating system to
@@ -57,7 +57,7 @@ This file is processed by the bin/SConsDoc.py module.
   </para>
   </section>
 
-  <section>
+  <section id="sect-gettext-simple">
   <title>Simple project</title>
     <para>
     Let's start with a very simple project, the "Hello world" program

--- a/doc/user/hierarchy.xml
+++ b/doc/user/hierarchy.xml
@@ -30,7 +30,7 @@ This file is processed by the bin/SConsDoc.py module.
 
 <title>Hierarchical Builds</title>
 
-<!--
+<!-- cons reference documentation:
 
 
 =head2 The Build command
@@ -913,7 +913,7 @@ void bar(void) { printf("bar/bar.c\n"); }
 
   <!--
 
-  <section>
+  <section id="sect-hierarchy-finding-sconstruct">
   <title>Executing From a Subdirectory:  the -D, -u and -U Options</title>
 
     <para>

--- a/doc/user/install.xml
+++ b/doc/user/install.xml
@@ -115,7 +115,7 @@ int main() { printf("Hello, world!\n"); }
      <scons_output_command>scons -Q install</scons_output_command>
   </scons_output>
 
-  <section>
+  <section id="sect-install-multiple">
   <title>Installing Multiple Files in a Directory</title>
 
     <para>
@@ -170,7 +170,7 @@ env.Alias('install', '__ROOT__/usr/bin')
 
   </section>
 
-  <section>
+  <section id="sect-install-different-name">
   <title>Installing a File Under a Different Name</title>
 
     <para>
@@ -209,7 +209,7 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-install-multiple-different-names">
   <title>Installing Multiple Files Under Different Names</title>
 
     <para>
@@ -256,7 +256,7 @@ int main() { printf("Goodbye, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-install-shared-lib">
   <title>Installing a Shared Library</title>
 
     <para>

--- a/doc/user/java.xml
+++ b/doc/user/java.xml
@@ -42,7 +42,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-java-builder">
   <title>Building Java Class Files:  the &b-Java; Builder</title>
 
     <para>
@@ -119,7 +119,7 @@ public class Example3
 
   </section>
 
-  <section>
+  <section id="sect-java-deps">
   <title>How &SCons; Handles Java Dependencies</title>
 
     <para>
@@ -246,7 +246,7 @@ Java('classes', 'src', JAVAVERSION='1.6')
 
   </section>
 
-  <section>
+  <section id="sect-java-jar">
   <title>Building Java Archive (<filename>.jar</filename>) Files:  the &b-Jar; Builder</title>
 
     <para>
@@ -387,7 +387,7 @@ public class Example4
 
   </section>
 
-  <section>
+  <section id="sect-java-javah">
   <title>Building C Header and Stub Files:  the &b-JavaH; Builder</title>
 
     <para>
@@ -608,7 +608,7 @@ public class Example3
 
   </section>
 
-  <section>
+  <section id="sect-java-rmic">
   <title>Building RMI Stub and Skeleton Class Files:  the &b-RMIC; Builder</title>
 
     <para>

--- a/doc/user/libraries.xml
+++ b/doc/user/libraries.xml
@@ -37,7 +37,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-building-libraries">
   <title>Building Libraries</title>
 
     <para>
@@ -98,7 +98,7 @@ void f3() { printf("f3.c\n"); }
 
     </para>
 
-    <section>
+    <section id="sect-building-libraries-from-objects">
     <title>Building Libraries From Source Code or Object Files</title>
 
       <para>
@@ -156,7 +156,7 @@ object file
 
     </section>
 
-    <section>
+    <section id="sect-building-static-libraries">
     <title>Building Static Libraries Explicitly:  the &b-StaticLibrary; Builder</title>
 
       <para>
@@ -183,7 +183,7 @@ StaticLibrary('foo', ['f1.c', 'f2.c', 'f3.c'])
 
     </section>
 
-    <section>
+    <section id="sect-building-shared-libraries">
     <title>Building Shared (DLL) Libraries:  the &b-SharedLibrary; Builder</title>
 
       <para>
@@ -243,7 +243,7 @@ void f3() { printf("f3.c\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-linking-libraries">
   <title>Linking with Libraries</title>
 
     <para>
@@ -354,7 +354,7 @@ Program('prog.c', LIBS=['foo'], LIBPATH='.')
 
   </section>
 
-  <section>
+  <section id="sect-libpath">
   <title>Finding Libraries:  the &cv-LIBPATH; Construction Variable</title>
 
     <para>

--- a/doc/user/make.xml
+++ b/doc/user/make.xml
@@ -26,9 +26,12 @@ This file is processed by the bin/SConsDoc.py module.
          xmlns="http://www.scons.org/dbxsd/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
+<!-- TOOD: placeholder file, not currently included in build -->
+
 <title>Converting From Make</title>
 
-<!--
+<!-- cons reference documentation:
 
 =head1 Why Cons? Why not Make?
 
@@ -103,7 +106,7 @@ the makefiles.
 
  </para>
 
- <section>
+ <section id="sect-make-diff">
  <title>Differences Between &Make; and &SCons;</title>
 
    <para>
@@ -114,7 +117,7 @@ the makefiles.
 
  </section>
 
- <section>
+ <section id="sect-make-adv">
  <title>Advantages of &SCons; Over &Make;</title>
 
    <para>

--- a/doc/user/parse_flags_arg.xml
+++ b/doc/user/parse_flags_arg.xml
@@ -22,7 +22,7 @@ This file is processed by the bin/SConsDoc.py module.
     %variables-mod;
 ]>
 
-<section id="sect-parse_flags_"
+<section id="sect-parse-flags"
          xmlns="http://www.scons.org/dbxsd/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
@@ -38,7 +38,7 @@ This file is processed by the bin/SConsDoc.py module.
  described for the &MergeFlags; method.
  This also works when calling &f-link-env-Clone;,
  as well as in overrides to builder methods
- (see <xref linkend="builder_overrides"/>).
+ (see <xref linkend="sect-builder-overrides"/>).
 
  </para>
 

--- a/doc/user/preface.xml
+++ b/doc/user/preface.xml
@@ -78,7 +78,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   <!--
 
-  <section>
+  <section id="sect-why-scons">
   <title>Why &SCons;?</title>
 
     <para>
@@ -180,7 +180,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   <!--
 
-  <section>
+  <section id="sect-conventions">
   <title>Conventions</title>
 
     <para>

--- a/doc/user/python.xml
+++ b/doc/user/python.xml
@@ -27,13 +27,17 @@ This file is processed by the bin/SConsDoc.py module.
           xmlns="http://www.scons.org/dbxsd/v1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
+
+<!-- TOOD: placeholder file, not currently included in build -->
+
 <title>Python overview</title>
 
     <para>
 
     This section will provide a brief overview of
-    the Python programming language.
-    Skip this section if you are already familiar with Python
+    the &Python; programming language.
+    Skip this section if you are already familiar with &Python;
+    or if you plan to learn &Python; as you go along
     (or you're really intent on diving into &SCons;
     and just picking up things as you go).
 
@@ -44,8 +48,8 @@ This file is processed by the bin/SConsDoc.py module.
     Python has a lot of good
     documentation freely available on-line
     to help you get started.
-    The standard tutorial is available at XXX.
-
+    &Python;'s own tutorial is available at
+    <ulink url="https://docs.python.org/3/tutorial/"/>.
 
     </para>
 

--- a/doc/user/repositories.xml
+++ b/doc/user/repositories.xml
@@ -486,7 +486,7 @@ int main() { printf("Hello, world!\n"); }
 
   </section>
 
-  <section>
+  <section id="sect-repository-derived">
   <title>Finding derived files in repositories</title>
 
     <para>
@@ -581,7 +581,7 @@ cc -o hello hello.o /usr/repository1/file1.o /usr/repository1/file2.o
 
   </section>
 
-  <section>
+  <section id="sect-repository-local-copy">
   <title>Guaranteeing local copies of files</title>
 
     <para>

--- a/doc/user/run.xml
+++ b/doc/user/run.xml
@@ -28,7 +28,9 @@ This file is processed by the bin/SConsDoc.py module.
          xsi:schemaLocation="http://www.scons.org/dbxsd/v1.0 http://www.scons.org/dbxsd/v1.0/scons.xsd">
 <title>How to Run &SCons;</title>
 
-<!--
+<!-- TOOD: placeholder file, not currently included in build -->
+
+<!-- cons reference documentation
 
 =head1 Invoking Cons
 
@@ -320,7 +322,7 @@ do an unconstrained build before committing the integration).
 
   </para>
 
-  <section>
+  <section id="sect-run-cmdline">
   <title>Command-Line Options</title>
 
     <para>
@@ -331,7 +333,7 @@ do an unconstrained build before committing the integration).
 
   </section>
 
-  <section>
+  <section id="sect-run-args">
   <title>Getting at Command-Line Arguments</title>
 
     <para>
@@ -342,7 +344,7 @@ do an unconstrained build before committing the integration).
 
   </section>
 
-  <section>
+  <section id="sect-run-selective">
   <title>Selective Builds</title>
 
     <para>
@@ -355,7 +357,7 @@ do an unconstrained build before committing the integration).
 
   <!--
 
-  <section>
+  <section id="sect-run-pruning">
   <title>Build Pruning</title>
 
     <para>
@@ -368,7 +370,7 @@ do an unconstrained build before committing the integration).
 
   -->
 
-  <section>
+  <section id="sect-run-command">
   <title>Overriding Construction Variables</title>
 
     <para>

--- a/doc/user/scanners.xml
+++ b/doc/user/scanners.xml
@@ -144,7 +144,7 @@ over the file scanning rather than being called for each input line:
 
   </para>
 
-  <section id="simple-scanner">
+  <section id="sect-simple-scanner">
   <title>A Simple Scanner Example</title>
 
     <para>
@@ -375,7 +375,7 @@ cat
 
   </section>
 
-  <section id="scanner-search-paths">
+  <section id="sect-scanner-search-paths">
   <title>Adding a search path to a Scanner: &FindPathDirs;</title>
 
     <para>
@@ -457,7 +457,7 @@ kscan = Scanner(
 
   </section>
 
-  <section id="scanner-with-builder">
+  <section id="sect-scanner-with-builder">
   <title>Using scanners with Builders</title>
 
     <para>

--- a/doc/user/sconf.xml
+++ b/doc/user/sconf.xml
@@ -42,7 +42,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-configure-contexts">
   <title>&Configure_Contexts;</title>
 
     <para>
@@ -128,7 +128,7 @@ env = conf.Finish()
 
   </section>
 
-  <section>
+  <section id="sect-check-header">
   <title>Checking for the Existence of Header Files</title>
 
     <para>
@@ -190,7 +190,7 @@ env = conf.Finish()
 
   </section>
 
-  <section>
+  <section id="sect-check-func">
   <title>Checking for the Availability of a Function</title>
 
     <para>
@@ -211,7 +211,7 @@ env = conf.Finish()
 
   </section>
 
-  <section>
+  <section id="sect-check-lib">
   <title>Checking for the Availability of a Library</title>
 
     <para>
@@ -264,7 +264,7 @@ env = conf.Finish()
 
   </section>
 
-  <section>
+  <section id="sect-check-type">
   <title>Checking for the Availability of a &typedef;</title>
 
     <para>
@@ -303,7 +303,7 @@ env = conf.Finish()
     </sconstruct>
 
   </section>
-  <section>
+  <section id="sect-check-type-size">
   <title>Checking the size of a datatype</title>
     <para>
     Check the size of a datatype by using the &CheckTypeSize; method:
@@ -324,7 +324,7 @@ scons: `.' is up to date.
     </screen>
   </section>
 
-  <section>
+  <section id="sect-check-prog">
   <title>Checking for the Presence of a program</title>
 
     <para>
@@ -344,7 +344,7 @@ env = conf.Finish()
     </sconstruct>
 
   </section>
-  <section>
+  <section id="sect-sconf-custom-checks">
   <title>Extending &SCons;: Adding Your Own Custom Checks</title>
 
     <para>
@@ -501,7 +501,7 @@ scons: Building targets ...
 
   </section>
 
-  <section>
+  <section id="sect-no-config-when-cleaning">
   <title>Not Configuring When Cleaning Targets</title>
 
     <para>
@@ -554,7 +554,7 @@ Removed foo
 
   <!--
 
-  <section>
+  <section id="sect-config-option">
   <title>Controlling Configuration:  the &config; Option</title>
 
     <para>

--- a/doc/user/simple.xml
+++ b/doc/user/simple.xml
@@ -513,7 +513,7 @@ int main() { printf("Goodbye, world!\n"); }
 
  </section>
 
- <section id="sect_building_simple">
+ <section id="sect-building-simple">
  <title>Making the &SCons; Output Less Verbose</title>
 
    <para>

--- a/doc/user/troubleshoot.xml
+++ b/doc/user/troubleshoot.xml
@@ -62,7 +62,7 @@ This file is processed by the bin/SConsDoc.py module.
 
   </para>
 
-  <section>
+  <section id="sect-debug-explain">
   <title>Why is That Target Being Rebuilt?  the &debug-explain; Option</title>
 
     <para>
@@ -244,7 +244,7 @@ file3.c
 
   </section>
 
-  <section>
+  <section id="sect-dump-method">
   <title>What's in That Construction Environment?  the &f-Dump; Method</title>
 
     <para>
@@ -360,7 +360,7 @@ print(env.Dump('ENV'))
 
   </section>
 
-  <section>
+  <section id="sect-tree-option">
 
   <title>What Dependencies Does &SCons; Know About?  the &tree; Option</title>
 
@@ -601,7 +601,7 @@ inc.h
 
   </section>
 
-  <section>
+  <section id="sect-debug-presub">
 
   <title>How is &SCons; Constructing the Command Lines It Executes?  the &debug-presub; Option</title>
 
@@ -649,7 +649,7 @@ cc -o prog prog.o
 
   </section>
 
-  <section>
+  <section id="sect-debug-findlibs">
 
   <title>Where is &SCons; Searching for Libraries?  the &debug-findlibs; Option</title>
 
@@ -697,7 +697,7 @@ libs2/libbar.a
 
   <!--
 
-  <section>
+  <section id="sect-debug-includes">
 
   <title>What Implicit Dependencies Did the &SCons; Scanner find?  the &debug-includes; Option</title>
 
@@ -733,7 +733,7 @@ inc2/file2.h
 
   -->
 
-  <section>
+  <section id="sect-debug-stacktrace">
 
   <title>Where is &SCons; Blowing Up?  the &debug-stacktrace; Option</title>
 
@@ -805,7 +805,7 @@ Program('prog.c')
 
   </section>
 
-  <section>
+  <section id="sect-taskmastertrace">
 
   <title>How is &SCons; Making Its Decisions?  the &taskmastertrace; Option</title>
 
@@ -871,7 +871,7 @@ prog.c
 
   </section>
 
-  <section>
+  <section id="sect-debug-prepare">
 
   <title>Watch &SCons; prepare targets for building: the &debug-prepare; Option</title>
 
@@ -887,7 +887,7 @@ prog.c
 
   </section>
 
-  <section>
+  <section id="sect-debug-duplicate">
 
   <title>Why is a file disappearing?  the &debug-duplicate; Option</title>
 
@@ -909,7 +909,7 @@ prog.c
 
   </section>
 
-  <section>
+  <section id="sect-keep-it-simple">
 
   <title>Keep it simple</title>
 
@@ -942,7 +942,7 @@ prog.c
   <!--
 
 
-  <section>
+  <section id="sect-profile-option">
 
   <title>Where Are My Build Bottlenecks?  the &profile; Option</title>
 
@@ -958,7 +958,7 @@ prog.c
 
   <!--
 
-  <section>
+  <section id="sect-cache-debug-option">
   <title>Troubleshooting Shared Caching:  the &cache-debug; Option</title>
 
     <para>


### PR DESCRIPTION
All `<section>` tags in User Guide now have an `id="some-tag"` (many generated by editor autocomplete). Roughly half had previously been converted. This elminates obscure numeric auto- generated non-constant references in the output that look like:

  https://scons.org/doc/production/HTML/scons-user.html#id1514

The old way, any time a section is added, all sections following in the processing order would renumber the auto-generated anchor.

Involves no SCons code changes.

Doc contents don't change either. Added one link to one appendix chapter - but that chapter is not included in the Guide at the moment,  Two previously added tags, that were actually linked to, don't follow the naming convention I've been using, so those were adjusted at both the definition and the link location.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
