### PR TITLE
Fix logic to work when appveyor image doesn't have requested python.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,7 +57,7 @@ build_script:
 
   # NOTE: running powershell from cmd is intended because
   # it formats the output correctly
-  - cmd: powershell -Command "& { if($env:COVERAGE -eq 1) { coverage run -p --rcfile=$($env:COVERAGE_PROCESS_START) runtest.py -j 2 -t --exclude-list exclude_list.txt -a } else { C:\\%WINPYTHON%\\python.exe runtest.py -j 2 -t --exclude-list exclude_list.txt -a }; if($LastExitCode -eq 2 -Or $LastExitCode -eq 0) { $host.SetShouldExit(0 )} else {$host.SetShouldExit(1)}}"
+  - cmd: powershell -Command "& { if($env:COVERAGE -eq 1) { & ""$env:SCONS_PYTHON_BIN"" -m coverage run -p --rcfile=$($env:COVERAGE_PROCESS_START) runtest.py -j 2 -t --exclude-list exclude_list.txt -a } else { & ""$env:SCONS_PYTHON_BIN"" runtest.py -j 2 -t --exclude-list exclude_list.txt -a }; if($LastExitCode -eq 2 -Or $LastExitCode -eq 0) { $host.SetShouldExit(0 )} else {$host.SetShouldExit(1)}}"
 
 # run coverage even if there was a test failure
 on_finish:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
   # direct choco install supposed to work, but not? still doing in install.bat
   #- cinst: dmd ldc swig vswhere ixsltproc winflexbison3
   - ps: .\.appveyor\install.ps1
-  - ps: if ($env:COVERAGE -eq 1) { .\.appveyor\install-cov.ps1 }
+  - ps: .\.appveyor\install-cov.ps1
 
 # Build matrix will be number of images multiplied by #entries in matrix:,
 # less any excludes.
@@ -53,15 +53,15 @@ build_script:
 
   # setup coverage by creating the coverage config file, and adding coverage
   # to the sitecustomize so that all python processes start with coverage
-  - ps: if ($env:COVERAGE -eq 1) { .\.appveyor\coverage_setup.ps1 }
+  - ps: .\.appveyor\coverage_setup.ps1
 
   # NOTE: running powershell from cmd is intended because
   # it formats the output correctly
-  - cmd: powershell -Command "& { if($env:COVERAGE -eq 1) { & ""$env:SCONS_PYTHON_BIN"" -m coverage run -p --rcfile=$($env:COVERAGE_PROCESS_START) runtest.py -j 2 -t --exclude-list exclude_list.txt -a } else { & ""$env:SCONS_PYTHON_BIN"" runtest.py -j 2 -t --exclude-list exclude_list.txt -a }; if($LastExitCode -eq 2 -Or $LastExitCode -eq 0) { $host.SetShouldExit(0 )} else {$host.SetShouldExit(1)}}"
+  - cmd: powershell -File .appveyor\run_tests.ps1
 
 # run coverage even if there was a test failure
 on_finish:
-  - ps: if ($env:COVERAGE -eq 1) { .\.appveyor\coverage_report.ps1 }
+  - ps: .\.appveyor\coverage_report.ps1
   # running codecov in powershell causes an error so running in cmd
-  - cmd: if %COVERAGE% equ 1 codecov -X gcov --file coverage_xml.xml
+  - cmd: .appveyor\codecov_upload.bat
 

--- a/.appveyor/codecov_upload.bat
+++ b/.appveyor/codecov_upload.bat
@@ -1,0 +1,4 @@
+@echo off
+if "%COVERAGE%"=="1" (
+    "%SCONS_PYTHON_BIN%" -m codecov -X gcov --file coverage_xml.xml
+)

--- a/.appveyor/coverage_report.ps1
+++ b/.appveyor/coverage_report.ps1
@@ -1,5 +1,5 @@
 if ($env:COVERAGE -eq 1) {
-    & coverage combine;
-    & coverage report;
-    & coverage xml -i -o coverage_xml.xml;
+    & $env:SCONS_PYTHON_BIN -m coverage combine;
+    & $env:SCONS_PYTHON_BIN -m coverage report;
+    & $env:SCONS_PYTHON_BIN -m coverage xml -i -o coverage_xml.xml;
 }

