### PR TITLE
Deprecate Python 3.7 & 3.8 support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ NOTE: The 4.0.0 release of SCons dropped Python 2.7 support. Use 3.1.2 if
   Python 2.7 support is required (but note old SCons releases are unsupported).
 NOTE: Since SCons 4.3.0, Python 3.6.0 or above is required.
 NOTE: Since SCons 4.9.0, Python 3.7.0 or above is required.
-
+The last release to support Python 3.7 or Python 3.8 is NEXT_RELEASE.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Purge vim/emac local variable bloat.
     - Implement type hints for Node subclasses.
     - Ruff: Handle F401 exclusions more granularly, remove per-file exclusions.
+    - Deprecated Python 3.7 & 3.8 support.
 
   From William Deegan:
     - Fix SCons Docbook schema to work with lxml > 5

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ NOTE: The 4.0.0 release of SCons dropped Python 2.7 support. Use 3.1.2 if
   Python 2.7 support is required (but note old SCons releases are unsupported).
 NOTE: Since SCons 4.3.0, Python 3.6.0 or above is required.
 NOTE: Since SCons 4.9.0, Python 3.7.0 or above is required.
-The last release to support Python 3.7 or Python 3.8 is NEXT_RELEASE.
+NOTE: The last release to support Python 3.7 or Python 3.8 is NEXT_RELEASE.
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 

--- a/README-SF.rst
+++ b/README-SF.rst
@@ -50,6 +50,7 @@ Execution Requirements
 Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
+The last release to support Python 3.7 or Python 3.8 is NEXT_RELEASE.
 The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
 

--- a/README-local
+++ b/README-local
@@ -46,8 +46,10 @@ EXECUTION REQUIREMENTS
 Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
+The last release to support Python 3.7 or Python 3.8 is NEXT_RELEASE.
 The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
+
 
 The default SCons configuration assumes use of the Microsoft Visual C++
 compiler suite on WIN32 systems (either through the Visual Studio

--- a/README-package.rst
+++ b/README-package.rst
@@ -83,6 +83,7 @@ Execution Requirements
 Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
+The last release to support Python 3.7 or Python 3.8 is NEXT_RELEASE.
 The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
 

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ Execution Requirements
 Running SCons requires Python 3.7 or higher. There should be no other
 dependencies or requirements to run standard SCons.
 
+The last release to support Python 3.7 or Python 3.8 is NEXT_RELEASE.
 The last release to support Python 3.6 was 4.8.1.
 The last release to support Python 3.5 was 4.2.0.
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -23,6 +23,8 @@ DEPRECATED FUNCTIONALITY
 
 - List anything that's been deprecated since the last release
 
+- Deprecated Python 3.7 & 3.8 support.
+
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
 

--- a/ReleaseConfig
+++ b/ReleaseConfig
@@ -38,7 +38,7 @@ version_tuple = (4, 10, 2, 'a', 0)
 # cause a warning to be issued (assuming it's not disabled).  These values are
 # mandatory and must be present in the configuration file.
 unsupported_python_version = (3, 7, 0)
-deprecated_python_version = (3, 7, 0)
+deprecated_python_version = (3, 9, 0)
 
 # If release_date is (yyyy, mm, dd, hh, mm, ss), that is used as the release
 # date and time.  If release_date is (yyyy, mm, dd), it is used for the

--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -2360,9 +2360,6 @@ class ObjectContentsTestCase(unittest.TestCase):
     @mock.patch("subprocess.run", mock_subprocess_run)
     def test_scons_subproc_run(self):
         """Test the argument remapping options."""
-        # set phony Python versions to trigger the logic in scons_subproc_run:
-        # any version greater than 3.6, really
-        save_info, sys.version_info = sys.version_info, (3, 11, 1)
         env = Environment()
         self.assertEqual(scons_subproc_run(env), {"check": False})
         with self.subTest():
@@ -2380,25 +2377,6 @@ class ObjectContentsTestCase(unittest.TestCase):
                 scons_subproc_run(env, text=True),
                 {"text": True, "check": False},
             )
-
-        # 3.7:
-        sys.version_info = (3, 7, 2)
-        with self.subTest():
-            self.assertEqual(
-                scons_subproc_run(env, capture_output=True),
-                {"capture_output": True, "check": False},
-            )
-        with self.subTest():
-            self.assertEqual(
-                scons_subproc_run(env, text=True),
-                {"check": False, "text": True},
-            )
-        with self.subTest():
-            self.assertEqual(
-                scons_subproc_run(env, universal_newlines=True),
-                {"universal_newlines": True, "check": False},
-            )
-        sys.version_info = save_info
 
 
 if __name__ == "__main__":

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -68,7 +68,7 @@ from SCons import __version__ as SConsVersion
 
 # these define the range of versions SCons supports
 minimum_python_version = (3, 7, 0)
