### PR TITLE
fix: replace 64 bare except clauses with except Exception

### DIFF
--- a/SCons/ActionTests.py
+++ b/SCons/ActionTests.py
@@ -78,7 +78,7 @@ with open(sys.argv[1], 'w') as f:
     try:
         if sys.argv[3]:
             f.write("act.py: '" + os.environ[sys.argv[3]] + "'\\n")
-    except:
+    except Exception:
         pass
 
 if 'ACTPY_PIPE' in os.environ:

--- a/SCons/Node/FSTests.py
+++ b/SCons/Node/FSTests.py
@@ -1128,7 +1128,7 @@ class FSTestCase(_tempdirTestCase):
             except TypeError as x:
                 assert str(x) == ("Tried to lookup File '%s' as a Dir." %
                                   d1_f1), x
-            except:
+            except Exception:
                 raise
 
             try:
@@ -1136,7 +1136,7 @@ class FSTestCase(_tempdirTestCase):
             except TypeError as x:
                 assert str(x) == ("Tried to lookup File '%s' as a Dir." %
                                   d1_f1), x
-            except:
+            except Exception:
                 raise
 
             try:
@@ -1144,7 +1144,7 @@ class FSTestCase(_tempdirTestCase):
             except TypeError as x:
                 assert str(x) == ("Tried to lookup Dir '%s' as a File." %
                                   'd1'), x
-            except:
+            except Exception:
                 raise
 
         # Test that just specifying the drive works to identify

--- a/SCons/Node/NodeTests.py
+++ b/SCons/Node/NodeTests.py
@@ -136,7 +136,7 @@ class Environment:
     def get_scanner(self, scanner_key):
         try:
             return self._dict['SCANNERS'][0]
-        except:
+        except Exception:
             pass
 
         return []
@@ -837,7 +837,7 @@ class NodeTestCase(unittest.TestCase):
 
         try:
             node.add_depends([[five, six]])
-        except:
+        except Exception:
             pass
         else:
             raise Exception("did not catch expected exception")
@@ -869,7 +869,7 @@ class NodeTestCase(unittest.TestCase):
 
         try:
             node.add_source([[five, six]])
-        except:
+        except Exception:
             pass
         else:
             raise Exception("did not catch expected exception")
@@ -900,7 +900,7 @@ class NodeTestCase(unittest.TestCase):
 
         try:
             node.add_ignore([[five, six]])
-        except:
+        except Exception:
             pass
         else:
             raise Exception("did not catch expected exception")

--- a/SCons/Platform/win32.py
+++ b/SCons/Platform/win32.py
@@ -246,7 +246,7 @@ def get_system_root():
                 val, tok = SCons.Util.RegQueryValueEx(k, 'SystemRoot')
             except KeyboardInterrupt:
                 raise
-            except:
+            except Exception:
                 pass
 
     _system_root = val
@@ -363,7 +363,7 @@ def generate(env):
                 cmd_interp = os.path.join(val, 'command.com')
             except KeyboardInterrupt:
                 raise
-            except:
+            except Exception:
                 pass
 
     # For the special case of not having access to the registry, we

--- a/SCons/Script/Main.py
+++ b/SCons/Script/Main.py
@@ -274,7 +274,7 @@ class BuildTask(SCons.Taskmaster.OutOfDateTask):
                     raise SCons.Errors.BuildError(t, errstr)
                 except KeyboardInterrupt:
                     raise
-                except:
+                except Exception:
                     self.exception_set()
                 self.do_failed()
             else:
@@ -1542,7 +1542,7 @@ def main() -> None:
     except SCons.Errors.BuildError as e:
         print(e)
         exit_status = e.exitstatus
-    except:
+    except Exception:
         # An exception here is likely a builtin Python exception Python
         # code in an SConscript file.  Show them precisely what the
         # problem was and where it happened.

