### PR TITLE
Fixed GH Issue 4809. scoop.sh installed scons (and likely scons-local )created msvs project files would fail.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
   From William Deegan:
     - Fix SCons Docbook schema to work with lxml > 5
     - Update pyproject.toml to support Python 3.14 and remove restrictions on lxml version install
+    - MSVS: Fix msvs project file creation to work with scons-local packages, and with windows scoop.sh 
+      package manager installed SCons. (Based on work by Joseph Brill and Marcel Admiraal)
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -48,6 +48,10 @@ IMPROVEMENTS
   an override. Also, if override dict is empty, don't even call the
   Override factory function.
 
+- MSVS: Fix msvs project file creation to work with scons-local packages, and with windows scoop.sh 
+  package manager installed SCons. (Based on work by Joseph Brill and Marcel Admiraal)
+
+
 PACKAGING
 ---------
 

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -1478,11 +1478,14 @@ def _exec_main(parser, values) -> None:
         _main(parser)
 
 
-def main() -> None:
+def main(script_path) -> None:
     global OptionsParser
     global exit_status
     global first_command_start
     global ENABLE_JSON
+    global SCONS_SCRIPT_PATH
+
+    SCONS_SCRIPT_PATH = script_path
 
     # Check up front for a Python version we do not support.  We
     # delay the check for deprecated Python versions until later,

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -152,25 +152,34 @@ def msvs_parse_version(s):
     num, suite = version_re.match(s).groups()
     return float(num), suite
 
-# This is how we re-invoke SCons from inside MSVS Project files.
-# The problem is that we might have been invoked as either scons.bat
-# or scons.py.  If we were invoked directly as scons.py, then we could
-# use sys.argv[0] to find the SCons "executable," but that doesn't work
-# if we were invoked as scons.bat, which uses "python -c" to execute
-# things and ends up with "-c" as sys.argv[0].  Consequently, we have
-# the MSVS Project file invoke SCons the same way that scons.bat does,
-# which works regardless of how we were invoked.
+
 def getExecScriptMain(env, xml=None):
+    """
+    This is how we re-invoke SCons from inside MSVS Project files.
+    The problem is that we might have been invoked as either scons.bat
+    or scons.py.  If we were invoked directly as scons.py, then we could
+    use sys.argv[0] to find the SCons "executable," but that doesn't work
+    if we were invoked as scons.bat, which uses "python -c" to execute
+    things and ends up with "-c" as sys.argv[0].  Consequently, we have
+    the MSVS Project file invoke SCons the same way that scons.bat does,
+    which works regardless of how we were invoked.
+
+    :param env: Environment to operate on
+    :param xml: Extra XML to add to generated MSVS project file
+    """
     if 'SCONS_HOME' not in env:
         env['SCONS_HOME'] = os.environ.get('SCONS_HOME')
     scons_home = env.get('SCONS_HOME')
     if not scons_home and 'SCONS_LIB_DIR' in os.environ:
         scons_home = os.environ['SCONS_LIB_DIR']
     if scons_home:
-        exec_script_main = "from os.path import join; import sys; sys.path = [ r'%s' ] + sys.path; import SCons.Script; SCons.Script.main()" % scons_home
+        exec_script_main = f"import sys; sys.path = [ r'{scons_home}' ] + sys.path; import SCons.Script; SCons.Script.main()"
     else:
         version = SCons.__version__
