### PR TITLE
Make sure consistently using one docstring style

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -51,6 +51,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       need actual installed system programs (add -live suffix).
     - Test runner reworked to use Python logging; the portion of the test suite
       which tests the runner was adjusted to match.
+    - Switch remaining "original style" docstring parameter listings to
+      Google style.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,6 +53,8 @@ IMPROVEMENTS
 
 - Used Gemini to refactor runtest.py to better organized the code and add docstrings.
 
+- Switch remaining "original style" docstring parameter listings to Google style.
+
 
 PACKAGING
 ---------

--- a/SCons/Action.py
+++ b/SCons/Action.py
@@ -332,11 +332,11 @@ def _object_instance_content(obj):
     """
     Returns consistant content for a action class or an instance thereof
 
-    :Parameters:
-      - `obj` Should be either and action class or an instance thereof
+    Args:
+        obj: Should be either an action class or an instance thereof
 
-    :Returns:
-      bytearray or bytes representing the obj suitable for generating a signature from.
+    Returns:
+        bytearray or bytes representing the obj suitable for generating a signature from.
     """
     retval = bytearray()
 

--- a/SCons/Conftest.py
+++ b/SCons/Conftest.py
@@ -765,11 +765,11 @@ def _YesNoResult(context, ret, key, text, comment = None) -> None:
     r"""
     Handle the result of a test with a "yes" or "no" result.
 
-    :Parameters:
-      - `ret` is the return value: empty if OK, error message when not.
-      - `key` is the name of the symbol to be defined (HAVE_foo).
-      - `text` is the source code of the program used for testing.
-      - `comment` is the C comment to add above the line defining the symbol (the comment is automatically put inside a /\* \*/). If None, no comment is added.
+    Args:
+        ret: the return value, empty if OK, error message when not.
+        key: the name of the symbol to be defined (HAVE_foo).
+        text: the source code of the program used for testing.
+        comment: the C comment to add above the line defining the symbol (the comment is automatically put inside a /\* \*/). If None, no comment is added.
     """
     if key:
         _Have(context, key, not ret, comment)
@@ -784,10 +784,10 @@ def _Have(context, key, have, comment = None) -> None:
     r"""
     Store result of a test in context.havedict and context.headerfilename.
 
-    :Parameters:
-      - `key` - is a "HAVE_abc" name.  It is turned into all CAPITALS and non-alphanumerics are replaced by an underscore.
-      - `have`   - value as it should appear in the header file, include quotes when desired and escape special characters!
-      - `comment` is the C comment to add above the line defining the symbol (the comment is automatically put inside a /\* \*/). If None, no comment is added.
+    Args:
+        key: a "HAVE_abc" name.  It is turned into all CAPITALS and non-alphanumerics are replaced by an underscore.
+        have: value as it should appear in the header file, include quotes when desired and escape special characters!
+        comment: is the C comment to add above the line defining the symbol (the comment is automatically put inside a /\* \*/). If None, no comment is added.
 
 
     The value of "have" can be:
@@ -795,8 +795,6 @@ def _Have(context, key, have, comment = None) -> None:
       - 0      - Feature is not defined, add "/\* #undef key \*/". Adding "undef" is what autoconf does.  Not useful for the compiler, but it shows that the test was done.
       - number - Feature is defined to this number "#define key have". Doesn't work for 0 or 1, use a string then.
       - string - Feature is defined to this string "#define key have".
-
-
     """
     key_up = key.upper()
     key_up = re.sub('[^A-Z0-9_]', '_', key_up)
@@ -849,9 +847,9 @@ def _lang2suffix(lang):
     For an unrecognized language returns (None, None, msg).
 
     Where:
-      - lang   = the unified language name
-      - suffix = the suffix, including the leading dot
-      - msg    = an error message
+        lang: the unified language name
+        suffix: the suffix, including the leading dot
+        msg: an error message
     """
     if not lang or lang in ["C", "c"]:
         return ("C", ".c", None)

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -45,6 +45,7 @@ import SCons.Builder
 import SCons.CacheDir
 import SCons.Environment
 import SCons.Errors
+import SCons.Node.FS
 import SCons.PathList
 import SCons.Scanner.Dir
 import SCons.Subst
@@ -606,7 +607,7 @@ def processDefines(defs) -> list[str]:
             # TODO: do we need to quote value if it contains space?
             dlist.append(f"{name}={value[0]}")
         else:
-            dlist.append(str(define[0]))
+            dlist.append(str(defs[0]))
     elif is_Dict(defs):
         for macro, value in defs.items():
             if value is None:
@@ -685,10 +686,13 @@ class Variable_Method_Caller:
 def __libversionflags(env, version_var, flags_var):
     """
     if version_var is not empty, returns env[flags_var], otherwise returns None