--- a/SCons/Taskmaster/TaskmasterTests.py
+++ b/SCons/Taskmaster/TaskmasterTests.py
@@ -1145,7 +1145,7 @@ class TaskmasterTestCase(unittest.TestCase):
 
         try:
             1 // 0
-        except:
+        except Exception:
             # Moved from below
             t.exception_set(None)
             # pass
@@ -1172,7 +1172,7 @@ class TaskmasterTestCase(unittest.TestCase):
         t.exception_set((Exception1, ""))
         try:
             t.exception_raise()
-        except:
+        except Exception:
             exc_type, exc_value = sys.exc_info()[:2]
             assert exc_type == Exception1, exc_type
             assert str(exc_value) == '', "Expecting empty string got:%s (type %s)" % (exc_value, type(exc_value))
@@ -1185,7 +1185,7 @@ class TaskmasterTestCase(unittest.TestCase):
         t.exception_set((Exception2, "xyzzy"))
         try:
             t.exception_raise()
-        except:
+        except Exception:
             exc_type, exc_value = sys.exc_info()[:2]
             assert exc_type == Exception2, exc_type
             assert str(exc_value) == "xyzzy", exc_value
@@ -1197,12 +1197,12 @@ class TaskmasterTestCase(unittest.TestCase):
 
         try:
             1 // 0
-        except:
+        except Exception:
             tb = sys.exc_info()[2]
         t.exception_set((Exception3, "arg", tb))
         try:
             t.exception_raise()
-        except:
+        except Exception:
             exc_type, exc_value, exc_tb = sys.exc_info()
             assert exc_type == Exception3, exc_type
             assert str(exc_value) == "arg", exc_value

--- a/SCons/Taskmaster/__init__.py
+++ b/SCons/Taskmaster/__init__.py
@@ -851,7 +851,7 @@ class Taskmaster:
             #
             # try:
             #     self._validate_pending_children()
-            # except:
+            # except Exception:
             #     self.ready_exc = sys.exc_info()
             #     return node
 
@@ -1004,7 +1004,7 @@ class Taskmaster:
             #
             # try:
             #     self._validate_pending_children()
-            # except:
+            # except Exception:
             #     self.ready_exc = sys.exc_info()
             #     return node
 

--- a/SCons/Tool/MSCommon/vcTests.py
+++ b/SCons/Tool/MSCommon/vcTests.py
@@ -530,7 +530,7 @@ class MsvcQueryVersionToolsetTests(unittest.TestCase):
                             version=vcver, prefer_newest=prefer_newest
                         )
                         break
-                    except:
+                    except Exception:
                         pass
                 self.assertTrue(msvc_version, "msvc_version is undefined for msvc version {}".format(repr(symbol)))
                 if version_def.msvc_vernum > 14.0:

--- a/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
+++ b/SCons/Tool/docbook/docbook-xsl-1.76.1/extensions/docbook.py
@@ -24,7 +24,7 @@ def adjustColumnWidths(ctx, nodeset):
         pctxt = libxslt.xpathParserContext(_obj=ctx)
         ctxt = pctxt.context()
         tctxt = ctxt.transformContext()
-    except:
+    except Exception:
         pass
 
     # Get the nominal table width

--- a/SCons/Tool/gas.py
+++ b/SCons/Tool/gas.py
@@ -34,7 +34,7 @@ selection method.
 
 try:
     as_module = __import__('as', globals(), locals(), [])
-except:
+except Exception:
     as_module = __import__(__package__+'.as', globals(), locals(), ['*'])
 
 assemblers = ['as', 'gas']

--- a/SCons/Tool/install.py
+++ b/SCons/Tool/install.py
@@ -201,7 +201,7 @@ def copyFuncVersionedLib(dest, source, env) -> int:
         # remove the link if it is already there
         try:
             os.remove(dest)
-        except:
+        except Exception:
             pass
         copy2(source, dest)
         st = os.stat(source)

--- a/SCons/Tool/jar.py
+++ b/SCons/Tool/jar.py
@@ -130,7 +130,7 @@ def Jar(env, target=None, source=[], *args, **kw):
         try:
             # make target from the first source file
             target = os.path.splitext(str(source[0]))[0] + env.subst('$JARSUFFIX')
