### PR TITLE
Stop using assert in e2e tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Additional small tweaks to Environment.py type hints, fold some overly
       long function signature lines, and some linting-insipired cleanups.
     - Test framework: tweak module docstrings
+    - Test suite: end to end tests don't use assert in result checks
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -62,6 +62,8 @@ long function signature lines, and some linting-insipired cleanups.
 
 - Test framework: tweak module docstrings
 
+- Test suite: end to end tests don't use assert in result checks
+
 
 PACKAGING
 ---------

--- a/test/D/Support/executablesSearch.py
+++ b/test/D/Support/executablesSearch.py
@@ -68,18 +68,18 @@ if __name__ == '__main__':
             self.assertRaises(KeyError, isExecutableOfToolAvailable, self.test, None)
 
         def test_dmd_tool(self):
-            self.assertEqual(
-                self.test.where_is('dmd', path) is not None or self.test.where_is('gdmd', path) is not None,
+            self.test.fail_test(
+                (self.test.where_is('dmd', path) is not None or self.test.where_is('gdmd', path) is not None) !=
                 isExecutableOfToolAvailable(self.test, 'dmd'))
 
         def test_gdc_tool(self):
-            self.assertEqual(
-                self.test.where_is('gdc', path) is not None,
+            self.test.fail_test(
+                (self.test.where_is('gdc', path) is not None) !=
                 isExecutableOfToolAvailable(self.test, 'gdc'))
 
         def test_ldc_tool(self):
-            self.assertEqual(
-                self.test.where_is('ldc2', path) is not None or self.test.where_is('ldc', path) is not None,
+            self.test.fail_test(
+                (self.test.where_is('ldc2', path) is not None or self.test.where_is('ldc', path) is not None) !=
                 isExecutableOfToolAvailable(self.test, 'ldc'))
 
     unittest.main()

--- a/test/MSVS/common-prefix.py
+++ b/test/MSVS/common-prefix.py
@@ -139,7 +139,7 @@ vcproj = test.read(['work1', 'Test.vcproj'], 'r')
 expected_vcprojfile = vcproj_template % locals()
 expect = test.msvs_substitute(expected_vcprojfile, '8.0', 'work1', 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.subdir('work2')
 
@@ -165,6 +165,6 @@ vcproj = test.read(['work2', 'Test.vcproj'], 'r')
 expected_vcprojfile = vcproj_template % locals()
 expect = test.msvs_substitute(expected_vcprojfile, '8.0', 'work2', 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.pass_test()

--- a/test/MSVS/runfile.py
+++ b/test/MSVS/runfile.py
@@ -115,6 +115,6 @@ test.must_exist(test.workpath('work1', 'Test.vcproj'))
 vcproj = test.read(['work1', 'Test.vcproj'], 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '8.0', 'work1', 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.pass_test()

--- a/test/MSVS/vs-6.0-clean.py
+++ b/test/MSVS/vs-6.0-clean.py
@@ -72,12 +72,12 @@ test.must_exist(test.workpath('Test.dsp'))
 dsp = test.read('Test.dsp', 'r')
 expect = test.msvs_substitute(expected_dspfile, '6.0', None, 'SConstruct')
 # don't compare the pickled data
-assert dsp[:len(expect)] == expect, test.diff_substr(expect, dsp)
+test.fail_test(dsp[:len(expect)] != expect, message=test.diff_substr(expect, dsp))
 
 test.must_exist(test.workpath('Test.dsw'))
 dsw = test.read('Test.dsw', 'r')
 expect = test.msvs_substitute(expected_dswfile, '6.0', None, 'SConstruct')
-assert dsw == expect, test.diff_substr(expect, dsw)
+test.fail_test(dsw != expect, message=test.diff_substr(expect, dsw))
 
 test.run(arguments='-c .')
 

--- a/test/MSVS/vs-6.0-files.py
+++ b/test/MSVS/vs-6.0-files.py
@@ -50,12 +50,12 @@ test.must_exist(test.workpath('Test.dsp'))
 dsp = test.read('Test.dsp', 'r')
 expect = test.msvs_substitute(expected_dspfile, '6.0', None, 'SConstruct')
 # don't compare the pickled data
-assert dsp[:len(expect)] == expect, test.diff_substr(expect, dsp)
+test.fail_test(dsp[:len(expect)] != expect, message=test.diff_substr(expect, dsp))
 
 test.must_exist(test.workpath('Test.dsw'))
 dsw = test.read('Test.dsw', 'r')
 expect = test.msvs_substitute(expected_dswfile, '6.0', None, 'SConstruct')
-assert dsw == expect, test.diff_substr(expect, dsw)
+test.fail_test(dsw != expect, message=test.diff_substr(expect, dsw))
 
 test.run(arguments='-c .')
 

--- a/test/MSVS/vs-6.0-variant_dir.py
+++ b/test/MSVS/vs-6.0-variant_dir.py
@@ -56,12 +56,12 @@ test.run(arguments=".")
 dsp = test.read(['src', 'Test.dsp'], 'r')
 expect = test.msvs_substitute(expected_dspfile, '6.0', None, 'SConstruct')
 # don't compare the pickled data
-assert dsp[:len(expect)] == expect, test.diff_substr(expect, dsp)
+test.fail_test(dsp[:len(expect)] != expect, message=test.diff_substr(expect, dsp))
 
 test.must_exist(test.workpath('src', 'Test.dsw'))
 dsw = test.read(['src', 'Test.dsw'], 'r')
 expect = test.msvs_substitute(expected_dswfile, '6.0', 'src')
-assert dsw == expect, test.diff_substr(expect, dsw)
+test.fail_test(dsw != expect, message=test.diff_substr(expect, dsw))
 
 test.must_match(['build', 'Test.dsp'], """\
 This is just a placeholder file.

--- a/test/MSVS/vs-7.0-clean.py
+++ b/test/MSVS/vs-7.0-clean.py
@@ -73,13 +73,13 @@ test.must_exist(test.workpath('Test.vcproj'))
 vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.0', None, 'SConstruct')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.run(arguments='-c .')
 

--- a/test/MSVS/vs-7.0-files.py
+++ b/test/MSVS/vs-7.0-files.py
@@ -51,13 +51,13 @@ test.must_exist(test.workpath('Test.vcproj'))
 vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.0', None, 'SConstruct')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.run(arguments='-c .')
 
@@ -86,6 +86,6 @@ vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct',
                               python=python)
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.pass_test()

--- a/test/MSVS/vs-7.0-scc-files.py
+++ b/test/MSVS/vs-7.0-scc-files.py
@@ -99,13 +99,13 @@ vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct',
                               vcproj_sccinfo=expected_vcproj_sccinfo)
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.0', None, 'SConstruct',
                               sln_sccinfo=expected_sln_sccinfo)
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.pass_test()

--- a/test/MSVS/vs-7.0-scc-legacy-files.py
+++ b/test/MSVS/vs-7.0-scc-legacy-files.py
@@ -80,12 +80,12 @@ vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct',
                               vcproj_sccinfo=expected_vcproj_sccinfo)
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.0', None, 'SConstruct')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.pass_test()

--- a/test/MSVS/vs-7.0-variant_dir.py
+++ b/test/MSVS/vs-7.0-variant_dir.py
@@ -54,13 +54,13 @@ test.run(arguments=".")
 vcproj = test.read(['src', 'Test.vcproj'], 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('src', 'Test.sln'))
 sln = test.read(['src', 'Test.sln'], 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.0', 'src')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.must_match(['build', 'Test.vcproj'], """\
 This is just a placeholder file.

--- a/test/MSVS/vs-7.1-clean.py
+++ b/test/MSVS/vs-7.1-clean.py
@@ -73,13 +73,13 @@ test.must_exist(test.workpath('Test.vcproj'))
 vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.1', None, 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.1', None, 'SConstruct')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.run(arguments='-c .')
 

--- a/test/MSVS/vs-7.1-files.py
+++ b/test/MSVS/vs-7.1-files.py
@@ -51,13 +51,13 @@ test.must_exist(test.workpath('Test.vcproj'))
 vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.1', None, 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.1', None, 'SConstruct')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.run(arguments='-c .')
 
@@ -86,6 +86,6 @@ vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.1', None, 'SConstruct',
                               python=python)
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.pass_test()

--- a/test/MSVS/vs-7.1-scc-files.py
+++ b/test/MSVS/vs-7.1-scc-files.py
@@ -99,13 +99,13 @@ vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.1', None, 'SConstruct',
                               vcproj_sccinfo=expected_vcproj_sccinfo)
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.1', None, 'SConstruct',
                               sln_sccinfo=expected_sln_sccinfo)
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.pass_test()

--- a/test/MSVS/vs-7.1-scc-legacy-files.py
+++ b/test/MSVS/vs-7.1-scc-legacy-files.py
@@ -80,12 +80,12 @@ vcproj = test.read('Test.vcproj', 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.1', None, 'SConstruct',
                               vcproj_sccinfo=expected_vcproj_sccinfo)
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('Test.sln'))
 sln = test.read('Test.sln', 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.1', None, 'SConstruct')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.pass_test()

--- a/test/MSVS/vs-7.1-variant_dir.py
+++ b/test/MSVS/vs-7.1-variant_dir.py
@@ -54,13 +54,13 @@ test.run(arguments=".")
 vcproj = test.read(['src', 'Test.vcproj'], 'r')
 expect = test.msvs_substitute(expected_vcprojfile, '7.0', None, 'SConstruct')
 # don't compare the pickled data
-assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
 test.must_exist(test.workpath('src', 'Test.sln'))
 sln = test.read(['src', 'Test.sln'], 'r')
 expect = test.msvs_substitute(expected_slnfile, '7.0', 'src')
 # don't compare the pickled data
-assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 test.must_match(['build', 'Test.vcproj'], """\
 This is just a placeholder file.

--- a/test/MSVS/vs-files.py
+++ b/test/MSVS/vs-files.py
@@ -61,13 +61,13 @@ for vc_version in TestSConsMSVS.get_tested_proj_file_vc_versions():
     vcxproj = test.read(project_file, 'r')
     expect = test.msvs_substitute(expected_vcprojfile, vc_version, None, 'SConstruct')
     # don't compare the pickled data
-    assert vcxproj[:len(expect)] == expect, test.diff_substr(expect, vcxproj)
+    test.fail_test(vcxproj[:len(expect)] != expect, message=test.diff_substr(expect, vcxproj))
 
     test.must_exist(test.workpath('Test.sln'))
     sln = test.read('Test.sln', 'r')
     expect = test.msvs_substitute(expected_slnfile, vc_version, None, 'SConstruct')
     # don't compare the pickled data
-    assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+    test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
     test.run(arguments='-c .')
 
@@ -102,7 +102,7 @@ for vc_version in TestSConsMSVS.get_tested_proj_file_vc_versions():
     expect = test.msvs_substitute(expected_vcprojfile, vc_version, None, 'SConstruct',
                                   python=python)
     # don't compare the pickled data
-    assert vcxproj[:len(expect)] == expect, test.diff_substr(expect, vcxproj)
+    test.fail_test(vcxproj[:len(expect)] != expect, message=test.diff_substr(expect, vcxproj))
 
     del os.environ['PYTHON_ROOT']
 

--- a/test/MSVS/vs-mult-auto-guid.py
+++ b/test/MSVS/vs-mult-auto-guid.py
@@ -117,13 +117,13 @@ for vc_version in TestSConsMSVS.get_tested_proj_file_vc_versions():
         vcproj = test.read(project_file_1, 'r')
         expect = test.msvs_substitute(expected_vcprojfile_1, vc_version, None, 'SConstruct', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath(project_file_2))
         vcproj = test.read(project_file_2, 'r')
         expect = test.msvs_substitute(expected_vcprojfile_2, vc_version, None, 'SConstruct', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath(solution_file))
         sln = test.read(solution_file, 'r')
@@ -133,19 +133,19 @@ for vc_version in TestSConsMSVS.get_tested_proj_file_vc_versions():
             solution_guid_1=solution_guid_1, solution_guid_2=solution_guid_2,
         )
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath(solution_file_1))
         sln = test.read(solution_file_1, 'r')
         expect = test.msvs_substitute(expected_slnfile_1, vc_version, subdir='src', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath(solution_file_2))
         sln = test.read(solution_file_2, 'r')
         expect = test.msvs_substitute(expected_slnfile_2, vc_version, subdir='src', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         if filters_file_expected:
             test.must_exist(test.workpath(filters_file_1))

--- a/test/MSVS/vs-mult-auto-vardir-guid.py
+++ b/test/MSVS/vs-mult-auto-vardir-guid.py
@@ -123,13 +123,13 @@ SConscript('src/SConscript', variant_dir='build')
         vcproj = test.read(['src', project_file_1], 'r')
         expect = test.msvs_substitute(expected_vcprojfile_1, vc_version, None, 'SConstruct', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath('src', project_file_2))
         vcproj = test.read(['src', project_file_2], 'r')
         expect = test.msvs_substitute(expected_vcprojfile_2, vc_version, None, 'SConstruct', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath('src', solution_file))
         sln = test.read(['src', solution_file], 'r')
@@ -139,19 +139,19 @@ SConscript('src/SConscript', variant_dir='build')
             solution_guid_1=solution_guid_1, solution_guid_2=solution_guid_2,
         )
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath('src', solution_file_1))
         sln = test.read(['src', solution_file_1], 'r')
         expect = test.msvs_substitute(expected_slnfile_1, vc_version, subdir='src', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath('src', solution_file_2))
         sln = test.read(['src', solution_file_2], 'r')
         expect = test.msvs_substitute(expected_slnfile_2, vc_version, subdir='src', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         if filters_file_expected:
             test.must_exist(test.workpath('src', filters_file_1))

--- a/test/MSVS/vs-mult-auto-vardir.py
+++ b/test/MSVS/vs-mult-auto-vardir.py
@@ -118,13 +118,13 @@ SConscript('src/SConscript', variant_dir='build')
         vcproj = test.read(['src', project_file_1], 'r')
         expect = test.msvs_substitute(expected_vcprojfile_1, vc_version, None, 'SConstruct', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath('src', project_file_2))
         vcproj = test.read(['src', project_file_2], 'r')
         expect = test.msvs_substitute(expected_vcprojfile_2, vc_version, None, 'SConstruct', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath('src', solution_file))
         sln = test.read(['src', solution_file], 'r')
@@ -133,19 +133,19 @@ SConscript('src/SConscript', variant_dir='build')
             solution_guid_1=solution_guid_1, solution_guid_2=solution_guid_2,
         )
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath('src', solution_file_1))
         sln = test.read(['src', solution_file_1], 'r')
         expect = test.msvs_substitute(expected_slnfile_1, vc_version, subdir='src', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath('src', solution_file_2))
         sln = test.read(['src', solution_file_2], 'r')
         expect = test.msvs_substitute(expected_slnfile_2, vc_version, subdir='src', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         if filters_file_expected:
             test.must_exist(test.workpath('src', filters_file_1))

--- a/test/MSVS/vs-mult-auto.py
+++ b/test/MSVS/vs-mult-auto.py
@@ -112,13 +112,13 @@ for vc_version in TestSConsMSVS.get_tested_proj_file_vc_versions():
         vcproj = test.read(project_file_1, 'r')
         expect = test.msvs_substitute(expected_vcprojfile_1, vc_version, None, 'SConstruct', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath(project_file_2))
         vcproj = test.read(project_file_2, 'r')
         expect = test.msvs_substitute(expected_vcprojfile_2, vc_version, None, 'SConstruct', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+        test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
         test.must_exist(test.workpath(solution_file))
         sln = test.read(solution_file, 'r')
@@ -127,19 +127,19 @@ for vc_version in TestSConsMSVS.get_tested_proj_file_vc_versions():
             solution_guid_1=solution_guid_1, solution_guid_2=solution_guid_2,
         )
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath(solution_file_1))
         sln = test.read(solution_file_1, 'r')
         expect = test.msvs_substitute(expected_slnfile_1, vc_version, subdir='src', project_guid=project_guid_1)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         test.must_exist(test.workpath(solution_file_2))
         sln = test.read(solution_file_2, 'r')
         expect = test.msvs_substitute(expected_slnfile_2, vc_version, subdir='src', project_guid=project_guid_2)
         # don't compare the pickled data
-        assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+        test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
         if filters_file_expected:
             test.must_exist(test.workpath(filters_file_1))

--- a/test/MSVS/vs-mult-noauto-vardir.py
+++ b/test/MSVS/vs-mult-noauto-vardir.py
@@ -89,19 +89,19 @@ SConscript('src/SConscript', variant_dir='build')
     vcproj = test.read(['src', project_file_1], 'r')
     expect = test.msvs_substitute(expected_vcprojfile_1, vc_version, None, 'SConstruct', project_guid=project_guid_1)
     # don't compare the pickled data
-    assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+    test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
     test.must_exist(test.workpath('src', project_file_2))
     vcproj = test.read(['src', project_file_2], 'r')
     expect = test.msvs_substitute(expected_vcprojfile_2, vc_version, None, 'SConstruct', project_guid=project_guid_2)
     # don't compare the pickled data
-    assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+    test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
     test.must_exist(test.workpath('src', solution_file))
     sln = test.read(['src', solution_file], 'r')
     expect = test.msvs_substitute_projects(expected_slnfile, subdir='src')
     # don't compare the pickled data
-    assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+    test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
     if filters_file_expected:
         test.must_exist(test.workpath('src', filters_file_1))

--- a/test/MSVS/vs-mult-noauto.py
+++ b/test/MSVS/vs-mult-noauto.py
@@ -83,19 +83,19 @@ for vc_version in TestSConsMSVS.get_tested_proj_file_vc_versions():
     vcproj = test.read(project_file_1, 'r')
     expect = test.msvs_substitute(expected_vcprojfile_1, vc_version, None, 'SConstruct', project_guid=project_guid_1)
     # don't compare the pickled data
-    assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+    test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
     test.must_exist(test.workpath(project_file_2))
     vcproj = test.read(project_file_2, 'r')
     expect = test.msvs_substitute(expected_vcprojfile_2, vc_version, None, 'SConstruct', project_guid=project_guid_2)
     # don't compare the pickled data
-    assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+    test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
     test.must_exist(test.workpath(solution_file))
     sln = test.read(solution_file, 'r')
     expect = test.msvs_substitute_projects(expected_slnfile, subdir='src')
     # don't compare the pickled data
-    assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+    test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
     if filters_file_expected:
         test.must_exist(test.workpath(filters_file_1))

--- a/test/MSVS/vs-scc-files.py
+++ b/test/MSVS/vs-scc-files.py
@@ -114,14 +114,14 @@ env.MSVSProject(target = '{project_file}',
     expect = test.msvs_substitute(expected_vcprojfile, vc_version, None, 'SConstruct',
                                   vcproj_sccinfo=expected_vcproj_sccinfo)
     # don't compare the pickled data
-    assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+    test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
     test.must_exist(test.workpath('Test.sln'))
     sln = test.read('Test.sln', 'r')
     expect = test.msvs_substitute(expected_slnfile, vc_version, None, 'SConstruct',
                                   sln_sccinfo=expected_sln_sccinfo)
     # don't compare the pickled data
-    assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+    test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 if test:
     test.pass_test()

--- a/test/MSVS/vs-scc-legacy-files.py
+++ b/test/MSVS/vs-scc-legacy-files.py
@@ -98,13 +98,13 @@ env.MSVSProject(target = '{project_file}',
     expect = test.msvs_substitute(expected_vcprojfile, vc_version, None, 'SConstruct',
                                   vcproj_sccinfo=expected_vcproj_sccinfo)
     # don't compare the pickled data
-    assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+    test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
     test.must_exist(test.workpath('Test.sln'))
     sln = test.read('Test.sln', 'r')
     expect = test.msvs_substitute(expected_slnfile, vc_version, None, 'SConstruct')
     # don't compare the pickled data
-    assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+    test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
 if test:
     test.pass_test()

--- a/test/MSVS/vs-variant_dir.py
+++ b/test/MSVS/vs-variant_dir.py
@@ -62,13 +62,13 @@ SConscript('src/SConscript', variant_dir='build')
     vcproj = test.read(['src', project_file], 'r')
     expect = test.msvs_substitute(expected_vcprojfile, vc_version, None, 'SConstruct')
     # don't compare the pickled data
-    assert vcproj[:len(expect)] == expect, test.diff_substr(expect, vcproj)
+    test.fail_test(vcproj[:len(expect)] != expect, message=test.diff_substr(expect, vcproj))
 
     test.must_exist(test.workpath('src', 'Test.sln'))
     sln = test.read(['src', 'Test.sln'], 'r')
     expect = test.msvs_substitute(expected_slnfile, '8.0', 'src')
     # don't compare the pickled data
-    assert sln[:len(expect)] == expect, test.diff_substr(expect, sln)
+    test.fail_test(sln[:len(expect)] != expect, message=test.diff_substr(expect, sln))
 
     test.must_match(['build', project_file], """\
 This is just a placeholder file.

--- a/test/Variables/BoolVariable.py
+++ b/test/Variables/BoolVariable.py
@@ -34,8 +34,7 @@ test = TestSCons.TestSCons()
 SConstruct_path = test.workpath('SConstruct')
 
 def check(expect):
-    result = test.stdout().split('\n')
-    assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
+    test.must_contain_all_lines(test.stdout(), expect)
 
 
 test.write(SConstruct_path, """\

--- a/test/Variables/EnumVariable.py
+++ b/test/Variables/EnumVariable.py
@@ -34,8 +34,7 @@ test = TestSCons.TestSCons()
 SConstruct_path = test.workpath('SConstruct')
 
 def check(expect):
-    result = test.stdout().split('\n')
-    assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
+    test.must_contain_all_lines(test.stdout(), expect)
 
 test.write(SConstruct_path, """\
 from SCons.Variables.EnumVariable import EnumVariable as EV

--- a/test/Variables/ListVariable.py
+++ b/test/Variables/ListVariable.py
@@ -36,9 +36,7 @@ test = TestSCons.TestSCons()
 SConstruct_path = test.workpath('SConstruct')
 
 def check(expected):
-    result = test.stdout().split('\n')
-    r = result[1 : len(expected) + 1]
-    assert r == expected, (r, expected)
+    test.must_contain_all_lines(test.stdout(), expected)
 
 
 test.write(SConstruct_path, """\

--- a/test/Variables/PackageVariable.py
+++ b/test/Variables/PackageVariable.py
@@ -38,9 +38,7 @@ test = TestSCons.TestSCons()
 SConstruct_path = test.workpath('SConstruct')
 
 def check(expect: list[str]) -> None:
-    result = test.stdout().split('\n')
-    # skip first line and any lines beyond the length of expect
-    assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
+    test.must_contain_all_lines(test.stdout(), expect)
 
 test.write(SConstruct_path, """\
 from SCons.Variables.PackageVariable import PackageVariable as PV

--- a/test/Variables/PathVariable.py
+++ b/test/Variables/PathVariable.py
@@ -37,8 +37,7 @@ test = TestSCons.TestSCons()
 SConstruct_path = test.workpath('SConstruct')
 
 def check(expect):
-    result = test.stdout().split('\n')
-    assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
+    test.must_contain_all_lines(test.stdout(), expect)
 
 
 test.subdir('lib', 'qt', ['qt', 'lib'], 'nolib')

--- a/test/Variables/Variables.py
+++ b/test/Variables/Variables.py
@@ -117,42 +117,41 @@ print(env['VALIDATE'])
 print(env['valid_key'])
 
 # unspecified variables should not be set:
-assert 'UNSPECIFIED' not in env
+print('UNSPECIFIED' in env)
 
 # undeclared variables should be ignored:
-assert 'UNDECLARED' not in env
+print('UNDECLARED' in env)
 
 # calling Update() should not effect variables that
 # are not declared on the variables object:
 r = env['RELEASE_BUILD']
 opts = Variables()
 opts.Update(env)
-assert env['RELEASE_BUILD'] == r
+print(env['RELEASE_BUILD'] == r)
 
 Default(env.Alias('dummy', None))
 """)
 
 def check(expect):
-    result = test.stdout().split('\n')
-    assert result[1:len(expect)+1] == expect, (result[1:len(expect)+1], expect)
+    test.must_contain_all_lines(test.stdout(), expect)
 
 test.run()
-check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v'])
+check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.run(arguments='RELEASE_BUILD=1')
-check(['1', '1', cc, (ccflags + ' -O -g').strip(), 'v', 'v'])
+check(['1', '1', cc, (ccflags + ' -O -g').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.run(arguments='RELEASE_BUILD=1 DEBUG_BUILD=0')
-check(['1', '0', cc, (ccflags + ' -O').strip(), 'v', 'v'])
+check(['1', '0', cc, (ccflags + ' -O').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.run(arguments='CC=not_a_c_compiler')
-check(['0', '1', 'not_a_c_compiler', (ccflags + ' -g').strip(), 'v', 'v'])
+check(['0', '1', 'not_a_c_compiler', (ccflags + ' -g').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.run(arguments='UNDECLARED=foo')
-check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v'])
+check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.run(arguments='CCFLAGS=--taco')
-check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v'])
+check(['0', '1', cc, (ccflags + ' -g').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.write('custom.py', """\
 DEBUG_BUILD=0
@@ -160,10 +159,10 @@ RELEASE_BUILD=1
 """)
 
 test.run()
-check(['1', '0', cc, (ccflags + ' -O').strip(), 'v', 'v'])
+check(['1', '0', cc, (ccflags + ' -O').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.run(arguments='DEBUG_BUILD=1')
-check(['1', '1', cc, (ccflags + ' -O -g').strip(), 'v', 'v'])
+check(['1', '1', cc, (ccflags + ' -O -g').strip(), 'v', 'v', 'False', 'False', 'True'])
 
 test.run(arguments='-h', stdout="""\
 scons: Reading SConscript files ...
@@ -173,6 +172,9 @@ scons: Reading SConscript files ...
 %s
 v
 v
+False
+False
+True
 scons: done reading SConscript files.
 Variables settable in custom.py or on the command line:
 
@@ -243,7 +245,8 @@ def checkSave(file, expected):
     with open(file, 'r') as f:
         contents = f.read()
     exec(contents, gdict, ldict)
-    assert expected == ldict, "%s\n...not equal to...\n%s" % (expected, ldict)
+    if expected != ldict:
+        test.fail_test(message=f"Error: {expected}\n...not equal to...\n{ldict}")
 
 # First test with no command line variables
 # This should just leave the custom.py settings

--- a/test/option/hash-format.py
+++ b/test/option/hash-format.py
@@ -82,9 +82,8 @@ AssertionError: [a-z0-9]+
         expected_dblite = test.workpath('.sconsign_sha256.dblite')
         test.run('.')
 
-    assert os.path.isfile(expected_dblite), \
-        "%s does not exist when running algorithm %s" % (expected_dblite,
-                                                         algorithm)
+    if not os.path.isfile(expected_dblite):
+        test.fail_test(message="%s does not exist when running algorithm %s" % (expected_dblite, algorithm))
 
     test.run('-C .')
     os.unlink(expected_dblite)

--- a/test/option/option--duplicate.py
+++ b/test/option/option--duplicate.py
@@ -85,9 +85,9 @@ description = {
 def testLink(file, type):
     nl = os.stat(file).st_nlink
     islink = os.path.islink(file)
-    assert criterion[type](nl, islink), \
-           "Expected %s to be %s (nl %d, islink %d)" \
-           % (file, description[type], nl, islink)
+    if not criterion[type](nl, islink):
+        test.fail_test(message="Expected %s to be %s (nl %d, islink %d)"
+                       % (file, description[type], nl, islink))
 
 def RunTest(order, type, bss):
     # Test the command-line --duplicate option.

--- a/test/overrides.py
+++ b/test/overrides.py
@@ -87,8 +87,8 @@ with open('hello.not_exe', 'w') as f:
 
 test.run(arguments='hello.not_exe')
 
-assert test.read('hello.not_obj', mode='r') == 'this is no object file!'
-assert test.read('hello.not_exe', mode='r') == 'this is not a program!'
+test.must_match('hello.not_obj', expect='this is no object file!')
+test.must_match('hello.not_exe', expect='this is not a program!')
 
 test.up_to_date(arguments='hello.not_exe')
 
@@ -124,8 +124,8 @@ scons: warning: Did you mean to use `(target|source)' instead of `(targets|sourc
 scons: warning: Did you mean to use `(target|source)' instead of `(targets|sources)'\?
 """ + TestSCons.file_expr))
 
-assert test.read('goodbye.not_obj', mode='r') == 'this is no object file!'
-assert test.read('goodbye.not_exe', mode='r') == 'this is not a program!'
+test.must_match('goodbye.not_obj', expect='this is no object file!')
+test.must_match('goodbye.not_exe', expect='this is not a program!')
 
 
 


### PR DESCRIPTION
When an end-to-end test script checks results from a `test.run()`, it should not use assert statements - those are not harvested by the test framework. Instead, use test methods designed for the purpose, either `match` functions (for test output vs expected text or file contents vs expected text), or `fail_test` with a condition. This gives better reporting in test journals.

This is a test-only change, no scons functionality change or docs impact.

Fixes #4836

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