-    :param env:
-    :param version_var:
-    :param flags_var:
-    :return:
+
+    Args:
+        env:
+        version_var:
+        flags_var:
+
+    Returns:
     """
     try:
         if env.subst('$' + version_var):
@@ -701,11 +705,14 @@ def __libversionflags(env, version_var, flags_var):
 def __lib_either_version_flag(env, version_var1, version_var2, flags_var):
     """
     if $version_var1 or $version_var2 is not empty, returns env[flags_var], otherwise returns None
-    :param env:
-    :param version_var1:
-    :param version_var2:
-    :param flags_var:
-    :return:
+
+    Args:
+        env:
+        version_var1:
+        version_var2:
+        flags_var:
+
+    Returns:
     """
     try:
         if env.subst('$' + version_var1) or env.subst('$' + version_var2):

--- a/SCons/Tool/applelink.py
+++ b/SCons/Tool/applelink.py
@@ -49,14 +49,18 @@ class AppleLinkInvalidCompatibilityVersionException(Exception):
 
 
 def _applelib_check_valid_version(version_string):
-    """
-    Check that the version # is valid.
+    """Check that the version # is valid.
+
     X[.Y[.Z]]
     where X 0-65535
     where Y either not specified or 0-255
     where Z either not specified or 0-255
-    :param version_string:
-    :return:
+
+    Args:
+        version_string:
+
+    Returns:
+        A tuple of the outcome and an information string (empty if True)
     """
     parts = version_string.split('.')
     if len(parts) > 3:
@@ -83,11 +87,14 @@ def _applelib_currentVersionFromSoVersion(source, target, env, for_signature) ->
     Otherwise if APPLELINK_CURRENT_VERSION is not specified, env['SHLIBVERSION']
     will be used.
 
-    :param source:
-    :param target:
-    :param env:
-    :param for_signature:
-    :return: A string providing the flag to specify the current_version of the shared library
+    Args:
+        source:
+        target:
+        env:
+        for_signature:
+
+    Returns:
+        A string providing the flag to specify the current_version of the shared library
     """
     if env.get('APPLELINK_NO_CURRENT_VERSION', False):
         return ""
@@ -114,11 +121,14 @@ def _applelib_compatVersionFromSoVersion(source, target, env, for_signature) -> 
     Otherwise if APPLELINK_COMPATIBILITY_VERSION is not specified
     the first two parts of env['SHLIBVERSION'] will be used with a .0 appended.
 
-    :param source:
-    :param target:
-    :param env:
-    :param for_signature:
-    :return: A string providing the flag to specify the compatibility_version of the shared library
+    Args:
+        source:
+        target:
+        env:
+        for_signature:
+
+    Returns:
+        A string providing the flag to specify the compatibility_version of the shared library
     """
     if env.get('APPLELINK_NO_COMPATIBILITY_VERSION', False):
         return ""

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -73,8 +73,12 @@ def make_emit_compilation_DB_entry(comstr):
     * command line
     * source
     * target
-    :param comstr: unevaluated command line
-    :return: an emitter which has captured the above
+
+    Args:
+        comstr: unevaluated command line
+
+    Returns:
+        an emitter which has captured the above
     """
     user_action = SCons.Action.Action(comstr)
 
@@ -82,12 +86,15 @@ def make_emit_compilation_DB_entry(comstr):
         """
         This emitter will be added to each c/c++ object build to capture the info needed
         for clang tools