-        except:
+        except Exception:
             # TODO: W0702: No exception type(s) specified
             # something strange is happening but attempt anyways
             SCons.Warnings.warn(
@@ -193,7 +193,7 @@ def Jar(env, target=None, source=[], *args, **kw):
                 # source is string try to convert it to file
                 target_nodes.extend(file_to_class(env.fs.File(src)))
                 continue
-            except:
+            except Exception:
                 # TODO: W0702: No exception type(s) specified
                 pass
 
@@ -201,7 +201,7 @@ def Jar(env, target=None, source=[], *args, **kw):
                 # source is string try to covnert it to dir
                 target_nodes.extend(dir_to_class(env.fs.Dir(src)))
                 continue
-            except:
+            except Exception:
                 # TODO: W0702: No exception type(s) specified
                 pass
 

--- a/SCons/Tool/msvs.py
+++ b/SCons/Tool/msvs.py
@@ -830,7 +830,7 @@ class _GenerateV6DSP(_DSPGenerator):
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             return # unable to unpickle any data for some reason
 
         self.sources.update(data)
@@ -1125,7 +1125,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             return # unable to unpickle any data for some reason
 
         self.configs.update(data)
@@ -1145,7 +1145,7 @@ class _GenerateV7DSP(_DSPGenerator, _GenerateV7User):
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             return # unable to unpickle any data for some reason
 
         self.sources.update(data)
@@ -1653,7 +1653,7 @@ class _GenerateV7DSW(_DSWGenerator):
             data = pickle.loads(datas)
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             return # unable to unpickle any data for some reason
 
         self.configs.update(data)

--- a/SCons/Tool/rpmutils.py
+++ b/SCons/Tool/rpmutils.py
@@ -529,7 +529,7 @@ def updateRpmDicts(rpmrc, pyfile) -> None:
                             for arch in sorted(entries.keys()):
                                 out.write("  '%s' : ['%s'],\n" % (arch, "','".join(entries[arch])))
                             out.write("}\n\n")
-    except:
+    except Exception:
         pass
 
 def usage() -> None:

--- a/SCons/Tool/xgettext.py
+++ b/SCons/Tool/xgettext.py
@@ -102,7 +102,7 @@ def _update_pot_file(target, source, env):
         cmd = _CmdRunner('$XGETTEXTCOM', '$XGETTEXTCOMSTR')
         action = SCons.Action.Action(cmd, strfunction=cmd.strfunction)
         status = action([target[0]], source, env)
-    except:
+    except Exception:
         # Something went wrong.
         env.Execute(SCons.Action.Action(nop, "Leaving " + chdir_str))
         # Revert working dirs to previous state and re-throw exception.
@@ -274,7 +274,7 @@ def generate(env, **kw) -> None:
             )
     try:
         env['XGETTEXT'] = _detect_xgettext(env)
-    except:
+    except Exception:
         env['XGETTEXT'] = 'xgettext'
     # NOTE: sources="$SOURCES" would work as well. However, we use following
     # construction to convert absolute paths provided by scons onto paths
@@ -327,5 +327,5 @@ def exists(env):
     """ Check, whether the tool exists """
     try:
         return _xgettext_exists(env)
-    except:
+    except Exception:
         return False

--- a/bin/scons-proc.py
+++ b/bin/scons-proc.py
@@ -175,7 +175,7 @@ class SCons_XML:
     def write_mod(self, filename):
         try:
             description = self.values[0].description
-        except:
+        except Exception:
             description = ""
         if not filename:
             return

--- a/bin/scons-test.py
+++ b/bin/scons-test.py
@@ -122,7 +122,7 @@ for name in zf.namelist():
     dir = os.path.dirname(dest)
     try:
         os.makedirs(dir)
-    except:
+    except Exception:
         pass
     printname(dest)
     # if the file exists, then delete it before writing