-        exec_script_main = "from os.path import join; import sys; sys.path = [ join(sys.prefix, 'Lib', 'site-packages', 'scons-%(version)s'), join(sys.prefix, 'scons-%(version)s'), join(sys.prefix, 'Lib', 'site-packages', 'scons'), join(sys.prefix, 'scons') ] + sys.path; import SCons.Script; SCons.Script.main()" % locals()
+        # *** ADDED SCONS PARENT PATH ***
+        scons_parent = os.path.abspath(os.path.join(os.path.dirname(SCons.__file__), ".."))
+        # *** ADDED SCONS PARENT PATH TO END OF THE PREFIX LIST ***
+        exec_script_main = f"import sys; sys.path = [ r'{scons_parent}' ] + sys.path; import SCons.Script; SCons.Script.main()"
     if xml:
         exec_script_main = xmlify(exec_script_main)
     return exec_script_main

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -53,6 +53,19 @@ from SCons.Tool.MSCommon import (
 
 tool_name = 'msvs'
 
+
+# The string for the Python executable we tell the Project file to use
+# is either sys.executable or, if an external PYTHON_ROOT environment
+# variable exists, $(PYTHON)ROOT\\python.exe (generalized a little to
+# pluck the actual executable name from sys.executable).
+try:
+    python_root = os.environ['PYTHON_ROOT']
+except KeyError:
+    python_executable = sys.executable
+else:
+    python_executable = os.path.join('$$(PYTHON_ROOT)',
+                                     os.path.split(sys.executable)[1])
+    
 ##############################################################################
 # Below here are the classes and functions for generation of
 # DSP/DSW/SLN/VCPROJ files.
@@ -169,24 +182,13 @@ def get_msvs_scons(env, xml=None):
     if not scons_script_path:
         scons_script_path = SCons.Script.Main.SCONS_SCRIPT_PATH
 
-
-    exec_script_main = f'"{python_executable}"  "{scons_script_path}"'
+    exec_script_main = f'"{python_executable}" "{scons_script_path}"'
 
     if xml:
         exec_script_main = xmlify(exec_script_main)
     return exec_script_main
 
-# The string for the Python executable we tell the Project file to use
-# is either sys.executable or, if an external PYTHON_ROOT environment
-# variable exists, $(PYTHON)ROOT\\python.exe (generalized a little to
-# pluck the actual executable name from sys.executable).
-try:
-    python_root = os.environ['PYTHON_ROOT']
-except KeyError:
-    python_executable = sys.executable
-else:
-    python_executable = os.path.join('$$(PYTHON_ROOT)',
-                                     os.path.split(sys.executable)[1])
+
 
 class Config:
     pass

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -170,7 +170,7 @@ def get_msvs_scons(env, xml=None):
         scons_script_path = SCons.Script.Main.SCONS_SCRIPT_PATH
 
 
-    exec_script_main = f"{python_executable}  {scons_script_path}"
+    exec_script_main = f'"{python_executable}"  "{scons_script_path}"'
 
     if xml:
         exec_script_main = xmlify(exec_script_main)

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -170,7 +170,7 @@ def get_msvs_scons(env, xml=None):
         scons_script_path = SCons.Script.Main.SCONS_SCRIPT_PATH
 
 
-    exec_script_main = f"{python_executable} -c {scons_script_path}"
+    exec_script_main = f"{python_executable}  {scons_script_path}"
 
     if xml:
         exec_script_main = xmlify(exec_script_main)
@@ -2148,7 +2148,7 @@ def generate(env) -> None:
     # MSVSSCONSFLAGS. This helps support consumers who use wrapper scripts to
     # invoke scons.
     if 'MSVSSCONS' not in env:
-        env['MSVSSCONS'] = getExecScriptMain(env)
+        env['MSVSSCONS'] = get_msvs_scons(env)
     if 'MSVSSCONSFLAGS' not in env:
         env['MSVSSCONSFLAGS'] = '-C "${MSVSSCONSCRIPT.dir.get_abspath()}" -f ${MSVSSCONSCRIPT.name}'
 

--- a/scripts/scons.py
+++ b/scripts/scons.py
@@ -94,4 +94,4 @@ if __name__ == "__main__":
 
     # this does all the work, and calls sys.exit
     # with the proper exit status when done.
-    SCons.Script.main()
+    SCons.Script.main(os.path.abspath(__file__))

--- a/test/MSVS/common-prefix.py
+++ b/test/MSVS/common-prefix.py
@@ -64,9 +64,9 @@ vcproj_template = """\
 \t\t\t>
 \t\t\t<Tool
 \t\t\t\tName="VCNMakeTool"
-\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
+\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
 \t\t\t\tOutput="Test.exe"
 \t\t\t\tPreprocessorDefinitions=""
 \t\t\t\tIncludeSearchPath=""
@@ -137,7 +137,7 @@ test.run(chdir='work1', arguments="Test.vcproj")
 test.must_exist(test.workpath('work1', 'Test.vcproj'))
 vcproj = test.read(['work1', 'Test.vcproj'], 'r')
 expected_vcprojfile = vcproj_template % locals()
-expect = test.msvs_substitute(expected_vcprojfile, '8.0', 'work1', 'SConstruct')
+expect = test.msvs_substitute(expected_vcprojfile, '8.0', subdir='work1', sconscript='SConstruct')
 # don't compare the pickled data
 assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
 

--- a/test/MSVS/runfile.py
+++ b/test/MSVS/runfile.py
@@ -64,9 +64,9 @@ expected_vcprojfile = """\
 \t\t\t>
 \t\t\t<Tool
 \t\t\t\tName="VCNMakeTool"
-\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
+\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
 \t\t\t\tOutput="runfile.exe"
 \t\t\t\tPreprocessorDefinitions=""
 \t\t\t\tIncludeSearchPath=""

--- a/test/MSVS/vs-mult-auto-vardir.py
+++ b/test/MSVS/vs-mult-auto-vardir.py
@@ -118,6 +118,7 @@ SConscript('src/SConscript', variant_dir='build')
         vcproj = test.read(['src', project_file_1], 'r')
         expect = test.msvs_substitute(expected_vcprojfile_1, vc_version, None, 'SConstruct', project_guid=project_guid_1)
         # don't compare the pickled data
+
         assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
 
         test.must_exist(test.workpath('src', project_file_2))

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -900,9 +900,10 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions(env=Non
             project_guid = PROJECT_GUID
 
         if 'SCONS_LIB_DIR' in os.environ:
-            exec_script_main = f"from os.path import join; import sys; sys.path = [ r'{os.environ['SCONS_LIB_DIR']}' ] + sys.path; import SCons.Script; SCons.Script.main()"
+            exec_script_main = f"import sys; sys.path = [ r'{os.environ['SCONS_LIB_DIR']}' ] + sys.path; import SCons.Script; SCons.Script.main()"
         else:
-            exec_script_main = f"from os.path import join; import sys; sys.path = [ join(sys.prefix, 'Lib', 'site-packages', 'scons-{self.scons_version}'), join(sys.prefix, 'scons-{self.scons_version}'), join(sys.prefix, 'Lib', 'site-packages', 'scons'), join(sys.prefix, 'scons') ] + sys.path; import SCons.Script; SCons.Script.main()"
+            exec_script_main = f"import sys; sys.path = [ scons_parent ] + sys.path; import SCons.Script; SCons.Script.main()"
+
         exec_script_main_xml = exec_script_main.replace("'", "&apos;")
 
         result = input.replace(r'<WORKPATH>', workpath)

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -92,8 +92,8 @@ CFG=Test - Win32 Release
 # PROP BASE Use_Debug_Libraries 0
 # PROP BASE Output_Dir ""
 # PROP BASE Intermediate_Dir ""
-# PROP BASE Cmd_Line "echo Starting SCons && "<PYTHON>" -c "<SCONS_SCRIPT_MAIN>" -C "<WORKPATH>" -f SConstruct "Test.exe""
-# PROP BASE Rebuild_Opt "-c && echo Starting SCons && "<PYTHON>" -c "<SCONS_SCRIPT_MAIN>" -C "<WORKPATH>" -f SConstruct "Test.exe""
+# PROP BASE Cmd_Line "echo Starting SCons && "<PYTHON>" "<SCONS_SCRIPT_PATH>" -C "<WORKPATH>" -f SConstruct "Test.exe""
+# PROP BASE Rebuild_Opt "-c && echo Starting SCons && "<PYTHON>" "<SCONS_SCRIPT_PATH>" -C "<WORKPATH>" -f SConstruct "Test.exe""
 # PROP BASE Target_File "Test.exe"
 # PROP BASE Bsc_Name ""
 # PROP BASE Target_Dir ""
@@ -101,8 +101,8 @@ CFG=Test - Win32 Release
 # PROP Use_Debug_Libraries 0
 # PROP Output_Dir ""
 # PROP Intermediate_Dir ""
-# PROP Cmd_Line "echo Starting SCons && "<PYTHON>" -c "<SCONS_SCRIPT_MAIN>" -C "<WORKPATH>" -f SConstruct "Test.exe""
-# PROP Rebuild_Opt "-c && echo Starting SCons && "<PYTHON>" -c "<SCONS_SCRIPT_MAIN>" -C "<WORKPATH>" -f SConstruct "Test.exe""
+# PROP Cmd_Line "echo Starting SCons && "<PYTHON>" "<SCONS_SCRIPT_PATH>" -C "<WORKPATH>" -f SConstruct "Test.exe""
+# PROP Rebuild_Opt "-c && echo Starting SCons && "<PYTHON>" "<SCONS_SCRIPT_PATH>" -C "<WORKPATH>" -f SConstruct "Test.exe""
 # PROP Target_File "Test.exe"
 # PROP Bsc_Name ""
 # PROP Target_Dir ""
@@ -263,9 +263,9 @@ expected_vcprojfile_7_0 = """\
 \t\t\tATLMinimizesCRunTimeLibraryUsage="FALSE">
 \t\t\t<Tool
 \t\t\t\tName="VCNMakeTool"
-\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
+\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
 \t\t\t\tOutput="Test.exe"/>
 \t\t</Configuration>
 \t</Configurations>
@@ -388,9 +388,9 @@ expected_vcprojfile_7_1 = """\
 \t\t\tATLMinimizesCRunTimeLibraryUsage="FALSE">
 \t\t\t<Tool
 \t\t\t\tName="VCNMakeTool"
-\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
-\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
+\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;Test.exe&quot;"
+\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;Test.exe&quot;"
 \t\t\t\tOutput="Test.exe"/>
 \t\t</Configuration>
 \t</Configurations>
@@ -513,9 +513,9 @@ expected_vcprojfile_fmt = """\
 \t\t\t>
 \t\t\t<Tool
 \t\t\t\tName="VCNMakeTool"
-\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;"
-\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;"
-\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;%(PROJECT_BASENAME)s.exe&quot;"
+\t\t\t\tBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;"
+\t\t\t\tReBuildCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;"
+\t\t\t\tCleanCommandLine="echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;%(PROJECT_BASENAME)s.exe&quot;"
 \t\t\t\tOutput="%(PROJECT_BASENAME)s.exe"
 \t\t\t\tPreprocessorDefinitions="DEF1;DEF2;DEF3=1234"
 \t\t\t\tIncludeSearchPath="%(INCLUDE_DIRS)s"
@@ -607,9 +607,9 @@ expected_vcxprojfile_fmt = """\
 \t<PropertyGroup Label="UserMacros" />
 \t<PropertyGroup>
 \t<_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-\t\t<NMakeBuildCommandLine Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;</NMakeBuildCommandLine>
-\t\t<NMakeReBuildCommandLine Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;</NMakeReBuildCommandLine>
-\t\t<NMakeCleanCommandLine Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; -c &quot;<SCONS_SCRIPT_MAIN_XML>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;%(PROJECT_BASENAME)s.exe&quot;</NMakeCleanCommandLine>
+\t\t<NMakeBuildCommandLine Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;</NMakeBuildCommandLine>
+\t\t<NMakeReBuildCommandLine Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct &quot;%(PROJECT_BASENAME)s.exe&quot;</NMakeReBuildCommandLine>
+\t\t<NMakeCleanCommandLine Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo Starting SCons &amp;&amp; &quot;<PYTHON>&quot; &quot;<SCONS_SCRIPT_PATH>&quot; -C &quot;<WORKPATH>&quot; -f SConstruct -c &quot;%(PROJECT_BASENAME)s.exe&quot;</NMakeCleanCommandLine>
 \t\t<NMakeOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PROJECT_BASENAME)s.exe</NMakeOutput>
 \t\t<NMakePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">DEF1;DEF2;DEF3=1234</NMakePreprocessorDefinitions>
 \t\t<NMakeIncludeSearchPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(INCLUDE_DIRS)s</NMakeIncludeSearchPath>
@@ -899,18 +899,19 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions(env=Non
         if project_guid is None:
             project_guid = PROJECT_GUID
 
-        if 'SCONS_LIB_DIR' in os.environ:
-            exec_script_main = f"import sys; sys.path = [ r'{os.environ['SCONS_LIB_DIR']}' ] + sys.path; import SCons.Script; SCons.Script.main()"
+        if 'MSVS_SCONS' in os.environ:
+            exec_script_main = f'{os.environ['MSVS_SCONS']}'
         else:
-            exec_script_main = f"import sys; sys.path = [ scons_parent ] + sys.path; import SCons.Script; SCons.Script.main()"
+            exec_script_main = f'{self.program}'
+
 
         exec_script_main_xml = exec_script_main.replace("'", "&apos;")
 
         result = input.replace(r'<WORKPATH>', workpath)
         result = result.replace(r'<PYTHON>', python)
         result = result.replace(r'<SCONSCRIPT>', sconscript)
-        result = result.replace(r'<SCONS_SCRIPT_MAIN>', exec_script_main)
-        result = result.replace(r'<SCONS_SCRIPT_MAIN_XML>', exec_script_main_xml)
+        result = result.replace(r'<SCONS_SCRIPT_PATH>', exec_script_main)
+        result = result.replace(r'<SCONS_SCRIPT_PATH_XML>', exec_script_main_xml)
         result = result.replace(r'<PROJECT_GUID>', project_guid)
         result = result.replace('<SCC_VCPROJ_INFO>\n', vcproj_sccinfo)
         result = result.replace('<SCC_SLN_INFO>\n', sln_sccinfo)
@@ -1177,17 +1178,18 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions(env=Non
         if solution_guid_2 is None:
             solution_guid_2 = SOLUTION_GUID_2
 
-        if 'SCONS_LIB_DIR' in os.environ:
-            exec_script_main = f"from os.path import join; import sys; sys.path = [ r'{os.environ['SCONS_LIB_DIR']}' ] + sys.path; import SCons.Script; SCons.Script.main()"
+        if 'MSVS_SCONS' in os.environ:
+            exec_script_main = f'{os.environ['MSVS_SCONS']}'
         else:
-            exec_script_main = f"from os.path import join; import sys; sys.path = [ join(sys.prefix, 'Lib', 'site-packages', 'scons-{self.scons_version}'), join(sys.prefix, 'scons-{self.scons_version}'), join(sys.prefix, 'Lib', 'site-packages', 'scons'), join(sys.prefix, 'scons') ] + sys.path; import SCons.Script; SCons.Script.main()"
+            exec_script_main = f'{self.program}'
+
         exec_script_main_xml = exec_script_main.replace("'", "&apos;")
 
         result = input.replace(r'<WORKPATH>', workpath)
         result = result.replace(r'<PYTHON>', python)
         result = result.replace(r'<SCONSCRIPT>', sconscript)
-        result = result.replace(r'<SCONS_SCRIPT_MAIN>', exec_script_main)
-        result = result.replace(r'<SCONS_SCRIPT_MAIN_XML>', exec_script_main_xml)
+        result = result.replace(r'<SCONS_SCRIPT_PATH>', exec_script_main)
+        result = result.replace(r'<SCONS_SCRIPT_PATH_XML>', exec_script_main_xml)
         result = result.replace(r'<PROJECT_GUID_1>', project_guid_1)
         result = result.replace(r'<PROJECT_GUID_2>', project_guid_2)
         result = result.replace(r'<SOLUTION_GUID_1>', solution_guid_1)


### PR DESCRIPTION
Fixed GH Issue #4809 4809. scoop.sh installed scons (and likely scons-local )created msvs project files would fail.

See #4810 for discussion.
This is the implementation of the fix discussed in that PR.

Largely the work of.
@jcbrill  & @madmiraal

Note: I tested this live with the SConstruct from #4809 and [scoop.sh](https://scoop.sh) installed scons
(And then locally editing scoop installed scons' msvs.py"
 
## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