--- a/.appveyor/coverage_report.ps1
+++ b/.appveyor/coverage_report.ps1
@@ -1,5 +1,7 @@
+Write-Host "Entering .appveyor/coverage_report.ps1"
 if ($env:COVERAGE -eq 1) {
     & $env:SCONS_PYTHON_BIN -m coverage combine;
     & $env:SCONS_PYTHON_BIN -m coverage report;
     & $env:SCONS_PYTHON_BIN -m coverage xml -i -o coverage_xml.xml;
 }
+Write-Host "Exiting .appveyor/coverage_report.ps1"

--- a/.appveyor/coverage_setup.ps1
+++ b/.appveyor/coverage_setup.ps1
@@ -1,6 +1,8 @@
 if ($env:COVERAGE -eq 1) {
     $env:COVERAGE_PROCESS_START = "$($env:APPVEYOR_BUILD_FOLDER)\.coveragerc";
     $env:COVERAGE_FILE = "$($env:APPVEYOR_BUILD_FOLDER)\.coverage";
+    Set-AppveyorBuildVariable -Name "COVERAGE_PROCESS_START" -Value "$env:COVERAGE_PROCESS_START"
+    Set-AppveyorBuildVariable -Name "COVERAGE_FILE" -Value "$env:COVERAGE_FILE"
     New-Item -ItemType Directory -Force -Path "$($env:PYSITEDIR)";
 
     (Get-Content -path .coverage_templates\.coveragerc.template -Raw) -replace '\$PWD',"$((Get-Location) -replace '\\', '/')" | Set-Content -Path "$($env:COVERAGE_PROCESS_START)";

--- a/.appveyor/coverage_setup.ps1
+++ b/.appveyor/coverage_setup.ps1
@@ -1,3 +1,4 @@
+Write-Host "Entering .appveyor/coverage_setup.ps1"
 if ($env:COVERAGE -eq 1) {
     $env:COVERAGE_PROCESS_START = "$($env:APPVEYOR_BUILD_FOLDER)\.coveragerc";
     $env:COVERAGE_FILE = "$($env:APPVEYOR_BUILD_FOLDER)\.coverage";
@@ -13,3 +14,4 @@ if ($env:COVERAGE -eq 1) {
     Write-Host "$($env:COVERAGE_PROCESS_START)";
     Get-Content -Path "$($env:COVERAGE_PROCESS_START)";
 }
+Write-Host "Exiting .appveyor/coverage_setup.ps1"

--- a/.appveyor/exclude_tests.ps1
+++ b/.appveyor/exclude_tests.ps1
@@ -1,3 +1,4 @@
+Write-Host "Entering .appveyor/exclude_tests.ps1"
 New-Item -Name exclude_list.txt -ItemType File;
 
 # exclude VS 10.0 because it hangs the testing until this is resolved:
@@ -6,3 +7,4 @@ $workaround_image = "Visual Studio 2015";
 if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq $workaround_image) {
     Add-Content -Path 'exclude_list.txt' -Value 'test\MSVS\vs-10.0-exec.py';
 }
+Write-Host "Exiting .appveyor/exclude_tests.ps1"

--- a/.appveyor/ignore_git_bins.ps1
+++ b/.appveyor/ignore_git_bins.ps1
@@ -1,5 +1,7 @@
+Write-Host "Entering .appveyor/ignore_git_bins.ps1"
 dir "C:\Program Files\Git\usr\bin\x*.exe";
 if (Test-Path "C:\Program Files\Git\usr\bin\xsltproc.EXE" ) {
     Remove-Item  "C:\Program Files\Git\usr\bin\xsltproc.EXE" -ErrorAction Ignore;
 }
 dir "C:\Program Files\Git\usr\bin\x*.exe";
+Write-Host "Exiting .appveyor/ignore_git_bins.ps1"

--- a/.appveyor/install-cov.ps1
+++ b/.appveyor/install-cov.ps1
@@ -1,3 +1,5 @@
-$pythonExe = $env:SCONS_PYTHON_BIN
-$env:PYSITEDIR = & $pythonExe -c "import sys; print(sys.path[-1])"
-& $pythonExe -m pip install -U --progress-bar off coverage codecov
+if ($env:COVERAGE -eq 1) {
+    $pythonExe = $env:SCONS_PYTHON_BIN
+    $env:PYSITEDIR = & $pythonExe -c "import sys; print(sys.path[-1])"
+    & $pythonExe -m pip install -U --progress-bar off coverage codecov
+}

--- a/.appveyor/install-cov.ps1
+++ b/.appveyor/install-cov.ps1
@@ -1,3 +1,3 @@
-$pythonExe = "C:\$($env:WINPYTHON)\python.exe"
+$pythonExe = $env:SCONS_PYTHON_BIN
 $env:PYSITEDIR = & $pythonExe -c "import sys; print(sys.path[-1])"
 & $pythonExe -m pip install -U --progress-bar off coverage codecov

--- a/.appveyor/install-cov.ps1
+++ b/.appveyor/install-cov.ps1
@@ -1,5 +1,7 @@
+Write-Host "Entering .appveyor/install-cov.ps1"
 if ($env:COVERAGE -eq 1) {
     $pythonExe = $env:SCONS_PYTHON_BIN
     $env:PYSITEDIR = & $pythonExe -c "import sys; print(sys.path[-1])"
     & $pythonExe -m pip install -U --progress-bar off coverage codecov
 }
+Write-Host "Exiting .appveyor/install-cov.ps1"

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,4 +1,5 @@
 Write-Host "Entering .appveyor/install.ps1"
+Write-Host "Build using $env:WINPYTHON"
 $pythonExe = "C:\$($env:WINPYTHON)\python.exe"
 
 # If the initial call to python --version fails, call "choco install %WINPYTHON%"
@@ -59,6 +60,8 @@ foreach ($name in $checkNames) {
     if ($cmds) {
         $pythonExe = ($cmds | Select-Object -First 1).Path
         break
+    } else {
+        write-host "Didn't find $name"
     }
 }
 

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -69,6 +69,7 @@ foreach ($name in $checkNames) {
     $cmds = Get-Command $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -notlike "*\msys64\*" -and $_.Path -notlike "*\cygwin\*" }
     if ($cmds) {
         $pythonExe = ($cmds | Select-Object -First 1).Path
+        $pythonExe --version
         break
     } else {
         Write-Host "Didn't find $name"

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -19,6 +19,24 @@ if (-not $pyVersionSucceeded) {
     choco install --allow-empty-checksums $env:WINPYTHON
 }
 
+# Use mingw 32 bit until #3291 is resolved
+# Add python and python user-base to path for pip installs
+$extraPaths = @(
+    "C:\$($env:WINPYTHON)",
+    "C:\$($env:WINPYTHON)\Scripts",
+    "C:\MinGW\bin",
+    "C:\MinGW\msys\1.0\bin",
+    "C:\cygwin\bin",
+    "C:\msys64\usr\bin",
+    "C:\msys64\mingw64\bin"
+)
+
+if (-not $pyVersionSucceeded) {
+    $extraPaths = @("C:\ProgramData\chocolatey\bin") + $extraPaths
+} else {
+    $extraPaths += "C:\ProgramData\chocolatey\bin"
+}
+
 # Ensure we have the correct path to the python executable
 if (Get-Command $env:WINPYTHON -ErrorAction SilentlyContinue) {
     $pythonExe = (Get-Command $env:WINPYTHON).Path
@@ -42,23 +60,7 @@ Set-AppveyorBuildVariable -Name "SCONS_PYTHON_BIN" -Value "$pythonExe"
 $env:PYSITEDIR = & $pythonExe -c "import sys; print(sys.path[-1])"
 Set-AppveyorBuildVariable -Name "PYSITEDIR" -Value "$env:PYSITEDIR"
 
-# Use mingw 32 bit until #3291 is resolved
-# Add python and python user-base to path for pip installs
-$extraPaths = @(
-    "C:\$($env:WINPYTHON)",
-    "C:\$($env:WINPYTHON)\Scripts",
-    "C:\MinGW\bin",
-    "C:\MinGW\msys\1.0\bin",
-    "C:\cygwin\bin",
-    "C:\msys64\usr\bin",
-    "C:\msys64\mingw64\bin"
-)
 
-if (-not $pyVersionSucceeded) {
-    $extraPaths = @("C:\ProgramData\chocolatey\bin") + $extraPaths
-} else {
-    $extraPaths += "C:\ProgramData\chocolatey\bin"
-}
 
 $env:PATH = ($extraPaths + @($env:PATH)) -join ';'
 

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -32,6 +32,8 @@ if (-not $pythonExe -or -not (Test-Path $pythonExe)) {
 
 Write-Host "Using Python at: $pythonExe"
 
+Write-Host "PATH: $env:PATH"
+
 # Set SCONS_PYTHON_BIN for future steps
 Set-AppveyorBuildVariable -Name "SCONS_PYTHON_BIN" -Value "$pythonExe"
 

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,3 +1,4 @@
+Write-Host "Entering .appveyor/install.ps1"
 $pythonExe = "C:\$($env:WINPYTHON)\python.exe"
 
 # If the initial call to python --version fails, call "choco install %WINPYTHON%"
@@ -66,3 +67,4 @@ choco install --allow-empty-checksums dmd ldc swig vswhere xsltproc winflexbison
 
 # Show environment variables
 Get-ChildItem Env: | Sort-Object Name
+Write-Host "Exiting .appveyor/install.ps1"

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -17,7 +17,7 @@ try {
 
 if (-not $pyVersionSucceeded) {
     Write-Host "Python version check failed or Python not found at $pythonExe. Installing $env:WINPYTHON via Chocolatey..."
-    choco install --allow-empty-checksums $env:WINPYTHON
+    choco install --force --allow-empty-checksums $env:WINPYTHON
     dir C:\ProgramData\chocolatey\bin\python*.exe
     dir c:\python*
 }
@@ -69,7 +69,7 @@ foreach ($name in $checkNames) {
     $cmds = Get-Command $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -notlike "*\msys64\*" -and $_.Path -notlike "*\cygwin\*" }
     if ($cmds) {
         $pythonExe = ($cmds | Select-Object -First 1).Path
-        $pythonExe --version
+        & "$env:SCONS_PYTHON_BIN" --version
         break
     } else {
         Write-Host "Didn't find $name"

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -37,6 +37,8 @@ if (-not $pyVersionSucceeded) {
     $extraPaths += "C:\ProgramData\chocolatey\bin"
 }
 
+$env:PATH = ($extraPaths + @($env:PATH)) -join ';'
+
 # Ensure we have the correct path to the python executable
 if (Get-Command $env:WINPYTHON -ErrorAction SilentlyContinue) {
     $pythonExe = (Get-Command $env:WINPYTHON).Path
@@ -59,10 +61,6 @@ Set-AppveyorBuildVariable -Name "SCONS_PYTHON_BIN" -Value "$pythonExe"
 # Set PYSITEDIR
 $env:PYSITEDIR = & $pythonExe -c "import sys; print(sys.path[-1])"
 Set-AppveyorBuildVariable -Name "PYSITEDIR" -Value "$env:PYSITEDIR"
-
-
-
-$env:PATH = ($extraPaths + @($env:PATH)) -join ';'
 
 # pip installs
 & $pythonExe -m pip install -U --progress-bar off pip setuptools wheel

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -19,11 +19,26 @@ if (-not $pyVersionSucceeded) {
     choco install --allow-empty-checksums $env:WINPYTHON
 }
 
-# Use mingw 32 bit until #3291 is resolved
 # Add python and python user-base to path for pip installs
-$extraPaths = @(
-    "C:\$($env:WINPYTHON)",
-    "C:\$($env:WINPYTHON)\Scripts",
+if ($pyVersionSucceeded) {
+    $pythonPaths = @(
+        "C:\$($env:WINPYTHON)",
+        "C:\$($env:WINPYTHON)\Scripts"
+    )
+} else {
+    # If we had to use choco, don't add the potentially missing/broken C:\Python paths
+    $pythonPaths = @()
+}
+
+# Always add chocolatey bin, but prioritize it if we just installed python there
+if (-not $pyVersionSucceeded) {
+    $pythonPaths = @("C:\ProgramData\chocolatey\bin") + $pythonPaths
+} else {
+    $pythonPaths += "C:\ProgramData\chocolatey\bin"
+}
+
+# Add tools AFTER python paths to avoid picking up MSYS/Cygwin python shims
+$toolPaths = @(
     "C:\MinGW\bin",
     "C:\MinGW\msys\1.0\bin",
     "C:\cygwin\bin",
@@ -31,19 +46,19 @@ $extraPaths = @(
     "C:\msys64\mingw64\bin"
 )
 
-if (-not $pyVersionSucceeded) {
-    $extraPaths = @("C:\ProgramData\chocolatey\bin") + $extraPaths
-} else {
-    $extraPaths += "C:\ProgramData\chocolatey\bin"
-}
+$env:PATH = ($pythonPaths + $toolPaths + @($env:PATH)) -join ';'
 
-$env:PATH = ($extraPaths + @($env:PATH)) -join ';'
+# Ensure we have the correct path to the python executable, 
+# explicitly avoiding MSYS/Cygwin versions.
+$pythonExe = $null
+$checkNames = @($env:WINPYTHON, "python.exe", "python3.exe")
 
-# Ensure we have the correct path to the python executable
-if (Get-Command $env:WINPYTHON -ErrorAction SilentlyContinue) {
-    $pythonExe = (Get-Command $env:WINPYTHON).Path
-} elseif (Get-Command python.exe -ErrorAction SilentlyContinue) {
-    $pythonExe = (Get-Command python.exe).Path
+foreach ($name in $checkNames) {
+    $cmds = Get-Command $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -notlike "*\msys64\*" -and $_.Path -notlike "*\cygwin\*" }
+    if ($cmds) {
+        $pythonExe = ($cmds | Select-Object -First 1).Path
+        break
+    }
 }
 
 if (-not $pythonExe -or -not (Test-Path $pythonExe)) {

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -18,8 +18,19 @@ if (-not $pyVersionSucceeded) {
     choco install --allow-empty-checksums $env:WINPYTHON
 }
 
+# Ensure we have the correct path to the python executable
+if (Get-Command $env:WINPYTHON -ErrorAction SilentlyContinue) {
+    $pythonExe = (Get-Command $env:WINPYTHON).Path
+} elseif (Get-Command python.exe -ErrorAction SilentlyContinue) {
+    $pythonExe = (Get-Command python.exe).Path
+}
+
+# Set SCONS_PYTHON_BIN for future steps
+Set-AppveyorBuildVariable -Name "SCONS_PYTHON_BIN" -Value "$pythonExe"
+
 # Set PYSITEDIR
 $env:PYSITEDIR = & $pythonExe -c "import sys; print(sys.path[-1])"
+Set-AppveyorBuildVariable -Name "PYSITEDIR" -Value "$env:PYSITEDIR"
 
 # Use mingw 32 bit until #3291 is resolved
 # Add python and python user-base to path for pip installs

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -23,17 +23,14 @@ if (-not $pyVersionSucceeded) {
 }
 
 # Add python and python user-base to path for pip installs
-if ($pyVersionSucceeded) {
-    $pythonPaths = @(
-        "C:\$($env:WINPYTHON)"
-    )
-} else {
-    # If we had to use choco, don't add the potentially missing/broken C:\Python paths
-    $pythonPaths = @()
+$pythonPaths = @()
+if (Test-Path "C:\$($env:WINPYTHON)") {
+    $pythonPaths += "C:\$($env:WINPYTHON)"
 }
 
-# Always add chocolatey bin, but prioritize it if we just installed python there
-if (-not $pyVersionSucceeded) {
+# Always add chocolatey bin
+# Prioritize it if we just installed python there AND C:\PythonXX wasn't found
+if (-not $pyVersionSucceeded -and -not (Test-Path "C:\$($env:WINPYTHON)")) {
     $pythonPaths = @("C:\ProgramData\chocolatey\bin") + $pythonPaths
 } else {
     $pythonPaths += "C:\ProgramData\chocolatey\bin"

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -19,6 +19,7 @@ if (-not $pyVersionSucceeded) {
     Write-Host "Python version check failed or Python not found at $pythonExe. Installing $env:WINPYTHON via Chocolatey..."
     choco install --allow-empty-checksums $env:WINPYTHON
     dir C:\ProgramData\chocolatey\bin\python*.exe
+    dir c:\python*
 }
 
 # Add python and python user-base to path for pip installs
@@ -49,7 +50,7 @@ $toolPaths = @(
 )
 
 $env:PATH = ($pythonPaths + $toolPaths + @($env:PATH)) -join ';'
-# Ensure we have the correct path to the python executable, 
+# Ensure we have the correct path to the python executable,
 # explicitly avoiding MSYS/Cygwin versions.
 $pythonExe = $null
 

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -47,13 +47,19 @@ Set-AppveyorBuildVariable -Name "PYSITEDIR" -Value "$env:PYSITEDIR"
 $extraPaths = @(
     "C:\$($env:WINPYTHON)",
     "C:\$($env:WINPYTHON)\Scripts",
-    "C:\ProgramData\chocolatey\bin",
     "C:\MinGW\bin",
     "C:\MinGW\msys\1.0\bin",
     "C:\cygwin\bin",
     "C:\msys64\usr\bin",
     "C:\msys64\mingw64\bin"
 )
+
+if (-not $pyVersionSucceeded) {
+    $extraPaths = @("C:\ProgramData\chocolatey\bin") + $extraPaths
+} else {
+    $extraPaths += "C:\ProgramData\chocolatey\bin"
+}
+
 $env:PATH = ($extraPaths + @($env:PATH)) -join ';'
 
 # pip installs

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -17,6 +17,7 @@ try {
 if (-not $pyVersionSucceeded) {
     Write-Host "Python version check failed or Python not found at $pythonExe. Installing $env:WINPYTHON via Chocolatey..."
     choco install --allow-empty-checksums $env:WINPYTHON
+    dir C:\ProgramData\chocolatey\bin\python*.exe
 }
 
 # Add python and python user-base to path for pip installs
@@ -48,7 +49,7 @@ $toolPaths = @(
 
 $env:PATH = ($pythonPaths + $toolPaths + @($env:PATH)) -join ';'
 
-# Ensure we have the correct path to the python executable, 
+# Ensure we have the correct path to the python executable,
 # explicitly avoiding MSYS/Cygwin versions.
 $pythonExe = $null
 $checkNames = @($env:WINPYTHON, "python.exe", "python3.exe")

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -25,8 +25,7 @@ if (-not $pyVersionSucceeded) {
 # Add python and python user-base to path for pip installs
 if ($pyVersionSucceeded) {
     $pythonPaths = @(
-        "C:\$($env:WINPYTHON)",
-        "C:\$($env:WINPYTHON)\Scripts"
+        "C:\$($env:WINPYTHON)"
     )
 } else {
     # If we had to use choco, don't add the potentially missing/broken C:\Python paths
@@ -50,7 +49,7 @@ $toolPaths = @(
 )
 
 $env:PATH = ($pythonPaths + $toolPaths + @($env:PATH)) -join ';'
-# Ensure we have the correct path to the python executable,
+# Ensure we have the correct path to the python executable, 
 # explicitly avoiding MSYS/Cygwin versions.
 $pythonExe = $null
 
@@ -69,13 +68,20 @@ foreach ($name in $checkNames) {
     $cmds = Get-Command $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -notlike "*\msys64\*" -and $_.Path -notlike "*\cygwin\*" }
     if ($cmds) {
         $pythonExe = ($cmds | Select-Object -First 1).Path
-        & "$env:SCONS_PYTHON_BIN" --version
+
+        $pyDir = Split-Path -Parent $pythonExe
+        $pyScripts = Join-Path $pyDir "Scripts"
+        if (Test-Path $pyScripts) {
+            Write-Host "Adding $pyScripts to PATH"
+            $env:PATH = "$pyScripts;$env:PATH"
+        }
+
+        & $pythonExe --version
         break
     } else {
         Write-Host "Didn't find $name"
     }
 }
-
 if (-not $pythonExe -or -not (Test-Path $pythonExe)) {
     Write-Error "Could not find a valid Python executable (WINPYTHON=$env:WINPYTHON). Aborting."
     exit 1

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -49,19 +49,28 @@ $toolPaths = @(
 )
 
 $env:PATH = ($pythonPaths + $toolPaths + @($env:PATH)) -join ';'
-
-# Ensure we have the correct path to the python executable,
+# Ensure we have the correct path to the python executable, 
 # explicitly avoiding MSYS/Cygwin versions.
 $pythonExe = $null
-$checkNames = @($env:WINPYTHON, "python.exe", "python3.exe")
+
+# Derive a version-specific shim name (e.g. Python310 -> python3.10.exe)
+$pyVersion = $env:WINPYTHON -replace "Python", "" # e.g. "310"
+if ($pyVersion -match "^(\d)(\d+)$") {
+    $specName = "python$($Matches[1]).$($Matches[2]).exe" # e.g. "python3.10.exe"
+} else {
+    $specName = "python.exe"
+}
+
+$checkNames = @("$env:WINPYTHON.exe", $specName, "python.exe", "python3.exe")
 
 foreach ($name in $checkNames) {
+    Write-Host "Checking for Python shim: $name"
     $cmds = Get-Command $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -notlike "*\msys64\*" -and $_.Path -notlike "*\cygwin\*" }
     if ($cmds) {
         $pythonExe = ($cmds | Select-Object -First 1).Path
         break
     } else {
-        write-host "Didn't find $name"
+        Write-Host "Didn't find $name"
     }
 }
 

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -25,6 +25,13 @@ if (Get-Command $env:WINPYTHON -ErrorAction SilentlyContinue) {
     $pythonExe = (Get-Command python.exe).Path
 }
 
+if (-not $pythonExe -or -not (Test-Path $pythonExe)) {
+    Write-Error "Could not find a valid Python executable (WINPYTHON=$env:WINPYTHON). Aborting."
+    exit 1
+}
+
+Write-Host "Using Python at: $pythonExe"
+
 # Set SCONS_PYTHON_BIN for future steps
 Set-AppveyorBuildVariable -Name "SCONS_PYTHON_BIN" -Value "$pythonExe"
 

--- a/.appveyor/run_tests.ps1
+++ b/.appveyor/run_tests.ps1
@@ -1,10 +1,10 @@
 if ($env:COVERAGE -eq 1) {
     & "$env:SCONS_PYTHON_BIN" -m coverage run -p --rcfile "$env:COVERAGE_PROCESS_START" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
 } else {
-    & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
+    & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt test/Actions
 }
 
-# Treat exit code 2 (some tests failed) as success for AppVeyor 
+# Treat exit code 2 (some tests failed) as success for AppVeyor
 # as per original configuration.
 if ($LastExitCode -eq 2 -or $LastExitCode -eq 0) {
     exit 0

--- a/.appveyor/run_tests.ps1
+++ b/.appveyor/run_tests.ps1
@@ -5,7 +5,7 @@ Write-Host "SCONS_PYTHON_BIN: $env:SCONS_PYTHON_BIN"
 if ($env:COVERAGE -eq 1) {
     & "$env:SCONS_PYTHON_BIN" -m coverage run -p --rcfile "$env:COVERAGE_PROCESS_START" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
 } else {
-    & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt
+    & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
 }
 
 # Treat exit code 2 (some tests failed) as success for AppVeyor

--- a/.appveyor/run_tests.ps1
+++ b/.appveyor/run_tests.ps1
@@ -1,0 +1,13 @@
+if ($env:COVERAGE -eq 1) {
+    & "$env:SCONS_PYTHON_BIN" -m coverage run -p --rcfile "$env:COVERAGE_PROCESS_START" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
+} else {
+    & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
+}
+
+# Treat exit code 2 (some tests failed) as success for AppVeyor 
+# as per original configuration.
+if ($LastExitCode -eq 2 -or $LastExitCode -eq 0) {
+    exit 0
+} else {
+    exit $LastExitCode
+}

--- a/.appveyor/run_tests.ps1
+++ b/.appveyor/run_tests.ps1
@@ -1,3 +1,8 @@
+
+
+Write-Host "COVERAGE: $env:COVERAGE"
+Write-Host "SCONS_PYTHON_BIN: $env:SCONS_PYTHON_BIN"
+
 if ($env:COVERAGE -eq 1) {
     & "$env:SCONS_PYTHON_BIN" -m coverage run -p --rcfile "$env:COVERAGE_PROCESS_START" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
 } else {

--- a/.appveyor/run_tests.ps1
+++ b/.appveyor/run_tests.ps1
@@ -5,10 +5,10 @@ Write-Host "SCONS_PYTHON_BIN: $env:SCONS_PYTHON_BIN"
 if ($env:COVERAGE -eq 1) {
     & "$env:SCONS_PYTHON_BIN" -m coverage run -p --rcfile "$env:COVERAGE_PROCESS_START" runtest.py -j 2 -t --exclude-list exclude_list.txt -a
 } else {
-    & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt test/Actions
+    & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt
 }
 
-# Treat exit code 2 (some tests failed) as success for AppVeyor 
+# Treat exit code 2 (some tests failed) as success for AppVeyor
 # as per original configuration.
 if ($LastExitCode -eq 2 -or $LastExitCode -eq 0) {
     Write-Host "Exiting .appveyor/run_tests.ps1"

--- a/.appveyor/run_tests.ps1
+++ b/.appveyor/run_tests.ps1
@@ -1,5 +1,4 @@
-
-
+Write-Host "Entering .appveyor/run_tests.ps1"
 Write-Host "COVERAGE: $env:COVERAGE"
 Write-Host "SCONS_PYTHON_BIN: $env:SCONS_PYTHON_BIN"
 
@@ -9,10 +8,12 @@ if ($env:COVERAGE -eq 1) {
     & "$env:SCONS_PYTHON_BIN" runtest.py -j 2 -t --exclude-list exclude_list.txt test/Actions
 }
 
-# Treat exit code 2 (some tests failed) as success for AppVeyor
+# Treat exit code 2 (some tests failed) as success for AppVeyor 
 # as per original configuration.
 if ($LastExitCode -eq 2 -or $LastExitCode -eq 0) {
+    Write-Host "Exiting .appveyor/run_tests.ps1"
     exit 0
 } else {
+    Write-Host "Exiting .appveyor/run_tests.ps1"
     exit $LastExitCode
 }

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,8 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
     - Used Gemini to refactor runtest.py to better organized the code and add docstrings.
     - Added script for release process to find all contributors in a release and highlight
       new contributors. (Using Gemini AI)
+    - Fix Appveyor scripting to install unavailable python versions when needed and use them
+      for testing.
 
   From Mats Wichmann:
     - Introduce some unit tests for the file locking utility routines

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -124,6 +124,9 @@ DEVELOPMENT
   existing test environments into a single package. Adjusted AppVeyor to
   only run for targets unsupported by GitHub runners.
 
+- Fix Appveyor scripting to install unavailable python versions when needed and use them
+  for testing.
+
 
 Thanks to the following contributors listed below for their contributions to this release.
 ==========================================================================================


### PR DESCRIPTION
AppVeyor: use dynamic python detection and export to build environment
- Use Get-Command to find the path of the requested Python version.
- Export SCONS_PYTHON_BIN, PYSITEDIR, and coverage variables using Set-AppveyorBuildVariable to ensure they persist across shell steps.
- Update test and coverage scripts to use the exported python path.
- This ensures Python 3.12 and newer are correctly located and used even if the path differs from the hardcoded C:\Python... defaults.

Assisted-by: Gemini

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [x] I have updated the appropriate documentation
