### PR TITLE
Further tweak CacheDir for races

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -70,6 +70,9 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       the general unavailablility of the obsolete build-time Qt3 package.
     - A few more typing cleanups in Environment (and in one case which
       affected it in the Node package).
+    - Adjust race protection for CacheDir - now uses a unique temporary
+      directory for each writer before doing the move, instead of depending
+      on a one-time uuid to make a path to the file.
 
 
 RELEASE 4.10.1 - Sun, 16 Nov 2025 10:51:57 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -47,6 +47,10 @@ FIXES
 
 - Fix --debug=includes for case of multiple source files.
 
+- Adjust race protection for CacheDir - now uses a unique temporary
+  directory for each writer before doing the move, instead of depending
+  on a one-time uuid to make a path to the file.
+
 IMPROVEMENTS
 ------------
 

--- a/SCons/CacheDir.py
+++ b/SCons/CacheDir.py
@@ -31,10 +31,10 @@ import shutil
 import stat
 import sys
 import tempfile
-import uuid
 
 import SCons.Action
 import SCons.Errors
+# import SCons.Node.FS  # used for hash_chunksice, but causes import loop
 import SCons.Warnings
 import SCons.Util
 
@@ -49,7 +49,6 @@ cache_debug = False
 cache_force = False
 cache_show = False
 cache_readonly = False
-cache_tmp_uuid = uuid.uuid4().hex
 
 def CacheRetrieveFunc(target, source, env) -> int:
     t = target[0]
@@ -110,7 +109,6 @@ def CachePushFunc(target, source, env) -> None:
 
     cd.CacheDebug('CachePush(%s):  pushing to %s\n', t, cachefile)
 
-    tempfile = "%s.tmp%s"%(cachefile,cache_tmp_uuid)
     errfmt = "Unable to copy %s to cache. Cache file is %s"
 
     try:
@@ -119,11 +117,13 @@ def CachePushFunc(target, source, env) -> None:
         msg = errfmt % (str(target), cachefile)
         raise SCons.Errors.SConsEnvironmentError(msg)
     try:
-        if fs.islink(t.get_internal_path()):
-            fs.symlink(fs.readlink(t.get_internal_path()), tempfile)
-        else:
-            cd.copy_to_cache(env, t.get_internal_path(), tempfile)
-        fs.rename(tempfile, cachefile)
+        with tempfile.TemporaryDirectory(dir=cachedir) as temp_dir:
+            temp_file = os.path.join(temp_dir, os.path.basename(cachefile))
+            if fs.islink(t.get_internal_path()):
+                fs.symlink(fs.readlink(t.get_internal_path()), temp_file)
+            else:
+                cd.copy_to_cache(env, t.get_internal_path(), temp_file)
+            fs.rename(temp_file, cachefile)
 
     except OSError:
         # It's possible someone else tried writing the file at the


### PR DESCRIPTION
Some `CacheDir` race conditions appear to still exist in the field. The existing mechanism tries to create a random-enough temporary filename to use for the copy of the object to be cached, before doing an atomic rename to the final filename in the cache. The temporary filename uses a uuid suffix which has a miniscule chance of not being unique across SCons invocations, but which is unchanging within a single invocation.  The new proposal is to use Python's `tempfile` module to create a unqiue temporary directory for each cache write, copy the file there, then do the rename. One could further imagine wrapping critical code sections in filelock calls but that's not done in this change (`FileLock` is currently to protect initial `CacheDir` creation operations as that had been a source of conflicts in a multi-threaded build, but not for individual cache writes or reads).

There is no test: I spent a fair bit of time with AI assistance trying to create a reliable reproducer without success - through ever more contrived scenarios it still wouldn't fail. So while this may help, it's still a bit of "flying blind".  

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [X] I have updated `CHANGES.txt` and `RELEASE.txt` (and read the `README.rst`).
* [X] I have updated the appropriate documentation