--- a/bin/scons-unzip.py
+++ b/bin/scons-unzip.py
@@ -58,7 +58,7 @@ for name in zf.namelist():
     dir = os.path.dirname(dest)
     try:
         os.makedirs(dir)
-    except:
+    except Exception:
         pass
     printname(dest)
     # if the file exists, then delete it before writing

--- a/site_scons/Utilities.py
+++ b/site_scons/Utilities.py
@@ -29,7 +29,7 @@ def whereis(filename):
             if os.path.isfile(f_ext):
                 try:
                     st = os.stat(f_ext)
-                except:
+                except Exception:
                     continue
                 if stat.S_IMODE(st.st_mode) & stat.S_IXUSR:
                     return f_ext

--- a/src/test_interrupts.py
+++ b/src/test_interrupts.py
@@ -41,7 +41,7 @@ test = TestSCons.TestSCons()
 # try:
 #   # do something, e.g.
 #   return a['x']
-# except:
+# except Exception:
 #   # do the exception handling
 #   a['x'] = getx()
 #   return a['x']
@@ -97,7 +97,7 @@ for f in files:
         lastend = match.end()
         try:
             indent_list = try_except_lines[match.group('indent')]
-        except:
+        except Exception:
             indent_list = []
         line_num = 1 + contents[:match.start()].count('\n')
         indent_list.append( (line_num, match.group('try_or_except') ) )

--- a/test/Configure/Streamer1.py
+++ b/test/Configure/Streamer1.py
@@ -48,7 +48,7 @@ def hello(target, source, env):
     print('hello!\\n') # this breaks the script
     with open(env.subst('$TARGET', target = target),'w') as f:
       f.write('yes')
-  except:
+  except Exception:
     # write to file, as stdout/stderr is broken
     traceback.print_exc(file=open('traceback','w'))
   return 0

--- a/test/Java/swig-dependencies.py
+++ b/test/Java/swig-dependencies.py
@@ -135,7 +135,7 @@ foopack_jar = env.Jar(target = 'foopack.jar', source = 'classes')
 # being defined but not used.
 try:
     test.run(arguments = '.', stderr=None)
-except:
+except Exception:
     # catch exception which is causing failure for issue not related to java.
     # Bug ticket reported also this seems work fine when running outsite
     # the test framework

--- a/test/VariantDir/VariantDir.py
+++ b/test/VariantDir/VariantDir.py
@@ -114,7 +114,7 @@ env2.Program(target='foo4', source='f4.c')
 
 try:
     fortran = env.subst('$FORTRAN')
-except:
+except Exception:
     fortran = None
 
 if fortran and env.Detect(fortran):

--- a/testing/framework/TestCmdTests.py
+++ b/testing/framework/TestCmdTests.py
@@ -1854,14 +1854,14 @@ class read_TestCase(TestCmdTestCase):
             contents = test.read('no_file')
         except IOError:  # expect "No such file or directory"
             pass
-        except:
+        except Exception:
             raise
 
         try:
             test.read(test.workpath('file_x'), mode='w')
         except ValueError:  # expect "mode must begin with 'r'
             pass
-        except:
+        except Exception:
             raise
 
         def _file_matches(file, contents, expected) -> None:
@@ -3309,7 +3309,7 @@ class unlink_TestCase(TestCmdTestCase):
             contents = test.unlink('no_file')
         except OSError:  # expect "No such file or directory"
             pass
-        except:
+        except Exception:
             raise
 
         test.unlink("file1")
@@ -3338,7 +3338,7 @@ class unlink_TestCase(TestCmdTestCase):
                     test.unlink('file5')
                 except OSError:  # expect "Permission denied"
                     pass
-                except:
+                except Exception:
                     raise
             finally:
                 os.chmod(test.workdir, 0o700)
@@ -3416,7 +3416,7 @@ class unlink_files_TestCase(TestCmdTestCase):
                     test.unlink_files('', ['file5'])
                 except OSError:  # expect "Permission denied"
                     pass
