### PR TITLE
Bump README copyright years

### DIFF
--- a/README-SF.rst
+++ b/README-SF.rst
@@ -611,5 +611,5 @@ many contributors, including but not at all limited to:
 
 \... and many others.
 
-Copyright (c) 2001 - 2024 The SCons Foundation
+Copyright (c) 2001 - 2026 The SCons Foundation
 

--- a/README-package.rst
+++ b/README-package.rst
@@ -194,5 +194,5 @@ For More Information
 Check the SCons web site at https://scons.org
 
 
-Copyright (c) 2001 - 2024 The SCons Foundation
+Copyright (c) 2001 - 2026 The SCons Foundation
 

--- a/README.rst
+++ b/README.rst
@@ -301,4 +301,4 @@ many contributors, including but not at all limited to:
 
 \... and many others.
 
-Copyright (c) 2001 - 2024 The SCons Foundation
+Copyright (c) 2001 - 2026 The SCons Foundation


### PR DESCRIPTION
Three of the project README files were marked through 2024, now -2026.