-        :param target: target node(s)
-        :param source: source node(s)
-        :param env: Environment for use building this node
-        :return: target(s), source(s)
-        """
 
+        Args:
+            target: target node(s)
+            source: source node(s)
+            env: Environment for use building this node
+
+        Returns:
+            A tuple of target(s), source(s)
+        """
         dbtarget = __CompilationDbNode(source)
 
         entry = env.__COMPILATIONDB_Entry(
@@ -122,13 +129,13 @@ def compilation_db_entry_action(target, source, env, **kw) -> None:
     Create a dictionary with evaluated command line, target, source
     and store that info as an attribute on the target
     (Which has been stored in __COMPILATION_DB_ENTRIES array
-    :param target: target node(s)
-    :param source: source node(s)
-    :param env: Environment for use building this node
-    :param kw:
-    :return: None
-    """
 
+    Args:
+        target: target node(s)
+        source: source node(s)
+        env: Environment for use building this node
+        kw: additional keyword args (ignored)
+    """
     command = env["__COMPILATIONDB_UACTION"].strfunction(
         target=env["__COMPILATIONDB_UOUTPUT"],
         source=env["__COMPILATIONDB_USOURCE"],

--- a/SCons/Tool/compilation_db.py
+++ b/SCons/Tool/compilation_db.py
@@ -73,12 +73,8 @@ def make_emit_compilation_DB_entry(comstr):
     * command line
     * source
     * target
-
-    Args:
-        comstr: unevaluated command line
-
-    Returns:
-        an emitter which has captured the above
+    :param comstr: unevaluated command line
+    :return: an emitter which has captured the above
     """
     user_action = SCons.Action.Action(comstr)
 
@@ -86,15 +82,12 @@ def make_emit_compilation_DB_entry(comstr):
         """
         This emitter will be added to each c/c++ object build to capture the info needed
         for clang tools
-
-        Args:
-            target: target node(s)
-            source: source node(s)
-            env: Environment for use building this node
-
-        Returns:
-            A tuple of target(s), source(s)
+        :param target: target node(s)
+        :param source: source node(s)
+        :param env: Environment for use building this node
+        :return: target(s), source(s)
         """
+
         dbtarget = __CompilationDbNode(source)
 
         entry = env.__COMPILATIONDB_Entry(
@@ -129,13 +122,13 @@ def compilation_db_entry_action(target, source, env, **kw) -> None:
     Create a dictionary with evaluated command line, target, source
     and store that info as an attribute on the target
     (Which has been stored in __COMPILATION_DB_ENTRIES array
-
-    Args:
-        target: target node(s)
-        source: source node(s)
-        env: Environment for use building this node
-        kw: additional keyword args (ignored)
+    :param target: target node(s)
+    :param source: source node(s)
+    :param env: Environment for use building this node
+    :param kw:
+    :return: None
     """
+
     command = env["__COMPILATIONDB_UACTION"].strfunction(
         target=env["__COMPILATIONDB_UOUTPUT"],
         source=env["__COMPILATIONDB_USOURCE"],

--- a/SCons/Tool/cyglink.py
+++ b/SCons/Tool/cyglink.py
@@ -78,12 +78,16 @@ def cyglink_shlib_symlink_emitter(target, source, env, **kw):
     """
     On cygwin, we only create a symlink from the non-versioned implib to the versioned implib.
     We don't version the shared library itself.
-    :param target:
-    :param source:
-    :param env:
-    :param kw:
-    :return:
-    """
+
+    Args:
+        target:
+        source:
+        env:
+        kw:
+
+    Returns:
+        A tuple of target, source
+     """
     verbose = True
 
     if 'variable_prefix' in kw:

--- a/SCons/Tool/linkCommon/LoadableModule.py
+++ b/SCons/Tool/linkCommon/LoadableModule.py
@@ -30,14 +30,20 @@ def ldmod_symlink_emitter(target, source, env, **kw):
     return shlib_symlink_emitter(target, source, env, variable_prefix='LDMODULE')
 
 
-def _get_ldmodule_stem(target, source, env, for_signature):
-    """
-    Get the basename for a library (so for libxyz.so, return xyz)
-    :param target:
-    :param source:
-    :param env:
-    :param for_signature:
-    :return:
+def _get_ldmodule_stem(target, source, env, for_signature) -> str:
+    """Get the basename for a library.
+
+    Strips off the loadable module prefix and suffix defined in the
+    construction environment (e.g. ``libxyz.so`` -> ``xyz``)
+
+    Args:
+        target:
+        source:
+        env:
+        for_signature:
+
+    Returns:
+        The extracted basename
     """
     target_name = str(target)
     ldmodule_prefix = env.subst('$LDMODULEPREFIX')
@@ -83,17 +89,15 @@ def _LDMODULEVERSION(target, source, env, for_signature):
         return ""
 
 def setup_loadable_module_logic(env) -> None:
-    """
-    Just the logic for loadable modules
+    """Just the logic for loadable modules
 
     For most platforms, a loadable module is the same as a shared
     library.  Platforms which are different can override these, but
     setting them the same means that LoadableModule works everywhere.
 
-    :param env:
-    :return:
+    Args:
+        env:
     """
-
     createLoadableModuleBuilder(env)
 
     env['_get_ldmodule_stem'] = _get_ldmodule_stem

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -534,7 +534,7 @@ def pass_test(self=None, condition: bool = True, function=None) -> None:
     a condition argument is supplied; if so the completion processing
     takes place only if the condition is true.
 
-    the test passes only if the condition is true.
+    The test passes only if the condition is true.
 
     Args:
         self: a test class instance. Must be passed in explicitly
@@ -551,16 +551,20 @@ def pass_test(self=None, condition: bool = True, function=None) -> None:
     sys.exit(0)
 
 
-def match_exact(lines=None, matches=None, newline=os.sep):
+def match_exact(
+    lines: str | list | None = None,
+    matches: str | list | None = None,
+    newline: str = os.sep,
+) -> int | None:
     """Match function using exact match.
 
-    :param lines: data lines
-    :type lines: str or list[str]
-    :param matches: expected lines to match
-    :type matches: str or list[str]
-    :param newline: line separator
-    :returns: None on failure, 1 on success.
+    Args:
+        lines: Data lines.
+        matches: Expected lines to match.
+        newline: Line separator.
 
+    Returns:
+        None on failure, 1 on success.
     """
     if isinstance(lines, bytes):
         newline = to_bytes(newline)
@@ -577,19 +581,21 @@ def match_exact(lines=None, matches=None, newline=os.sep):
     return 1
 
 
-def match_caseinsensitive(lines=None, matches=None):
+def match_caseinsensitive(
+    lines: str | list | None = None, matches: str | list | None = None
+) -> int | None:
     """Match function using case-insensitive matching.
 
     Only a simplistic comparison is done, based on casefolding
     the strings. This may still fail but is the suggestion of
     the Unicode Standard.
 
-    :param lines: data lines
-    :type lines: str or list[str]
-    :param matches: expected lines to match
-    :type matches: str or list[str]
-    :returns: None on failure, 1 on success.
+    Args:
+        lines: Data lines.
+        matches: Expected lines to match.
 
+    Returns:
+        None on failure, 1 on success.
     """
     if not is_List(lines):
         lines = lines.split("\n")
@@ -603,15 +609,15 @@ def match_caseinsensitive(lines=None, matches=None):
     return 1
 
 
-def match_re(lines=None, res=None):
+def match_re(lines: str | list | None = None, res: str | list | None = None) -> int | None:
     """Match function using line-by-line regular expression match.
 
-    :param lines: data lines
-    :type lines: str or list[str]
-    :param res: regular expression(s) for matching
-    :type res: str or list[str]
-    :returns: None on failure, 1 on success.
+    Args:
+        lines: Data lines.
+        res: Regular expression(s) for matching.
 
+    Returns:
+        None on failure, 1 on success.
     """
     if not is_List(lines):
         # CRs mess up matching (Windows) so split carefully
@@ -635,18 +641,20 @@ def match_re(lines=None, res=None):
     return 1
 
 
-def match_re_dotall(lines=None, res=None):
+def match_re_dotall(
+    lines: str | list | None = None, res: str | list | None = None
+) -> Match[str] | None:
     """Match function using regular expression match.
 
-    Unlike match_re, the arguments are converted to strings (if necessary)
+    Unlike :math:`match_re`, the arguments are converted to strings (if necessary)
     and must match exactly.
 
-    :param lines: data lines
-    :type lines: str or list[str]
-    :param res: regular expression(s) for matching
-    :type res: str or list[str]
-    :returns: a match object on match, else None, like re.match
+    Args:
+        lines: Data lines.
+        res: Regular expression(s) for matching.
 
+    Returns:
+        A match object on match, else None, like :meth:`re.match`.
     """
     if not isinstance(lines, str):
         lines = "\n".join(lines)
@@ -735,7 +743,7 @@ def diff_re(
     are regular expressions.  This is a really dumb thing that
     just compares each line in turn, so it doesn't look for
     chunks of matching lines and the like--but at least it lets
-    you know exactly which line first didn't compare correctl...
+    you know exactly which line first didn't compare correctly.
 
     Raises:
         re.error: if a regex fails to compile
@@ -2152,7 +2160,7 @@ class TestCmd:
                     do_chmod(os.path.join(dirpath, name))
             do_chmod(top)
 
-    def write(self, file, content, mode: str = 'wb'):
+    def write(self, file: str | list, content: str | bytes, mode: str = 'wb'):
         """Writes data to file.
 
         The file is created under the temporary working directory.
@@ -2160,13 +2168,11 @@ class TestCmd:
         write is converted to the required type rather than failing
         if there is a str/bytes mistmatch.
 
-        :param file: name of file to write to. If a list, treated
-            as components of a path and concatenated into a path.
-        :type file: str or list(str)
-        :param content: data to write.
-        :type  content: str or bytes
-        :param mode: file mode, default is binary.
-        :type mode: str
+        Args:
+            file: Name of file to write to. If a list, treated as
+                components of a path and concatenated into a path.
+            content: Data to write.
+            mode: File mode, default is binary.
         """
         file = self.canonicalize(file)
         if mode[0] != 'w':

--- a/testing/framework/TestCmd.py
+++ b/testing/framework/TestCmd.py
@@ -552,8 +552,8 @@ def pass_test(self=None, condition: bool = True, function=None) -> None:
 
 
 def match_exact(
-    lines: str | list | None = None,
-    matches: str | list | None = None,
+    lines: str | list[str] | None = None,
+    matches: str | list[str] | None = None,
     newline: str = os.sep,
 ) -> int | None:
     """Match function using exact match.
@@ -582,7 +582,8 @@ def match_exact(
 
 
 def match_caseinsensitive(
-    lines: str | list | None = None, matches: str | list | None = None
+    lines: str | list[str] | None = None,
+    matches: str | list[str] | None = None,
 ) -> int | None:
     """Match function using case-insensitive matching.
 
@@ -609,7 +610,10 @@ def match_caseinsensitive(
     return 1
 
 
-def match_re(lines: str | list | None = None, res: str | list | None = None) -> int | None:
+def match_re(
+    lines: str | list[str] | None = None,
+    res: str | list[str] | None = None,
+) -> int | None:
     """Match function using line-by-line regular expression match.
 
     Args:
@@ -642,7 +646,8 @@ def match_re(lines: str | list | None = None, res: str | list | None = None) -> 
 
 
 def match_re_dotall(
-    lines: str | list | None = None, res: str | list | None = None
+    lines: str | list[str] | None = None,
+    res: str | list[str] | None = None,
 ) -> Match[str] | None:
     """Match function using regular expression match.
 
@@ -2160,7 +2165,7 @@ class TestCmd:
                     do_chmod(os.path.join(dirpath, name))
             do_chmod(top)
 
-    def write(self, file: str | list, content: str | bytes, mode: str = 'wb'):
+    def write(self, file: str | list[str], content: str | bytes, mode: str = 'wb'):
         """Writes data to file.
 
         The file is created under the temporary working directory.


### PR DESCRIPTION
The remaining files that have old-style aka reST-style docstrings are switched to Google style.  This does *not* remove the inline reST-style annotations for functions, classes, modules, etc. - that's a different topic, we want to keep those so API docs are generated with hyperlinks to the referenced element.

In a bit of "burying the lede"... there was an actual bugfix here, in `Defaults.py` a copy-pasted chunk ended up with a reference to a variable that was not in scope at that point (in `processDefines`). Was glancing at `Defaults.py` in an IDE to see what it thought was broken, and it was red on that one.

Some minor de-linting in `Defaults.py` and `Node/FS.py`, and fix an annotation error in `FS.py` (`invalidate_node_memos`) - of course that one has no runtime effect.

This has no doc or test changes, it's nearly all docstrings, type annotations and moving imports - none of which have runtime effects. 


## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