-                except:
+                except Exception:
                     raise
             finally:
                 os.chmod(test.workdir, 0o700)
@@ -3496,7 +3496,7 @@ class workdir_TestCase(TestCmdTestCase):
             test = TestCmd.TestCmd(workdir=no_such_subdir)
         except OSError:  # expect "No such file or directory"
             pass
-        except:
+        except Exception:
             raise
 
         test = TestCmd.TestCmd(workdir='foo')
@@ -3511,7 +3511,7 @@ class workdir_TestCase(TestCmdTestCase):
             test.workdir_set(no_such_subdir)
         except OSError:
             pass  # expect "No such file or directory"
-        except:
+        except Exception:
             raise
         assert workdir_bar == test.workdir
 
@@ -3682,7 +3682,7 @@ class write_TestCase(TestCmdTestCase):
             test.write(['bar', 'file3'], "Test file #3 (should not get created)\n")
         except IOError:  # expect "No such file or directory"
             pass
-        except:
+        except Exception:
             raise
         test.write(test.workpath('file4'), "Test file #4.\n")
         test.write(test.workpath('foo', 'file5'), "Test file #5.\n")
@@ -3692,14 +3692,14 @@ class write_TestCase(TestCmdTestCase):
             )
         except IOError:  # expect "No such file or directory"
             pass
-        except:
+        except Exception:
             raise
 
         try:
             test.write('file7', "Test file #8.\n", mode='r')
         except ValueError:  # expect "mode must begin with 'w'
             pass
-        except:
+        except Exception:
             raise
 
         test.write('file8', "Test file #8.\n", mode='w')
@@ -3711,7 +3711,7 @@ class write_TestCase(TestCmdTestCase):
                 test.write('file10', "Test file #10 (should not get created).\n")
             except IOError:  # expect "Permission denied"
                 pass
-            except:
+            except Exception:
                 raise
 
         assert os.path.isdir(test.workpath('foo'))

--- a/testing/framework/TestCommon.py
+++ b/testing/framework/TestCommon.py
@@ -581,7 +581,7 @@ class TestCommon(TestCmd):
             )
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             print(f"Unexpected contents of `{file}'")
             self.diff(expect, file_contents, 'contents ')
             raise
@@ -613,7 +613,7 @@ class TestCommon(TestCmd):
             )
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             print(f"Unexpected contents of `{file}'")
             self.diff(golden_file_contents, file_contents, 'contents ')
             raise

--- a/testing/framework/TestSCons.py
+++ b/testing/framework/TestSCons.py
@@ -1769,7 +1769,7 @@ try:
         # not clear this is useful: 'lib' does not contain linkable libs
         lib_path = os.path.join(exec_prefix, 'lib')
     print(lib_path)
-except:
+except Exception:
     include = os.path.join(sys.prefix, 'include', py_ver)
     print(include)
     lib_path = os.path.join(sys.prefix, 'lib', py_ver, 'config')

--- a/testing/framework/TestSConsMSVS.py
+++ b/testing/framework/TestSConsMSVS.py
@@ -989,7 +989,7 @@ print("self._msvs_versions =%%s"%%str(SCons.Tool.MSCommon.query_versions(env=Non
     def validate_msvs_file(self, file) -> None:
         try:
             x = ElementTree.parse(file)
-        except:
+        except Exception:
             print("--------------------------------------------------------------")
             print("--------------------------------------------------------------")
             print(traceback.format_exc())

--- a/testing/framework/TestSConsTar.py
+++ b/testing/framework/TestSConsTar.py
@@ -102,7 +102,7 @@ if sys.platform == 'win32':
         try:
             result = subprocess.run([f"{tar}", "--version"], capture_output=True, text=True, check=True)
             version_str = result.stdout.strip()
-        except:
+        except Exception:
             version_str = None
 
         if not version_str:


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches SystemExit, KeyboardInterrupt, and GeneratorExit which is rarely intended.