-deprecated_python_version = (3, 7, 0)
+deprecated_python_version = (3, 9, 0)
 
 # ordered list of SConstruct names to look for if there is no -f flag
 KNOWN_SCONSTRUCT_NAMES = [

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -103,6 +103,20 @@ support for &Python; 3.6 is removed.
 The CPython project retired 3.6 in Sept 2021:
 <ulink url="https://peps.python.org/pep-0494"/>.
 </para>
+<para>
+<emphasis>Changed in version NEXT_RELEASE:</emphasis>
+support for &Python; 3.7 is deprecated and will be removed
+in a future &SCons; release.
+The CPython project retired 3.7 in June 2023:
+<ulink url="https://peps.python.org/pep-0537"/>.
+</para>
+<para>
+<emphasis>Changed in version NEXT_RELEASE:</emphasis>
+support for &Python; 3.8 is deprecated and will be removed
+in a future &SCons; release.
+The CPython project retired 3.8 in Sept 2024:
+<ulink url="https://peps.python.org/pep-0569"/>.
+</para>
 
 <para>
 You set up an &SCons; build by writing a script

--- a/test/SCONSFLAGS.py
+++ b/test/SCONSFLAGS.py
@@ -28,7 +28,7 @@ import os
 import TestCmd
 import TestSCons
 
-test = TestSCons.TestSCons(match = TestCmd.match_re_dotall,ignore_python_version=0)
+test = TestSCons.TestSCons(match=TestCmd.match_re_dotall, ignore_python_version=False)
 
 wpath = test.workpath()
 
@@ -36,7 +36,8 @@ test.write('SConstruct', r"""
 Help("Help text.\n")
 """)
 
-expect = """scons: Reading SConscript files ...
+expect_help = """\
+scons: Reading SConscript files ...
 scons: done reading SConscript files.
 Help text.
 
@@ -45,31 +46,33 @@ Use scons -H for help about SCons built-in command-line options.
 
 os.environ['SCONSFLAGS'] = ''
 
-test.run(arguments = '-h',
-         stdout = expect,
-         stderr = TestSCons.deprecated_python_expr)
+test.run(arguments='-h',
+         stdout=expect_help,
+         stderr=TestSCons.deprecated_python_expr)
 
 os.environ['SCONSFLAGS'] = '-h'
 
-test.run(stdout = expect,
-         stderr = TestSCons.deprecated_python_expr)
+test.run(stdout=expect_help,
+         stderr=TestSCons.deprecated_python_expr)
 
-# No TestSCons.deprecated_python_expr because the -H option gets
+# Don't check for deprecated_python_expr because the -H option gets
 # processed before the SConscript files and therefore before we check
 # for the deprecation warning.
-test.run(arguments = "-H")
+os.environ['SCONSFLAGS'] = ''
+test.run(arguments="-H")
 
 test.must_not_contain_any_line(test.stdout(), ['Help text.'])
 test.must_contain_all_lines(test.stdout(), ['-H, --help-options'])
 
-expect = r"""usage: scons [OPTIONS] [VARIABLES] [TARGETS]
+expect_no_opt = TestSCons.deprecated_python_expr + \
+r"""usage: scons \[OPTIONS\] \[VARIABLES\] \[TARGETS\]
 
 SCons Error: no such option: -Z
 """
 
-test.run(arguments="-Z", status=2, stderr=expect, match=TestSCons.match_exact)
+test.run(arguments="-Z", status=2, stdout=None, stderr=expect_no_opt)
 
 os.environ['SCONSFLAGS'] = '-Z'
-test.run(status=2, stderr=expect, match=TestSCons.match_exact)
+test.run(status=2, stdout=None, stderr=expect_no_opt)
 
 test.pass_test()

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -58,8 +58,8 @@ default_version = '4.10.2ayyyymmdd'
 
 # TODO: these need to be hand-edited when there are changes
 python_version_unsupported = (3, 7, 0)
-python_version_deprecated = (3, 7, 0)
-python_version_supported_str = "3.7.0"  # str of lowest non-deprecated Python
+python_version_deprecated = (3, 9, 0)
+python_version_supported_str = "3.9.0"  # str of lowest non-deprecated Python
 
 SConsVersion = default_version
 

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -190,17 +190,17 @@ def deprecated_python_version(version=sys.version_info):
 
 
 if deprecated_python_version():
-    msg = r"""
-scons: warning: Support for Python older than %s is deprecated (%s detected).
+    deprecated_python_msg = rf"""
+scons: warning: Support for Python older than {python_version_supported_str} is deprecated ({python_version_string()} detected).
     If this will cause hardship, contact scons-dev@python.org
 """
     deprecated_python_expr = (
-        re_escape(msg % (python_version_supported_str, python_version_string()))
+        re_escape(deprecated_python_msg )
         + file_expr
     )
-    del msg
 else:
     deprecated_python_expr = ""
+    deprecated_python_msg = ""
 
 
 def initialize_sconsflags(ignore_python_version):


### PR DESCRIPTION
Originally part of #4825, this PR simply deprecates Python 3.7 & 3.8. The only other change is removing a check in `ActionTests.py`, as I realized that was conditional on 3.6 specifically, so it being bumped to 3.7 was a mistake

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
